### PR TITLE
Feat: CLI settings init&deploy

### DIFF
--- a/templates/cli/lib/commands/deploy.js.twig
+++ b/templates/cli/lib/commands/deploy.js.twig
@@ -2,7 +2,7 @@ const inquirer = require("inquirer");
 const JSONbig = require("json-bigint")({ storeAsString: false });
 const { Command } = require("commander");
 const { localConfig } = require("../config");
-const { questionsDeployFunctions, questionsGetEntrypoint, questionsDeployCollections, questionsConfirmDeployCollections } = require("../questions");
+const { questionsDeploySettings, questionsDeployFunctions, questionsGetEntrypoint, questionsDeployCollections, questionsConfirmDeployCollections } = require("../questions");
 const { actionRunner, success, log, error, commandDescriptions } = require("../parser");
 const { functionsGet, functionsCreate, functionsUpdate, functionsCreateDeployment, functionsUpdateDeployment, functionsListVariables, functionsDeleteVariable, functionsCreateVariable } = require('./functions');
 const {
@@ -25,6 +25,12 @@ const {
     databasesListIndexes,
     databasesDeleteIndex
 } = require("./databases");
+const {
+    projectsUpdateAuthLimit,
+    projectsUpdateServiceStatus,
+    projectsUpdateAuthStatus
+} = require("./projects");
+
 
 const POOL_DEBOUNCE = 2000; // in milliseconds
 const POOL_MAX_DEBOUNCES = 30;
@@ -593,6 +599,80 @@ const deployCollection = async ({ all, yes } = {}) => {
     }
 }
 
+const deploySettings = async ({ yes } = {}) => {
+    const project = localConfig.getProject();
+  
+    if(!project.projectId) {
+      throw new Error("Project is not set. Please run `appwrite init project` to initialize the current directory with an Appwrite project.");
+    }
+
+    const settings = localConfig.getSettings();
+
+    if(Object.keys(settings).length <= 0) {
+        error(`Settings not found in the current directory. Skipping ...`);
+    }
+
+    if(!yes) {
+        answers = await inquirer.prompt(questionsDeploySettings[0])
+        if (answers.override !== "YES") {
+            log(`Received "${answers.override}". Skipping ...`);
+            return;
+        }
+    }
+
+    log(`Deploying settings ...`)
+
+    await projectsUpdateAuthLimit({
+        projectId: project.projectId,
+        limit: settings.authLimit,
+        parseOutput: false,
+    });
+
+    for(const key in settings) {
+        if(!key.startsWith('service')) {
+            continue;
+        }
+
+        const service = key.slice(7 + 6 + 3).toLowerCase(); // 7+6+3 chars = Remove 'serviceStatusFor' prefix
+        const status = settings[key];
+
+        await projectsUpdateServiceStatus({
+            projectId: project.projectId,
+            service,
+            status,
+            parseOutput: false,
+        })
+    }
+
+    // From appwrite/appwrite, app/config/auth.php
+    const methods = {
+        EmailPassword: 'email-password',
+        UsersAuthMagicURL: 'magic-url',
+        Anonymous: 'anonymous',
+        Invites: 'invites',
+        JWT: 'jwt',
+        Phone: 'phone'
+    }
+
+    for(const key in settings) {
+        if(!key.startsWith('auth') || key === 'authLimit') {
+            continue;
+        }
+
+        const method = methods[key.slice(4)]; // 4 chars = Remove 'auth' prefix
+        const status = settings[key];
+
+        await projectsUpdateAuthStatus({
+            projectId: project.projectId,
+            method,
+            status,
+            parseOutput: false,
+        })
+    }
+
+    success(`Deployed settings`);
+}
+
 deploy
     .command("function")
     .description("Deploy functions in the current directory.")
@@ -607,6 +687,12 @@ deploy
     .option(`--all`, `Flag to deploy all functions`)
     .option(`--yes`, `Flag to confirm all warnings`)
     .action(actionRunner(deployCollection));
