### PR TITLE
Bump dependencies flutter

### DIFF
--- a/templates/flutter/pubspec.yaml.twig
+++ b/templates/flutter/pubspec.yaml.twig
@@ -13,11 +13,16 @@ dependencies:
     sdk: flutter
   cookie_jar: ^3.0.1
   device_info_plus: ^4.1.2
-  flutter_web_auth_2: ^1.0.1
+  flutter_web_auth_2: ^1.1.1
   http: ^0.13.5
   package_info_plus: ^1.4.3+1
   path_provider: ^2.0.11
   web_socket_channel: ^2.2.0
+
+# cause device_info_plus depends on 2.7.0 and flutter_web_auth_2 depends on 3.0.0, 
+# you may get version conflict error. And flutter_web_auth_2 latest version supports windows implementation
+dependency_overrides:
+  win32: '2.7.0' 
 
 dev_dependencies:
   flutter_lints: ^2.0.1

--- a/templates/flutter/pubspec.yaml.twig
+++ b/templates/flutter/pubspec.yaml.twig
@@ -19,8 +19,7 @@ dependencies:
   path_provider: ^2.0.11
   web_socket_channel: ^2.2.0
 
-# cause device_info_plus depends on 2.7.0 and flutter_web_auth_2 depends on 3.0.0, 
-# you may get version conflict error. And flutter_web_auth_2 latest version supports windows implementation
+# TODO: Remove this when device_info_plus bumps their dependency of win32 to 3.0.0
 dependency_overrides:
   win32: '2.7.0' 
 

--- a/templates/flutter/pubspec.yaml.twig
+++ b/templates/flutter/pubspec.yaml.twig
@@ -13,15 +13,12 @@ dependencies:
     sdk: flutter
   cookie_jar: ^3.0.1
   device_info_plus: ^4.1.2
-  flutter_web_auth_2: ^1.1.1
+  flutter_web_auth_2: ^1.1.2
   http: ^0.13.5
   package_info_plus: ^1.4.3+1
   path_provider: ^2.0.11
   web_socket_channel: ^2.2.0
 
-# TODO: Remove this when device_info_plus bumps their dependency of win32 to 3.0.0
-dependency_overrides:
-  win32: '2.7.0' 
 
 dev_dependencies:
   flutter_lints: ^2.0.1


### PR DESCRIPTION
## What does this PR do?
Upgrades [`flutter_web_auth_2`](https://pub.dev/packages/flutter_web_auth_2) dependencies to latest version. The latest version of the plugin supports windows implementation.

## Test Plan

N/A

## Related PRs and Issues

See PR [#7](https://github.com/ThexXTURBOXx/flutter_web_auth_2/issues/7) of [flutter_web_auth](https://github.com/ThexXTURBOXx/flutter_web_auth_2/)


### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
Yes😄
