### PR TITLE
Oauth clear hsitory

### DIFF
--- a/templates/flutter/lib/src/client_io.dart.twig
+++ b/templates/flutter/lib/src/client_io.dart.twig
@@ -310,6 +310,7 @@ class ClientIO extends ClientBase with ClientMixin {
     return FlutterWebAuth2.authenticate(
       url: url.toString(),
       callbackUrlScheme: callbackUrlScheme != null && Platform.isWindows ? callbackUrlScheme : "appwrite-callback-" + config['project']!,
+      preferEphemeral: true,
     ).then((value) async {
       Uri url = Uri.parse(value);
       final key = url.queryParameters['key'];


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

- Set `preferEphemeral` to true so android and iOS doesn't keep activity history of OAuth web browser (solves an issue raised in discord that after completing OAuth login, android hardware back key was taking back to web browser again)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

- [x] I have read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
