### PR TITLE
Ruby SDK: Remove --save flag from gem install command

### DIFF
--- a/templates/ruby/README.md.twig
+++ b/templates/ruby/README.md.twig
@@ -25,7 +25,7 @@
 To install via [Gem](https://rubygems.org/):
 
 ```bash
-gem install {{ language.params.gemPackage }} --save
+gem install {{ language.params.gemPackage }}
 ```
 
 {% if sdk.gettingStarted %}


### PR DESCRIPTION
Closes #296 

Per https://github.com/appwrite/docs/pull/104 , the Ruby gem install command should not have the `--save` flag. This PR simply removes that flag from the `Readme.md` file so it can match the Appwrite Docs.