### PR TITLE
Make sure attributes with $ use _ instead in GraphQL examples

### DIFF
--- a/templates/graphql/docs/example.md.twig
+++ b/templates/graphql/docs/example.md.twig
@@ -58,7 +58,7 @@ mutation {
         {%~ for definition in spec.definitions %}
         {%~ if definition.name == method.responseModel %}
         {%~ for property in definition.properties | filter(p => p.required) %}
-        {{ property.name | caseCamel }}
+        {{ property.name | replace({'$': '_'}) }}
         {%~ endfor %}
         {%~ if definition.additionalProperties %}
         data


### PR DESCRIPTION
## What does this PR do?

`$` is reserved so we had to replace all `$` with `_`

## Test Plan

Manually generated examples.

databases/get-document.md:

```graphql
query {
    databasesGetDocument(
        databaseId: "[DATABASE_ID]",
        collectionId: "[COLLECTION_ID]",
        documentId: "[DOCUMENT_ID]"
    ) {
        _id
        _collectionId
        _databaseId
        _createdAt
        _updatedAt
        _permissions
        data
    }
}
```

account/get.md:

```graphql
query {
    accountGet {
        _id
        _createdAt
        _updatedAt
        name
        registration
        status
        passwordUpdate
        email
        phone
        emailVerification
        phoneVerification
        prefs
    }
}
```


## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes