### PR TITLE
Fix SSL Verification in Python SDK

### DIFF
--- a/templates/python/package/client.py.twig
+++ b/templates/python/package/client.py.twig
@@ -74,7 +74,7 @@ class Client:
                 json=json,
                 files=files,
                 headers=headers,
-                verify=self._self_signed,
+                verify=(not self._self_signed),
             )
 
             response.raise_for_status()


### PR DESCRIPTION
All the SDKs verify SSL certificates by default except for the Python SDK due to a but in the logic for SSL verification. This change fixes the logic to ensure SSL verification is done by default.

Closes: https://github.com/appwrite/sdk-for-python/issues/40

Before the update, SSL verification isn't done and there is a warning that SSL verification isn't done. The following screenshot shows the warning as well as the request continuing to https://dne.appwrite.io/v1 (which results in HTTP Status 400 as expected).

![Python SDK SSL Warning](https://user-images.githubusercontent.com/1477010/137228411-2bced568-f7df-4d49-b536-3ce0be9c584a.png)

After the update, SSL verification is done and the request is not sent due to the SSL handshake failure:

![Python SDK Error](https://user-images.githubusercontent.com/1477010/137228552-1e83a71b-43f1-4439-90a2-d8672a6ffc26.png)


