### PR TITLE
Fix url used for checking offline status

### DIFF
--- a/templates/flutter/lib/src/client_offline_mixin.dart.twig
+++ b/templates/flutter/lib/src/client_offline_mixin.dart.twig
@@ -183,7 +183,7 @@ class ClientOfflineMixin {
 
   Future<void> checkOnlineStatus() async {
     try {
-      final url = Uri.parse('{{spec.endpoint}}/version');
+      final url = Uri.parse('{{sdk.url}}/version');
       await http.head(url).timeout(Duration(seconds: 1));
       isOnline.value = true;
     } catch (_) {


### PR DESCRIPTION
## What does this PR do?

spec.endpoint is actually set to https://HOSTNAME/v1 which can't be used to check the online status. However, sdk.url is https://appwrite.io which can be used to check for internet connectivity.

## Test Plan

Manual

## Related PRs and Issues

Previous PR:

* https://github.com/appwrite/sdk-generator/pull/618

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes