### PR TITLE
Fix: File upload var name

### DIFF
--- a/templates/node/lib/services/service.js.twig
+++ b/templates/node/lib/services/service.js.twig
@@ -133,7 +133,7 @@ class {{ service.name | caseUcfirst }} extends Service {
             }
 
             const stream = Stream.Readable.from(currentChunk);
-            payload['{{ parameter.name }}'] = { type: 'file', file: stream, filename: file.filename };
+            payload['{{ parameter.name }}'] = { type: 'file', file: stream, filename: '{{ parameter.name }}'.filename };
 
             response = await selfClient.call('{{ method.method | caseLower }}', path, headers, payload{% if method.type == 'location' %}, 'arraybuffer'{% endif %});
 

--- a/templates/node/lib/services/service.js.twig
+++ b/templates/node/lib/services/service.js.twig
@@ -133,7 +133,7 @@ class {{ service.name | caseUcfirst }} extends Service {
             }
 
             const stream = Stream.Readable.from(currentChunk);
-            payload['{{ parameter.name }}'] = { type: 'file', file: stream, filename: '{{ parameter.name }}'.filename };
+            payload['{{ parameter.name }}'] = { type: 'file', file: stream, filename: {{ parameter.name }}.filename };
 
             response = await selfClient.call('{{ method.method | caseLower }}', path, headers, payload{% if method.type == 'location' %}, 'arraybuffer'{% endif %});
 


### PR DESCRIPTION
The code works if parameter is `file`, but not if `code` (when functions.createDeployment())