### PR TITLE
Upgrade device_info_plus for Flutter

### DIFF
--- a/templates/flutter/pubspec.yaml.twig
+++ b/templates/flutter/pubspec.yaml.twig
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   cookie_jar: ^3.0.1
-  device_info_plus: ^4.1.2
+  device_info_plus: ^5.0.5
   flutter_web_auth_2: ^1.1.2
   http: ^0.13.5
   package_info_plus: ^1.4.3+1


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

It upgrades the `device_info_plus` dependency for Flutter.

Since the major version was updated, apps can't use `appwrite` together with the latest version of `device_info_plus` at the moment (at least not without`dependency_overrides`).

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes