### PR TITLE
Update to use flutter_web_auth_2 dependency

### DIFF
--- a/templates/flutter/lib/src/client_browser.dart.twig
+++ b/templates/flutter/lib/src/client_browser.dart.twig
@@ -1,7 +1,7 @@
 import 'dart:html' as html;
 import 'dart:math';
 import 'package:flutter/foundation.dart';
-import 'package:flutter_web_auth/flutter_web_auth.dart';
+import 'package:flutter_web_auth_2/flutter_web_auth_2.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/browser_client.dart';
 import 'client_mixin.dart';
@@ -209,7 +209,7 @@ class ClientBrowser extends ClientBase with ClientMixin {
 
   @override
   Future webAuth(Uri url) {
-  return FlutterWebAuth.authenticate(
+  return FlutterWebAuth2.authenticate(
       url: url.toString(),
       callbackUrlScheme: "appwrite-callback-" + config['project']!,
     );

--- a/templates/flutter/lib/src/client_io.dart.twig
+++ b/templates/flutter/lib/src/client_io.dart.twig
@@ -6,7 +6,7 @@ import 'package:http/http.dart' as http;
 import 'package:http/io_client.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:path_provider/path_provider.dart';
-import 'package:flutter_web_auth/flutter_web_auth.dart';
+import 'package:flutter_web_auth_2/flutter_web_auth_2.dart';
 import 'client_mixin.dart';
 import 'client_base.dart';
 import 'cookie_manager.dart';
@@ -302,7 +302,7 @@ class ClientIO extends ClientBase with ClientMixin {
 
   @override
   Future webAuth(Uri url) {
-    return FlutterWebAuth.authenticate(
+    return FlutterWebAuth2.authenticate(
       url: url.toString(),
       callbackUrlScheme: "appwrite-callback-" + config['project']!,
     ).then((value) async {

--- a/templates/flutter/pubspec.yaml.twig
+++ b/templates/flutter/pubspec.yaml.twig
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   cookie_jar: ^3.0.1
   device_info_plus: ^4.1.2
-  flutter_web_auth: ^0.4.1
+  flutter_web_auth_2: ^1.0.1
   http: ^0.13.5
   package_info_plus: ^1.4.3+1
   path_provider: ^2.0.11


### PR DESCRIPTION
## What does this PR do?

Changes the package dependency from [flutter_web_auth](https://pub.dev/packages/flutter_web_auth) to [flutter_web_auth_2](https://pub.dev/packages/flutter_web_auth_2) because the original dependency can be considered abandoned.

## Test Plan

I forked the `sdk_for_flutter` read-only repo at https://github.com/startcommerce/appwrite_flutter and tested the same changes by authenticating with GitHub OAuth in a Flutter web application.

## Related PRs and Issues

See the following issue https://github.com/appwrite/sdk-for-flutter/issues/64.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Affirmative. Will. Robinson.