### PR TITLE
Change default Function ID to unique()

### DIFF
--- a/templates/cli/lib/questions.js.twig
+++ b/templates/cli/lib/questions.js.twig
@@ -160,7 +160,7 @@ const questionsInitFunction = [
     type: "input",
     name: "id",
     message: "What ID would you like to have for your function?",
-    default: "myAwesomeFunction"
+    default: "unique()"
   },
   {
     type: "list",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

When generating a function with the Appwrite CLI, it prompts for an ID, and provides myAwesomeFunction as the default. This should be unique() instead if they don't enter anything so it generates a random ID.

## Test Plan

- [x] Manual

### Before

## Related PRs and Issues

NIL

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes