### PR TITLE
Fix: Deno Chunk Upload

### DIFF
--- a/templates/deno/src/services/service.ts.twig
+++ b/templates/deno/src/services/service.ts.twig
@@ -150,6 +150,9 @@ export class {{ service.name | caseUcfirst }} extends Service {
                         totalBuffer[(blockIndex * Client.DENO_READ_CHUNK_SIZE) + byteIndex] = buf[byteIndex];
                     }
                 }
+
+                // Shrink empty bytes
+                totalBuffer = new Uint8Array(totalBuffer.buffer, 0);
                 
                 payload['{{ parameter.name }}'] = new File([totalBuffer], basename({{ parameter.name | caseCamel | escapeKeyword }}));
 

--- a/templates/deno/src/services/service.ts.twig
+++ b/templates/deno/src/services/service.ts.twig
@@ -135,7 +135,8 @@ export class {{ service.name | caseUcfirst }} extends Service {
                     headers['x-{{spec.title | caseLower }}-id'] = id;
                 }
                 
-                const totalBuffer = new Uint8Array(Client.CHUNK_SIZE);
+                let totalBuffer = new Uint8Array(Client.CHUNK_SIZE);
+                let lastBufferIndex = -1;
 
                 for (let blockIndex = 0; blockIndex < Client.CHUNK_SIZE / Client.DENO_READ_CHUNK_SIZE; blockIndex++) {
                     const buf = new Uint8Array(Client.DENO_READ_CHUNK_SIZE);
@@ -148,11 +149,21 @@ export class {{ service.name | caseUcfirst }} extends Service {
 
                     for (let byteIndex = 0; byteIndex < Client.DENO_READ_CHUNK_SIZE; byteIndex++) {
                         totalBuffer[(blockIndex * Client.DENO_READ_CHUNK_SIZE) + byteIndex] = buf[byteIndex];
+
+                        if(buf[byteIndex] !== 0) {
+                            lastBufferIndex = (blockIndex * Client.DENO_READ_CHUNK_SIZE) + byteIndex;
+                        }
                     }
                 }
 
                 // Shrink empty bytes
-                totalBuffer = new Uint8Array(totalBuffer.buffer, 0);
+                if(lastBufferIndex !== -1) {
+                    const newTotalBuffer = new Uint8Array(lastBufferIndex + 1);
+                    for(let index = 0; index <= lastBufferIndex; index++) {
+                        newTotalBuffer[index] = totalBuffer[index];
+                    }
+                    totalBuffer = newTotalBuffer;
+                }
                 
                 payload['{{ parameter.name }}'] = new File([totalBuffer], basename({{ parameter.name | caseCamel | escapeKeyword }}));
 


### PR DESCRIPTION
Currently, if you upload a 7MB file, the whole 10MB is uploaded, the rest of the data being zeros:

![CleanShot 2022-04-20 at 13 18 27](https://user-images.githubusercontent.com/19310830/164219384-c2de72cf-383f-44a4-9c76-fc91401cb5fa.png)

This PR fixes the issue and shrinks the buffer to remove zeros, making the file exact size.