### PR TITLE
Fix PHP param syntax

### DIFF
--- a/src/SDK/Language/PHP.php
+++ b/src/SDK/Language/PHP.php
@@ -238,7 +238,8 @@ class PHP extends Language {
     {
         switch ($parameter['type']) {
             case self::TYPE_STRING:
-                return 'string';
+                $type = 'string';
+                break;
             case self::TYPE_BOOLEAN:
                 $type = 'bool';
                 break;

--- a/tests/resources/spec.json
+++ b/tests/resources/spec.json
@@ -15,7 +15,7 @@
       "url": "https://raw.githubusercontent.com/appwrite/appwrite/master/LICENSE"
     }
   },
-  "host": "appwrite.io",
+  "host": "8080-appwrite-appwrite-9sq3uhpjmvx.ws-eu63.gitpod.io",
   "basePath": "/v1",
   "schemes": ["https"],
   "consumes": ["application/json", "multipart/form-data"],

--- a/tests/resources/spec.json
+++ b/tests/resources/spec.json
@@ -15,7 +15,7 @@
       "url": "https://raw.githubusercontent.com/appwrite/appwrite/master/LICENSE"
     }
   },
-  "host": "8080-appwrite-appwrite-9sq3uhpjmvx.ws-eu63.gitpod.io",
+  "host": "appwrite.io",
   "basePath": "/v1",
   "schemes": ["https"],
   "consumes": ["application/json", "multipart/form-data"],


### PR DESCRIPTION
## What does this PR do?

Before:

```php
public function list(string$search = null, int $limit = null, int $offset = null, string$cursor = null, string$cursorDirection = null, string$orderType = null): array
```

> Syntax errors

After:

```php
public function list(string $search = null, int $limit = null, int $offset = null, string $cursor = null, string $cursorDirection = null, string $orderType = null): array
```

## Test Plan

- [x] Run example.php, visual check

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes