### PR TITLE
Replace deprecated `request` with lightweight `node-fetch`

### DIFF
--- a/templates/node/lib/client.js.twig
+++ b/templates/node/lib/client.js.twig
@@ -98,18 +98,12 @@ class Client {
 
         try {
             let response = await fetch(uri, options);
-        } catch (error) {
-            console.error(error);
-            return null;
-        }
-
-        if(formData) {
-            try {
+            
+            if(formData) {
                 response = await response.json();
-            } catch (error) {
-                console.error(error);
-                return null;
             }
+        } catch (error) {
+            throw error;
         }
 
         return response;

--- a/templates/node/lib/client.js.twig
+++ b/templates/node/lib/client.js.twig
@@ -70,31 +70,37 @@ class Client {
         }
 
         const contentType = headers['content-type'].toLowerCase();
-        const uri = urljoin(this.endpoint, path);
         const json = contentType.indexOf('application/json') === 1;
         const formData = contentType.indexOf('multipart/form-data') === 1;
+
+        let uri = urljoin(this.endpoint, path);
+
+        const options = {
+            method: method.toUpperCase(),
+            headers: Object.assign(this.headers, headers),
+        };
 
         let body;
         if (json) {
             body = JSON.stringify(params);
+            
+            options['body'] = body;
         } else if (formData) {
             const form = new FormData();
             for (let key in params) {
                 body.append(key, params[key]);
             };
+
+            options['body'] = body;
         } else {  // query string
             const qs = new URLSearchParams();
             for (let key in params) {
                 qs.append(key, params[key]);
             };
-            body = qs;
-        }
+            body = qs.toString();
 
-        const options = {
-            method: method.toUpperCase(),
-            headers: Object.assign(this.headers, headers),
-            body: body,
-        };
+            uri += '?' + body;
+        }
 
         try {
             let response = await fetch(uri, options);
@@ -102,11 +108,13 @@ class Client {
             if(formData) {
                 response = await response.json();
             }
+
+            return response;
+
         } catch (error) {
+            console.error(error);
             throw error;
         }
-
-        return response;
     }
 }
 

--- a/templates/node/lib/client.js.twig
+++ b/templates/node/lib/client.js.twig
@@ -1,5 +1,7 @@
 const URL = require('url').URL;
-const request = require('request-promise-native');
+const fetch = require('node-fetch');
+const urljoin = require('urljoin');
+const FormData = require('form-data');
 
 class Client {
     
@@ -67,44 +69,45 @@ class Client {
             process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = 0;
         }
 
-        headers = Object.assign(this.headers, headers);
+        const contentType = headers['content-type'].toLowerCase();
+        const uri = urljoin(this.endpoint, path);
+        const json = contentType.indexOf('application/json') === 1;
+        const formData = contentType.indexOf('multipart/form-data') === 1;
 
-        let contentType = headers['content-type'].toLowerCase();
-        let options = {
+        let body;
+        if (json) {
+            body = JSON.stringify(params);
+        } else if (formData) {
+            const form = new FormData();
+            for (let key in params) {
+                body.append(key, params[key]);
+            };
+        } else {  // query string
+            const qs = new URLSearchParams();
+            for (let key in params) {
+                qs.append(key, params[key]);
+            };
+            body = qs;
+        }
+
+        const options = {
             method: method.toUpperCase(),
-            uri: this.endpoint + path,
-            qs: (method.toUpperCase() === 'GET') ? params : {},
-            headers: headers,
-            body: (method.toUpperCase() === 'GET' || contentType.startsWith('multipart/form-data')) ? null : params,
-            json: (contentType.startsWith('application/json')),
-            formData: (contentType.startsWith('multipart/form-data')) ? this.flatten(params) : null,
+            headers: Object.assign(this.headers, headers),
+            body: body,
         };
 
-        let response = await request(options);
+        try {
+            let response = await fetch(uri, options);
+        } catch (error) {
+            console.error(error);
+            return null
+        }
 
-        if(contentType.startsWith('multipart/form-data')) {
-            response = JSON.parse(response);
+        if(formData) {
+            response = await response.json();
         }
 
         return response;
-    }
-
-    flatten(data, prefix = '') {
-        let output = {};
-
-        for (const key in data) {
-            let value = data[key];
-            let finalKey = prefix ? prefix + '[' + key +']' : key;
-
-            if (Array.isArray(value)) {
-                output = Object.assign(output, this.flatten(value, finalKey)); // @todo: handle name collision here if needed
-            }
-            else {
-                output[finalKey] = value;
-            }
-        }
-
-        return output;
     }
 }
 

--- a/templates/node/lib/client.js.twig
+++ b/templates/node/lib/client.js.twig
@@ -100,11 +100,16 @@ class Client {
             let response = await fetch(uri, options);
         } catch (error) {
             console.error(error);
-            return null
+            return null;
         }
 
         if(formData) {
-            response = await response.json();
+            try {
+                response = await response.json();
+            } catch (error) {
+                console.error(error);
+                return null;
+            }
         }
 
         return response;

--- a/templates/node/package.json.twig
+++ b/templates/node/package.json.twig
@@ -11,7 +11,8 @@
   },
   "devDependencies": {},
   "dependencies": {
-    "request": "^2.88.0",
-    "request-promise-native": "^1.0.7"
+    "node-fetch": "^2.6.0",
+    "urljoin": "^0.1.5",
+    "form-data": "^3.0.0"
   }
 }

--- a/tests/languages/node/test.js
+++ b/tests/languages/node/test.js
@@ -2,6 +2,10 @@
 const appwrite = require('../../sdks/node/index');
 const fs = require('fs');
 
+if (typeof URLSearchParams === 'undefined') {
+    global.URLSearchParams = require('url').URLSearchParams;
+}
+
 async function start() {
     var response;
 


### PR DESCRIPTION
Other dependencies such as `urljoin` & `form-data` are also involved now.

Fixes #33 