### PR TITLE
Fix Archive not being deleted when the deploy request fails

### DIFF
--- a/templates/cli/lib/commands/command.js.twig
+++ b/templates/cli/lib/commands/command.js.twig
@@ -139,6 +139,7 @@ const {{ service.name | caseLower }}{{ method.name | caseUcfirst }} = async ({ {
                     throw err
                 });{% endif %}
 
+
                 if (!id) {
                         id = response['$id'];
                 }

--- a/templates/cli/lib/commands/command.js.twig
+++ b/templates/cli/lib/commands/command.js.twig
@@ -134,7 +134,7 @@ const {{ service.name | caseLower }}{{ method.name | caseUcfirst }} = async ({ {
                 payload['{{ parameter.name }}'] = stream;
 
                 response = await client.call('{{ method.method | caseLower }}', path, headers, payload{% if method.type == 'location' %}, 'arraybuffer'{% endif %}).catch(err => {
-                    fs.unlinkSync(archivePath]);
+                    fs.unlinkSync(archivePath);
                     throw err
                 });
 

--- a/templates/cli/lib/commands/command.js.twig
+++ b/templates/cli/lib/commands/command.js.twig
@@ -104,6 +104,7 @@ const {{ service.name | caseLower }}{{ method.name | caseUcfirst }} = async ({ {
             fs.unlinkSync(archivePath);
             throw err
         });{% endif %}
+
     } else {
         const streamFilePath = payload['{{ parameter.name }}'];
         let id = undefined;

--- a/templates/cli/lib/commands/command.js.twig
+++ b/templates/cli/lib/commands/command.js.twig
@@ -101,7 +101,7 @@ const {{ service.name | caseLower }}{{ method.name | caseUcfirst }} = async ({ {
             '{{ key }}': '{{ header }}',
 {% endfor %}
         }, payload{% if method.type == 'location' %}, 'arraybuffer'{% endif %}).catch(err => {
-            fs.unlinkSync(payload['{{ parameter.name }}']);
+            fs.unlinkSync(archivePath);
             throw err
         });
     } else {
@@ -134,7 +134,7 @@ const {{ service.name | caseLower }}{{ method.name | caseUcfirst }} = async ({ {
                 payload['{{ parameter.name }}'] = stream;
 
                 response = await client.call('{{ method.method | caseLower }}', path, headers, payload{% if method.type == 'location' %}, 'arraybuffer'{% endif %}).catch(err => {
-                    fs.unlinkSync(payload['{{ parameter.name }}']);
+                    fs.unlinkSync(archivePath]);
                     throw err
                 });
 

--- a/templates/cli/lib/commands/command.js.twig
+++ b/templates/cli/lib/commands/command.js.twig
@@ -100,7 +100,10 @@ const {{ service.name | caseLower }}{{ method.name | caseUcfirst }} = async ({ {
 {% for key, header in method.headers %}
             '{{ key }}': '{{ header }}',
 {% endfor %}
-        }, payload{% if method.type == 'location' %}, 'arraybuffer'{% endif %});
+        }, payload{% if method.type == 'location' %}, 'arraybuffer'{% endif %}).catch(err => {
+            fs.unlinkSync(payload['{{ parameter.name }}']);
+            throw err
+        });
     } else {
         const streamFilePath = payload['{{ parameter.name }}'];
         let id = undefined;
@@ -130,7 +133,10 @@ const {{ service.name | caseLower }}{{ method.name | caseUcfirst }} = async ({ {
                 });
                 payload['{{ parameter.name }}'] = stream;
 
-                response = await client.call('{{ method.method | caseLower }}', path, headers, payload{% if method.type == 'location' %}, 'arraybuffer'{% endif %});
+                response = await client.call('{{ method.method | caseLower }}', path, headers, payload{% if method.type == 'location' %}, 'arraybuffer'{% endif %}).catch(err => {
+                    fs.unlinkSync(payload['{{ parameter.name }}']);
+                    throw err
+                });
 
                 if (!id) {
                         id = response['$id'];

--- a/templates/cli/lib/commands/command.js.twig
+++ b/templates/cli/lib/commands/command.js.twig
@@ -100,10 +100,10 @@ const {{ service.name | caseLower }}{{ method.name | caseUcfirst }} = async ({ {
 {% for key, header in method.headers %}
             '{{ key }}': '{{ header }}',
 {% endfor %}
-        }, payload{% if method.type == 'location' %}, 'arraybuffer'{% endif %}).catch(err => {
+        }, payload{% if method.type == 'location' %}, 'arraybuffer'{% endif %}){% if method.packaging %}.catch(err => {
             fs.unlinkSync(archivePath);
             throw err
-        });
+        });{% endif %}
     } else {
         const streamFilePath = payload['{{ parameter.name }}'];
         let id = undefined;
@@ -133,10 +133,10 @@ const {{ service.name | caseLower }}{{ method.name | caseUcfirst }} = async ({ {
                 });
                 payload['{{ parameter.name }}'] = stream;
 
-                response = await client.call('{{ method.method | caseLower }}', path, headers, payload{% if method.type == 'location' %}, 'arraybuffer'{% endif %}).catch(err => {
+                response = await client.call('{{ method.method | caseLower }}', path, headers, payload{% if method.type == 'location' %}, 'arraybuffer'{% endif %}){% if method.packaging %}.catch(err => {
                     fs.unlinkSync(archivePath);
                     throw err
-                });
+                });{% endif %}
 
                 if (!id) {
                         id = response['$id'];


### PR DESCRIPTION
This PR adds a catch to the HTTP calls made in the CLI when we are deploying functions. The catch will make sure we delete the archive then will throw the error again so our handler can deal with it.