### PR TITLE
fix-flutter-oauth2-under-windows

### DIFF
--- a/templates/flutter/base/requests/oauth.twig
+++ b/templates/flutter/base/requests/oauth.twig
@@ -31,4 +31,4 @@
           query: query.join('&')
         );
 
-      return client.webAuth(url);
+      return client.webAuth(url, callbackUrlScheme: success);

--- a/templates/flutter/lib/src/client.dart.twig
+++ b/templates/flutter/lib/src/client.dart.twig
@@ -19,7 +19,7 @@ abstract class Client {
           bool selfSigned = false}) =>
       createClient(endPoint: endPoint, selfSigned: selfSigned);
 
-  Future webAuth(Uri url);
+  Future webAuth(Uri url, {String? callbackUrlScheme});
 
   Future<Response> chunkedUpload({
     required String path,

--- a/templates/flutter/lib/src/client_browser.dart.twig
+++ b/templates/flutter/lib/src/client_browser.dart.twig
@@ -211,10 +211,10 @@ class ClientBrowser extends ClientBase with ClientMixin {
   }
 
   @override
-  Future webAuth(Uri url) {
+  Future webAuth(Uri url, {String? callbackUrlScheme}) {
   return FlutterWebAuth2.authenticate(
       url: url.toString(),
-      callbackUrlScheme: "appwrite-callback-" + config['project']!,
+      callbackUrlScheme: callbackUrlScheme ?? "appwrite-callback-" + config['project']!,
     );
   }
 }

--- a/templates/flutter/lib/src/client_io.dart.twig
+++ b/templates/flutter/lib/src/client_io.dart.twig
@@ -304,10 +304,10 @@ class ClientIO extends ClientBase with ClientMixin {
   }
 
   @override
-  Future webAuth(Uri url) {
+  Future webAuth(Uri url, {String? callbackUrlScheme}) {
     return FlutterWebAuth2.authenticate(
       url: url.toString(),
-      callbackUrlScheme: "appwrite-callback-" + config['project']!,
+      callbackUrlScheme: callbackUrlScheme != null && Platform.isWindows ? callbackUrlScheme : "appwrite-callback-" + config['project']!,
     ).then((value) async {
       Uri url = Uri.parse(value);
       final key = url.queryParameters['key'];


### PR DESCRIPTION
## What does this PR do?

It fixes the broken createOAuth2Session under windows in the flutter sdk. This is discussed in detail here https://github.com/appwrite/sdk-for-flutter/issues/96. 

## Test Plan

Create a minimal APP with the flutter SDK and try to sign in with OAuth2.
The success URL must look something like this
http://localhost:{free_windows_port}/v1/auth/oauth2/success

## Related PRs and Issues
[96](https://github.com/appwrite/sdk-for-flutter/issues/96)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

YES