### PR TITLE
Fix Kotlin exceptions for Java 16+

### DIFF
--- a/templates/android/library/src/main/java/io/appwrite/Client.kt.twig
+++ b/templates/android/library/src/main/java/io/appwrite/Client.kt.twig
@@ -327,8 +327,17 @@ class Client @JvmOverloads constructor(
                         .charStream()
                         .buffered()
                         .use(BufferedReader::readText)
+                        
                     val error = if (response.headers["content-type"]?.contains("application/json") == true) {
-                        body.fromJson()
+                        val map = gson.fromJson<Map<String, Any>>(
+                            body,
+                            object : TypeToken<Map<String, Any>>(){}.type
+                        )
+                        {{ spec.title | caseUcfirst }}Exception(
+                            map["message"] as? String ?: "", 
+                            (map["code"] as Number).toInt(), 
+                            body
+                        )
                     } else {
                         {{ spec.title | caseUcfirst }}Exception(body, response.code)
                     }

--- a/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
@@ -286,8 +286,17 @@ class Client @JvmOverloads constructor(
                         .charStream()
                         .buffered()
                         .use(BufferedReader::readText)
+                        
                     val error = if (response.headers["content-type"]?.contains("application/json") == true) {
-                        body.fromJson()
+                        val map = gson.fromJson<Map<String, Any>>(
+                            body,
+                            object : TypeToken<Map<String, Any>>(){}.type
+                        )
+                        {{ spec.title | caseUcfirst }}Exception(
+                            map["message"] as? String ?: "", 
+                            (map["code"] as Number).toInt(), 
+                            body
+                        )
                     } else {
                         {{ spec.title | caseUcfirst }}Exception(body, response.code)
                     }


### PR DESCRIPTION
In Java 16+, GSON reflection fails because it can not access private properties inside a module it does not own. To work around this we can use an explicit `TypeToken` which will avoid reflection.

Closes https://github.com/appwrite/sdk-for-kotlin/issues/16