### PR TITLE
The Storage service getFilePreview was giving error due to integer params

### DIFF
--- a/templates/flutter/lib/client.dart.twig
+++ b/templates/flutter/lib/client.dart.twig
@@ -112,6 +112,9 @@ class Client {
         }
 
         if (method == HttpMethod.get) {
+            params.keys.forEach((key) {if (params[key] is int || params[key] is double) {
+              params[key] = params[key].toString();
+            }});
             return http.get(path, queryParameters: params, options: options);
         } else {
             return http.request(path, data: params, options: options);

--- a/templates/flutter/lib/services/service.dart.twig
+++ b/templates/flutter/lib/services/service.dart.twig
@@ -92,6 +92,9 @@ class {{ service.name | caseUcfirst }} extends Service {
               client.cookieJar.saveFromResponse(Uri.parse(client.endPoint), cookies);
           });
 {% elseif method.type == 'location' %}
+        params.keys.forEach((key) {if (params[key] is int || params[key] is double) {
+              params[key] = params[key].toString();
+            }});
         Uri endpoint = Uri.parse(client.endPoint);
         Uri location = new Uri(scheme: endpoint.scheme,
           host: endpoint.host,


### PR DESCRIPTION
## Problem
The storage service getFilePreview was giving error because parameters like width, height, and quality were integers and Uri doesn't support int as queryParameters, as in URL there is no such thing as int or any other types except for String.

## Solution
Looping through the params before passing to queryParams and converting any int and double values to string. It's done in two places at the moment
   1. In storage service for localtion Uri and
   2. In Client before sending get request.