### PR TITLE
Collect body bytes

### DIFF
--- a/templates/swift/Sources/Client.swift.twig
+++ b/templates/swift/Sources/Client.swift.twig
@@ -285,7 +285,7 @@ open class Client {
                 case is Bool.Type:
                     return true as! T
                 case is ByteBuffer.Type:
-                    return response.body as! T
+                    return try await response.body.collect(upTo: Int.max) as! T
                 default:
                     let data = try await response.body.collect(upTo: Int.max)
                     let dict = try JSONSerialization.jsonObject(with: data) as? [String: Any]


### PR DESCRIPTION
- Collect body bytes when returning `ByteBuffer` for downloads

Resolves https://github.com/appwrite/sdk-for-apple/issues/16