### PR TITLE
Add proper Linux support in Web Auth

### DIFF
--- a/templates/flutter/lib/src/client_io.dart.twig
+++ b/templates/flutter/lib/src/client_io.dart.twig
@@ -305,11 +305,13 @@ class ClientIO extends ClientBase with ClientMixin {
     return res;
   }
 
+  bool get _customSchemeAllowed => Platform.isWindows || Platform.isLinux;
+
   @override
   Future webAuth(Uri url, {String? callbackUrlScheme}) {
     return FlutterWebAuth2.authenticate(
       url: url.toString(),
-      callbackUrlScheme: callbackUrlScheme != null && Platform.isWindows ? callbackUrlScheme : "appwrite-callback-" + config['project']!,
+      callbackUrlScheme: callbackUrlScheme != null && _customSchemeAllowed ? callbackUrlScheme : "appwrite-callback-" + config['project']!,
       preferEphemeral: true,
     ).then((value) async {
       Uri url = Uri.parse(value);


### PR DESCRIPTION
## What does this PR do?

This PR enables proper Linux support using `flutter_web_auth_2` which now supports Linux thanks to the work done in https://github.com/ThexXTURBOXx/flutter_web_auth_2/pull/31

## Test Plan

No test needed as this adds a single check that enables custom URL schemes being allowed on Linux (needed due to the currently implemented workaround approach)

## Related PRs and Issues

https://github.com/ThexXTURBOXx/flutter_web_auth_2/pull/31
https://github.com/appwrite/sdk-for-flutter/pull/127

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes