### PR TITLE
fix(c#): example docs syntax

### DIFF
--- a/templates/dotnet/docs/example.md.twig
+++ b/templates/dotnet/docs/example.md.twig
@@ -4,14 +4,14 @@ Client client = new Client();
 
 {% if method.security|length > 0 %}
 client
-  .SetEndPoint("https://[HOSTNAME_OR_IP]/v1") # Your API Endpoint
+  .SetEndPoint("https://[HOSTNAME_OR_IP]/v1") // Your API Endpoint
 {% for node in method.security %}
 {% for key,header in node|keys %}
-  .Set{{header | caseUcfirst}}("{{node[header]["x-appwrite"]["demo"]}}") # {{node[header].description}}
+  .Set{{header | caseUcfirst}}("{{node[header]["x-appwrite"]["demo"]}}") // {{node[header].description}}
 {% endfor %}
 {% endfor %};
 
 {% endif %}
 {{ service.name | caseUcfirst }} {{ service.name | caseCamel }} = new {{ service.name | caseUcfirst }}(client);
 
-result = {{ service.name | caseCamel }}.{{ method.name | caseCamel }}({% for parameter in method.parameters.all %}{% if parameter.required %}{% if not loop.first %}, {% endif %}{{ parameter | paramExample }}{% endif %}{% endfor %});
+{% if method.type == 'location' %}string{% else %}HttpResponseMessage{% endif %} result = await {{ service.name | caseCamel }}.{{ method.name | caseUcfirst }}({% for parameter in method.parameters.all %}{% if parameter.required %}{% if not loop.first %}, {% endif %}{{ parameter | paramExample }}{% endif %}{% endfor %});


### PR DESCRIPTION
Found some minor things to fix the docs:

- fixes comments to `//`
- fixes casing on method call
- fixes data type for response 