### PR TITLE
Fix Xcode 14 hang risk warnings

### DIFF
--- a/templates/swift/Sources/Services/Service.swift.twig
+++ b/templates/swift/Sources/Services/Service.swift.twig
@@ -31,7 +31,7 @@ open class {{ service.name | caseUcfirst }}: Service {
         {%~ if 'multipart/form-data' in method.consumes %}
         onProgress: ((UploadProgress) -> Void)? = nil
         {%~ endif %}
-    ) async throws -> {{ method | returnType(spec) | raw }} {
+    ){%~ if not method.type == "webAuth" %} async{% endif %} throws -> {{ method | returnType(spec) | raw }} {
         {{~ include('swift/base/params.twig') }}
         {%~ if method.type == 'webAuth' %}
         {{~ include('swift/base/requests/OAuth.twig') }}
@@ -109,4 +109,4 @@ open class {{ service.name | caseUcfirst }}: Service {
 
 {% endfor %}
 
-}
+%}

--- a/templates/swift/Sources/Services/Service.swift.twig
+++ b/templates/swift/Sources/Services/Service.swift.twig
@@ -31,7 +31,7 @@ open class {{ service.name | caseUcfirst }}: Service {
         {%~ if 'multipart/form-data' in method.consumes %}
         onProgress: ((UploadProgress) -> Void)? = nil
         {%~ endif %}
-    ){%~ if not method.type == "webAuth" %} async{% endif %} throws -> {{ method | returnType(spec) | raw }} {
+    ){%~ if method.type != "webAuth" %} async{% endif %} throws -> {{ method | returnType(spec) | raw }} {
         {{~ include('swift/base/params.twig') }}
         {%~ if method.type == 'webAuth' %}
         {{~ include('swift/base/requests/OAuth.twig') }}
@@ -109,4 +109,4 @@ open class {{ service.name | caseUcfirst }}: Service {
 
 {% endfor %}
 
-%}
+}

--- a/tests/AppleSwift55Test.php
+++ b/tests/AppleSwift55Test.php
@@ -26,7 +26,7 @@ class AppleSwift55Test extends Base
         ...Base::LARGE_FILE_RESPONSES,
         ...Base::LARGE_FILE_RESPONSES,
         ...Base::EXCEPTION_RESPONSES,
-        //...Base::REALTIME_RESPONSES,
+        ...Base::REALTIME_RESPONSES,
         ...Base::COOKIE_RESPONSES,
         ...Base::QUERY_HELPER_RESPONSES,
         ...Base::PERMISSION_HELPER_RESPONSES,

--- a/tests/languages/apple/Tests.swift
+++ b/tests/languages/apple/Tests.swift
@@ -31,12 +31,12 @@ class Tests: XCTestCase {
         let realtime = Realtime(client)
         var realtimeResponse = "Realtime failed!"
 
-//         let expectation = XCTestExpectation(description: "realtime server")
-//
-//         realtime.subscribe(channels: ["tests"]) { message in
-//             realtimeResponse = message.payload!["response"] as! String
-//             expectation.fulfill()
-//         }
+        let expectation = XCTestExpectation(description: "realtime server")
+
+        realtime.subscribe(channels: ["tests"]) { message in
+            realtimeResponse = message.payload!["response"] as! String
+            expectation.fulfill()
+        }
         
         var mock: Mock
 
@@ -132,8 +132,8 @@ class Tests: XCTestCase {
             print(error.localizedDescription)
         }
 
-//         wait(for: [expectation], timeout: 10.0)
-//         print(realtimeResponse)
+        wait(for: [expectation], timeout: 10.0)
+        print(realtimeResponse)
 
         mock = try await general.setCookie()
         print(mock.result)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes "hang risk" warnings for realtime in Xcode 14: `Thread running at QOS_CLASS_USER_INTERACTIVE waiting on a lower QoS thread running at QOS_CLASS_DEFAULT. Investigate ways to avoid priority inversions`

- Move thread event loop group creation to a background thread
- Remove blocking wait for channel upgrade
- Remove async from webauth methods

## Test Plan

Manual test

## Related PRs and Issues

Related https://github.com/appwrite/sdk-for-apple/issues/24

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes