### PR TITLE
fix(web): iife namespace to window

### DIFF
--- a/templates/web/rollup.config.js.twig
+++ b/templates/web/rollup.config.js.twig
@@ -20,8 +20,8 @@ export default {
         {
             format: "iife",
             file: pkg.jsdelivr,
-            name: "Appwrite",
-            esModule: false,
+            name: "window",
+            extend: true,
             globals: {
                 "cross-fetch": "window",
                 "FormData": "FormData",

--- a/tests/languages/web/index.html
+++ b/tests/languages/web/index.html
@@ -17,7 +17,7 @@
             let response;
 
             // Init SDK
-            let sdk = new Appwrite.Appwrite();
+            let sdk = new Appwrite();
 
             // Foo
             response = await sdk.foo.get("string", 123, ["string in array"]);


### PR DESCRIPTION
- Changes iife usage from `Appwrite` namespace to `window`
- Usage is now `const sdk = new Appwrite()` or `const sdk = new window.Appwrite()`