### PR TITLE
Automate CLI SDK deployment to Docker Hub

### DIFF
--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -226,6 +226,12 @@ class CLI extends PHP {
                 'template'      => '/cli/app/services/init.php.twig',
                 'minify'        => false,
             ],
+            [
+                'scope'         => 'default',
+                'destination'   => '.travis.yml',
+                'template'      => '/cli/.travis.yml.twig',
+                'minify'        => false,
+            ],
         ];
     }
 

--- a/templates/cli/.travis.yml.twig
+++ b/templates/cli/.travis.yml.twig
@@ -1,0 +1,31 @@
+os: linux
+dist: xenial
+
+language: shell
+
+services:
+- docker
+
+before_install:
+- curl -fsSL https://get.docker.com | sh
+- echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
+- mkdir -p $HOME/.docker
+- echo '{"experimental":"enabled"}' | sudo tee $HOME/.docker/config.json
+- sudo service docker start
+- >
+  if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
+    echo "${DOCKERHUB_PULL_PASSWORD}" | docker login --username "${DOCKERHUB_PULL_USERNAME}" --password-stdin
+  fi
+- docker --version
+- docker run --rm --privileged linuxkit/binfmt:v0.8
+- docker buildx create --use
+
+script:
+- docker ps; docker buildx ls
+
+deploy:
+  - provider: script
+    edge: true
+    script: docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x -t appwrite/cli:$TRAVIS_TAG ./ --push
+    on:
+      tags: true


### PR DESCRIPTION
This PR adds a `twig` template to automate deployment of the CLI SDK upon tag creation.