### PR TITLE
Fix: Web file error message

### DIFF
--- a/templates/web/src/sdk.ts.twig
+++ b/templates/web/src/sdk.ts.twig
@@ -514,6 +514,11 @@ class {{ spec.title | caseUcfirst }} {
 {% if 'multipart/form-data' in method.consumes %}
 {% for parameter in method.parameters.all %}
 {% if parameter.type == 'file' %}
+
+            if(!({{ parameter.name | caseCamel | escapeKeyword }} instanceof File)) {
+                throw new {{spec.title | caseUcfirst}}Exception('Parameter "{{ parameter.name | caseCamel | escapeKeyword }}" has to be a File.');
+            }
+
             const size = {{ parameter.name | caseCamel | escapeKeyword }}.size;
 
             if (size <= {{ spec.title | caseUcfirst }}.CHUNK_SIZE) {


### PR DESCRIPTION
As reported here: https://github.com/appwrite/appwrite/issues/3209

You create file input. you get `event.target.value`. You get an array of files. I consider it a common mistake to try to pass the value directly into Appwrite.

Currently, Appwrite doesn't tell anything. During chunk upload logic the size will be `undefined`, resulting in 0 chunks being uploaded, but also probably no error thrown.

With this new logic, we check if a variable type is `File`, and throw a proper error if you pass an array, buffer, file path, base64, or anything that is unsupported.

Example of generated code:

<img width="689" alt="CleanShot 2022-05-13 at 08 40 00@2x" src="https://user-images.githubusercontent.com/19310830/168226292-b4446194-b588-4117-80ed-2cbcf8d5ccd6.png">
