### PR TITLE
Feat: CLI teams init&deploy

### DIFF
--- a/templates/cli/lib/commands/deploy.js.twig
+++ b/templates/cli/lib/commands/deploy.js.twig
@@ -611,7 +611,7 @@ const deployTeam = async ({ all, yes } = {}) => {
         teamIds.push(...configTeams.map((t) => t.$id));
     }
 
-    if(teamIds.length <= 0) {
+    if(teamIds.length === 0) {
         let answers = await inquirer.prompt(questionsDeployTeams[0])
         teamIds.push(...answers.teams);
     }

--- a/templates/cli/lib/commands/deploy.js.twig
+++ b/templates/cli/lib/commands/deploy.js.twig
@@ -2,7 +2,7 @@ const inquirer = require("inquirer");
 const JSONbig = require("json-bigint")({ storeAsString: false });
 const { Command } = require("commander");
 const { localConfig } = require("../config");
-const { questionsDeployFunctions, questionsGetEntrypoint, questionsDeployCollections, questionsConfirmDeployCollections } = require("../questions");
+const { questionsDeployTeams, questionsDeployFunctions, questionsGetEntrypoint, questionsDeployCollections, questionsConfirmDeployCollections } = require("../questions");
 const { actionRunner, success, log, error, commandDescriptions } = require("../parser");
 const { functionsGet, functionsCreate, functionsUpdate, functionsCreateDeployment, functionsUpdateDeployment, functionsListVariables, functionsDeleteVariable, functionsCreateVariable } = require('./functions');
 const {
@@ -25,6 +25,11 @@ const {
     databasesListIndexes,
     databasesDeleteIndex
 } = require("./databases");
+const {
+    teamsGet,
+    teamsUpdate,
+    teamsCreate
+} = require("./teams");
 
 const POOL_DEBOUNCE = 2000; // in milliseconds
 const POOL_MAX_DEBOUNCES = 30;
@@ -593,6 +598,76 @@ const deployCollection = async ({ all, yes } = {}) => {
     }
 }
 
+const deployTeam = async ({ all, yes } = {}) => {
+    let response = {};
+
+    let teamIds = [];
+    const configTeams = localConfig.getTeams();
+
+    if(all) {
+        if (configTeams.length === 0) {
+            throw new Error("No teams found in the current directory. Run `appwrite init team` to fetch all your teams.");
+        }
+        teamIds.push(...configTeams.map((t) => t.$id));
+    }
+
+    if(teamIds.length <= 0) {
+        let answers = await inquirer.prompt(questionsDeployTeams[0])
+        teamIds.push(...answers.teams);
+    }
+
+    let teams = [];
+
+    for(const teamId of teamIds) {
+        const idTeams = configTeams.filter((t) => t.$id === teamId);
+        teams.push(...idTeams);
+    }
+
+    for (let team of teams) {
+        log(`Deploying team ${team.name} ( ${team['$id']} )`)
+
+        try {
+            response = await teamsGet({
+                teamId: team['$id'],
+                parseOutput: false,
+            })
+            log(`Team ${team.name} ( ${team['$id']} ) already exists.`);
+
+            if(!yes) {
+                answers = await inquirer.prompt(questionsDeployTeams[1])
+                if (answers.override !== "YES") {
+                    log(`Received "${answers.override}". Skipping ${team.name} ( ${team['$id']} )`);
+                    continue;
+                }
+            }
+
+            log(`Updating team ...`)
+
+            await teamsUpdate({
+                teamId: team['$id'],
+                name: team.name,
+                parseOutput: false
+            });
+
+            success(`Deployed ${team.name} ( ${team['$id']} )`);
+        } catch (e) {
+            if (e.code == 404) {
+                log(`Team ${team.name} does not exist in the project. Creating ... `);
+
+                response = await teamsCreate({
+                    teamId: team['$id'],
+                    name: team.name,
+                    parseOutput: false
+                })
+
+                success(`Deployed ${team.name} ( ${team['$id']} )`);
+            } else {
+                throw e;
+            }
+        }
+    }
+}
+
 deploy
     .command("function")
     .description("Deploy functions in the current directory.")
@@ -607,6 +682,13 @@ deploy
     .option(`--all`, `Flag to deploy all functions`)
     .option(`--yes`, `Flag to confirm all warnings`)
     .action(actionRunner(deployCollection));
+
+deploy
+    .command("team")
+    .description("Deploy teams in the current project.")
+    .option(`--all`, `Flag to deploy all teams`)
+    .option(`--yes`, `Flag to confirm all warnings`)
+    .action(actionRunner(deployTeam));
 
 module.exports = {
     deploy

--- a/templates/cli/lib/commands/init.js.twig
+++ b/templates/cli/lib/commands/init.js.twig
@@ -3,7 +3,7 @@ const path = require("path");
 const childProcess = require('child_process');
 const { Command } = require("commander");
 const inquirer = require("inquirer");
-const { teamsCreate } = require("./teams");
+const { teamsCreate, teamsList } = require("./teams");
 const { projectsCreate } = require("./projects");
 const { functionsCreate } = require("./functions");
 const { databasesListCollections, databasesList } = require("./databases");
@@ -186,6 +186,24 @@ const initCollection = async ({ all, databaseId } = {}) => {
   success();
 }
 
+const initTeam = async () => {
+  // TODO: Pagination?
+  let response = await teamsList({
+    queries: [ 'limit(100)' ],
+    parseOutput: false
+  })
+
+  let teams = response.teams;
+  log(`Found ${teams.length} teams`);
+
+  teams.forEach(async team => {
+    log(`Fetching ${team.name} ...`);
+    localConfig.addTeam(team);
+  });
+
+  success();
+}
+
 init
   .command("project")
   .description("Initialise your {{ spec.title|caseUcfirst }} project")
@@ -202,6 +220,11 @@ init
   .option(`--databaseId <databaseId>`, `Database ID`)
   .option(`--all`, `Flag to initialize all databases`)
   .action(actionRunner(initCollection))
+
+init
+  .command("team")
+  .description("Initialise your Appwrite teams")
+  .action(actionRunner(initTeam))
 
 module.exports = {
   init,

--- a/templates/cli/lib/config.js.twig
+++ b/templates/cli/lib/config.js.twig
@@ -166,6 +166,45 @@ class Local extends Config {
         this.set("collections", collections);
     }
 
+    getTeams() {
+        if (!this.has("teams")) {
+            return [];
+        }
+        return this.get("teams");
+    }
+
+    getTeam($id) {
+        if (!this.has("teams")) {
+            return {};
+        }
+
+        let teams = this.get("teams");
+        for (let i = 0; i < teams.length; i++) {
+            if (teams[i]['$id'] == $id) {
+                return teams[i];
+            }
+        }
+
+        return {};
+    }
+    
+    addTeam(props) {
+        if (!this.has("teams")) {
+            this.set("teams", []);
+        }
+
+        let teams = this.get("teams");
+        for (let i = 0; i < teams.length; i++) {
+            if (teams[i]['$id'] == props['$id']) {
+                teams[i] = props;
+                this.set("teams", teams);
+                return;
+            }
+        }
+        teams.push(props);
+        this.set("teams", teams);
+    }
+
     getProject() {
         if (!this.has("projectId") || !this.has("projectName")) {
             return {};

--- a/templates/cli/lib/questions.js.twig
+++ b/templates/cli/lib/questions.js.twig
@@ -300,6 +300,32 @@ const questionsGetEntrypoint = [
   },
 ]
 
+const questionsDeployTeams = [
+  {
+    type: "checkbox",
+    name: "teams",
+    message: "Which teams would you like to deploy?",
+    choices: () => {
+      let teams = localConfig.getTeams();
+      if (teams.length === 0) {
+        throw new Error("No teams found in the current directory. Run `appwrite init team` to fetch all your teams.");
+      }
+      let choices = teams.map((team, idx) => {
+        return {
+          name: `${team.name} (${team['$id']})`,
+          value: team.$id
+        }
+      })
+      return choices;
+    }
+  },
+  {
+    type: "input",
+    name: "override",
+    message: 'Are you sure you want to override this team? This can lead to loss of data! Type "YES" to confirm.'
+  },
+]
+
 module.exports = {
   questionsInitProject,
   questionsLogin,
@@ -307,5 +333,6 @@ module.exports = {
   questionsInitCollection,
   questionsDeployFunctions,
   questionsDeployCollections,
+  questionsDeployTeams,
   questionsGetEntrypoint
 };


### PR DESCRIPTION
## What does this PR do?

As implemented by init&deploy collection, this PR adds the same logic for teams. It' common practice to have a predefined structure of teams (mods/admins/...), just like it's common for databases. Since appwrite.json is supposed to be a source of truth for initial setup of Appwrite project, it should include structure of teams.

This PR gets us one small step closer to "Deploy to Appwrite" 1-click setup.

## Test Plan

- [x] Manual QA

https://user-images.githubusercontent.com/19310830/193421101-6c296c12-ab48-45e3-80de-63f68bd91b6c.mp4

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes