### PR TITLE
Fix: Powershell install

### DIFF
--- a/example.php
+++ b/example.php
@@ -169,7 +169,7 @@ try {
 
     $sdk
         ->setName('NAME')
-        ->setVersion('0.0.19')
+        ->setVersion('0.16.0')
         ->setDescription('Repo description goes here')
         ->setShortDescription('Repo short description goes here')
         ->setURL('https://appwrite.io')

--- a/templates/cli/install.ps1.twig
+++ b/templates/cli/install.ps1.twig
@@ -21,6 +21,7 @@ ${{ spec.title | upper }}_DOWNLOAD_DIR = Join-Path -Path $env:TEMP -ChildPath "{
 
 # {{ spec.title | caseUcfirst }} CLI location
 ${{ spec.title | upper }}_INSTALL_DIR = Join-Path -Path $env:LOCALAPPDATA -ChildPath "{{ spec.title | caseUcfirst }}"
+${{ spec.title | upper }}_INSTALL_FILE = Join-Path -Path ${{ spec.title | upper }}_INSTALL_DIR -ChildPath "{{ language.params.executableName }}.exe"
 
 $USER_PATH_ENV_VAR = [Environment]::GetEnvironmentVariable("PATH", "User")
 
@@ -53,8 +54,8 @@ function DownloadBinary {
       Invoke-WebRequest -Uri $GITHUB_x64_URL -OutFile ${{ spec.title | upper }}_DOWNLOAD_DIR
     }
    
-
-   Move-Item ${{ spec.title | upper }}_DOWNLOAD_DIR ${{ spec.title | upper }}_INSTALL_DIR
+    New-Item -ItemType Directory -Force -Path ${{ spec.title | upper }}_INSTALL_DIR | Out-Null
+    Move-Item ${{ spec.title | upper }}_DOWNLOAD_DIR ${{ spec.title | upper }}_INSTALL_FILE
 }
 
 
@@ -65,6 +66,7 @@ function Install {
         Write-Host "Skipping to add {{ spec.title | caseUcfirst }} to User Path."
     } else {
         [System.Environment]::SetEnvironmentVariable("PATH", $USER_PATH_ENV_VAR + ";${{ spec.title | upper }}_INSTALL_DIR", "User")
+        $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User") 
     }
 }
 


### PR DESCRIPTION
- File must end with `.exe` for it to work. Instead of making `Appwrite` file, we now make `appwrite.exe` inside `Appwrite` folder
- After installation, if we change PATH env, we also refresh it, so you can instantly use without restarting powershell. that's something like `source` on linux

## Tests

- [x] Manual QA