### PR TITLE
Updated coding conventions

### DIFF
--- a/templates/cli/src/Client.php.twig
+++ b/templates/cli/src/Client.php.twig
@@ -27,7 +27,7 @@ class Client
      *
      * @var array
      */
-    private $headers = [
+    protected $headers = [
         'content-type' => '',
         'x-sdk-version' => '{{spec.title | caseDash}}:{{ language.name | caseLower }}:{{ sdk.version }}',
 {% for key,header in spec.global.defaultHeaders %}
@@ -40,7 +40,7 @@ class Client
      *
      * @var array
      */
-    private $preferences = [
+    protected $preferences = [
         self::PREFERENCE_ENDPOINT => '',
         self::PREFERENCE_SELF_SIGNED => '',
 {% for header in spec.global.headers %}
@@ -92,13 +92,13 @@ class Client
         return $this;
     }
 
-     /**
+    /**
      * Load user preferences from the JSON file
      * 
      * @param string $filename 
      * @return bool
      */
-    private function loadPreferences(string $filename = self::USER_PREFERENCES_FILE): bool
+    protected function loadPreferences(string $filename = self::USER_PREFERENCES_FILE): bool
     {
         try {
             $jsondata = @file_get_contents($filename);
@@ -119,12 +119,12 @@ class Client
     }
 
     /**
-    * Function to write user preferences to
-    * the JSON file
-    * 
-    * @param string $filename 
-    * @return int
-    */
+     * Function to write user preferences to
+     * the JSON file
+     * 
+     * @param string $filename 
+     * @return int
+     */
     function savePreferences(string $filename = self::USER_PREFERENCES_FILE): int
     {
         $jsondata = json_encode($this->preferences, JSON_PRETTY_PRINT);
@@ -132,12 +132,12 @@ class Client
         return $result;
     }
 
-     /**
+    /**
      * Check if all the preferences have been successfully loaded.
      * 
      * @return bool
      */
-    private function isPreferenceLoaded() : bool {
+    protected function isPreferenceLoaded() : bool {
         if(empty($this->getPreference(self::PREFERENCE_ENDPOINT))) return false;
 {% for header in spec.global.headers %}
 {% if header.key != 'Mode' and header.key != 'JWT' %}
@@ -289,7 +289,7 @@ class Client
      * @param string $prefix
      * @return array
      */
-    private function flatten(array $data, $prefix = '')
+    protected function flatten(array $data, $prefix = '')
     {
         $output = [];
 

--- a/templates/cli/src/Parser.php.twig
+++ b/templates/cli/src/Parser.php.twig
@@ -11,7 +11,7 @@ class Parser {
      *
      * @var array
      */
-    private const colors = array(
+    protected const colors = array(
         'blue',
         'red',
         'green',
@@ -27,23 +27,23 @@ class Parser {
      *
      * @var bool
      */
-    private const tableColor = self::colors[0];
+    protected const tableColor = self::colors[0];
 
     /**
      * Color for the table column headers
      *
      * @var string
      */
-    private const headerColor = self::colors[2];
+    protected const headerColor = self::colors[2];
 
-     /**
+    /**
      * Parse the response from the server 
      *
-     * @param string $value 
+     * @param array $response 
      * @return void
      */
-    public function parseResponse($response) {
-        
+    public function parseResponse($response)
+    {
         foreach ($response as $key => $value) {
             if (is_array($value) && count($value) !== 0 ) {
                 $this->drawKeyValue($key, '');
@@ -62,10 +62,12 @@ class Parser {
      * @param string $value 
      * @return void
      */
-    private function drawKeyValue($key, $value){
+    protected function drawKeyValue($key, $value)
+    {
         if(is_bool($value)) {
             $value = $value ? 'true' : 'false';
-        } else if (is_array($value)) {
+        }
+        else if (is_array($value)) {
             $value = '{}';
         }
 
@@ -78,7 +80,7 @@ class Parser {
      * @param int $index
      * @return string
      */
-    private function getColor($index = -1) : string {
+    protected function getColor($index = -1) : string {
         if ($index != -1) return self::colors[$index % count(self::colors) ];
         return self::colors[array_rand(self::colors)];
     }
@@ -91,7 +93,7 @@ class Parser {
      * @param string $tableColor
      * @return void
      */
-    private function drawTable($data, $headerColor, $tableColor) {
+    protected function drawTable($data, $headerColor, $tableColor) {
         if (!is_array($data) || !is_array($data[0])) return;
 
         $keys = array_keys($data[0]);
@@ -124,7 +126,7 @@ class Parser {
         $table->display();
     }
 
-    public function formatArray(Array $arr) {
+    public function formatArray(array $arr) {
         $descriptionColumnLimit = 60;
         $commandNameColumnLimit = 20;
         $mask = "\t%-${commandNameColumnLimit}.${commandNameColumnLimit}s %-${descriptionColumnLimit}.${descriptionColumnLimit}s\n";


### PR DESCRIPTION
- `protected` are usually dev friendlier than `private` method
- Fixed some indentations and coding standards
- Arrays should be casted as `array` and not `Array`