### PR TITLE
feat: improvements to sdk-generator

### DIFF
--- a/example.php
+++ b/example.php
@@ -12,8 +12,6 @@ use Appwrite\SDK\Language\Python;
 use Appwrite\SDK\Language\Ruby;
 use Appwrite\SDK\Language\Dart;
 use Appwrite\SDK\Language\Go;
-use Appwrite\SDK\Language\Java;
-use Appwrite\SDK\Language\Typescript;
 use Appwrite\SDK\Language\Deno;
 use Appwrite\SDK\Language\HTTP;
 use Appwrite\SDK\Language\Swift;
@@ -96,31 +94,7 @@ try {
     ;
 
     $sdk->generate(__DIR__ . '/examples/web');
-
-    // TypeScript
-    $sdk  = new SDK(new Typescript(), new Swagger2($spec));
-
-    $sdk
-        ->setName('NAME')
-        ->setDescription('Repo description goes here')
-        ->setShortDescription('Repo short description goes here')
-        ->setVersion('0.0.0')
-        ->setURL('https://example.com')
-        ->setLogo('https://appwrite.io/v1/images/console.png')
-        ->setLicenseContent('test test test')
-        ->setWarning('**WORK IN PROGRESS - NOT READY FOR USAGE**')
-        ->setChangelog('**CHANGELOG**')
-        ->setGitUserName('repoowner')
-        ->setGitRepoName('reponame')
-        ->setTwitter('appwrite_io')
-        ->setDiscord('564160730845151244', 'https://appwrite.io/discord')
-        ->setDefaultHeaders([
-            'X-Appwrite-Response-Format' => '0.7.0',
-        ])
-    ;
-
-    $sdk->generate(__DIR__ . '/examples/typescript');
-
+    
     // Deno
     $sdk  = new SDK(new Deno(), new Swagger2($spec));
 
@@ -293,31 +267,6 @@ try {
 
     $sdk->generate(__DIR__ . '/examples/go');
 
-    // Java
-
-    $sdk  = new SDK(new Java(), new Swagger2($spec));
-
-    $sdk
-        ->setName('NAME')
-        ->setNamespace('io appwrite')
-        ->setDescription('Repo description goes here')
-        ->setShortDescription('Repo short description goes here')
-        ->setURL('https://example.com')
-        ->setGitUserName('appwrite')
-        ->setGitRepoName('java-sdk')
-        ->setLogo('https://appwrite.io/v1/images/console.png')
-        ->setLicenseContent('test test test')
-        ->setWarning('**WORK IN PROGRESS - NOT READY FOR USAGE**')
-        ->setChangelog('**CHANGELOG**')
-        ->setVersion('0.0.1')
-        ->setTwitter('appwrite_io')
-        ->setDiscord('564160730845151244', 'https://appwrite.io/discord')
-        ->setDefaultHeaders([
-            'X-Appwrite-Response-Format' => '0.7.0',
-        ])
-    ;
-
-    $sdk->generate(__DIR__ . '/examples/java');
 
     // Swift
     $sdk  = new SDK(new Swift(), new Swagger2($spec));

--- a/example.php
+++ b/example.php
@@ -36,7 +36,7 @@ try {
     //$spec = getSSLPage('https://appwrite.io/v1/open-api-2.json?extensions=1');
     // $spec = getSSLPage('https://appwrite.io/v1/open-api-2.json?extensions=1'); // Enable only with Appwrite local server running on port 80
     // $spec = getSSLPage('https://appwrite.io/v1/open-api-2.json?extensions=1&platform=console'); // Enable only with Appwrite local server running on port 80
-    
+    // $spec = file_get_contents('https://appwrite.io/specs/swagger2?platform=client');
     $spec = file_get_contents('./specs/swagger-appwrite.0.8.0.json');
 
     if(empty($spec)) {
@@ -94,7 +94,7 @@ try {
     ;
 
     $sdk->generate(__DIR__ . '/examples/web');
-    
+
     // Deno
     $sdk  = new SDK(new Deno(), new Swagger2($spec));
 

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -537,7 +537,9 @@ class SDK
         ];
 
         foreach ($this->language->getFiles() as $file) {
-            $template       = $this->twig->load($file['template']); /* @var $template \Twig\TemplateWrapper */
+            if ($file['scope'] != 'copy') {
+                $template = $this->twig->load($file['template']); /* @var $template \Twig\TemplateWrapper */
+            }
             $destination    = $target . '/' . $file['destination'];
             $block          = $file['block'] ?? null;
             $minify         = $file['minify'] ?? false;
@@ -547,6 +549,9 @@ class SDK
                     $this->render($template, $destination, $block, $params, $minify);
                     break;
                 case 'copy':
+                    if (!file_exists(dirname($destination))) {
+                        mkdir(dirname($destination), 0777, true);
+                    }
                     copy(realpath(__DIR__.'/../../templates/' . $file['template']), $destination);
                     break;
                 case 'service':


### PR DESCRIPTION
* Remove Unused Java and Typescript SDK generation
* When copying files, create directories in destination path if it doesn't exist
* Do not load twig templates if scope is `copy`  
* Added a link to the production Swagger spec for convenience 