### PR TITLE
Grammatical mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 The SDK Generator uses predefined language settings as [Twig templates](https://twig.symfony.com/) to generate codebases based on different API specs.
 
-Currently, the only spec supported is Swagger 2.0, but we intend to add support for more specification in the near future. This generator is still lacking support for any definition/models specs.
+Currently, the only spec supported is Swagger 2.0, but we intend to add support for more specifications in the near future. This generator is still lacking support for any definition/models specs.
 
 ## Getting Started
 


### PR DESCRIPTION
It seems that specification may not agree in number with other words in this phrase.