### PR TITLE
Fix CLI deleting variables on function deploy

### DIFF
--- a/templates/cli/lib/commands/deploy.js.twig
+++ b/templates/cli/lib/commands/deploy.js.twig
@@ -167,7 +167,7 @@ const deployFunction = async () => {
                 functionId: func['$id'],
                 name: func.name,
                 execute: func.execute,
-                vars: func.vars,
+                vars: response.vars,
                 events: func.events,
                 schedule: func.schedule,
                 timeout: func.timeout,

--- a/templates/cli/lib/commands/init.js.twig
+++ b/templates/cli/lib/commands/init.js.twig
@@ -100,7 +100,6 @@ const initFunction = async () => {
     path: `functions/${answers.name}`,
     entrypoint: answers.runtime.entrypoint || '',
     execute: response.execute,
-    vars: response.vars,
     events: response.events,
     schedule: response.schedule,
     timeout: response.timeout,


### PR DESCRIPTION
This PR fixes the CLI deleting all function variables when deploying a function, it also removes environment variables from the stored data as this could potentially be a security problem.