### PR TITLE
Feat default response header

### DIFF
--- a/tests/resources/spec.json
+++ b/tests/resources/spec.json
@@ -34,6 +34,13 @@
       "description": "",
       "in": "header",
       "x-appwrite": { "demo": "en" }
+    },
+    "ResponseFilter": {
+      "type":"apiKey",
+      "name":"X-Appwrite-Response-Format",
+      "description":"",
+      "in":"header",
+      "x-appwrite":{"demo":"0.7.0"}
     }
   },
   "paths": {


### PR DESCRIPTION
Hey, 
As we discussed I tried by adding a Response filter to a global header in the test spec, generated test SDK, here is what PHP client seems to generate

```
   /**
     * Set ResponseFilter
     *
     * @param string $value
     *
     * @return Client
     */
    public function setResponseFilter($value)
    {
        $this->addHeader('X-Appwrite-Response-Format', $value);

        return $this;
    }
```

Alll other SDKs have similar output. 
