### PR TITLE
Fix: JSON object parsing

### DIFF
--- a/templates/cli/lib/commands/command.js.twig
+++ b/templates/cli/lib/commands/command.js.twig
@@ -55,6 +55,11 @@ const {{ service.name | caseLower }}{{ method.name | caseUcfirst }} = async ({ {
         payload['{{ parameter.name }}'] = filePath;
     }
 
+{% elseif parameter.type == 'object' %}
+    if (typeof {{ parameter.name | caseCamel | escapeKeyword }} !== 'undefined') {
+        payload['{{ parameter.name }}'] = JSON.parse({{ parameter.name | caseCamel | escapeKeyword}});
+    }
+
 {% else %}
     if (typeof {{ parameter.name | caseCamel | escapeKeyword }} !== 'undefined') {
         payload['{{ parameter.name }}'] = {{ parameter.name | caseCamel | escapeKeyword}}{% if method.consumes[0] == "multipart/form-data" and ( parameter.type != "string" and parameter.type != "array" ) %}.toString(){% endif %};


### PR DESCRIPTION
Currently, prefs are passed as string into CLI, but are expected as object by server, resulting in invalid 4XX error:
![CleanShot 2022-03-31 at 13 44 25](https://user-images.githubusercontent.com/19310830/161047523-9165b5cb-d513-4af4-a04d-50bcb36a17b9.png)

With these changes, if expected type is object, input from CLI is automatically parsed with `JSON.parse()`, resulting in successful execution:

![CleanShot 2022-03-31 at 13 45 15](https://user-images.githubusercontent.com/19310830/161047613-1d85fdf5-12c9-4056-b92a-cc148f3822f4.png)

![CleanShot 2022-03-31 at 13 45 26](https://user-images.githubusercontent.com/19310830/161047649-76d17c6f-35ff-42ca-979c-ad11328ee9bc.png)

