### PR TITLE
fix(dotnet): prevent headers from being an array

### DIFF
--- a/templates/dotnet/src/Appwrite/Client.cs.twig
+++ b/templates/dotnet/src/Appwrite/Client.cs.twig
@@ -138,6 +138,9 @@ namespace {{ spec.title | caseUcfirst }}
                 }
                 else
                 {
+                    if (http.DefaultRequestHeaders.Contains(header.Key)) {
+                        http.DefaultRequestHeaders.Remove(header.Key);
+                    }
                     http.DefaultRequestHeaders.Add(header.Key, header.Value);
                 }
             }
@@ -150,6 +153,9 @@ namespace {{ spec.title | caseUcfirst }}
                 }
                 else
                 {
+                    if (request.Headers.Contains(header.Key)) {
+                        request.Headers.Remove(header.Key);
+                    }
                     request.Headers.Add(header.Key, header.Value);
                 }
             }


### PR DESCRIPTION
In some occasions it is possible to transform headers like project or api key to a comma seperated list. This fix prevents it 👍 

> If the specified header is already present, values are added to the comma-separated list of values associated with the header.