### PR TITLE
Fix Ruby handling non-JSON responses

### DIFF
--- a/templates/ruby/lib/container/client.rb.twig
+++ b/templates/ruby/lib/container/client.rb.twig
@@ -93,18 +93,26 @@ module {{spec.title | caseUcfirst}}
                 
                 return fetch(method, uri, headers, {}, limit - 1)
             end
-            
-            begin
-                res = JSON.parse(response.body);
-            rescue JSON::ParserError => e
-                raise {{spec.title | caseUcfirst}}::Exception.new(response.body, response.code, nil)
+
+            if response.content_type == 'application/json'
+                begin
+                    json = JSON.parse(response.body)
+
+                    if response.class == Net::HTTPClientError || response.class == Net::HTTPServerError
+                        raise {{spec.title | caseUcfirst}}::Exception.new(json['message'], json['status'], response)
+                    end
+                rescue JSON::ParserError => e
+                    raise {{spec.title | caseUcfirst}}::Exception.new(e.message, response.code, response)
+                end
+
+                return json
             end
 
-            if(response.code.to_i >= 400)
-                raise {{spec.title | caseUcfirst}}::Exception.new(res['message'], res['status'], res)
+            if response.class == Net::HTTPClientError || response.class == Net::HTTPServerError
+                raise {{spec.title | caseUcfirst}}::Exception.new(response.body, response.code, response)
             end
 
-            return res;
+            return response.body if response.body_permitted?
         end
         
         def encodeFormData(value, key=nil)


### PR DESCRIPTION
Appropriately handle empty or non-JSON response bodies

Closes #289 