### PR TITLE
Fix: CLI function deploy

### DIFF
--- a/templates/cli/lib/commands/deploy.js.twig
+++ b/templates/cli/lib/commands/deploy.js.twig
@@ -149,7 +149,7 @@ const deployFunction = async () => {
     let response = {};
 
     let answers = await inquirer.prompt(questionsDeployFunctions)
-    let functions = answers.functions
+    let functions = answers.functions.map((func) => JSONbig.parse(func))
 
     for (let func of functions) {
         log(`Deploying function ${func.name} ( ${func['$id']} )`)

--- a/templates/cli/lib/questions.js.twig
+++ b/templates/cli/lib/questions.js.twig
@@ -197,7 +197,7 @@ const questionsDeployFunctions = [
       let choices = functions.map((func, idx) => {
         return {
           name: `${func.name} (${func['$id']})`,
-          value: func
+          value: JSONbig.stringify(func)
         }
       })
       return choices;


### PR DESCRIPTION
Currently if you:
```
appwrite login
appwrite init project
appwrite init function
appwrite deploy function
```

It fails in deploy function with message:
<img width="997" alt="CleanShot 2022-05-19 at 09 11 11@2x" src="https://user-images.githubusercontent.com/19310830/169232513-3d9f6e37-eab3-4633-9a59-ffb094454cb5.png">

Problem solved by applying the same strategy as there already is regarding deploy collections - instead of passing BigIntJSON objects, we pass strings and then parse them. This seems to be a limitation of `inquirer` library.

- [x] Manual QA

<img width="536" alt="CleanShot 2022-05-19 at 09 11 18@2x" src="https://user-images.githubusercontent.com/19310830/169232650-82e6c136-a838-4949-833c-f6aecbe1659a.png">


