### PR TITLE
Flutter: check if init is already in progress

### DIFF
--- a/templates/flutter/lib/src/client_io.dart.twig
+++ b/templates/flutter/lib/src/client_io.dart.twig
@@ -34,6 +34,7 @@ class ClientIO extends ClientBase with ClientMixin {
   @override
   late Map<String, String> config;
   bool selfSigned;
+  bool _initProgress = false;
   bool _initialized = false;
   String? _endPointRealtime;
   late http.Client _httpClient;
@@ -41,6 +42,7 @@ class ClientIO extends ClientBase with ClientMixin {
   late CookieJar _cookieJar;
   final List<Interceptor> _interceptors = [];
 
+  bool get initProgress => _initProgress;
   bool get initialized => _initialized;
   CookieJar get cookieJar => _cookieJar;
   @override
@@ -126,6 +128,8 @@ class ClientIO extends ClientBase with ClientMixin {
   }
 
   Future init() async {
+    if(_initProgress) return;
+    _initProgress = true;
     // if web skip cookie implementation and origin header as those are automatically handled by browsers
     final Directory cookieDir = await _getCookiePath();
     _cookieJar = PersistCookieJar(storage: FileStorage(cookieDir.path));
@@ -168,6 +172,7 @@ class ClientIO extends ClientBase with ClientMixin {
         'user-agent', '${packageInfo.packageName}/${packageInfo.version} $device');
 
     _initialized = true;
+    _initProgress = false;
   }
 
   Future<http.BaseRequest> _interceptRequest(http.BaseRequest request) async {
@@ -326,6 +331,9 @@ class ClientIO extends ClientBase with ClientMixin {
     Map<String, dynamic> params = const {},
     ResponseType? responseType,
   }) async {
+    while (!_initialized && _initProgress) {
+      await Future.delayed(Duration(milliseconds: 10));
+    }
     if (!_initialized) {
       await init();
     }

--- a/templates/flutter/lib/src/realtime_io.dart.twig
+++ b/templates/flutter/lib/src/realtime_io.dart.twig
@@ -23,6 +23,9 @@ class RealtimeIO extends RealtimeBase with RealtimeMixin {
 
   Future<WebSocketChannel> _getWebSocket(Uri uri) async {
     Map<String, String>? headers;
+    while (!(client as ClientIO).initialized && (client as ClientIO).initProgress) {
+      await Future.delayed(Duration(milliseconds: 10));
+    }
     if (!(client as ClientIO).initialized) {
       await (client as ClientIO).init();
     }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Prevent concurrent init calls in Flutter SDK
## Test Plan

Existing test

## Related PRs and Issues

- #417 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

YES