### PR TITLE
Update install.sh.twig for Apple Silicon Mac

### DIFF
--- a/templates/cli/install.sh.twig
+++ b/templates/cli/install.sh.twig
@@ -64,6 +64,11 @@ getSystemInfo() {
     if [ "$OS" == "linux" ] && [ "${{ spec.title | upper }}_INSTALL_DIR" == "/usr/local/bin" ]; then
         USE_SUDO="true"
     fi
+    
+    # Need root access if its Apple Silicon
+    if [ "$OS" == "darwin" ] && [[ "$(uname -a)" = *ARM64* ]]; then
+        USE_SUDO="true"
+    fi
 
     printf "${GREEN}\nOS : $OS \nARCH : $ARCH \nREQUIRES ROOT : $USE_SUDO\n\n${NC}"
 }


### PR DESCRIPTION
`curl -sL https://appwrite.io/cli/install.sh | bash` fails on Apple Silicon Mac

Apple Silicon Mac need root access to write to `"/usr/local/bin"`

I report an issue [here](https://github.com/appwrite/sdk-for-cli/issues/18) with more details.

The update will set `USE_SUDO` to `"true"` if run on Apple Silicon Mac

using `[[ "$(uname -a)" = *ARM64* ]]` to avoid the case when the user runs in Rosetta mode

which `uname -m` will give `x86_64` even we are running on Apple Silicon(shall be `arm64`). [reference](https://stackoverflow.com/questions/65259300/detect-apple-silicon-from-command-line)