### PR TITLE
fix(node): proper response type for location requests

### DIFF
--- a/templates/node/lib/client.js.twig
+++ b/templates/node/lib/client.js.twig
@@ -67,7 +67,7 @@ class Client {
         return this;
     }
       
-    async call(method, path = '', headers = {}, params = {}) {
+    async call(method, path = '', headers = {}, params = {}, responseType = 'json') {
         if(this.selfSigned) { // Allow self signed requests
             process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = 0;
         }
@@ -102,7 +102,8 @@ class Client {
             params: (method.toUpperCase() === 'GET') ? params : {},
             headers: headers,
             data: (method.toUpperCase() === 'GET' || contentType.startsWith('multipart/form-data')) ? formData : params,
-            json: (contentType.startsWith('application/json'))
+            json: (contentType.startsWith('application/json')),
+            responseType: responseType
         };
         try {
             let response = await axios(options);

--- a/templates/node/lib/services/service.js.twig
+++ b/templates/node/lib/services/service.js.twig
@@ -36,7 +36,7 @@ class {{ service.name | caseUcfirst }} extends Service {
                 '{{ parameter.name }}': {{ parameter.name | caseCamel }}{% if not loop.last %},{% endif %}
 
 {% endfor %}
-            });
+            }{% if method.type == 'location' %}, 'arraybuffer'{% endif %});
     }
 {% endfor %}
 }


### PR DESCRIPTION
- fixes response type in the request config when request is of type `location`
- prevents encoding on binary files returned from the SDK method