### PR TITLE
Enhance Travis CI setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
+dist: xenial
+
 language: php
 
 php:
-- 7.3
+  - 7.3
 
 notifications:
   email:
-  - team@appwrite.io
+    - team@appwrite.io
 
 before_script: composer install
 
 script:
-- vendor/bin/phpunit --configuration phpunit.xml
+  - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,6 @@
     "require-dev": {
         "phpunit/phpunit": "^7.0"
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/tests/SDKTest.php
+++ b/tests/SDKTest.php
@@ -26,7 +26,7 @@ class SDKTest extends TestCase
                 'php-7.2' => 'docker run --rm -v $(pwd):/app -w /app php:7.2-cli php tests/php/test.php',
                 'php-7.3' => 'docker run --rm -v $(pwd):/app -w /app php:7.3-cli php tests/php/test.php',
             ],
-            
+
         ],
         'node' => [
             'class' => 'Appwrite\SDK\Language\Node',
@@ -60,7 +60,7 @@ class SDKTest extends TestCase
     public function testHTTPSuccess()
     {
         $output = [];
-        
+
         /**
          * SDK Generation
          */
@@ -71,20 +71,20 @@ class SDKTest extends TestCase
 
         try {
             $spec = file_get_contents(realpath(__DIR__ . '/resources/spec.json'));
-        
+
             if(empty($spec)) {
                 throw new Exception('Failed to fetch spec from Appwrite server');
             }
 
             foreach ($this->languages as $language => $options) {
                 $sdk  = new SDK(new $options['class'](), new Swagger2($spec));
-        
+
                 $sdk
                     ->setLicenseContent('demo license')
                 ;
-        
+
                 $sdk->generate(__DIR__ . '/sdks/' . $language);
-                
+
                 //continue;
 
                 $output = [];
@@ -96,13 +96,13 @@ class SDKTest extends TestCase
 
                 foreach ($options['envs'] as $key => $command) {
                     echo "Running tests for the {$key} environment...\n";
-                    
+
                     $output = [];
-        
+
                     exec($command, $output);
 
                     //var_dump($output);
-        
+
                     $this->assertEquals($output[0], 'GET:/v1/mock/tests/foo:passed');
                     $this->assertEquals($output[1], 'POST:/v1/mock/tests/foo:passed');
                     $this->assertEquals($output[2], 'PUT:/v1/mock/tests/foo:passed');


### PR DESCRIPTION
# Changed log
- Add `php-7.1` and `php-7.2` tests on Travis CI build.
- The `PHPUnit` will read `phpunit.xml ` configuration by default.
It's fine to remove this command option.