### PR TITLE
Added parameter for DB constructor to be named constructor

### DIFF
--- a/templates/ruby/docs/example.md.twig
+++ b/templates/ruby/docs/example.md.twig
@@ -10,7 +10,7 @@ client
 {% endfor %}
 {% endfor %}
 
-{{ service.name | caseSnake }} = {{spec.title | caseUcfirst}}::{{ service.name | caseUcfirst }}.new(client{% if service.globalParams | length %}{% for parameter in service.globalParams %}, {{parameter.name|caseCamel}}:{{ parameter | paramExample }}{% endfor %}{% endif %})
+{{ service.name | caseSnake }} = {{spec.title | caseUcfirst}}::{{ service.name | caseUcfirst }}.new(client{% if service.globalParams | length %}{% for parameter in service.globalParams %}, {{parameter.name|caseSnake}}:{{ parameter | paramExample }}{% endfor %}{% endif %})
 
 response = {{ service.name | caseSnake }}.{{ method.name | caseSnake }}({% for parameter in method.parameters.all | filter((param) => not param.isGlobal) %}{% if parameter.required %}{% if not loop.first %}, {% endif %}{{parameter.name|caseSnake}}: {% if parameter | paramExample == "InputFile.new" %}{{spec.title | caseUcfirst}}::{{ parameter | paramExample }}{% else %}{{ parameter | paramExample }}{% endif %}{% endif %}{% endfor %})
 

--- a/templates/ruby/docs/example.md.twig
+++ b/templates/ruby/docs/example.md.twig
@@ -10,7 +10,7 @@ client
 {% endfor %}
 {% endfor %}
 
-{{ service.name | caseSnake }} = {{spec.title | caseUcfirst}}::{{ service.name | caseUcfirst }}.new(client{% if service.globalParams | length %}{% for parameter in service.globalParams %}, {{ parameter | paramExample }}{% endfor %}{% endif %})
+{{ service.name | caseSnake }} = {{spec.title | caseUcfirst}}::{{ service.name | caseUcfirst }}.new(client{% if service.globalParams | length %}{% for parameter in service.globalParams %}, {{parameter.name|caseCamel}}:{{ parameter | paramExample }}{% endfor %}{% endif %})
 
 response = {{ service.name | caseSnake }}.{{ method.name | caseSnake }}({% for parameter in method.parameters.all | filter((param) => not param.isGlobal) %}{% if parameter.required %}{% if not loop.first %}, {% endif %}{{parameter.name|caseSnake}}: {% if parameter | paramExample == "InputFile.new" %}{{spec.title | caseUcfirst}}::{{ parameter | paramExample }}{% else %}{{ parameter | paramExample }}{% endif %}{% endif %}{% endfor %})
 

--- a/templates/ruby/docs/example.md.twig
+++ b/templates/ruby/docs/example.md.twig
@@ -10,7 +10,7 @@ client
 {% endfor %}
 {% endfor %}
 
-{{ service.name | caseSnake }} = {{spec.title | caseUcfirst}}::{{ service.name | caseUcfirst }}.new(client{% if service.globalParams | length %}{% for parameter in service.globalParams %}, {{parameter.name|caseSnake}}:{{ parameter | paramExample }}{% endfor %}{% endif %})
+{{ service.name | caseSnake }} = {{spec.title | caseUcfirst}}::{{ service.name | caseUcfirst }}.new(client{% if service.globalParams | length %}{% for parameter in service.globalParams %}, {{parameter.name | caseSnake}}:{{ parameter | paramExample }}{% endfor %}{% endif %})
 
 response = {{ service.name | caseSnake }}.{{ method.name | caseSnake }}({% for parameter in method.parameters.all | filter((param) => not param.isGlobal) %}{% if parameter.required %}{% if not loop.first %}, {% endif %}{{parameter.name|caseSnake}}: {% if parameter | paramExample == "InputFile.new" %}{{spec.title | caseUcfirst}}::{{ parameter | paramExample }}{% else %}{{ parameter | paramExample }}{% endif %}{% endif %}{% endfor %})
 


### PR DESCRIPTION
New generated examples will look like this:
```ruby
require 'appwrite'

client = Appwrite::Client.new

client
    .set_endpoint('https://[HOSTNAME_OR_IP]/v1') # Your API Endpoint
    .set_project('5df5acd0d48c2') # Your project ID

databases = Appwrite::Databases.new(client, database_id:'[DATABASE_ID]')

response = databases.create(name: '[NAME]')

puts response.inspect
```