+
+deploy
+    .command("settings")
+    .description("Deploy settings of the current project.")
+    .option(`--yes`, `Flag to confirm all warnings`)
+    .action(actionRunner(deploySettings));
 
 module.exports = {
     deploy

--- a/templates/cli/lib/commands/init.js.twig
+++ b/templates/cli/lib/commands/init.js.twig
@@ -4,7 +4,7 @@ const childProcess = require('child_process');
 const { Command } = require("commander");
 const inquirer = require("inquirer");
 const { teamsCreate } = require("./teams");
-const { projectsCreate } = require("./projects");
+const { projectsCreate, projectsGet } = require("./projects");
 const { functionsCreate } = require("./functions");
 const { databasesListCollections, databasesList } = require("./databases");
 const { sdkForConsole } = require("../sdks");
@@ -186,6 +186,33 @@ const initCollection = async ({ all, databaseId } = {}) => {
   success();
 }
 
+const initSettings = async () => {
+  const project = localConfig.getProject();
+  
+  if(!project.projectId) {
+    throw new Error("Project is not set. Please run `appwrite init project` to initialize the current directory with an Appwrite project.");
+  }
+
+  log(`Fetching settings ...`);
+
+  let response = await projectsGet({
+    projectId: project.projectId,
+    parseOutput: false
+  })
+
+  const settings = {};
+
+  for(const key in response) {
+    if(key.startsWith('auth') || key.startsWith('service')) {
+      settings[key] = response[key];
+    }
+  }
+
+  localConfig.setSettings(settings);
+
+  success();
+}
+
 init
   .command("project")
   .description("Initialise your {{ spec.title|caseUcfirst }} project")
@@ -202,6 +229,11 @@ init
   .option(`--databaseId <databaseId>`, `Database ID`)
   .option(`--all`, `Flag to initialize all databases`)
   .action(actionRunner(initCollection))
+
+init
+  .command("settings")
+  .description("Initialise your Appwrite project settings")
+  .action(actionRunner(initSettings));
 
 module.exports = {
   init,

--- a/templates/cli/lib/config.js.twig
+++ b/templates/cli/lib/config.js.twig
@@ -166,6 +166,17 @@ class Local extends Config {
         this.set("collections", collections);
     }
 
+    getSettings() {
+        if (!this.has("settings")) {
+            return {};
+        }
+        return this.get("settings");
+    }
+
+    setSettings(settings) {
+        this.set("settings", settings);
+    }
+
     getProject() {
         if (!this.has("projectId") || !this.has("projectName")) {
             return {};

--- a/templates/cli/lib/questions.js.twig
+++ b/templates/cli/lib/questions.js.twig
@@ -300,6 +300,14 @@ const questionsGetEntrypoint = [
   },
 ]
 
+const questionsDeploySettings = [
+  {
+    type: "input",
+    name: "override",
+    message: 'Are you sure you want to override this project settings? This can lead to loss of data! Type "YES" to confirm.'
+  },
+]
+
 module.exports = {
   questionsInitProject,
   questionsLogin,
@@ -307,5 +315,6 @@ module.exports = {
   questionsInitCollection,
   questionsDeployFunctions,
   questionsDeployCollections,
+  questionsDeploySettings,
   questionsGetEntrypoint
 };


### PR DESCRIPTION
## What does this PR do?

As implemented by init&deploy collection, this PR adds the same logic for project settings. It' common practice to have a predefined structure of a project (enabled services, auth methods, users limit), just like it's common for databases. Since appwrite.json is supposed to be a source of truth for initial setup of Appwrite project, it should project settings.

This PR gets us one small step closer to "Deploy to Appwrite" 1-click setup.

Settings include:
- Max users limit
- Status (enabled/disabled) of auth methods (not OAuth)
- Status (enabled/disabled) of project services

## Test Plan

- [x] Manual QA

https://user-images.githubusercontent.com/19310830/193423232-575a8d9a-4522-4340-85ea-46a788c4d0fc.mp4

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes