### PR TITLE
Support nested array types

### DIFF
--- a/src/SDK/Language.php
+++ b/src/SDK/Language.php
@@ -38,10 +38,10 @@ abstract class Language {
     abstract public function getFiles();
 
     /**
-     * @param $type
+     * @param array $parameter
      * @return string
      */
-    abstract public function getTypeName($type);
+    abstract public function getTypeName(array $parameter): string;
 
     /**
      * @param array $param

--- a/src/SDK/Language/Dart.php
+++ b/src/SDK/Language/Dart.php
@@ -116,34 +116,32 @@ class Dart extends Language {
     }
 
     /**
-     * @param $type
+     * @param array $parameter
      * @return string
      */
-    public function getTypeName($type)
+    public function getTypeName(array $parameter): string
     {
-        switch ($type) {
+        switch ($parameter['type']) {
             case self::TYPE_INTEGER:
                 return 'int';
-            break;
             case self::TYPE_STRING:
                 return 'String';
-            break;
             case self::TYPE_FILE:
                 return 'InputFile';
-            break;
             case self::TYPE_BOOLEAN:
                 return 'bool';
-            break;
             case self::TYPE_ARRAY:
-            	return 'List';
-	        case self::TYPE_OBJECT:
-		        return 'Map';
+                if (!empty($parameter['array']['type'])) {
+                    return 'List<' . $this->getTypeName($parameter['array']) . '>';
+                }
+                return 'List';
+            case self::TYPE_OBJECT:
+                return 'Map';
             case self::TYPE_NUMBER:
                 return 'double';
-            break;
         }
 
-        return $type;
+        return $parameter['type'];
     }
 
     /**

--- a/src/SDK/Language/Deno.php
+++ b/src/SDK/Language/Deno.php
@@ -93,34 +93,31 @@ class Deno extends JS
         ];
     }
 
-   /**
-     * @param $type
+    /**
+     * @param array $parameter
      * @return string
      */
-    public function getTypeName($type)
+    public function getTypeName(array $parameter): string
     {
-        switch ($type) {
+        switch ($parameter['type']) {
             case self::TYPE_INTEGER:
                 return 'number';
-            break;
             case self::TYPE_STRING:
                 return 'string';
-            break;
             case self::TYPE_FILE:
                 return 'InputFile';
-            break;
             case self::TYPE_BOOLEAN:
                 return 'boolean';
-            break;
             case self::TYPE_ARRAY:
+                if (!empty($parameter['array']['type'])) {
+                    return $this->getTypeName($parameter['array']) . '[]';
+                }
                 return 'string[]';
-            break;
             case self::TYPE_OBJECT:
                 return 'object';
-            break;
         }
 
-        return $type;
+        return $parameter['type'];
     }
 
     /**

--- a/src/SDK/Language/DotNet.php
+++ b/src/SDK/Language/DotNet.php
@@ -147,30 +147,27 @@ class DotNet extends Language {
      * @param $type
      * @return string
      */
-    public function getTypeName($type)
+    public function getTypeName(array $parameter): string
     {
-        switch ($type) {
+        switch ($parameter['type']) {
             case self::TYPE_INTEGER:
                 return 'int';
-                break;
             case self::TYPE_STRING:
                 return 'string';
-                break;
             case self::TYPE_FILE:
                 return 'FileInfo';
-                break;
             case self::TYPE_BOOLEAN:
                 return 'bool';
-                break;
             case self::TYPE_ARRAY:
+                if (!empty($parameter['array']['type'])) {
+                    return 'List<' . $this->getTypeName($parameter['array']) . '>';
+                }
                 return 'List<object>';
-                break;
             case self::TYPE_OBJECT:
                 return 'object';
-                break;
         }
 
-        return $type;
+        return $parameter['type'];
     }
 
     /**

--- a/src/SDK/Language/Go.php
+++ b/src/SDK/Language/Go.php
@@ -110,20 +110,20 @@ class Go extends Language {
     }
 
     /**
-     * @param $type
+     * @param array $parameter
+     * @param array $nestedTypes
      * @return string
      */
-    public function getTypeName($type)
+    public function getTypeName(array $parameter): string
     {
-        switch ($type) {
+        switch ($parameter['type']) {
             case self::TYPE_INTEGER:
                 return 'int';
             case self::TYPE_NUMBER:
                 return 'float64';
+            case self::TYPE_FILE:
             case self::TYPE_STRING:
                 return 'string';
-            case self::TYPE_FILE:
-                return 'string'; // '*os.File';
             case self::TYPE_BOOLEAN:
                 return 'bool';
             case self::TYPE_OBJECT:
@@ -132,7 +132,7 @@ class Go extends Language {
                 return '[]interface{}';
         }
 
-        return $type;
+        return $parameter['type'];
     }
 
     /**

--- a/src/SDK/Language/HTTP.php
+++ b/src/SDK/Language/HTTP.php
@@ -36,29 +36,27 @@ class HTTP extends Language {
      * @param $type
      * @return string
      */
-    public function getTypeName($type)
+    public function getTypeName(array $parameter): string
     {
-        switch ($type) {
+        switch ($parameter['type']) {
             case self::TYPE_INTEGER:
                 return 'int';
-            break;
             case self::TYPE_STRING:
                 return 'String';
-            break;
             case self::TYPE_FILE:
                 return 'MultipartFile';
-            break;
             case self::TYPE_BOOLEAN:
                 return 'bool';
-            break;
             case self::TYPE_ARRAY:
-            	return 'List';
-			case self::TYPE_OBJECT:
-				return 'dynamic';
-            break;
+                if (!empty($parameter['array']['type'])) {
+                    return 'List<' . $this->getTypeName($parameter['array']) . '>';
+                }
+                return 'List';
+            case self::TYPE_OBJECT:
+                return 'dynamic';
         }
 
-        return $type;
+        return $parameter['type'];
     }
 
     /**

--- a/src/SDK/Language/JS.php
+++ b/src/SDK/Language/JS.php
@@ -117,24 +117,26 @@ abstract class JS extends Language {
     }
 
     /**
-     * @param $type
+     * @param array $parameter
+     * @param array $nestedTypes
      * @return string
      */
-    public function getTypeName($type)
+    public function getTypeName(array $parameter): string
     {
-        switch ($type) {
+        switch ($parameter['type']) {
             case self::TYPE_INTEGER:
             case self::TYPE_NUMBER:
                 return 'number';
-            break;
             case self::TYPE_ARRAY:
+                if (!empty($parameter['array']['type'])) {
+                    return $this->getTypeName($parameter['array']) . '[]';
+                }
                 return 'string[]';
             case self::TYPE_FILE:
                 return 'File';
-            break;
         }
 
-        return $type;
+        return $parameter['type'];
     }
 
     /**

--- a/src/SDK/Language/Kotlin.php
+++ b/src/SDK/Language/Kotlin.php
@@ -101,9 +101,9 @@ class Kotlin extends Language {
      * @param $type
      * @return string
      */
-    public function getTypeName($type)
+    public function getTypeName(array $parameter): string
     {
-        switch ($type) {
+        switch ($parameter['type']) {
             case self::TYPE_INTEGER:
                 return 'Long';
             case self::TYPE_NUMBER:
@@ -115,12 +115,15 @@ class Kotlin extends Language {
             case self::TYPE_BOOLEAN:
                 return 'Boolean';
             case self::TYPE_ARRAY:
-            	return 'List<Any>';
-			case self::TYPE_OBJECT:
-				return 'Any';
+                if (!empty($parameter['array']['type'])) {
+                    return 'List<' . $this->getTypeName($parameter['array']) . '>';
+                }
+                return 'List<Any>';
+            case self::TYPE_OBJECT:
+                return 'Any';
         }
 
-        return $type;
+        return $parameter['type'];
     }
 
     /**

--- a/src/SDK/Language/Node.php
+++ b/src/SDK/Language/Node.php
@@ -13,24 +13,26 @@ class Node extends JS
     }
 
     /**
-     * @param $type
+     * @param array $parameter
+     * @param array $nestedTypes
      * @return string
      */
-    public function getTypeName($type)
+    public function getTypeName(array $parameter): string
     {
-        switch ($type) {
+        switch ($parameter['type']) {
             case self::TYPE_INTEGER:
             case self::TYPE_NUMBER:
                 return 'number';
-            break;
             case self::TYPE_ARRAY:
+                if (!empty($parameter['array']['type'])) {
+                    return $this->getTypeName($parameter['array']) . '[]';
+                }
                 return 'string[]';
             case self::TYPE_FILE:
                 return 'InputFile';
-            break;
         }
 
-        return $type;
+        return $parameter['type'];
     }
 
     /**

--- a/src/SDK/Language/PHP.php
+++ b/src/SDK/Language/PHP.php
@@ -212,12 +212,15 @@ class PHP extends Language {
     }
 
     /**
-     * @param $type
+     * @param array $parameter
+     * @param array $nestedTypes
      * @return string
      */
-    public function getTypeName($type)
+    public function getTypeName(array $parameter): string
     {
-        switch ($type) {
+        switch ($parameter['type']) {
+            case self::TYPE_STRING:
+                return 'string';
             case self::TYPE_BOOLEAN:
                 $type = 'bool';
                 break;
@@ -225,6 +228,7 @@ class PHP extends Language {
             case self::TYPE_INTEGER:
                 $type = 'int';
                 break;
+            case self::TYPE_ARRAY:
             case self::TYPE_OBJECT:
                 $type = 'array';
                 break;

--- a/src/SDK/Language/Python.php
+++ b/src/SDK/Language/Python.php
@@ -207,10 +207,11 @@ class Python extends Language {
     }
 
     /**
-     * @param $type
+     * @param array $parameter
      * @return string
+     * @throws Exception
      */
-    public function getTypeName($type)
+    public function getTypeName(array $parameter): string
     {
         throw new Exception('Method not supported for Python SDKs');
     }

--- a/src/SDK/Language/Ruby.php
+++ b/src/SDK/Language/Ruby.php
@@ -185,18 +185,28 @@ class Ruby extends Language {
     }
 
     /**
-     * @param $type
+     * @param array $parameter
+     * @param array $nestedTypes
      * @return string
      */
-    public function getTypeName($type)
+    public function getTypeName(array $parameter): string
     {
-        switch ($type) {
+        switch ($parameter['type']) {
             case self::TYPE_INTEGER:
+                return 'Integer';
             case self::TYPE_NUMBER:
-                return 'number';
+                return 'Float';
+            case self::TYPE_STRING:
+                return 'String';
+            case self::TYPE_ARRAY:
+                return 'Array';
+            case self::TYPE_OBJECT:
+                return 'Hash';
+            case self::TYPE_BOOLEAN:
+                return '';
+            default:
+                return $parameter['type'];
         }
-
-        return $type;
     }
 
     /**

--- a/src/SDK/Language/Swift.php
+++ b/src/SDK/Language/Swift.php
@@ -294,12 +294,12 @@ class Swift extends Language {
     }
 
     /**
-     * @param $type
+     * @param array $parameter
      * @return string
      */
-    public function getTypeName($type)
+    public function getTypeName(array $parameter): string
     {
-        switch ($type) {
+        switch ($parameter['type']) {
             case self::TYPE_INTEGER:
                 return 'Int';
             case self::TYPE_NUMBER:
@@ -311,12 +311,15 @@ class Swift extends Language {
             case self::TYPE_BOOLEAN:
                 return 'Bool';
             case self::TYPE_ARRAY:
-                 return '[Any]';
+                if (!empty($parameter['array']['type'])) {
+                    return '[' . $this->getTypeName($parameter['array']) . ']';
+                }
+                return '[Any]';
             case self::TYPE_OBJECT:
                 return 'Any';
         }
 
-        return $type;
+        return $parameter['type'];
     }
 
     /**

--- a/src/SDK/Language/Web.php
+++ b/src/SDK/Language/Web.php
@@ -175,26 +175,26 @@ class Web extends JS
         return $output;
     }
 
-    public function getTypeName($type, $method = []): string
+    public function getTypeName(array $parameter, array $method = []): string
     {
-        switch ($type) {
+        switch ($parameter['type']) {
             case self::TYPE_INTEGER:
             case self::TYPE_NUMBER:
                 return 'number';
-                break;
             case self::TYPE_ARRAY:
+                if (!empty($parameter['array']['type'])) {
+                    return $this->getTypeName($parameter['array']) . '[]';
+                }
                 return 'string[]';
             case self::TYPE_FILE:
                 return 'File';
             case self::TYPE_OBJECT:
                 if (empty($method)) {
-                    return $type;
+                    return $parameter['type'];
                 }
-
                 switch ($method['responseModel']) {
                     case 'user':
                         return "Partial<Preferences>";
-                        break;
                     case 'document':
                         if ($method['method'] === 'post') {
                             return "Omit<Document, keyof Models.Document>";
@@ -203,10 +203,9 @@ class Web extends JS
                             return "Partial<Omit<Document, keyof Models.Document>>";
                         }
                 }
-                break;
         }
 
-        return $type;
+        return $parameter['type'];
     }
 
     protected function populateGenerics(string $model, array $spec, array &$generics, bool $skipFirst = false)
@@ -320,7 +319,7 @@ class Web extends JS
             return $ret;
         }
 
-        return $this->getTypeName($property['type']);
+        return $this->getTypeName($property);
     }
 
     public function getFilters(): array

--- a/templates/android/library/src/main/java/io/appwrite/models/Model.kt.twig
+++ b/templates/android/library/src/main/java/io/appwrite/models/Model.kt.twig
@@ -1,4 +1,4 @@
-{% macro sub_schema(property) %}{% if property.sub_schema %}{% if property.type == 'array' %}List<{{property.sub_schema | caseUcfirst}}>{% else %}{{property.sub_schema | caseUcfirst}}{% endif %}{% else %}{% if property.type == 'object' and property.additionalProperties %}Map<String, Any>{% else %}{{property.type | typeName}}{% endif %}{% endif %}{% endmacro %}
+{% macro sub_schema(property) %}{% if property.sub_schema %}{% if property.type == 'array' %}List<{{property.sub_schema | caseUcfirst}}>{% else %}{{property.sub_schema | caseUcfirst}}{% endif %}{% else %}{% if property.type == 'object' and property.additionalProperties %}Map<String, Any>{% else %}{{property | typeName}}{% endif %}{% endif %}{% endmacro %}
 package {{ sdk.namespace | caseDot }}.models
 
 import com.google.gson.annotations.SerializedName

--- a/templates/android/library/src/main/java/io/appwrite/services/ServiceTemplate.kt.twig
+++ b/templates/android/library/src/main/java/io/appwrite/services/ServiceTemplate.kt.twig
@@ -1,4 +1,4 @@
-{% macro parameter(parameter) %}{{ parameter.name | caseCamel }}: {{ parameter.type | typeName }}{% if not parameter.required %}? = null{% endif %}{% endmacro %}
+{% macro parameter(parameter) %}{{ parameter.name | caseCamel }}: {{ parameter | typeName }}{% if not parameter.required %}? = null{% endif %}{% endmacro %}
 {% macro method_parameters(parameters, consumes) %}
 {% if parameters.all|length > 0 %}{% for parameter in parameters.all | filter((param) => not param.isGlobal) %}{{ '\n\t\t' }}{{ _self.parameter(parameter) }}{% if not loop.last %}{{ ',' }}{% endif %}{% endfor %}{% if 'multipart/form-data' in consumes %}, onProgress: ((UploadProgress) -> Unit)? = null{% endif %}{% endif %}
 {% endmacro %}
@@ -30,11 +30,11 @@ class {{ service.name | caseUcfirst }} : Service {
 
 {% if service.globalParams | length %}
 {% for parameter in service.globalParams %}
-    val {{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter.type | typeName | overrideIdentifier }}{% if not parameter.required %}?{% endif %}
+    val {{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter | typeName | overrideIdentifier }}{% if not parameter.required %}?{% endif %}
 
 {% endfor %}
 
-    public constructor(client: Client,{% for parameter in service.globalParams %} {{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter.type | typeName | overrideIdentifier }}{% if not parameter.required %}? = null{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}) : super(client) {
+    public constructor(client: Client,{% for parameter in service.globalParams %} {{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter | typeName | overrideIdentifier }}{% if not parameter.required %}? = null{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}) : super(client) {
 {% for parameter in service.globalParams %}
         this.{{ parameter.name | caseCamel | escapeKeyword }} = {{ parameter.name | caseCamel | escapeKeyword }}
 {% endfor %}

--- a/templates/cli/lib/commands/command.js.twig
+++ b/templates/cli/lib/commands/command.js.twig
@@ -15,7 +15,7 @@ const {{ service.name | caseLower }} = new Command("{{ service.name | caseLower 
 {% for method in service.methods %}
 const {{ service.name | caseLower }}{{ method.name | caseUcfirst }} = async ({ {% for parameter in method.parameters.all %}{{ parameter.name | caseCamel | escapeKeyword }}, {% endfor %}parseOutput = true, sdk = undefined{% if 'multipart/form-data' in method.consumes %}, onProgress = () => {}{% endif %}{% if method.type == 'location' %}, destination{% endif %}}) => {
 {% for parameter in method.parameters.all %}
-    /* @param {{ '{' }}{{ parameter.type | typeName }}{{ '}' }} {{ parameter.name | caseCamel | escapeKeyword }} */
+    /* @param {{ '{' }}{{ parameter | typeName }}{{ '}' }} {{ parameter.name | caseCamel | escapeKeyword }} */
 {% endfor %}
 
     let client = !sdk ? await {% if service.name == "projects" %}sdkForConsole(){% else %}sdkForProject(){% endif %} : sdk;
@@ -222,7 +222,7 @@ const {{ service.name | caseLower }}{{ method.name | caseUcfirst }} = async ({ {
 {% autoescape false %}
     .description(`{{ method.description | replace({'`':'\''}) | replace({'\n':' '}) | replace({'\n \n':' '}) }}`)
 {% for parameter in method.parameters.all %}
-    .{% if parameter.required %}requiredOption{% else %}option{% endif %}(`--{{ parameter.name | escapeKeyword }} <{{ parameter.name | escapeKeyword }}{% if parameter.array.type|length > 0 %}...{% endif %}>`, `{{ parameter.description | replace({'`':'\''}) | replace({'\n':' '}) | replace({'\n \n':' '}) }}`{% if parameter.type|typeName == 'boolean' %}, parseBool{% elseif parameter.type|typeName == 'number' %}, parseInteger{% endif %})
+    .{% if parameter.required %}requiredOption{% else %}option{% endif %}(`--{{ parameter.name | escapeKeyword }} <{{ parameter.name | escapeKeyword }}{% if parameter.array.type|length > 0 %}...{% endif %}>`, `{{ parameter.description | replace({'`':'\''}) | replace({'\n':' '}) | replace({'\n \n':' '}) }}`{% if parameter | typeName == 'boolean' %}, parseBool{% elseif parameter | typeName == 'number' %}, parseInteger{% endif %})
 {% endfor %}
 {% if method.type == 'location' %}
     .requiredOption(`--destination <path>`, `output file path.`)

--- a/templates/dart/lib/services/service.dart.twig
+++ b/templates/dart/lib/services/service.dart.twig
@@ -1,5 +1,5 @@
 part of {{ language.params.packageName }};
-{% macro parameter(parameter) %}{% if parameter.required %}required {{ parameter.type | typeName }}{% else %}{{ parameter.type | typeName }}?{% endif %} {{ parameter.name | caseCamel | overrideIdentifier }}{% endmacro %}
+{% macro parameter(parameter) %}{% if parameter.required %}required {{ parameter | typeName }}{% else %}{{ parameter | typeName }}?{% endif %} {{ parameter.name | caseCamel | overrideIdentifier }}{% endmacro %}
 {% macro method_parameters(parameters, consumes) %}
 {% if parameters|length > 0 %}{{ '{' }}{% for parameter in parameters %}{{ _self.parameter(parameter) }}{% if not loop.last %}, {% endif %}{% endfor %}{% if 'multipart/form-data' in consumes %}, Function(UploadProgress)? onProgress{% endif %}{{ '}' }}{% endif %}
 {% endmacro %}
@@ -14,7 +14,7 @@ class {{ service.name | caseUcfirst }} extends Service {
     {{ service.name | caseUcfirst }}(Client client{{ _self.service_params(service.globalParams) }}): super(client);
 {% if service.globalParams | length %}
 {% for parameter in service.globalParams %}
-    {{ parameter.type | typeName }}{% if not parameter.required %}?{% endif %} {{ parameter.name | caseCamel | overrideIdentifier }};
+    {{ parameter | typeName }}{% if not parameter.required %}?{% endif %} {{ parameter.name | caseCamel | overrideIdentifier }};
 {% endfor %}
 {% endif %}
 {% for method in service.methods %}

--- a/templates/dart/lib/src/models/model.dart.twig
+++ b/templates/dart/lib/src/models/model.dart.twig
@@ -1,4 +1,4 @@
-{% macro sub_schema(property) %}{% if property.sub_schema %}{% if property.type == 'array' %}List<{{property.sub_schema | caseUcfirst | overrideIdentifier}}>{% else %}{{property.sub_schema | caseUcfirst | overrideIdentifier }}{% endif %}{% else %}{% if property.type == 'object' and property.additionalProperties %}Map<String, dynamic>{% else %}{{property.type | typeName}}{% endif %}{% endif %}{% endmacro %}
+{% macro sub_schema(property) %}{% if property.sub_schema %}{% if property.type == 'array' %}List<{{property.sub_schema | caseUcfirst | overrideIdentifier}}>{% else %}{{property.sub_schema | caseUcfirst | overrideIdentifier }}{% endif %}{% else %}{% if property.type == 'object' and property.additionalProperties %}Map<String, dynamic>{% else %}{{property | typeName}}{% endif %}{% endif %}{% endmacro %}
 part of {{ language.params.packageName }}.models;
 
 /// {{ definition.description }}

--- a/templates/deno/src/models.d.ts.twig
+++ b/templates/deno/src/models.d.ts.twig
@@ -9,7 +9,7 @@
     {% elseif property.sub_schemas %}
         ({% for subProperty in property.sub_schemas %}{{subProperty | caseUcfirst}}{% if loop.last == false %} | {% endif %}{% endfor %}){% if property.type == 'array' %}[]{% endif %}
     {% else %}
-        {{property.type | typeName}}
+        {{property | typeName}}
     {% endif %}
 {% endapply %}
 {% endmacro %}

--- a/templates/deno/src/services/service.ts.twig
+++ b/templates/deno/src/services/service.ts.twig
@@ -43,17 +43,17 @@ export type UploadProgress = {
 export class {{ service.name | caseUcfirst }} extends Service {
 {% if service.globalParams | length %}
 {% for parameter in service.globalParams %}
-     protected {{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter.type | typeName }};
-     public set{{ parameter.name | caseUcfirst | escapeKeyword }}({{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter.type | typeName }}): void
+     protected {{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter | typeName }};
+     public set{{ parameter.name | caseUcfirst | escapeKeyword }}({{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter | typeName }}): void
      {
         this.{{ parameter.name | caseCamel | escapeKeyword }} = {{ parameter.name | caseCamel | escapeKeyword }};
      }
-     public get{{ parameter.name | caseUcfirst | escapeKeyword }}(): {{ parameter.type | typeName }}
+     public get{{ parameter.name | caseUcfirst | escapeKeyword }}(): {{ parameter | typeName }}
      {
         return this.{{ parameter.name | caseCamel | escapeKeyword }};
      }
 {% endfor %}
-     constructor(client: Client, {% for parameter in service.globalParams %} {{ parameter.name | caseCamel | escapeKeyword }}:{{ parameter.type | typeName }}{% if not parameter.required %}|null = null{% endif %}{% if not loop.last %}, {% endif %}{% endfor %})
+     constructor(client: Client, {% for parameter in service.globalParams %} {{ parameter.name | caseCamel | escapeKeyword }}:{{ parameter | typeName }}{% if not parameter.required %}|null = null{% endif %}{% if not loop.last %}, {% endif %}{% endfor %})
      {
         super(client);
 
@@ -73,12 +73,12 @@ export class {{ service.name | caseUcfirst }} extends Service {
      *
 {% endif %}
 {% for parameter in method.parameters.all | filter((param) => not param.isGlobal) %}
-     * @param {{ '{' }}{{ parameter.type | typeName }}{{ '}' }} {{ parameter.name | caseCamel | escapeKeyword }}
+     * @param {{ '{' }}{{ parameter | typeName }}{{ '}' }} {{ parameter.name | caseCamel | escapeKeyword }}
 {% endfor %}
      * @throws {AppwriteException}
      * @returns {Promise}
      */
-    async {{ method.name | caseCamel }}{% if generics %}<{{generics}}>{% endif %}({% for parameter in method.parameters.all | filter((param) => not param.isGlobal) %}{{ parameter.name | caseCamel | escapeKeyword }}{% if not parameter.required %}?{% endif %}: {{ parameter.type | typeName }}{% if not loop.last %}, {% endif %}{% endfor %}{% if 'multipart/form-data' in method.consumes %}, onProgress = (progress: UploadProgress) => {}{% endif %}): Promise<{% if method.type == 'webAuth' %}Response{% elseif method.type == 'location' %}Response{% else %}{% if method.responseModel and method.responseModel != 'any' %}{% if not spec.definitions[method.responseModel].additionalProperties %}Models.{% endif %}{{method.responseModel | caseUcfirst}}{% if generics_return %}<{{generics_return}}>{% endif %}{% else %}Response{% endif %}{% endif %}> {
+    async {{ method.name | caseCamel }}{% if generics %}<{{generics}}>{% endif %}({% for parameter in method.parameters.all | filter((param) => not param.isGlobal) %}{{ parameter.name | caseCamel | escapeKeyword }}{% if not parameter.required %}?{% endif %}: {{ parameter | typeName }}{% if not loop.last %}, {% endif %}{% endfor %}{% if 'multipart/form-data' in method.consumes %}, onProgress = (progress: UploadProgress) => {}{% endif %}): Promise<{% if method.type == 'webAuth' %}Response{% elseif method.type == 'location' %}Response{% else %}{% if method.responseModel and method.responseModel != 'any' %}{% if not spec.definitions[method.responseModel].additionalProperties %}Models.{% endif %}{{method.responseModel | caseUcfirst}}{% if generics_return %}<{{generics_return}}>{% endif %}{% else %}Response{% endif %}{% endif %}> {
 {% for parameter in method.parameters.all | filter((param) => not param.isGlobal) %}
 {% if parameter.required %}
         if (typeof {{ parameter.name | caseCamel | escapeKeyword }} === 'undefined') {

--- a/templates/dotnet/src/Appwrite/Services/ServiceTemplate.cs.twig
+++ b/templates/dotnet/src/Appwrite/Services/ServiceTemplate.cs.twig
@@ -1,6 +1,6 @@
 {% macro parameter(parameter) %}
 {% if parameter.name == 'orderType' %}{{ 'OrderType orderType = OrderType.ASC' }}{% else %}
-{{ parameter.type | typeName }}{% if not parameter.required and (parameter.type == 'boolean' or parameter.type == 'integer') %}?{% endif %} {{ parameter.name | caseCamel | escapeKeyword }}{{ parameter | paramDefault }}{% endif %}
+{{ parameter | typeName }}{% if not parameter.required and (parameter.type == 'boolean' or parameter.type == 'integer') %}?{% endif %} {{ parameter.name | caseCamel | escapeKeyword }}{{ parameter | paramDefault }}{% endif %}
 {% endmacro %}
 {% macro method_parameters(parameters) %}
 {% if parameters.all|length > 0 %}{% for parameter in parameters.all %}{{ _self.parameter(parameter) }}{% if not loop.last %}{{ ', ' }}{% endif %}{% endfor %}{% endif %}

--- a/templates/flutter/lib/services/service.dart.twig
+++ b/templates/flutter/lib/services/service.dart.twig
@@ -1,5 +1,5 @@
 part of {{ language.params.packageName }};
-{% macro parameter(parameter) %}{% if parameter.required %}required {{ parameter.type | typeName }}{% else %}{{ parameter.type | typeName }}?{% endif %} {{ parameter.name | caseCamel | overrideIdentifier }}{% endmacro %}
+{% macro parameter(parameter) %}{% if parameter.required %}required {{ parameter | typeName }}{% else %}{{ parameter | typeName }}?{% endif %} {{ parameter.name | caseCamel | overrideIdentifier }}{% endmacro %}
 {% macro method_parameters(parameters, consumes) %}
 {% if parameters|length > 0 %}{{ '{' }}{% for parameter in parameters %}{{ _self.parameter(parameter) }}{% if not loop.last %}, {% endif %}{% endfor %}{% if 'multipart/form-data' in consumes %}, Function(UploadProgress)? onProgress{% endif %}{{ '}' }}{% endif %}
 {% endmacro %}
@@ -14,7 +14,7 @@ class {{ service.name | caseUcfirst }} extends Service {
     {{ service.name | caseUcfirst }}(Client client{{ _self.service_params(service.globalParams) }}): super(client);
 {% if service.globalParams | length %}
 {% for parameter in service.globalParams %}
-    {{ parameter.type | typeName }}{% if not parameter.required %}?{% endif %} {{ parameter.name | caseCamel | overrideIdentifier }};
+    {{ parameter | typeName }}{% if not parameter.required %}?{% endif %} {{ parameter.name | caseCamel | overrideIdentifier }};
 {% endfor %}
 {% endif %}
 {% for method in service.methods %}

--- a/templates/flutter/lib/src/models/model.dart.twig
+++ b/templates/flutter/lib/src/models/model.dart.twig
@@ -1,4 +1,4 @@
-{% macro sub_schema(property) %}{% if property.sub_schema %}{% if property.type == 'array' %}List<{{property.sub_schema | caseUcfirst}}>{% else %}{{property.sub_schema | caseUcfirst}}{% endif %}{% else %}{% if property.type == 'object' and property.additionalProperties %}Map<String, dynamic>{% else %}{{property.type | typeName}}{% endif %}{% endif %}{% endmacro %}
+{% macro sub_schema(property) %}{% if property.sub_schema %}{% if property.type == 'array' %}List<{{property.sub_schema | caseUcfirst}}>{% else %}{{property.sub_schema | caseUcfirst}}{% endif %}{% else %}{% if property.type == 'object' and property.additionalProperties %}Map<String, dynamic>{% else %}{{property | typeName}}{% endif %}{% endif %}{% endmacro %}
 part of {{ language.params.packageName }}.models;
 
 /// {{ definition.description }}

--- a/templates/go/services/service.go.twig
+++ b/templates/go/services/service.go.twig
@@ -26,7 +26,7 @@ func New{{ service.name | caseUcfirst }}(clt Client) *{{ service.name | caseUcfi
 
 {% if method.description %}{{ ((method.name | caseUcfirst) ~ ' ' ~ method.description | caseLcfirst) | godocComment }}{% else %}// {{ method.name | caseUcfirst }}{% endif %}
 
-func (srv *{{ service.name | caseUcfirst }}) {{ method.name | caseUcfirst }}({% if method.parameters.all|length > 0 %}{% for parameter in method.parameters.all %}{{ parameter.name | caseUcfirst }} {{ parameter.type | typeName }}{% if not loop.last %}, {% endif %}{% endfor %}{% endif %}) (*ClientResponse, error) {
+func (srv *{{ service.name | caseUcfirst }}) {{ method.name | caseUcfirst }}({% if method.parameters.all|length > 0 %}{% for parameter in method.parameters.all %}{{ parameter.name | caseUcfirst }} {{ parameter | typeName }}{% if not loop.last %}, {% endif %}{% endfor %}{% endif %}) (*ClientResponse, error) {
 {% if method.parameters.path|length > 0 %}
 	r := strings.NewReplacer({% for parameter in method.parameters.path %}"{{ '{' }}{{ parameter.name | caseCamel }}{{ '}' }}", {{ parameter.name | caseUcfirst }}{% if not loop.last %}, {% endif %}{% endfor %})
 	path := r.Replace("{{ method.path }}")

--- a/templates/kotlin/src/main/kotlin/io/appwrite/models/Model.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/models/Model.kt.twig
@@ -1,4 +1,4 @@
-{% macro sub_schema(property) %}{% if property.sub_schema %}{% if property.type == 'array' %}List<{{property.sub_schema | caseUcfirst}}>{% else %}{{property.sub_schema | caseUcfirst}}{% endif %}{% else %}{% if property.type == 'object' and property.additionalProperties %}Map<String, Any>{% else %}{{property.type | typeName}}{% endif %}{% endif %}{% endmacro %}
+{% macro sub_schema(property) %}{% if property.sub_schema %}{% if property.type == 'array' %}List<{{property.sub_schema | caseUcfirst}}>{% else %}{{property.sub_schema | caseUcfirst}}{% endif %}{% else %}{% if property.type == 'object' and property.additionalProperties %}Map<String, Any>{% else %}{{property | typeName}}{% endif %}{% endif %}{% endmacro %}
 package {{ sdk.namespace | caseDot }}.models
 
 import com.google.gson.annotations.SerializedName

--- a/templates/kotlin/src/main/kotlin/io/appwrite/services/ServiceTemplate.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/services/ServiceTemplate.kt.twig
@@ -1,4 +1,4 @@
-{% macro parameter(parameter) %}{{ parameter.name | caseCamel }}: {{ parameter.type | typeName }}{% if not parameter.required %}? = null{% endif %}{% endmacro %}
+{% macro parameter(parameter) %}{{ parameter.name | caseCamel }}: {{ parameter | typeName }}{% if not parameter.required %}? = null{% endif %}{% endmacro %}
 {% macro method_parameters(parameters, consumes) %}
 {% if parameters.all|length > 0 %}{% for parameter in parameters.all | filter((param) => not param.isGlobal) %}{{ '\n\t\t' }}{{ _self.parameter(parameter) }}{% if not loop.last %}{{ ',' }}{% endif %}{% endfor %}{% if 'multipart/form-data' in consumes %}, onProgress: ((UploadProgress) -> Unit)? = null{% endif %}{% endif %}
 {% endmacro %}
@@ -28,11 +28,11 @@ class {{ service.name | caseUcfirst }} : Service {
 
 {% if service.globalParams | length %}
 {% for parameter in service.globalParams %}
-    val {{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter.type | typeName | overrideIdentifier }}{% if not parameter.required %}?{% endif %}
+    val {{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter | typeName | overrideIdentifier }}{% if not parameter.required %}?{% endif %}
 
 {% endfor %}
 
-    public constructor(client: Client,{% for parameter in service.globalParams %} {{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter.type | typeName | overrideIdentifier }}{% if not parameter.required %}? = null{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}) : super(client) {
+    public constructor(client: Client,{% for parameter in service.globalParams %} {{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter | typeName | overrideIdentifier }}{% if not parameter.required %}? = null{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}) : super(client) {
 {% for parameter in service.globalParams %}
         this.{{ parameter.name | caseCamel | escapeKeyword }} = {{ parameter.name | caseCamel | escapeKeyword }}
 {% endfor %}

--- a/templates/node/index.d.ts.twig
+++ b/templates/node/index.d.ts.twig
@@ -7,7 +7,7 @@
             {{property.sub_schema | caseUcfirst}}{% if property.type == 'array' %}[]{% endif %}
         {% endif %}
     {% else %}
-        {{property.type | typeName}}
+        {{property | typeName}}
     {% endif %}
 {% endapply %}
 {% endmacro %}
@@ -164,24 +164,24 @@ declare module "{{ language.params.npmPackage|caseDash }}" {
 
 {% for service in spec.services %}
   export class {{ service.name | caseUcfirst }} extends Service {
-    constructor(client: Client{% for parameter in service.globalParams %}, {{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter.type | typeName }}{% if not parameter.required %}|null{% endif %}{% endfor %});
+    constructor(client: Client{% for parameter in service.globalParams %}, {{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter | typeName }}{% if not parameter.required %}|null{% endif %}{% endfor %});
     
 {% if service.globalParams | length %}
 {% for parameter in service.globalParams %}
     /**
      * Get {{ parameter.name }}.
      *
-     * @returns {{ '{' }}{{ parameter.type | typeName }}{{ '}' }}
+     * @returns {{ '{' }}{{ parameter | typeName }}{{ '}' }}
      */
-    get{{ parameter.name | caseUcfirst | escapeKeyword }}(): {{ parameter.type | typeName }};
+    get{{ parameter.name | caseUcfirst | escapeKeyword }}(): {{ parameter | typeName }};
 
     /**
      * Set {{ parameter.name }}.
      *
-     * @param {{ '{' }}{{ parameter.type | typeName }}{{ '}' }} {{ parameter.name | caseCamel | escapeKeyword }}
+     * @param {{ '{' }}{{ parameter | typeName }}{{ '}' }} {{ parameter.name | caseCamel | escapeKeyword }}
      * @returns {void}
      */
-    set{{ parameter.name | caseUcfirst | escapeKeyword }}({{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter.type | typeName }}): void;
+    set{{ parameter.name | caseUcfirst | escapeKeyword }}({{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter | typeName }}): void;
 
 {% endfor %}
 {% endif %}
@@ -196,12 +196,12 @@ declare module "{{ language.params.npmPackage|caseDash }}" {
      *
 {% endif %}
 {% for parameter in method.parameters.all | filter((param) => not param.isGlobal) %}
-     * @param {{ '{' }}{{ parameter.type | typeName }}{{ '}' }} {{ parameter.name | caseCamel }}
+     * @param {{ '{' }}{{ parameter | typeName }}{{ '}' }} {{ parameter.name | caseCamel }}
 {% endfor %}
      * @throws {{ '{' }}{{ spec.title | caseUcfirst}}Exception}
      * @returns {Promise}
      */
-    {{ method.name | caseCamel }}{% if generics %}<{{generics}}>{% endif %}({% for parameter in method.parameters.all | filter((param) => not param.isGlobal) %}{{ parameter.name | caseCamel | escapeKeyword }}{% if not parameter.required %}?{% endif %}: {{ parameter.type | typeName }}{% if not loop.last %}, {% endif %}{% endfor %}): Promise<{% if method.type == 'location' %}Buffer{% else %}{% if method.responseModel and method.responseModel != 'any' %}{% if not spec.definitions[method.responseModel].additionalProperties %}Models.{% endif %}{{method.responseModel | caseUcfirst}}{% if generics_return %}<{{generics_return}}>{% endif %}{% else %}Response{% endif %}{% endif %}>;
+    {{ method.name | caseCamel }}{% if generics %}<{{generics}}>{% endif %}({% for parameter in method.parameters.all | filter((param) => not param.isGlobal) %}{{ parameter.name | caseCamel | escapeKeyword }}{% if not parameter.required %}?{% endif %}: {{ parameter | typeName }}{% if not loop.last %}, {% endif %}{% endfor %}): Promise<{% if method.type == 'location' %}Buffer{% else %}{% if method.responseModel and method.responseModel != 'any' %}{% if not spec.definitions[method.responseModel].additionalProperties %}Models.{% endif %}{{method.responseModel | caseUcfirst}}{% if generics_return %}<{{generics_return}}>{% endif %}{% else %}Response{% endif %}{% endif %}>;
 {% endfor %}
   }
 {% endfor %}

--- a/templates/node/lib/services/service.js.twig
+++ b/templates/node/lib/services/service.js.twig
@@ -13,7 +13,7 @@ class {{ service.name | caseUcfirst }} extends Service {
     /**
      * Set {{ parameter.name }}.
      *
-     * @param {{ '{' }}{{ parameter.type | typeName }}{{ '}' }} {{ parameter.name | caseCamel | escapeKeyword }}
+     * @param {{ '{' }}{{ parameter | typeName }}{{ '}' }} {{ parameter.name | caseCamel | escapeKeyword }}
      *
      * @return void
      */
@@ -24,7 +24,7 @@ class {{ service.name | caseUcfirst }} extends Service {
     /**
      * Get {{ parameter.name }}.
      *
-     * @return {{ parameter.type | typeName }}
+     * @return {{ parameter | typeName }}
      */
      get{{ parameter.name | caseUcfirst | escapeKeyword }}()
      {
@@ -50,7 +50,7 @@ class {{ service.name | caseUcfirst }} extends Service {
      *
 {% endif %}
 {% for parameter in method.parameters.all | filter((param) => not param.isGlobal) %}
-     * @param {{ '{' }}{{ parameter.type | typeName }}{{ '}' }} {{ parameter.name | caseCamel | escapeKeyword }}
+     * @param {{ '{' }}{{ parameter | typeName }}{{ '}' }} {{ parameter.name | caseCamel | escapeKeyword }}
 {% endfor %}
      * @throws {{ '{' }}{{ spec.title | caseUcfirst}}Exception}
      * @returns {Promise}

--- a/templates/php/src/Services/Service.php.twig
+++ b/templates/php/src/Services/Service.php.twig
@@ -11,20 +11,20 @@ class {{ service.name | caseUcfirst }} extends Service
 {
 {% if service.globalParams | length %}
 {% for parameter in service.globalParams %}
-     protected {{ parameter.type | typeName }} ${{ parameter.name | caseCamel | escapeKeyword }};
+     protected {{ parameter | typeName }} ${{ parameter.name | caseCamel | escapeKeyword }};
 
-     public function set{{ parameter.name | caseUcfirst | escapeKeyword }}({{ parameter.type | typeName }}${{ parameter.name | caseCamel | escapeKeyword }}): void
+     public function set{{ parameter.name | caseUcfirst | escapeKeyword }}({{ parameter | typeName }}${{ parameter.name | caseCamel | escapeKeyword }}): void
      {
           $this->{{ parameter.name | caseCamel | escapeKeyword }} = ${{ parameter.name | caseCamel | escapeKeyword }};
      }
 
-     public function get{{ parameter.name | caseUcfirst | escapeKeyword }}({{ parameter.type | typeName }}${{ parameter.name | caseCamel | escapeKeyword }}): {{ parameter.type | typeName }}
+     public function get{{ parameter.name | caseUcfirst | escapeKeyword }}({{ parameter | typeName }}${{ parameter.name | caseCamel | escapeKeyword }}): {{ parameter | typeName }}
      {
           return $this->{{ parameter.name | caseCamel | escapeKeyword }};
      }
 {% endfor %}
 
-     public function __construct(Client $client, {% for parameter in service.globalParams %} {{ parameter.type | typeName }}${{ parameter.name | caseCamel | escapeKeyword }}{% if not parameter.required %} = null{% endif %}{% if not loop.last %}, {% endif %}{% endfor %})
+     public function __construct(Client $client, {% for parameter in service.globalParams %} {{ parameter | typeName }}${{ parameter.name | caseCamel | escapeKeyword }}{% if not parameter.required %} = null{% endif %}{% if not loop.last %}, {% endif %}{% endfor %})
      {
           $this->client = $client;
 {% for parameter in service.globalParams %}
@@ -42,13 +42,13 @@ class {{ service.name | caseUcfirst }} extends Service
      *
 {% endif %}
 {% for parameter in method.parameters.all | filter((param) => not param.isGlobal) %}
-     * @param {{ parameter.type | typeName }}${{ parameter.name | caseCamel | escapeKeyword }}
+     * @param {{ parameter | typeName }}${{ parameter.name | caseCamel | escapeKeyword }}
 {% endfor %}
      * @throws {{spec.title | caseUcfirst}}Exception
      * @return {{ method | getReturn }}
 
      */
-    public function {{ method.name | caseCamel }}({% for parameter in method.parameters.all | filter((param) => not param.isGlobal ) %}{{ parameter.type | typeName }}${{ parameter.name | caseCamel | escapeKeyword }}{% if not parameter.required %} = null{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}{% if 'multipart/form-data' in method.consumes %}, callable $onProgress = null{% endif %}): {{ method | getReturn }}
+    public function {{ method.name | caseCamel }}({% for parameter in method.parameters.all | filter((param) => not param.isGlobal ) %}{{ parameter | typeName }}${{ parameter.name | caseCamel | escapeKeyword }}{% if not parameter.required %} = null{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}{% if 'multipart/form-data' in method.consumes %}, callable $onProgress = null{% endif %}): {{ method | getReturn }}
     {
         $path   = str_replace([{% for parameter in method.parameters.path %}'{{ '{' }}{{ parameter.name | caseCamel }}{{ '}' }}'{% if not loop.last %}, {% endif %}{% endfor %}], [{% for parameter in method.parameters.path %}${% if parameter.isGlobal %}this->{% endif %}{{ parameter.name | caseCamel | escapeKeyword }}{% if not loop.last %}, {% endif %}{% endfor %}], '{{ method.path }}');
 

--- a/templates/ruby/lib/container/models/model.rb.twig
+++ b/templates/ruby/lib/container/models/model.rb.twig
@@ -1,4 +1,4 @@
-{% macro sub_schema(property) %}{% if property.sub_schema %}{% if property.type == 'array' %}List<{{property.sub_schema | caseUcfirst}}>{% else %}{{property.sub_schema | caseUcfirst}}{% endif %}{% else %}{{property.type | typeName}}{% endif %}{% endmacro %}
+{% macro sub_schema(property) %}{% if property.sub_schema %}{% if property.type == 'array' %}List<{{property.sub_schema | caseUcfirst}}>{% else %}{{property.sub_schema | caseUcfirst}}{% endif %}{% else %}{{property | typeName}}{% endif %}{% endmacro %}
 #frozen_string_literal: true
 
 module {{ spec.title | caseUcfirst }}

--- a/templates/ruby/lib/container/services/service.rb.twig
+++ b/templates/ruby/lib/container/services/service.rb.twig
@@ -20,7 +20,7 @@ module {{spec.title | caseUcfirst}}
 {{ method.description | rubyComment }}
         #
 {% for parameter in method.parameters.all %}
-        # @param [{{ parameter.type | typeName }}] {{ parameter.name | caseSnake | escapeKeyword }} {{ parameter.description }}
+        # @param [{{ parameter | typeName }}] {{ parameter.name | caseSnake | escapeKeyword }} {{ parameter.description }}
 {% endfor %}
         #
         # @return [{{ method.responseModel | caseUcfirst }}]

--- a/templates/swift/Sources/Models/Model.swift.twig
+++ b/templates/swift/Sources/Models/Model.swift.twig
@@ -1,4 +1,4 @@
-{% macro sub_schema(property) %}{% if property.sub_schema %}{% if property.type == 'array' %}[{{property.sub_schema | caseUcfirst}}]{% else %}{{property.sub_schema | caseUcfirst}}{% endif %}{% else %}{% if property.type == 'object' and property.additionalProperties %}[String : Any]{% else %}{{property.type | typeName}}{% endif %}{% endif %}{% endmacro %}
+{% macro sub_schema(property) %}{% if property.sub_schema %}{% if property.type == 'array' %}[{{property.sub_schema | caseUcfirst}}]{% else %}{{property.sub_schema | caseUcfirst}}{% endif %}{% else %}{% if property.type == 'object' and property.additionalProperties %}[String : Any]{% else %}{{property | typeName}}{% endif %}{% endif %}{% endmacro %}
 
 /// {{ definition.description }}
 public class {{ definition.name | caseUcfirst }} {

--- a/templates/swift/Sources/Services/Service.swift.twig
+++ b/templates/swift/Sources/Services/Service.swift.twig
@@ -12,11 +12,11 @@ import {{spec.title | caseUcfirst}}Models
 open class {{ service.name | caseUcfirst }}: Service {
 {% if service.globalParams | length %}
 {% for parameter in service.globalParams %}
-    var {{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter.type | typeName }}{% if not parameter.required %}?{% endif %}
+    var {{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter | typeName }}{% if not parameter.required %}?{% endif %}
 {% endfor %}
 
 
-    public init(_ client: Client, {% for parameter in service.globalParams %}_ {{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter.type | typeName }}{% if not parameter.required %}? = nil{% endif %}{% if not loop.last %}, {% endif %}{% endfor %})
+    public init(_ client: Client, {% for parameter in service.globalParams %}_ {{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter | typeName }}{% if not parameter.required %}? = nil{% endif %}{% if not loop.last %}, {% endif %}{% endfor %})
     {
 {% for parameter in service.globalParams %}
         self.{{ parameter.name | caseCamel | escapeKeyword }} = {{ parameter.name | caseCamel | escapeKeyword }}
@@ -34,7 +34,7 @@ open class {{ service.name | caseUcfirst }}: Service {
     ///
 {% endif %}
 {% for parameter in method.parameters.all %}
-    /// @param {{ parameter.type | typeName | raw}} {{ parameter.name | caseCamel }}
+    /// @param {{ parameter | typeName | raw}} {{ parameter.name | caseCamel }}
 {% endfor %}
     /// @throws Exception
     /// @return array
@@ -44,7 +44,7 @@ open class {{ service.name | caseUcfirst }}: Service {
 {% endif %}
     open func {{ method.name | caseCamel }}(
 {% for parameter in method.parameters.all | filter((param) => not param.isGlobal) %}
-        {{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter.type | typeName | raw }}{% if not parameter.required %}? = nil{% endif %}{% if not loop.last or 'multipart/form-data' in method.consumes %},{% endif %}
+        {{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter | typeName | raw }}{% if not parameter.required %}? = nil{% endif %}{% if not loop.last or 'multipart/form-data' in method.consumes %},{% endif %}
 
 {% endfor %}
 {% if 'multipart/form-data' in method.consumes %}
@@ -154,7 +154,7 @@ open class {{ service.name | caseUcfirst }}: Service {
     ///
 {% endif %}
 {% for parameter in method.parameters.all | filter((param) => not param.isGlobal) %}
-    /// @param {{ parameter.type | typeName | raw}} {{ parameter.name | caseCamel }}
+    /// @param {{ parameter | typeName | raw}} {{ parameter.name | caseCamel }}
 {% endfor %}
     /// @throws Exception
     /// @return array
@@ -165,7 +165,7 @@ open class {{ service.name | caseUcfirst }}: Service {
 {% endif %}
     open func {{ method.name | caseCamel }}(
 {% for parameter in method.parameters.all | filter((param) => not param.isGlobal) %}
-        {{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter.type | typeName | raw }}{% if not parameter.required %}? = nil{% endif %},
+        {{ parameter.name | caseCamel | escapeKeyword }}: {{ parameter | typeName | raw }}{% if not parameter.required %}? = nil{% endif %},
 {% endfor %}
 {% if 'multipart/form-data' in method.consumes %}
         onProgress: ((UploadProgress) -> Void)? = nil,

--- a/templates/web/src/services/template.ts.twig
+++ b/templates/web/src/services/template.ts.twig
@@ -18,13 +18,13 @@ export class {{ service.name | caseUcfirst }} extends Service {
 {% endif %}
          *
 {% for parameter in method.parameters.all %}
-         * @param {{ '{' }}{{ parameter.type | getPropertyType(method) | raw }}{{ '}' }} {{ parameter.name | caseCamel | escapeKeyword }}
+         * @param {{ '{' }}{{ parameter | getPropertyType(method) | raw }}{{ '}' }} {{ parameter.name | caseCamel | escapeKeyword }}
 {% endfor %}
          * @throws {{ '{' }}{{ spec.title | caseUcfirst}}Exception}
          * @returns {% if method.type == 'webAuth' %}{void|string}{% elseif method.type == 'location' %}{URL}{% else %}{Promise}{% endif %}
 
          */
-        {% if method.type != 'location' and method.type != 'webAuth'%}async {% endif %}{{ method.name | caseCamel }}{{ method.responseModel | getGenerics(spec) | raw }}({% for parameter in method.parameters.all %}{{ parameter.name | caseCamel | escapeKeyword }}{% if not parameter.required %}?{% endif %}: {{ parameter.type | getPropertyType(method) | raw }}{% if not loop.last %}, {% endif %}{% endfor %}{% if 'multipart/form-data' in method.consumes %}, onProgress = (progress: UploadProgress) => {}{% endif %}): {{ method | getReturn(spec) | raw }} {
+        {% if method.type != 'location' and method.type != 'webAuth'%}async {% endif %}{{ method.name | caseCamel }}{{ method.responseModel | getGenerics(spec) | raw }}({% for parameter in method.parameters.all %}{{ parameter.name | caseCamel | escapeKeyword }}{% if not parameter.required %}?{% endif %}: {{ parameter | getPropertyType(method) | raw }}{% if not loop.last %}, {% endif %}{% endfor %}{% if 'multipart/form-data' in method.consumes %}, onProgress = (progress: UploadProgress) => {}{% endif %}): {{ method | getReturn(spec) | raw }} {
 {% for parameter in method.parameters.all %}
 {% if parameter.required %}
             if (typeof {{ parameter.name | caseCamel | escapeKeyword }} === 'undefined') {


### PR DESCRIPTION
Generates array types with their item type as a generic type parameter

E.g. `List<String>` instead of `List` or `List<Any>` for applicable languages, when a parameters 'array' 'type' property contains 'string'.
