### PR TITLE
Adding support for oAuth using universal_html

### DIFF
--- a/templates/flutter/lib/services/service.dart.twig
+++ b/templates/flutter/lib/services/service.dart.twig
@@ -12,6 +12,7 @@
 
 {% if(service.features.webAuth) %}
 import 'dart:io';
+import 'package:universal_html/html.dart' as html;
 {% endif %}
 
 import 'package:dio/dio.dart';
@@ -78,19 +79,26 @@ class {{ service.name | caseUcfirst }} extends Service {
           query: query.join('&')
         );
 
-        return FlutterWebAuth.authenticate(
-          url: url.toString(),
-          callbackUrlScheme: "appwrite-callback-" + client.config['project']
-          ).then((value) async {
-              Uri url = Uri.parse(value);
-              Cookie cookie = new Cookie(url.queryParameters['key'], url.queryParameters['secret']);
-              cookie.domain = Uri.parse(client.endPoint).host;
-              cookie.httpOnly = true;
-              cookie.path = '/';
-              List<Cookie> cookies = [cookie];
-              await client.init();
-              client.cookieJar.saveFromResponse(Uri.parse(client.endPoint), cookies);
-          });
+        if(kIsWeb) {
+          html.window.location.href = url.toString();
+          return null;
+        }else{
+
+          return FlutterWebAuth.authenticate(
+            url: url.toString(),
+            callbackUrlScheme: "appwrite-callback-" + client.config['project']
+            ).then((value) async {
+                Uri url = Uri.parse(value);
+                Cookie cookie = new Cookie(url.queryParameters['key'], url.queryParameters['secret']);
+                cookie.domain = Uri.parse(client.endPoint).host;
+                cookie.httpOnly = true;
+                cookie.path = '/';
+                List<Cookie> cookies = [cookie];
+                await client.init();
+                client.cookieJar.saveFromResponse(Uri.parse(client.endPoint), cookies);
+            });
+        }
+
 {% elseif method.type == 'location' %}
         params.keys.forEach((key) {if (params[key] is int || params[key] is double) {
           params[key] = params[key].toString();

--- a/templates/flutter/pubspec.yaml.twig
+++ b/templates/flutter/pubspec.yaml.twig
@@ -15,6 +15,7 @@ dependencies:
   cookie_jar: ^1.0.1
   dio_cookie_manager: ^1.0.0
   flutter_web_auth: ^0.2.4
+  universal_html: ^1.2.3
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
@eldadfux this PR adds support for oAuth on Flutter Web using universal_html, as suggested, I have just redirected the web to the oAuth url. In documentation we need to add that, if we are building for flutter web, we need to pass success and failure URL, that is how it gets redirected.

The success case works fine, we get logged in and redirected. I am  not sure how it works for failure case, we should get redirected, but not know how we can handle the error case, as i was not able to reproduce a error case.