### PR TITLE
Fix File Create Docs

### DIFF
--- a/src/SDK/Language/Deno.php
+++ b/src/SDK/Language/Deno.php
@@ -145,7 +145,7 @@ class Deno extends JS
                     $output .= '{}';
                     break;
                 case self::TYPE_FILE:
-                    $output .= "new File([fileBlob], 'file.png')";
+                    $output .= "'file.png'";
                     break;
             }
         }
@@ -164,7 +164,7 @@ class Deno extends JS
                     $output .= "'{$example}'";
                     break;
                 case self::TYPE_FILE:
-                    $output .= "new File([fileBlob], 'file.png')";
+                    $output .= "'file.png'";
                     break;
             }
         }

--- a/src/SDK/Language/Kotlin.php
+++ b/src/SDK/Language/Kotlin.php
@@ -197,7 +197,7 @@ class Kotlin extends Language {
         if(empty($example) && $example !== 0 && $example !== false) {
             switch ($type) {
                 case self::TYPE_FILE:
-                    $output .= 'File("./path-to-files/image.jpg")';
+                    $output .= 'File("file.png")';
                     break;
                 case self::TYPE_NUMBER:
                 case self::TYPE_INTEGER:

--- a/src/SDK/Language/Node.php
+++ b/src/SDK/Language/Node.php
@@ -127,7 +127,7 @@ class Node extends JS
                     $output .= '{}';
                     break;
                 case self::TYPE_FILE:
-                    $output .= "fs.createReadStream(__dirname + '/file.png')";
+                    $output .= "__dirname + '/file.png'";
                     break;
             }
         }
@@ -146,7 +146,7 @@ class Node extends JS
                     $output .= "'{$example}'";
                     break;
                 case self::TYPE_FILE:
-                    $output .= "fs.createReadStream(__dirname + '/file.png')";
+                    $output .= "__dirname + '/file.png'";
                     break;
             }
         }

--- a/src/SDK/Language/Node.php
+++ b/src/SDK/Language/Node.php
@@ -127,7 +127,7 @@ class Node extends JS
                     $output .= '{}';
                     break;
                 case self::TYPE_FILE:
-                    $output .= "__dirname + '/file.png'";
+                    $output .= "'file.png'";
                     break;
             }
         }
@@ -146,7 +146,7 @@ class Node extends JS
                     $output .= "'{$example}'";
                     break;
                 case self::TYPE_FILE:
-                    $output .= "__dirname + '/file.png'";
+                    $output .= "'file.png'";
                     break;
             }
         }

--- a/src/SDK/Language/PHP.php
+++ b/src/SDK/Language/PHP.php
@@ -309,7 +309,7 @@ class PHP extends Language {
                     $output .= '[]';
                     break;
                 case self::TYPE_FILE:
-                    $output .= "new \CURLFile('/path/to/file.png', 'image/png', 'file.png')";
+                    $output .= "'/path/to/file.png'";
                     break;
             }
         }
@@ -330,7 +330,7 @@ class PHP extends Language {
                     $output .= "'{$example}'";
                     break;
                 case self::TYPE_FILE:
-                    $output .= "new \CURLFile('/path/to/file.png', 'image/png', 'file.png')";
+                    $output .= "'/path/to/file.png'";
                     break;
             }
         }

--- a/src/SDK/Language/PHP.php
+++ b/src/SDK/Language/PHP.php
@@ -309,7 +309,7 @@ class PHP extends Language {
                     $output .= '[]';
                     break;
                 case self::TYPE_FILE:
-                    $output .= "'/path/to/file.png'";
+                    $output .= "'file.png'";
                     break;
             }
         }
@@ -330,7 +330,7 @@ class PHP extends Language {
                     $output .= "'{$example}'";
                     break;
                 case self::TYPE_FILE:
-                    $output .= "'/path/to/file.png'";
+                    $output .= "'file.png'";
                     break;
             }
         }

--- a/src/SDK/Language/Python.php
+++ b/src/SDK/Language/Python.php
@@ -295,7 +295,7 @@ class Python extends Language {
                     $output .= '{}';
                     break;
                 case self::TYPE_FILE:
-                    $output .= "'/path/to/file.png'"; 
+                    $output .= "'file.png'"; 
                     break;
             }
         }
@@ -314,7 +314,7 @@ class Python extends Language {
                     $output .= "'{$example}'";
                     break;
                 case self::TYPE_FILE:
-                    $output .= "'/path/to/file.png'"; 
+                    $output .= "'file.png'"; 
                     break;
             }
         }

--- a/src/SDK/Language/Python.php
+++ b/src/SDK/Language/Python.php
@@ -295,7 +295,7 @@ class Python extends Language {
                     $output .= '{}';
                     break;
                 case self::TYPE_FILE:
-                    $output .= "open('/path/to/file.png', 'rb')"; //TODO add file class
+                    $output .= "'/path/to/file.png'"; 
                     break;
             }
         }
@@ -314,7 +314,7 @@ class Python extends Language {
                     $output .= "'{$example}'";
                     break;
                 case self::TYPE_FILE:
-                    $output .= "open('/path/to/file.png', 'rb')"; //TODO add file class
+                    $output .= "'/path/to/file.png'"; 
                     break;
             }
         }

--- a/src/SDK/Language/Ruby.php
+++ b/src/SDK/Language/Ruby.php
@@ -284,7 +284,7 @@ class Ruby extends Language {
                     $output .= '{}';
                     break;
                 case self::TYPE_FILE:
-                    $output .= "'/path/to/file.png'";
+                    $output .= "'dir/file.png'";
                     break;
             }
         }
@@ -305,7 +305,7 @@ class Ruby extends Language {
                     $output .= "'{$example}'";
                     break;
                 case self::TYPE_FILE:
-                    $output .= "'/path/to/file.png'";
+                    $output .= "'file.png'";
                     break;
             }
         }

--- a/src/SDK/Language/Ruby.php
+++ b/src/SDK/Language/Ruby.php
@@ -284,7 +284,7 @@ class Ruby extends Language {
                     $output .= '{}';
                     break;
                 case self::TYPE_FILE:
-                    $output .= "File.new()";
+                    $output .= "'/path/to/file.png'";
                     break;
             }
         }
@@ -305,7 +305,7 @@ class Ruby extends Language {
                     $output .= "'{$example}'";
                     break;
                 case self::TYPE_FILE:
-                    $output .= "File.new()";
+                    $output .= "'/path/to/file.png'";
                     break;
             }
         }


### PR DESCRIPTION
Currently, the documentation for creating files passes in a file binary. Our current implementation only accepts a file path. This must be corrected in the documentation for all SDKs.

Node SDK ✅
Deno SDK ✅
PHP SDK ✅
Python SDK ✅
Ruby SDK ✅
Dart SDK ✅ (this hasn't changed)
Kotlin (Java) ✅ (this hasn't changed)
Kotlin (Kotlin) ✅ (this hasn't changed)
Swift ✅ (this hasn't changed)

Related to
https://github.com/appwrite/sdk-for-node/issues/32