### PR TITLE
Feat: Queries upgrade

### DIFF
--- a/templates/deno/src/query.ts.twig
+++ b/templates/deno/src/query.ts.twig
@@ -3,65 +3,65 @@ export type QueryTypesList = string[] | number[] | boolean[];
 export type QueryTypes = QueryTypesSingle | QueryTypesList;
 
 export class Query {
-    static equal = (attribute: string, value: QueryTypes): string =>
-        Query.addQuery("equal", attribute, value);
+  static equal = (attribute: string, value: QueryTypes): string =>
+    Query.addQuery("equal", attribute, value);
 
-    static notEqual = (attribute: string, value: QueryTypes): string =>
-        Query.addQuery("notEqual", attribute, value);
+  static notEqual = (attribute: string, value: QueryTypes): string =>
+    Query.addQuery("notEqual", attribute, value);
 
-    static lesser = (attribute: string, value: QueryTypes): string =>
-        Query.addQuery("lesser", attribute, value);
+  static lesser = (attribute: string, value: QueryTypes): string =>
+    Query.addQuery("lesser", attribute, value);
 
-    static lesserEqual = (attribute: string, value: QueryTypes): string =>
-        Query.addQuery("lesserEqual", attribute, value);
+  static lesserEqual = (attribute: string, value: QueryTypes): string =>
+    Query.addQuery("lesserEqual", attribute, value);
 
-    static greater = (attribute: string, value: QueryTypes): string =>
-        Query.addQuery("greater", attribute, value);
+  static greater = (attribute: string, value: QueryTypes): string =>
+    Query.addQuery("greater", attribute, value);
 
-    static greaterEqual = (attribute: string, value: QueryTypes): string =>
-        Query.addQuery("greaterEqual", attribute, value);
+  static greaterEqual = (attribute: string, value: QueryTypes): string =>
+    Query.addQuery("greaterEqual", attribute, value);
 
-    static search = (attribute: string, value: string): string =>
-        Query.addQuery("search", attribute, value);
+  static search = (attribute: string, value: string): string =>
+    Query.addQuery("search", attribute, value);
 
-    static orderDesc = (attribute: string): string =>
-        Query.addQuery("orderDesc", attribute, undefined);
+  static orderDesc = (attribute: string): string =>
+    Query.addQuery("orderDesc", attribute, undefined);
 
-    static orderAsc = (attribute: string): string =>
-        Query.addQuery("orderAsc", attribute, undefined);
+  static orderAsc = (attribute: string): string =>
+    Query.addQuery("orderAsc", attribute, undefined);
 
-    static cursorAfter = (documentId: string): string =>
-        Query.addQuery("cursorAfter", undefined, documentId);
+  static cursorAfter = (documentId: string): string =>
+    Query.addQuery("cursorAfter", undefined, documentId);
 
-    static cursorBefore = (documentId: string): string =>
-        Query.addQuery("cursorBefore", undefined, documentId);
+  static cursorBefore = (documentId: string): string =>
+    Query.addQuery("cursorBefore", undefined, documentId);
 
-    static limit = (value: number): string =>
-        Query.addQuery("limit", undefined, value);
+  static limit = (value: number): string =>
+    Query.addQuery("limit", undefined, value);
 
-    static offset = (value: number): string =>
-        Query.addQuery("offset", undefined, value);
+  static offset = (value: number): string =>
+    Query.addQuery("offset", undefined, value);
 
-    private static addQuery = (oper: string, attribute: string | undefined, value: QueryTypes | undefined): string => {
-        const params: string[] = [];
+  private static addQuery = (oper: string, attribute: string | undefined, value: QueryTypes | undefined): string => {
+    const params: string[] = [];
 
-        if (attribute) {
-            params.push(`"${attribute}"`);
-        }
-
-        if (value) {
-            params.push(
-                `[${(value instanceof Array ? value : [value])
-                    .map((v: QueryTypesSingle) => Query.parseValues(v))
-                    .join(", ")}]`
-            );
-        }
-
-        return `${oper}(${params.join(", ")})`;
+    if (attribute) {
+      params.push(`"${attribute}"`);
     }
 
-    private static parseValues = (value: QueryTypes): string =>
-        typeof value === "string" || value instanceof String
-            ? `"${value}"`
-            : `${value}`;
+    if (value) {
+      params.push(
+        `[${(value instanceof Array ? value : [value])
+          .map((v: QueryTypesSingle) => Query.parseValues(v))
+          .join(", ")}]`
+      );
+    }
+
+    return `${oper}(${params.join(", ")})`;
+  }
+
+  private static parseValues = (value: QueryTypes): string =>
+    typeof value === "string" || value instanceof String
+      ? `"${value}"`
+      : `${value}`;
 }

--- a/templates/deno/src/query.ts.twig
+++ b/templates/deno/src/query.ts.twig
@@ -3,36 +3,65 @@ export type QueryTypesList = string[] | number[] | boolean[];
 export type QueryTypes = QueryTypesSingle | QueryTypesList;
 
 export class Query {
-  static equal = (attribute: string, value: QueryTypes): string =>
-    Query.addQuery(attribute, "equal", value);
+    static equal = (attribute: string, value: QueryTypes): string =>
+        Query.addQuery("equal", attribute, value);
 
-  static notEqual = (attribute: string, value: QueryTypes): string =>
-    Query.addQuery(attribute, "notEqual", value);
+    static notEqual = (attribute: string, value: QueryTypes): string =>
+        Query.addQuery("notEqual", attribute, value);
 
-  static lesser = (attribute: string, value: QueryTypes): string =>
-    Query.addQuery(attribute, "lesser", value);
+    static lesser = (attribute: string, value: QueryTypes): string =>
+        Query.addQuery("lesser", attribute, value);
 
-  static lesserEqual = (attribute: string, value: QueryTypes): string =>
-    Query.addQuery(attribute, "lesserEqual", value);
+    static lesserEqual = (attribute: string, value: QueryTypes): string =>
+        Query.addQuery("lesserEqual", attribute, value);
 
-  static greater = (attribute: string, value: QueryTypes): string =>
-    Query.addQuery(attribute, "greater", value);
+    static greater = (attribute: string, value: QueryTypes): string =>
+        Query.addQuery("greater", attribute, value);
 
-  static greaterEqual = (attribute: string, value: QueryTypes): string =>
-    Query.addQuery(attribute, "greaterEqual", value);
+    static greaterEqual = (attribute: string, value: QueryTypes): string =>
+        Query.addQuery("greaterEqual", attribute, value);
 
-  static search = (attribute: string, value: string): string =>
-    Query.addQuery(attribute, "search", value);
+    static search = (attribute: string, value: string): string =>
+        Query.addQuery("search", attribute, value);
 
-  private static addQuery = (attribute: string, oper: string, value: QueryTypes): string =>
-    value instanceof Array
-      ? `${attribute}.${oper}(${value
-          .map((v: QueryTypesSingle) => Query.parseValues(v))
-          .join(",")})`
-      : `${attribute}.${oper}(${Query.parseValues(value)})`;
+    static orderDesc = (attribute: string): string =>
+        Query.addQuery("orderDesc", attribute, undefined);
 
-  private static parseValues = (value: QueryTypes): string =>
-    typeof value === "string" || value instanceof String
-      ? `"${value}"`
-      : `${value}`;
+    static orderAsc = (attribute: string): string =>
+        Query.addQuery("orderAsc", attribute, undefined);
+
+    static cursorAfter = (documentId: string): string =>
+        Query.addQuery("cursorAfter", undefined, documentId);
+
+    static cursorBefore = (documentId: string): string =>
+        Query.addQuery("cursorBefore", undefined, documentId);
+
+    static limit = (value: number): string =>
+        Query.addQuery("limit", undefined, value);
+
+    static offset = (value: number): string =>
+        Query.addQuery("offset", undefined, value);
+
+    private static addQuery = (oper: string, attribute: string | undefined, value: QueryTypes | undefined): string => {
+        const params: string[] = [];
+
+        if (attribute) {
+            params.push(`"${attribute}"`);
+        }
+
+        if (value) {
+            params.push(
+                `[${(value instanceof Array ? value : [value])
+                    .map((v: QueryTypesSingle) => Query.parseValues(v))
+                    .join(", ")}]`
+            );
+        }
+
+        return `${oper}(${params.join(", ")})`;
+    }
+
+    private static parseValues = (value: QueryTypes): string =>
+        typeof value === "string" || value instanceof String
+            ? `"${value}"`
+            : `${value}`;
 }

--- a/templates/deno/src/query.ts.twig
+++ b/templates/deno/src/query.ts.twig
@@ -4,61 +4,50 @@ export type QueryTypes = QueryTypesSingle | QueryTypesList;
 
 export class Query {
   static equal = (attribute: string, value: QueryTypes): string =>
-    Query.addQuery("equal", attribute, value);
+    Query.addQuery(attribute, "equal", value);
 
   static notEqual = (attribute: string, value: QueryTypes): string =>
-    Query.addQuery("notEqual", attribute, value);
+    Query.addQuery(attribute, "notEqual", value);
 
   static lesser = (attribute: string, value: QueryTypes): string =>
-    Query.addQuery("lesser", attribute, value);
+    Query.addQuery(attribute, "lesser", value);
 
   static lesserEqual = (attribute: string, value: QueryTypes): string =>
-    Query.addQuery("lesserEqual", attribute, value);
+    Query.addQuery(attribute, "lesserEqual", value);
 
   static greater = (attribute: string, value: QueryTypes): string =>
-    Query.addQuery("greater", attribute, value);
+    Query.addQuery(attribute, "greater", value);
 
   static greaterEqual = (attribute: string, value: QueryTypes): string =>
-    Query.addQuery("greaterEqual", attribute, value);
+    Query.addQuery(attribute, "greaterEqual", value);
 
   static search = (attribute: string, value: string): string =>
-    Query.addQuery("search", attribute, value);
+    Query.addQuery(attribute, "search", value);
 
   static orderDesc = (attribute: string): string =>
-    Query.addQuery("orderDesc", attribute, undefined);
+    `orderDesc("${attribute}")`;
 
   static orderAsc = (attribute: string): string =>
-    Query.addQuery("orderAsc", attribute, undefined);
+    `orderAsc("${attribute}")`;
 
   static cursorAfter = (documentId: string): string =>
-    Query.addQuery("cursorAfter", undefined, documentId);
+    `cursorAfter("${documentId}")`;
 
   static cursorBefore = (documentId: string): string =>
-    Query.addQuery("cursorBefore", undefined, documentId);
+    `cursorBefore("${documentId}")`;
 
   static limit = (value: number): string =>
-    Query.addQuery("limit", undefined, value);
+    `limit(${value})`;
 
   static offset = (value: number): string =>
-    Query.addQuery("offset", undefined, value);
+    `offset(${value})`;
 
-  private static addQuery = (oper: string, attribute: string | undefined, value: QueryTypes | undefined): string => {
-    const params: string[] = [];
-
-    if (attribute) {
-      params.push(`"${attribute}"`);
-    }
-
-    if (value) {
-      params.push(
-        `[${(value instanceof Array ? value : [value])
+  private static addQuery = (attribute: string, method: string, value: QueryTypes): string =>
+    value instanceof Array
+      ? `${method}("${attribute}", [${value
           .map((v: QueryTypesSingle) => Query.parseValues(v))
-          .join(", ")}]`
-      );
-    }
-
-    return `${oper}(${params.join(", ")})`;
-  }
+          .join(",")}])`
+      : `${method}("${attribute}", [${Query.parseValues(value)}])`;
 
   private static parseValues = (value: QueryTypes): string =>
     typeof value === "string" || value instanceof String


### PR DESCRIPTION
## What does this PR do?

Implements new query syntax into Query class helper. We went from `name.equal("Matej", "Eldad")` to `equal("name", ["Matej", "Eldad"])`.

Implemented in:

- [x] Deno

## Test Plan

WIP

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes