### PR TITLE
Fix the `InputFIle.fromBlob` method in NodeJS SDK

### DIFF
--- a/templates/node/lib/inputFile.js.twig
+++ b/templates/node/lib/inputFile.js.twig
@@ -21,8 +21,12 @@ class InputFile {
 
   static fromBlob = async (blob, filename) => {
     const buffer = await blob.arrayBuffer();
-    const stream = Readable.from(buffer.toString());
-    const size = Buffer.byteLength(buffer);
+    const stream = new Readable({
+      read() {
+        this.push(buffer);
+        this.push(null);
+      }
+    });
     return new InputFile(stream, filename);
   };
 

--- a/templates/node/lib/inputFile.js.twig
+++ b/templates/node/lib/inputFile.js.twig
@@ -19,8 +19,8 @@ class InputFile {
     return new InputFile(stream, filename, size);
   };
 
-  static fromBlob = (blob, filename) => {
-    const buffer = blob.arrayBuffer();
+  static fromBlob = async (blob, filename) => {
+    const buffer = await blob.arrayBuffer();
     const stream = Readable.from(buffer.toString());
     const size = Buffer.byteLength(buffer);
     return new InputFile(stream, filename);


### PR DESCRIPTION
## What does this PR do?

This PR awaits the `blob.arrayBuffer()` function in the `InputFile.fromBlob` method, as a result, making `fromBlob` async. This is required because the `blob.arrayBuffer()` returns `Promise<ArrayBuffer>` instead of just `ArrayBuffer`, which will cause a type error when it is used without `await`.

Here's the error screenshot:
![The error reads "The "string" argument must be of type string or an instance of Buffer or ArrayBuffer. Received an instance of Promise"](https://user-images.githubusercontent.com/52203828/197436592-63a8ceea-aac5-4da4-b953-0a334d7876f3.png)

> The "string" argument must be of type string or an instance of Buffer or ArrayBuffer. Received an instance of Promise

I also suggest making other `InputFile` methods async so there will be no difference in calling this one and the others.

## Test Plan

I have not written any tests, seeing as there aren't any tests for `fromBlob` to begin with.

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes