### PR TITLE
Recursively display response model attributes for graphql examples

### DIFF
--- a/templates/graphql/docs/example.md.twig
+++ b/templates/graphql/docs/example.md.twig
@@ -1,3 +1,21 @@
+{% macro getProperty(definitions, responseModel, depth) %}
+        {%~ for definition in definitions %}
+        {%~ if definition.name == responseModel %}
+        {%~ for property in definition.properties | filter(p => p.required) %}
+        {{ ("% " ~ depth * 4 ~ "s") |format("") }}{{ property.name | replace({'$': '_'}) }}{%~ if property.sub_schema %} {{ '{' }}
+            {{- '\n' -}}
+                {{- _self.getProperty(definitions, property.sub_schema, depth + 1) -}}
+            {{ ("% " ~ depth * 4 ~ "s") |format("") }}{{ '        }' }}
+        {%~ else %}
+            {{- '\n' -}}
+        {%~ endif %}
+        {%~ endfor %}
+        {%~ if definition.additionalProperties %}
+        {{ ("% " ~ depth * 4 ~ "s") |format("") }}data
+        {%~ endif %}
+        {%~ endif %}
+        {%~ endfor %}
+{% endmacro %}
 {% for key,header in method.headers %}
 {% if header == 'multipart/form-data' %}
 {% set boundary = 'cec8e8123c05ba25' %}
@@ -55,16 +73,7 @@ mutation {
         {%~ if method.responseModel == 'none' or method.responseModel == '' %}
         status
         {%~ else %}
-        {%~ for definition in spec.definitions %}
-        {%~ if definition.name == method.responseModel %}
-        {%~ for property in definition.properties | filter(p => p.required) %}
-        {{ property.name | replace({'$': '_'}) }}
-        {%~ endfor %}
-        {%~ if definition.additionalProperties %}
-        data
-        {%~ endif %}
-        {%~ endif %}
-        {%~ endfor %}
+        {{- _self.getProperty(spec.definitions, method.responseModel, 0) -}}
         {%~ endif %}
     }
 }


### PR DESCRIPTION
## What does this PR do?

GraphQL requests must always specify the attributes to be returned in the request. This PR ensures response models are processed recursively so that all examples display all attributes for nested models.

## Test Plan

Manually generated.

databases/list-documents.md:

```graphql
query {
    databasesListDocuments(
        databaseId: "[DATABASE_ID]",
        collectionId: "[COLLECTION_ID]"
    ) {
        total
        documents {
            _id
            _collectionId
            _databaseId
            _createdAt
            _updatedAt
            _permissions
            data
        }
    }
}
```

teams/get.md:

```graphql
query {
    teamsGet(
        teamId: "[TEAM_ID]"
    ) {
        _id
        _createdAt
        _updatedAt
        name
        total
    }
}
```

users/list.md:

```graphql
query {
    usersList {
        total
        users {
            _id
            _createdAt
            _updatedAt
            name
            password
            hash
            hashOptions
            registration
            status
            passwordUpdate
            email
            phone
            emailVerification
            phoneVerification
            prefs {
                data
            }
        }
    }
}
```

## Related PRs and Issues

* https://github.com/appwrite/appwrite/pull/4925

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes