### PR TITLE
Fix: CLI: Missing permissions after deploy

### DIFF
--- a/templates/cli/lib/commands/deploy.js.twig
+++ b/templates/cli/lib/commands/deploy.js.twig
@@ -505,7 +505,7 @@ const deployCollection = async ({ all } = {}) => {
                     collectionId: collection['$id'],
                     name: collection.name,
                     documentSecurity: collection.documentSecurity,
-                    '$permissions': collection['$permissions'],
+                    permissions: collection['$permissions'],
                     parseOutput: false
                 })
 


### PR DESCRIPTION
## What does this PR do?

After running `appwrite deploy collection`, all is created but collection does not have permissions (collection-level). This PR fixes it.

## Test Plan

None

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes