### PR TITLE
web - add index type to Models that have additionalProperties set to …

### DIFF
--- a/templates/web/src/sdk.ts.twig
+++ b/templates/web/src/sdk.ts.twig
@@ -13,6 +13,7 @@ namespace Models {
          * {{ property.description }}
          */
         {{ property.name | escapeKeyword }}{% if not property.required %}?{% endif %}: {{_self.sub_schema(property)}};
+        {% if definition.additionalProperties %}[key: string]?: any;{% endif %}
 {% endfor %}
     }
 {% endfor %}


### PR DESCRIPTION
…true

## Current behavior

In the web SDK typings, `Preferences` is a `type Preferences = {}` which makes it tricky to work with in projects with TypeScript strict mode on. 

## Expected behavior

`type Preferences` should be an indexable type or a Record. 
```ts
type Preferences = Record<string, any>;
// or
type Preferences = {
   [key: string]?: any;
}
```

This PR adds an indexable record to a model under `namespace Models` if its definition has `additionalProperties: true`

## Additional information

I'm not sure how to verify the change with the current tests setup of this repo. Any suggestions would be much appreciated