### PR TITLE
Add empty dictionary to Swift SDK examples.

### DIFF
--- a/src/SDK/Language/Swift.php
+++ b/src/SDK/Language/Swift.php
@@ -404,6 +404,10 @@ class Swift extends Language {
                 case self::TYPE_ARRAY:
                     $output .= '[]';
                     break;
+                case self::TYPE_OBJECT:
+                    $output .= '[:]';
+                    break;
+                
             }
         }
         else {
@@ -419,6 +423,9 @@ class Swift extends Language {
                     break;
                 case self::TYPE_STRING:
                     $output .= "\"{$example}\"";
+                    break;
+                case self::TYPE_OBJECT:
+                    $output .= '[:]';
                     break;
             }
         }


### PR DESCRIPTION
Current example shows an empty line for the Apple Client SDK:


<img width="859" alt="Screen Shot 2022-05-11 at 2 04 33 PM" src="https://user-images.githubusercontent.com/29069505/167916634-115f4d29-fdda-4236-bde4-6e56e1db5f93.png">

The database guide uses an empty dictionary `[:]`:


<img width="859" alt="Screen Shot 2022-05-11 at 2 05 25 PM" src="https://user-images.githubusercontent.com/29069505/167916781-7f2a3b9d-ea18-49f7-99eb-e2998e82e2da.png">

The newly generated examples will match the database guide:


<img width="859" alt="Screen Shot 2022-05-11 at 2 06 13 PM" src="https://user-images.githubusercontent.com/29069505/167916905-6d6a8f13-e412-4aa9-b32b-9007e4e2dbce.png">

