### PR TITLE
Fix "unexpected end of file" error

### DIFF
--- a/templates/node/lib/client.js.twig
+++ b/templates/node/lib/client.js.twig
@@ -9,6 +9,7 @@ class Client {
     constructor() {
         this.endpoint = '{{spec.endpoint}}';
         this.headers = {
+            'accept-encoding': '*',
             'content-type': '',
             'x-sdk-name': '{{ sdk.name }}',
             'x-sdk-platform': '{{ sdk.platform }}',


### PR DESCRIPTION
## What does this PR do?

Some API calls result in an error like:

```
Error: unexpected end of file
    at Client.call (.../appwrite-playground-for-node/node_modules/node-appwrite/lib/client.js:176:23)
    at processTicksAndRejections (.../appwrite-playground-for-node/lib/internal/process/task_queues.js:96:5)
    at async Databases.listCollections (.../appwrite-playground-for-node/node_modules/node-appwrite/lib/services/databases.js:186:16)
    at async listCollections (.../appwrite-playground-for-node/src/app.js:135:22)
    at async runAllTasks (.../appwrite-playground-for-node/src/app.js:504:5) {code: undefined, type: undefined, response: undefined, stack: 'Error: unexpected end of file
    at Client.c…ppwrite-playground-for-node/src/app.js:504:5)', message: 'unexpected end of file'}
```

This appears to be a bug in axios. See https://stackoverflow.com/questions/74779161/why-axios-returns-z-buf-error. This workaround adds a header that works around the problem.

## Test Plan

Manually tested with the playground for node.

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes