### PR TITLE
Added proper export for Query class

### DIFF
--- a/templates/node/lib/query.js.twig
+++ b/templates/node/lib/query.js.twig
@@ -32,3 +32,5 @@ class Query {
       ? `"${value}"`
       : `${value}`;
 }
+
+module.exports = Query;


### PR DESCRIPTION
Code:

```
const sdk = require("node-appwrite");
console.log(sdk.Query.equal("name", "Matej"));
```

Before this PR:

```
console.log(sdk.Query.equal("name", "Matej"));
                      ^

TypeError: sdk.Query.equal is not a function
    at Object.<anonymous> (/Users/meldiron/Desktop/delme/aw10del/app.js:2:23)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:17:47
```

After this PR:

```
name.equal("Matej")
```