### PR TITLE
Remove redundant status role method

### DIFF
--- a/templates/android/library/src/main/java/io/appwrite/Role.kt.twig
+++ b/templates/android/library/src/main/java/io/appwrite/Role.kt.twig
@@ -25,7 +25,5 @@ class Role {
         }
 
         fun member(id: String): String = "member:$id"
-
-        fun status(status: String): String = "status:$status"
     }
 }

--- a/templates/dart/lib/role.dart.twig
+++ b/templates/dart/lib/role.dart.twig
@@ -33,8 +33,4 @@ class Role {
     static String member(String id) {
         return 'member:$id';
     }
-    
-    static String status(String status) {
-        return 'status:$status';
-    }
 }

--- a/templates/deno/src/role.ts.twig
+++ b/templates/deno/src/role.ts.twig
@@ -31,8 +31,4 @@ export class Role {
     public static member(id: string): string {
         return `member:${id}`
     }
-    
-    public static status(status: string): string {
-        return `status:${status}`
-    }
 }

--- a/templates/kotlin/src/main/kotlin/io/appwrite/Role.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/Role.kt.twig
@@ -25,7 +25,5 @@ class Role {
         }
 
         fun member(id: String): String = "member:$id"
-
-        fun status(status: String): String = "status:$status"
     }
 }

--- a/templates/node/lib/role.js.twig
+++ b/templates/node/lib/role.js.twig
@@ -26,9 +26,6 @@ class Role {
     static member = (id) => {
         return 'member:' + id
     }
-    static status = (status) => {
-        return 'status:' + status
-    }
 }
 
 module.exports = Role;

--- a/templates/php/src/Role.php.twig
+++ b/templates/php/src/Role.php.twig
@@ -37,8 +37,4 @@ class Role
     {
         return "member:$id";
     }
-    public static function status(string $status): string
-    {
-        return "status:$status";
-    }
 }

--- a/templates/python/package/role.py.twig
+++ b/templates/python/package/role.py.twig
@@ -28,7 +28,3 @@ class Role:
     @staticmethod
     def member(id):
         return f'member:{id}'
-
-    @staticmethod
-    def status(status):
-        return f'status:{status}'

--- a/templates/ruby/lib/container/role.rb.twig
+++ b/templates/ruby/lib/container/role.rb.twig
@@ -35,9 +35,5 @@ module {{spec.title | caseUcfirst}}
         def self.member(id)
             "member:#{id}"
         end
-        
-        def self.status(status)
-            "status:#{status}"
-        end
     end
 end

--- a/templates/swift/Sources/Role.swift.twig
+++ b/templates/swift/Sources/Role.swift.twig
@@ -31,8 +31,4 @@ public class Role {
     public static func member(_ id: String) -> String {
         return "member:\(id)"
     }
-
-    public static func status(_ status: String) -> String {
-        return "status:\(status)"
-    }
 }

--- a/templates/web/src/role.ts.twig
+++ b/templates/web/src/role.ts.twig
@@ -31,8 +31,4 @@ export class Role {
     public static member(id: string): string {
         return `member:${id}`
     }
-    
-    public static status(status: string): string {
-        return `status:${status}`
-    }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Remove the `status` role method as this functionality is part of the `user` and `users` roles

## Test Plan

Existing tests

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes