### PR TITLE
Fix: Extra appwrite.json keys

### DIFF
--- a/templates/cli/lib/commands/init.js.twig
+++ b/templates/cli/lib/commands/init.js.twig
@@ -182,7 +182,11 @@ const initCollection = async ({ all, databaseId } = {}) => {
 
     collections.forEach(async collection => {
       log(`Fetching ${collection.name} ...`);
-      localConfig.addCollection(collection);
+      localConfig.addCollection({
+        ...collection,
+        '$createdAt': undefined,
+        '$updatedAt': undefined,
+      });
     });
   }
 
@@ -201,7 +205,12 @@ const initTeam = async () => {
 
   teams.forEach(async team => {
     log(`Fetching ${team.name} ...`);
-    localConfig.addTeam(team);
+    localConfig.addTeam({
+      ...team,
+      '$createdAt': undefined,
+      '$updatedAt': undefined,
+      'total': undefined
+    });
   });
 
   success();


### PR DESCRIPTION
## What does this PR do?

Removes keys `$createdAt`, `$updatedAt`, `total` from appwrite.json

## Test Plan

- [x] Manual QA

<img width="400" alt="CleanShot 2023-02-23 at 09 47 00@2x" src="https://user-images.githubusercontent.com/19310830/220859732-c12dafd7-26f3-4c60-a193-32cef508a444.png">


## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes