### PR TITLE
Feat: Improve CLI after 0.15

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -374,16 +374,16 @@
     "packages-dev": [
         {
             "name": "brianium/paratest",
-            "version": "v6.5.0",
+            "version": "v6.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paratestphp/paratest.git",
-                "reference": "d22afc08dab73d1dff07c700ed6a78f138f5020e"
+                "reference": "41fc4cc01422dae2d6bf6a0ce39756f57ac7d8a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/d22afc08dab73d1dff07c700ed6a78f138f5020e",
-                "reference": "d22afc08dab73d1dff07c700ed6a78f138f5020e",
+                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/41fc4cc01422dae2d6bf6a0ce39756f57ac7d8a9",
+                "reference": "41fc4cc01422dae2d6bf6a0ce39756f57ac7d8a9",
                 "shasum": ""
             },
             "require": {
@@ -412,7 +412,9 @@
                 "vimeo/psalm": "^4.23.0"
             },
             "bin": [
-                "bin/paratest"
+                "bin/paratest",
+                "bin/paratest.bat",
+                "bin/paratest_for_phpstorm"
             ],
             "type": "library",
             "autoload": {
@@ -448,7 +450,7 @@
             ],
             "support": {
                 "issues": "https://github.com/paratestphp/paratest/issues",
-                "source": "https://github.com/paratestphp/paratest/tree/v6.5.0"
+                "source": "https://github.com/paratestphp/paratest/tree/v6.5.1"
             },
             "funding": [
                 {
@@ -460,7 +462,7 @@
                     "type": "paypal"
                 }
             ],
-            "time": "2022-06-23T13:00:19+00:00"
+            "time": "2022-06-24T16:02:27+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -2483,16 +2485,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.1.1",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "6187424023fbffcd757789aeb517c9161b1eabee"
+                "reference": "7a86c1c42fbcb69b59768504c7bca1d3767760b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/6187424023fbffcd757789aeb517c9161b1eabee",
-                "reference": "6187424023fbffcd757789aeb517c9161b1eabee",
+                "url": "https://api.github.com/repos/symfony/console/zipball/7a86c1c42fbcb69b59768504c7bca1d3767760b7",
+                "reference": "7a86c1c42fbcb69b59768504c7bca1d3767760b7",
                 "shasum": ""
             },
             "require": {
@@ -2559,7 +2561,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.1.1"
+                "source": "https://github.com/symfony/console/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -2575,11 +2577,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-08T14:02:09+00:00"
+            "time": "2022-06-26T13:01:30+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.1.0",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
@@ -2626,7 +2628,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.1.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.1.1"
             },
             "funding": [
                 {
@@ -2872,16 +2874,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.1.0",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "d66cd8ab656780f62c4215b903a420eb86358957"
+                "reference": "925e713fe8fcacf6bc05e936edd8dd5441a21239"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d66cd8ab656780f62c4215b903a420eb86358957",
-                "reference": "d66cd8ab656780f62c4215b903a420eb86358957",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/925e713fe8fcacf6bc05e936edd8dd5441a21239",
+                "reference": "925e713fe8fcacf6bc05e936edd8dd5441a21239",
                 "shasum": ""
             },
             "require": {
@@ -2937,7 +2939,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.1.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.1.1"
             },
             "funding": [
                 {
@@ -2953,20 +2955,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-07T08:07:09+00:00"
+            "time": "2022-05-30T19:18:58+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v6.1.0",
+            "version": "v6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "d3edc75baf9f1d4f94879764dda2e1ac33499529"
+                "reference": "1903f2879875280c5af944625e8246d81c2f0604"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/d3edc75baf9f1d4f94879764dda2e1ac33499529",
-                "reference": "d3edc75baf9f1d4f94879764dda2e1ac33499529",
+                "url": "https://api.github.com/repos/symfony/string/zipball/1903f2879875280c5af944625e8246d81c2f0604",
+                "reference": "1903f2879875280c5af944625e8246d81c2f0604",
                 "shasum": ""
             },
             "require": {
@@ -3022,7 +3024,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.1.0"
+                "source": "https://github.com/symfony/string/tree/v6.1.2"
             },
             "funding": [
                 {
@@ -3038,7 +3040,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-22T08:18:23+00:00"
+            "time": "2022-06-26T16:35:04+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/example.php
+++ b/example.php
@@ -183,7 +183,7 @@ try {
         ->setTwitter('appwrite_io')
         ->setDiscord('564160730845151244', 'https://appwrite.io/discord')
         ->setDefaultHeaders([
-            'X-Appwrite-Response-Format' => '0.13.0',
+            'X-Appwrite-Response-Format' => '0.15.0',
         ])
     ;
 

--- a/templates/cli/lib/commands/deploy.js.twig
+++ b/templates/cli/lib/commands/deploy.js.twig
@@ -6,6 +6,8 @@ const { questionsDeployFunctions, questionsGetEntrypoint, questionsDeployCollect
 const { actionRunner, success, log, error, commandDescriptions } = require("../parser");
 const { functionsGet, functionsCreate, functionsUpdate, functionsCreateDeployment, functionsUpdateDeployment } = require('./functions');
 const {
+    databasesGet,
+    databasesCreate,
     databasesCreateBooleanAttribute,
     databasesGetCollection,
     databasesCreateCollection,
@@ -23,19 +25,18 @@ const {
     databasesDeleteIndex
 } = require("./databases");
 
-// TODO: Add databaseId everywhere
-
 const POOL_DEBOUNCE = 2000; // in milliseconds
 const POOL_MAX_DEBOUNCES = 30;
 
 const awaitPools = {
-    wipeAttributes: async (collectionId, iteration = 1) => {
+    wipeAttributes: async (databaseId, collectionId, iteration = 1) => {
         if (iteration > POOL_MAX_DEBOUNCES) {
             return false;
         }
 
         // TODO: Pagination?
-        const { attributes: remoteAttributes } = await databaseListAttributes({
+        const { attributes: remoteAttributes } = await databasesListAttributes({
+            databaseId,
             collectionId,
             limit: 100,
             parseOutput: false
@@ -46,15 +47,16 @@ const awaitPools = {
         }
 
         await new Promise(resolve => setTimeout(resolve, POOL_DEBOUNCE));
-        return await awaitPools.wipeAttributes(collectionId, iteration + 1);
+        return await awaitPools.wipeAttributes(databaseId, collectionId, iteration + 1);
     },
-    wipeIndexes: async (collectionId, iteration = 1) => {
+    wipeIndexes: async (databaseId, collectionId, iteration = 1) => {
         if (iteration > POOL_MAX_DEBOUNCES) {
             return false;
         }
 
         // TODO: Pagination?
-        const { indexes: remoteIndexes } = await databaseListIndexes({
+        const { indexes: remoteIndexes } = await databasesListIndexes({
+            databaseId,
             collectionId,
             limit: 100,
             parseOutput: false
@@ -65,15 +67,16 @@ const awaitPools = {
         }
 
         await new Promise(resolve => setTimeout(resolve, POOL_DEBOUNCE));
-        return await awaitPools.wipeIndexes(collectionId, iteration + 1);
+        return await awaitPools.wipeIndexes(databaseId, collectionId, iteration + 1);
     },
-    expectAttributes: async (collectionId, attributeKeys, iteration = 1) => {
+    expectAttributes: async (databaseId, collectionId, attributeKeys, iteration = 1) => {
         if (iteration > POOL_MAX_DEBOUNCES) {
             return false;
         }
 
         // TODO: Pagination?
-        const { attributes: remoteAttributes } = await databaseListAttributes({
+        const { attributes: remoteAttributes } = await databasesListAttributes({
+            databaseId,
             collectionId,
             limit: 100,
             parseOutput: false
@@ -96,15 +99,16 @@ const awaitPools = {
         }
 
         await new Promise(resolve => setTimeout(resolve, POOL_DEBOUNCE));
-        return await awaitPools.expectAttributes(collectionId, attributeKeys, iteration + 1);
+        return await awaitPools.expectAttributes(databaseId, collectionId, attributeKeys, iteration + 1);
     },
-    expectIndexes: async (collectionId, indexKeys, iteration = 1) => {
+    expectIndexes: async (databaseId, collectionId, indexKeys, iteration = 1) => {
         if (iteration > POOL_MAX_DEBOUNCES) {
             return false;
         }
 
         // TODO: Pagination?
-        const { indexes: remoteIndexes } = await databaseListIndexes({
+        const { indexes: remoteIndexes } = await databasesListIndexes({
+            databaseId,
             collectionId,
             limit: 100,
             parseOutput: false
@@ -127,7 +131,7 @@ const awaitPools = {
         }
 
         await new Promise(resolve => setTimeout(resolve, POOL_DEBOUNCE));
-        return await awaitPools.expectIndexes(collectionId, indexKeys, iteration + 1);
+        return await awaitPools.expectIndexes(databaseId, collectionId, indexKeys, iteration + 1);
     },
 }
 
@@ -162,7 +166,12 @@ const deployFunction = async ({ functionId, all } = {}) => {
     let functions = functionIds.map((id) => {
       const functions = localConfig.getFunctions();
       const func = functions.find((f) => f.$id === id);
-      return JSONbig.stringify(func);
+
+      if(!func) {
+        throw new Error("Function '" + id + "' not found.")
+      }
+
+      return func;
     });
     
     for (let func of functions) {
@@ -244,12 +253,13 @@ const deployFunction = async ({ functionId, all } = {}) => {
     }
 }
 
-const createAttribute = async (collectionId, attribute) => {
+const createAttribute = async (databaseId, collectionId, attribute) => {
     switch (attribute.type) {
         case 'string':
             switch (attribute.format) {
                 case 'email':
-                    return await databaseCreateEmailAttribute({
+                    return await databasesCreateEmailAttribute({
+                        databaseId,
                         collectionId,
                         key: attribute.key,
                         required: attribute.required,
@@ -258,7 +268,8 @@ const createAttribute = async (collectionId, attribute) => {
                         parseOutput: false
                     })
                 case 'url':
-                    return await databaseCreateUrlAttribute({
+                    return await databasesCreateUrlAttribute({
+                        databaseId,
                         collectionId,
                         key: attribute.key,
                         required: attribute.required,
@@ -267,7 +278,8 @@ const createAttribute = async (collectionId, attribute) => {
                         parseOutput: false
                     })
                 case 'ip':
-                    return await databaseCreateIpAttribute({
+                    return await databasesCreateIpAttribute({
+                        databaseId,
                         collectionId,
                         key: attribute.key,
                         required: attribute.required,
@@ -276,7 +288,8 @@ const createAttribute = async (collectionId, attribute) => {
                         parseOutput: false
                     })
                 case 'enum':
-                    return await databaseCreateEnumAttribute({
+                    return await databasesCreateEnumAttribute({
+                        databaseId,
                         collectionId,
                         key: attribute.key,
                         elements: attribute.elements,
@@ -286,7 +299,8 @@ const createAttribute = async (collectionId, attribute) => {
                         parseOutput: false
                     })
                 default:
-                    return await databaseCreateStringAttribute({
+                    return await databasesCreateStringAttribute({
+                        databaseId,
                         collectionId,
                         key: attribute.key,
                         size: attribute.size,
@@ -298,7 +312,8 @@ const createAttribute = async (collectionId, attribute) => {
 
             }
         case 'integer':
-            return await databaseCreateIntegerAttribute({
+            return await databasesCreateIntegerAttribute({
+                databaseId,
                 collectionId,
                 key: attribute.key,
                 required: attribute.required,
@@ -309,7 +324,8 @@ const createAttribute = async (collectionId, attribute) => {
                 parseOutput: false
             })
         case 'double':
-            return databaseCreateFloatAttribute({
+            return databasesCreateFloatAttribute({
+                databaseId,
                 collectionId,
                 key: attribute.key,
                 required: attribute.required,
@@ -320,7 +336,9 @@ const createAttribute = async (collectionId, attribute) => {
                 parseOutput: false
             })
         case 'boolean':
-            return databaseCreateBooleanAttribute({
+            return databasesCreateBooleanAttribute({
+                databaseId,
+                databaseId,
                 collectionId,
                 key: attribute.key,
                 required: attribute.required,
@@ -331,15 +349,55 @@ const createAttribute = async (collectionId, attribute) => {
     }
 }
 
-const deployCollection = async () => {
+const deployCollection = async ({ all } = {}) => {
     let response = {};
-    let answers = await inquirer.prompt(questionsDeployCollections[0])
-    let collections = answers.collections.map((collection) => JSONbig.parse(collection));
+
+    let collectionIds = [];
+    const configCollections = localConfig.getCollections();
+
+    if(all) {
+        if (configCollections.length === 0) {
+            throw new Error("No collections found in the current directory. Run `{{ language.params.executableName }} init collection` to fetch all your collections.");
+        }
+        collectionIds.push(...configCollections.map((c) => c.$id));
+    }
+
+    if(collectionIds.length <= 0) {
+        let answers = await inquirer.prompt(questionsDeployCollections[0])
+        collectionIds.push(...answers.collections);
+    }
+
+    let collections = [];
+
+    for(const collectionId of collectionIds) {
+        const idCollections = configCollections.filter((c) => c.$id === collectionId);
+        collections.push(...idCollections);
+    }
 
     for (let collection of collections) {
         log(`Deploying collection ${collection.name} ( ${collection['$id']} )`)
+
+        let databaseId;
+
         try {
-            response = await databaseGetCollection({
+            const database = await databasesGet({
+                databaseId: collection.databaseId,
+                parseOutput: false,
+            });
+            databaseId = database.$id;
+        } catch(err) {
+            log(`Database ${collection.databaseId} not found. Creating it now...`);
+            const database = await databasesCreate({
+                databaseId: collection.databaseId,
+                name: collection.databaseId,
+                parseOutput: false,
+            });
+            databaseId = database.$id;
+        }
+
+        try {
+            response = await databasesGetCollection({
+                databaseId,
                 collectionId: collection['$id'],
                 parseOutput: false,
             })
@@ -354,51 +412,55 @@ const deployCollection = async () => {
             log(`Updating attributes ... `);
 
             // TODO: Pagination?
-            const { indexes: remoteIndexes } = await databaseListIndexes({
+            const { indexes: remoteIndexes } = await databasesListIndexes({
+                databaseId,
                 collectionId: collection['$id'],
                 limit: 100,
                 parseOutput: false
             });
 
             await Promise.all(remoteIndexes.map(async index => {
-                await databaseDeleteIndex({
+                await databasesDeleteIndex({
+                    databaseId,
                     collectionId: collection['$id'],
                     key: index.key,
                     parseOutput: false
                 });
             }));
 
-            const deleteIndexesPoolStatus = await awaitPools.wipeIndexes(collection['$id']);
+            const deleteIndexesPoolStatus = await awaitPools.wipeIndexes(databaseId, collection['$id']);
             if (!deleteIndexesPoolStatus) {
                 throw new Error("Index deletion did not finish for too long.");
             }
 
             // TODO: Pagination?
-            const { attributes: remoteAttributes } = await databaseListAttributes({
+            const { attributes: remoteAttributes } = await databasesListAttributes({
+                databaseId,
                 collectionId: collection['$id'],
                 limit: 100,
                 parseOutput: false
             });
             
             await Promise.all(remoteAttributes.map(async attribute => {
-                await databaseDeleteAttribute({
+                await databasesDeleteAttribute({
+                    databaseId,
                     collectionId: collection['$id'],
                     key: attribute.key,
                     parseOutput: false
                 });
             }));
 
-            const deleteAttributesPoolStatus = await awaitPools.wipeAttributes(collection['$id']);
+            const deleteAttributesPoolStatus = await awaitPools.wipeAttributes(databaseId, collection['$id']);
             if (!deleteAttributesPoolStatus) {
                 throw new Error("Attribute deletion did not finish for too long.");
             }
 
             await Promise.all(collection.attributes.map(async attribute => {
-                await createAttribute(collection['$id'], attribute);
+                await createAttribute(databaseId, collection['$id'], attribute);
             }));
 
             const attributeKeys = collection.attributes.map(attribute => attribute.key);
-            const createPoolStatus = await awaitPools.expectAttributes(collection['$id'], attributeKeys);
+            const createPoolStatus = await awaitPools.expectAttributes(databaseId, collection['$id'], attributeKeys);
             if (!createPoolStatus) {
                 throw new Error("Attribute creation did not finish for too long.");
             }
@@ -407,7 +469,8 @@ const deployCollection = async () => {
 
             log(`Creating indexes ...`)
             await Promise.all(collection.indexes.map(async index => {
-                await databaseCreateIndex({
+                await databasesCreateIndex({
+                    databaseId,
                     collectionId: collection['$id'],
                     key: index.key,
                     type: index.type,
@@ -418,7 +481,7 @@ const deployCollection = async () => {
             }));
 
             const indexKeys = collection.indexes.map(attribute => attribute.key);
-            const indexPoolStatus = await awaitPools.expectIndexes(collection['$id'], indexKeys);
+            const indexPoolStatus = await awaitPools.expectIndexes(databaseId, collection['$id'], indexKeys);
             if (!indexPoolStatus) {
                 throw new Error("Index creation did not finish for too long.");
             }
@@ -427,7 +490,8 @@ const deployCollection = async () => {
         } catch (e) {
             if (e.code == 404) {
                 log(`Collection ${collection.name} does not exist in the project. Creating ... `);
-                response = await databaseCreateCollection({
+                response = await databasesCreateCollection({
+                    databaseId,
                     collectionId: collection['$id'],
                     name: collection.name,
                     permission: collection.permission,
@@ -438,11 +502,11 @@ const deployCollection = async () => {
 
                 log(`Creating attributes ... `);
                 await Promise.all(collection.attributes.map(async attribute => {
-                    await createAttribute(collection['$id'], attribute);
+                    await createAttribute(databaseId, collection['$id'], attribute);
                 }));
 
                 const attributeKeys = collection.attributes.map(attribute => attribute.key);
-                const attributePoolStatus = await awaitPools.expectAttributes(collection['$id'], attributeKeys);
+                const attributePoolStatus = await awaitPools.expectAttributes(databaseId, collection['$id'], attributeKeys);
                 if (!attributePoolStatus) {
                     throw new Error("Attribute creation did not finish for too long.");
                 }
@@ -451,7 +515,8 @@ const deployCollection = async () => {
 
                 log(`Creating indexes ...`);
                 await Promise.all(collection.indexes.map(async index => {
-                    await databaseCreateIndex({
+                    await databasesCreateIndex({
+                        databaseId,
                         collectionId: collection['$id'],
                         key: index.key,
                         type: index.type,
@@ -462,7 +527,7 @@ const deployCollection = async () => {
                 }));
 
                 const indexKeys = collection.indexes.map(attribute => attribute.key);
-                const indexPoolStatus = await awaitPools.expectIndexes(collection['$id'], indexKeys);
+                const indexPoolStatus = await awaitPools.expectIndexes(databaseId, collection['$id'], indexKeys);
                 if (!indexPoolStatus) {
                     throw new Error("Index creation did not finish for too long.");
                 }
@@ -487,6 +552,7 @@ deploy
 deploy
     .command("collection")
     .description("Deploy collections in the current project.")
+    .option(`--all`, `Flag to deploy all functions`)
     .action(actionRunner(deployCollection));
 
 module.exports = {

--- a/templates/cli/lib/commands/deploy.js.twig
+++ b/templates/cli/lib/commands/deploy.js.twig
@@ -133,18 +133,8 @@ const awaitPools = {
 
 const deploy = new Command("deploy")
     .description(commandDescriptions['deploy'])
-    .option("--all", "Flag to deploy collections and functions")
-    .action(actionRunner(async ({ all }, command) => {
-        if (all == undefined) {
-            command.help()
-        }
-
-        try {
-            await deployFunction();
-        } catch (e) {
-            error(e.message);
-        }
-        await deployCollection()
+    .action(actionRunner(async (_options, command) => {
+        command.help()
     }));
 
 const deployFunction = async ({ functionId, all } = {}) => {

--- a/templates/cli/lib/commands/deploy.js.twig
+++ b/templates/cli/lib/commands/deploy.js.twig
@@ -6,22 +6,24 @@ const { questionsDeployFunctions, questionsGetEntrypoint, questionsDeployCollect
 const { actionRunner, success, log, error, commandDescriptions } = require("../parser");
 const { functionsGet, functionsCreate, functionsUpdate, functionsCreateDeployment, functionsUpdateDeployment } = require('./functions');
 const {
-    databaseCreateBooleanAttribute,
-    databaseGetCollection,
-    databaseCreateCollection,
-    databaseCreateStringAttribute,
-    databaseCreateIntegerAttribute,
-    databaseCreateFloatAttribute,
-    databaseCreateEmailAttribute,
-    databaseCreateIndex,
-    databaseCreateUrlAttribute,
-    databaseCreateIpAttribute,
-    databaseCreateEnumAttribute,
-    databaseDeleteAttribute,
-    databaseListAttributes,
-    databaseListIndexes,
-    databaseDeleteIndex
-} = require("./database");
+    databasesCreateBooleanAttribute,
+    databasesGetCollection,
+    databasesCreateCollection,
+    databasesCreateStringAttribute,
+    databasesCreateIntegerAttribute,
+    databasesCreateFloatAttribute,
+    databasesCreateEmailAttribute,
+    databasesCreateIndex,
+    databasesCreateUrlAttribute,
+    databasesCreateIpAttribute,
+    databasesCreateEnumAttribute,
+    databasesDeleteAttribute,
+    databasesListAttributes,
+    databasesListIndexes,
+    databasesDeleteIndex
+} = require("./databases");
+
+// TODO: Add databaseId everywhere
 
 const POOL_DEBOUNCE = 2000; // in milliseconds
 const POOL_MAX_DEBOUNCES = 30;
@@ -145,12 +147,34 @@ const deploy = new Command("deploy")
         await deployCollection()
     }));
 
-const deployFunction = async () => {
+const deployFunction = async ({ functionId, all } = {}) => {
     let response = {};
 
-    let answers = await inquirer.prompt(questionsDeployFunctions)
-    let functions = answers.functions.map((func) => JSONbig.parse(func))
+    const functionIds = [];
 
+    if(functionId) {
+        functionIds.push(functionId);
+    } else if(all) {
+        const functions = localConfig.getFunctions();
+        if (functions.length === 0) {
+            throw new Error("No functions found in the current directory.");
+        }
+        functionIds.push(...functions.map((func, idx) => {
+            return func.$id;
+        }));
+    }
+
+    if(functionIds.length <= 0) {
+        const answers = await inquirer.prompt(questionsDeployFunctions);
+        functionIds.push(...answers.functions);
+    }
+
+    let functions = functionIds.map((id) => {
+      const functions = localConfig.getFunctions();
+      const func = functions.find((f) => f.$id === id);
+      return JSONbig.stringify(func);
+    });
+    
     for (let func of functions) {
         log(`Deploying function ${func.name} ( ${func['$id']} )`)
 
@@ -466,6 +490,8 @@ const deployCollection = async () => {
 deploy
     .command("function")
     .description("Deploy functions in the current directory.")
+    .option(`--functionId <functionId>`, `Function ID`)
+    .option(`--all`, `Flag to deploy all functions`)
     .action(actionRunner(deployFunction));
 
 deploy

--- a/templates/cli/lib/commands/generic.js.twig
+++ b/templates/cli/lib/commands/generic.js.twig
@@ -6,7 +6,7 @@ const { globalConfig, localConfig } = require("../config");
 const { actionRunner, success, parseBool, commandDescriptions, log, parse } = require("../parser");
 {% if sdk.test != "true" %}
 const { questionsLogin } = require("../questions");
-const { accountCreateSession, accountDeleteSession } = require("./account");
+const { accountCreateEmailSession, accountDeleteSession } = require("./account");
 
 const login = new Command("login")
     .description(commandDescriptions['login'])
@@ -15,7 +15,7 @@ const login = new Command("login")
 
         let client = await sdkForConsole(false);
 
-        await accountCreateSession({
+        await accountCreateEmailSession({
             email: answers.email,
             password: answers.password,
             parseOutput: false,

--- a/templates/cli/lib/commands/init.js.twig
+++ b/templates/cli/lib/commands/init.js.twig
@@ -6,10 +6,10 @@ const inquirer = require("inquirer");
 const { teamsCreate } = require("./teams");
 const { projectsCreate } = require("./projects");
 const { functionsCreate } = require("./functions");
-const { databaseListCollections } = require("./database");
+const { databasesListCollections, databasesList } = require("./databases");
 const { sdkForConsole } = require("../sdks");
 const { localConfig } = require("../config");
-const { questionsInitProject, questionsInitFunction } = require("../questions");
+const { questionsInitProject, questionsInitFunction, questionsInitCollection } = require("../questions");
 const { success, log, actionRunner, commandDescriptions } = require("../parser");
 
 const init = new Command("init")
@@ -40,7 +40,7 @@ const initProject = async () => {
 
     let teamId = response['$id'];
     response = await projectsCreate({
-      projectId: 'unique()',
+      projectId: answers.id,
       name: answers.project,
       teamId,
       parseOutput: false
@@ -54,6 +54,7 @@ const initProject = async () => {
 }
 
 const initFunction = async () => {
+  // TODO: Add CI/CD support (ID, name, runtime)
   let answers = await inquirer.prompt(questionsInitFunction)
 
   if (fs.existsSync(path.join(process.cwd(), 'functions', answers.name))) {
@@ -65,7 +66,7 @@ const initFunction = async () => {
   }
 
   let response = await functionsCreate({
-    functionId: 'unique()',
+    functionId: answers.id,
     name: answers.name,
     runtime: answers.runtime.id,
     parseOutput: false
@@ -110,20 +111,43 @@ const initFunction = async () => {
   success();
 }
 
-const initCollection = async () => {
-  // TODO: Pagination?
-  let response = await databaseListCollections({
-    limit: 100,
-    parseOutput: false
-  })
+const initCollection = async ({ all, databaseId } = {}) => {
+  const databaseIds = [];
 
-  let collections = response.collections;
-  log(`Found ${collections.length} collections`);
+  console.log(all);
 
-  collections.forEach(async collection => {
-    log(`Fetching ${collection.name} ...`);
-    localConfig.addCollection(collection);
-  });
+  if(databaseId) {
+    databaseIds.push(databaseId);
+  } else if(all) {
+      let allDatabases = await databasesList({
+        parseOutput: false
+      })
+      console.log(allDatabases);
+      databaseIds.push(...allDatabases.databases);
+  }
+
+  if(databaseIds.length <= 0) {
+      let answers = await inquirer.prompt(questionsInitCollection)
+      if (!answers.databases) process.exit(1)
+      databaseIds.push(...answers.databases);
+  }
+
+  for(const databaseId of databaseIds) {
+    // TODO: Pagination?
+    let response = await databasesListCollections({
+      databaseId,
+      limit: 100,
+      parseOutput: false
+    })
+
+    let collections = response.collections;
+    log(`Found ${collections.length} collections`);
+
+    collections.forEach(async collection => {
+      log(`Fetching ${collection.name} ...`);
+      localConfig.addCollection(collection);
+    });
+  }
 
   success();
 }
@@ -141,6 +165,8 @@ init
 init
   .command("collection")
   .description("Initialise your {{ spec.title|caseUcfirst }} collections")
+  .option(`--databaseId <databaseId>`, `Database ID`)
+  .option(`--all`, `Flag to initialize all databases`)
   .action(actionRunner(initCollection))
 
 module.exports = {

--- a/templates/cli/lib/commands/init.js.twig
+++ b/templates/cli/lib/commands/init.js.twig
@@ -14,14 +14,8 @@ const { success, log, actionRunner, commandDescriptions } = require("../parser")
 
 const init = new Command("init")
   .description(commandDescriptions['init'])
-  .option("--all", "Flag to initialize projects and collection")
-  .action(actionRunner(async ({ all }, command) => {
-    if (all == undefined) {
-      command.help()
-    }
-
-    await initProject();
-    await initCollection()
+  .action(actionRunner(async (_options, command) => {
+    command.help();
   }));
 
 const initProject = async () => {
@@ -114,16 +108,14 @@ const initFunction = async () => {
 const initCollection = async ({ all, databaseId } = {}) => {
   const databaseIds = [];
 
-  console.log(all);
-
   if(databaseId) {
     databaseIds.push(databaseId);
   } else if(all) {
       let allDatabases = await databasesList({
         parseOutput: false
       })
-      console.log(allDatabases);
-      databaseIds.push(...allDatabases.databases);
+
+      databaseIds.push(...allDatabases.databases.map((d) => d.$id));
   }
 
   if(databaseIds.length <= 0) {

--- a/templates/cli/lib/parser.js.twig
+++ b/templates/cli/lib/parser.js.twig
@@ -150,7 +150,7 @@ const logo = {{ language.params.logo | raw }};
 const commandDescriptions = {
     "account": `The account command allows you to authenticate and manage a user account.`,
     "avatars": `The avatars command aims to help you complete everyday tasks related to your app image, icons, and avatars.`,
-    "database": `The database command allows you to create structured collections of documents, query and filter lists of documents.`,
+    "databases": `The databases command allows you to create structured collections of documents, query and filter lists of documents.`,
     "deploy": `The deploy command provides a convenient wrapper for deploying your functions and collections.`,
     "functions": `The functions command allows you view, create and manage your Cloud Functions.`,
     "health": `The health command allows you to both validate and monitor your {{ spec.title|caseUcfirst }} server's health.`,

--- a/templates/cli/lib/questions.js.twig
+++ b/templates/cli/lib/questions.js.twig
@@ -267,7 +267,7 @@ const questionsDeployCollections = [
       let choices = collections.map((collection, idx) => {
         return {
           name: `${collection.name} (${collection['$id']})`,
-          value: JSONbig.stringify(collection)
+          value: collection.$id
         }
       })
       return choices;

--- a/templates/cli/lib/questions.js.twig
+++ b/templates/cli/lib/questions.js.twig
@@ -1,6 +1,7 @@
 const { localConfig } = require('./config');
 const { projectsList } = require('./commands/projects');
 const { functionsListRuntimes } = require('./commands/functions');
+const { databasesList } = require('./commands/databases');
 const JSONbig = require("json-bigint")({ storeAsString: false });
 
 const getIgnores = (runtime) => {
@@ -109,6 +110,15 @@ const questionsInitProject = [
     },
   },
   {
+    type: "input",
+    name: "id",
+    message: "What ID would you like to have for your project?",
+    default: "myAwesomeProject",
+    when(answers) {
+      return answers.start == "new";
+    },
+  },
+  {
     type: "list",
     name: "project",
     message: "Choose your {{ spec.title|caseUcfirst }} project.",
@@ -147,6 +157,12 @@ const questionsInitFunction = [
     default: "My Awesome Function"
   },
   {
+    type: "input",
+    name: "id",
+    message: "What ID would you like to have for your function?",
+    default: "myAwesomeFunction"
+  },
+  {
     type: "list",
     name: "runtime",
     message: "What runtime would you like to use?",
@@ -159,6 +175,31 @@ const questionsInitFunction = [
         return {
           name: `${runtime.name} (${runtime['$id']})`,
           value: { id: runtime['$id'], entrypoint: getEntrypoint(runtime['$id']), ignore: getIgnores(runtime['$id'])},
+        }
+      })
+      return choices;
+    }
+  }
+];
+
+const questionsInitCollection = [
+  {
+    type: "checkbox",
+    name: "databases",
+    message: "From which database would you like to init collections?",
+    choices: async () => {
+      let response = await databasesList({
+        parseOutput: false
+      })
+      let databases = response["databases"]
+
+      if(databases.length <= 0) {
+        throw new Error("No databases found. Please create one in project console.")
+      }
+      let choices = databases.map((database, idx) => {
+        return {
+          name: `${database.name} (${database.$id})`,
+          value: database.$id
         }
       })
       return choices;
@@ -204,8 +245,8 @@ const questionsDeployFunctions = [
       }
       let choices = functions.map((func, idx) => {
         return {
-          name: `${func.name} (${func['$id']})`,
-          value: JSONbig.stringify(func)
+          name: `${func.name} (${func.$id})`,
+          value: func.$id
         }
       })
       return choices;
@@ -258,6 +299,7 @@ module.exports = {
   questionsInitProject,
   questionsLogin,
   questionsInitFunction,
+  questionsInitCollection,
   questionsDeployFunctions,
   questionsDeployCollections,
   questionsGetEntrypoint


### PR DESCRIPTION
- Removed `--all` option from `appwrite init`
- Removed `--all` option from `appwrite deploy`
- Added `--all` option to `appwrite init collection`
- Added `--all` option to `appwrite deploy collection`
- Added `--all` option to `appwrite deploy function`
- During `appwrite init project` it now also asks for Project ID
- During `appwrite init function` it now also asks for Function ID
- During `appwrite init collection` you can now pick one or many databases to pull collections from
- Added `--databaseId <id>` to `appwrite init collection`
- Fixed `databases` command descriton
- Fixed `appwrite login`
- `appwrite database` is now `appwrite databases`
- each `appwrite databases` command now required `--databaseId`
- `appwrite account createSession` is now `appwrite account createEmailSession`

+ all new methods that other SDKs got