### PR TITLE
skipping badCertificateCallback implementation on selfSigned on flutt…

### DIFF
--- a/templates/flutter/lib/client.dart.twig
+++ b/templates/flutter/lib/client.dart.twig
@@ -99,7 +99,7 @@ class Client {
     }
 
     Future<Response> call(HttpMethod method, {String path = '', Map<String, String> headers = const {}, Map<String, dynamic> params = const {}}) async {
-        if(selfSigned) {
+        if(selfSigned && !kIsWeb) {
             // Allow self signed requests
             (http.httpClientAdapter as DefaultHttpClientAdapter).onHttpClientCreate = (HttpClient client) {
                 client.badCertificateCallback = (X509Certificate cert, String host, int port) => true;


### PR DESCRIPTION
…er web

as it was causing error regarding the type mismatch of HTTP Client adapter
It's fixes the latest issue commented on
https://github.com/appwrite/sdk-for-flutter/issues/5#issuecomment-688424199

Skipping the badCertificateCallback override if in web platform