### PR TITLE
fix(php): overall improvements

### DIFF
--- a/templates/php/src/Services/Service.php.twig
+++ b/templates/php/src/Services/Service.php.twig
@@ -2,7 +2,7 @@
 
 namespace {{ spec.title | caseUcfirst }}\Services;
 
-use Exception;
+use {{ spec.title | caseUcfirst }}\{{spec.title | caseUcfirst}}Exception;
 use {{ spec.title | caseUcfirst }}\Client;
 use {{ spec.title | caseUcfirst }}\Service;
 
@@ -19,24 +19,42 @@ class {{ service.name | caseUcfirst }} extends Service
 {% for parameter in method.parameters.all %}
      * @param {{ parameter.type | typeName }}${{ parameter.name | caseCamel }}
 {% endfor %}
-     * @throws Exception
-     * @return array
+     * @throws {{spec.title | caseUcfirst}}Exception
+     * @return {% if method.type == 'location' %}string{% else %}array{% endif %}
+
      */
-    public function {{ method.name | caseCamel }}({% for parameter in method.parameters.all %}{{ parameter.type | typeName }}${{ parameter.name | caseCamel }}{{ parameter | paramDefault }}{% if not loop.last %}, {% endif %}{% endfor %}):array
+    public function {{ method.name | caseCamel }}({% for parameter in method.parameters.all %}{{ parameter.type | typeName }}${{ parameter.name | caseCamel }}{% if not parameter.required %} = null{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}): {% if method.type == 'location' %}string{% else %}array{% endif %}
+
     {
+{% for parameter in method.parameters.all %}
+{% if parameter.required %}
+        if (empty(${{ parameter.name | caseCamel }})) {
+            throw new {{spec.title | caseUcfirst}}Exception('Missing required parameter: "{{ parameter.name | caseCamel }}"');
+        }
+
+{% endif %}
+{% endfor %}
         $path   = str_replace([{% for parameter in method.parameters.path %}'{{ '{' }}{{ parameter.name | caseCamel }}{{ '}' }}'{% if not loop.last %}, {% endif %}{% endfor %}], [{% for parameter in method.parameters.path %}${{ parameter.name | caseCamel }}{% if not loop.last %}, {% endif %}{% endfor %}], '{{ method.path }}');
         $params = [];
 
 {% for parameter in method.parameters.query %}
-        $params['{{ parameter.name }}'] = ${{ parameter.name | caseCamel }};
+        if (!is_null(${{ parameter.name | caseCamel }})) {
+            $params['{{ parameter.name }}'] = ${{ parameter.name | caseCamel }};
+        }
+
 {% endfor %}
 {% for parameter in method.parameters.body %}
-        $params['{{ parameter.name }}'] = ${{ parameter.name | caseCamel }};
+        if (!is_null(${{ parameter.name | caseCamel }})) {
+            $params['{{ parameter.name }}'] = ${{ parameter.name | caseCamel }};
+        }
+
 {% endfor %}
 {% for parameter in method.parameters.formData %}
-        $params['{{ parameter.name }}'] = ${{ parameter.name | caseCamel }};
-{% endfor %}
+        if (!is_null(${{ parameter.name | caseCamel }})) {
+            $params['{{ parameter.name }}'] = ${{ parameter.name | caseCamel }};
+        }
 
+{% endfor %}
         return $this->client->call(Client::METHOD_{{ method.method | caseUpper }}, $path, [
 {% for parameter in method.parameters.header %}
             '{{ parameter.name }}' => ${{ parameter.name | caseCamel }},


### PR DESCRIPTION
- add param checking
- added proper return type for files

before:
```php
public function updateDocument(string $collectionId, string $documentId, array $data, array $read = [], array $write = []):array
    {
        $path   = str_replace(['{collectionId}', '{documentId}'], [$collectionId, $documentId], '/database/collections/{collectionId}/documents/{documentId}');
        $params = [];

        $params['data'] = $data;
        $params['read'] = $read;
        $params['write'] = $write;

        return $this->client->call(Client::METHOD_PATCH, $path, [
            'content-type' => 'application/json',
        ], $params);
    }
```
after:
```php
public function updateDocument(string $collectionId, string $documentId, array $data, array $read = null, array $write = null): array
    {
        if (empty($collectionId)) {
            throw new AppwriteException('Missing required parameter: "collectionId"');
        }

        if (empty($documentId)) {
            throw new AppwriteException('Missing required parameter: "documentId"');
        }

        if (empty($data)) {
            throw new AppwriteException('Missing required parameter: "data"');
        }

        $path   = str_replace(['{collectionId}', '{documentId}'], [$collectionId, $documentId], '/database/collections/{collectionId}/documents/{documentId}');
        $params = [];

        if (!is_null($data)) {
            $params['data'] = $data;
        }

        if (!is_null($read)) {
            $params['read'] = $read;
        }

        if (!is_null($write)) {
            $params['write'] = $write;
        }

        return $this->client->call(Client::METHOD_PATCH, $path, [
            'content-type' => 'application/json',
        ], $params);
    }
```