### PR TITLE
fix dart sdk exception missing await

### DIFF
--- a/templates/dart/.travis.yml.twig
+++ b/templates/dart/.travis.yml.twig
@@ -19,6 +19,6 @@ install:
 deploy:
   provider: script
   skip_cleanup: true
-  script: pub publish -f
+  script: dart format ./lib/ && pub publish -f
   on:
     tags: true

--- a/templates/dart/lib/client.dart.twig
+++ b/templates/dart/lib/client.dart.twig
@@ -80,7 +80,7 @@ class Client {
         try {
 
             if(headers['content-type'] == 'multipart/form-data') {
-                return http.request(path, data: FormData.fromMap(params), options: options);
+                return await http.request(path, data: FormData.fromMap(params), options: options);
             }
 
             if (method == HttpMethod.get) {
@@ -88,9 +88,9 @@ class Client {
                 params[key] = params[key].toString();
                 }});
                 
-                return http.get(path, queryParameters: params, options: options);
+                return await http.get(path, queryParameters: params, options: options);
             } else {
-                return http.request(path, data: params, options: options);
+                return await http.request(path, data: params, options: options);
             }
         } on DioError catch(e) {
           if(e.response == null) {


### PR DESCRIPTION
Hey, looks like I missed the await keyword, which doesn't catch the error so the exceptions are not working. This should fix that.