### PR TITLE
Fix: Node exception types

### DIFF
--- a/templates/deno/mod.ts.twig
+++ b/templates/deno/mod.ts.twig
@@ -4,7 +4,7 @@ import { Permission } from "./src/permission.ts";
 import { Role } from "./src/role.ts";
 import { ID } from "./src/id.ts";
 import { InputFile } from "./src/inputFile.ts";
-import { {{spec.title | caseUcfirst}}Exception } from "./src/exception.ts";
+import { {{spec.title | caseUcfirst}}Exception, {{spec.title | caseUcfirst}}ExceptionResponse } from "./src/exception.ts";
 {% for service in spec.services %}
 import { {{service.name | caseUcfirst}} } from "./src/services/{{service.name | caseDash}}.ts";
 {% endfor %}
@@ -17,6 +17,7 @@ export {
     ID,
     InputFile,
     {{spec.title | caseUcfirst}}Exception,
+    type {{spec.title | caseUcfirst}}ExceptionResponse,
 {% for service in spec.services %}
     {{service.name | caseUcfirst}},
 {% endfor %}

--- a/templates/deno/src/exception.ts.twig
+++ b/templates/deno/src/exception.ts.twig
@@ -1,10 +1,19 @@
-export class {{ spec.title | caseUcfirst}}Exception {
+export type {{spec.title | caseUcfirst}}ExceptionResponse = {
+    message: string;
+    code: number;
+    type: string;
+    version: string;
+};
+
+export class {{ spec.title | caseUcfirst}}Exception extends Error {
     message: String;
     code: Number;
-    response: any;
+    response?: {{spec.title | caseUcfirst}}ExceptionResponse;
     type: String;
 
-    constructor(message: String, code: Number = 0, type: String = "", response: any = "") {
+    constructor(message: String, code: Number = 0, type: String = "", response?: {{spec.title | caseUcfirst}}ExceptionResponse) {
+        super(message);
+        this.name = '{{spec.title | caseUcfirst}}Exception';
         this.message = message;
         this.code = code;
         this.type = type;

--- a/templates/node/index.d.ts.twig
+++ b/templates/node/index.d.ts.twig
@@ -125,9 +125,9 @@ declare module "{{ language.params.npmPackage|caseDash }}" {
   export class {{spec.title | caseUcfirst}}Exception extends Error {
     public code: number;
     public type: string;
-    public response: {{spec.title | caseUcfirst}}ExceptionResponse;
+    public response?: {{spec.title | caseUcfirst}}ExceptionResponse;
 
-    constructor(message: string, code?: number, type?: string, response?: {{spec.title | caseUcfirst}}ExceptionResponse);
+    constructor(message: string, code: number = 0, type: string = '', response?: {{spec.title | caseUcfirst}}ExceptionResponse);
   }
 
   export class Service {

--- a/templates/node/index.d.ts.twig
+++ b/templates/node/index.d.ts.twig
@@ -115,10 +115,19 @@ declare module "{{ language.params.npmPackage|caseDash }}" {
 {% endfor %}
   }
 
-  export class AppwriteException extends Error {
-    public code: number | null;
-    public response: string | null;
-    constructor(message: string, code?: number, response?: string);
+  export type {{spec.title | caseUcfirst}}ExceptionResponse = {
+        message: string;
+        code: number;
+        type: string;
+        version: string;
+  };
+
+  export class {{spec.title | caseUcfirst}}Exception extends Error {
+    public code: number;
+    public type: string;
+    public response: {{spec.title | caseUcfirst}}ExceptionResponse;
+
+    constructor(message: string, code?: number, type?: string, response?: {{spec.title | caseUcfirst}}ExceptionResponse);
   }
 
   export class Service {

--- a/templates/node/lib/client.js.twig
+++ b/templates/node/lib/client.js.twig
@@ -134,7 +134,7 @@ class Client {
                         throw new {{spec.title | caseUcfirst}}Exception(error.response.data.message, error.response.status, error.response.data.type, error.response.data);
                     }
                 } else {
-                    throw new {{spec.title | caseUcfirst}}Exception(error.response.statusText, error.response.status, error.response.data);
+                    throw new {{spec.title | caseUcfirst}}Exception(error.response.statusText, error.response.status, '', error.response.data);
                 }
             } else {
                 throw new {{spec.title | caseUcfirst}}Exception(error.message);

--- a/templates/node/lib/exception.js.twig
+++ b/templates/node/lib/exception.js.twig
@@ -1,6 +1,8 @@
 class {{spec.title | caseUcfirst}}Exception extends Error {
   constructor(message, code, type, response) {
     super(message);
+    this.name = '{{spec.title | caseUcfirst}}Exception';
+    this.message = message;
     this.code = code;
     this.type = type;
     this.response = response;

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -76,11 +76,19 @@ export type UploadProgress = {
     chunksUploaded: number;
 }
 
+export type {{spec.title | caseUcfirst}}ExceptionResponse = {
+    message: string;
+    code: number;
+    type: string;
+    version: string;
+};
+
 class {{spec.title | caseUcfirst}}Exception extends Error {
     code: number;
-    response: string;
+    response?: {{spec.title | caseUcfirst}}ExceptionResponse;
     type: string;
-    constructor(message: string, code: number = 0, type: string = '', response: string = '') {
+
+    constructor(message: string, code: number = 0, type: string = '', response?: {{spec.title | caseUcfirst}}ExceptionResponse) {
         super(message);
         this.name = '{{spec.title | caseUcfirst}}Exception';
         this.message = message;


### PR DESCRIPTION
## What does this PR do?

Type definitions in Node were not in sync with actual functionality regarding exceptions.

## Test Plan

- [x] Manual QA

<img width="720" alt="CleanShot 2022-09-19 at 08 06 21@2x" src="https://user-images.githubusercontent.com/19310830/190958193-8b784bc7-6a58-43ff-b179-665d23e26b4b.png">
<img width="783" alt="CleanShot 2022-09-19 at 08 06 34@2x" src="https://user-images.githubusercontent.com/19310830/190958201-6a5a4efa-40c1-4f0b-80e8-c9c13b108464.png">



## Related PRs and Issues

- https://github.com/appwrite/sdk-for-node/issues/46

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes 😊