### PR TITLE
Allow empty array param

### DIFF
--- a/templates/cli/lib/commands/command.js.twig
+++ b/templates/cli/lib/commands/command.js.twig
@@ -81,6 +81,10 @@ const {{ service.name | caseLower }}{{ method.name | caseUcfirst }} = async ({ {
     }
 
 {% else %}
+{% if parameter.type == 'array' %}
+    {{ parameter.name | caseCamel | escapeKeyword}} = {{ parameter.name | caseCamel | escapeKeyword}} === true ? [] : {{ parameter.name | caseCamel | escapeKeyword}};
+{% endif %}
+
     if (typeof {{ parameter.name | caseCamel | escapeKeyword }} !== 'undefined') {
         payload['{{ parameter.name }}'] = {{ parameter.name | caseCamel | escapeKeyword}}{% if method.consumes[0] == "multipart/form-data" and ( parameter.type != "string" and parameter.type != "array" ) %}.toString(){% endif %};
     }
@@ -224,7 +228,7 @@ const {{ service.name | caseLower }}{{ method.name | caseUcfirst }} = async ({ {
 {% autoescape false %}
     .description(`{{ method.description | replace({'`':'\''}) | replace({'\n':' '}) | replace({'\n \n':' '}) }}`)
 {% for parameter in method.parameters.all %}
-    .{% if parameter.required %}requiredOption{% else %}option{% endif %}(`--{{ parameter.name | escapeKeyword }} <{{ parameter.name | escapeKeyword }}{% if parameter.array.type|length > 0 %}...{% endif %}>`, `{{ parameter.description | replace({'`':'\''}) | replace({'\n':' '}) | replace({'\n \n':' '}) }}`{% if parameter | typeName == 'boolean' %}, parseBool{% elseif parameter | typeName == 'number' %}, parseInteger{% endif %})
+    .{% if parameter.required %}requiredOption{% else %}option{% endif %}(`--{{ parameter.name | escapeKeyword }} {% if parameter.array.type|length > 0 %}[{% else %}<{% endif %}{{ parameter.name | escapeKeyword }}{% if parameter.array.type|length > 0 %}...{% endif %}{% if parameter.array.type|length > 0 %}]{% else %}>{% endif %}`, `{{ parameter.description | replace({'`':'\''}) | replace({'\n':' '}) | replace({'\n \n':' '}) }}`{% if parameter | typeName == 'boolean' %}, parseBool{% elseif parameter | typeName == 'number' %}, parseInteger{% endif %})
 {% endfor %}
 {% if method.type == 'location' %}
     .requiredOption(`--destination <path>`, `output file path.`)


### PR DESCRIPTION
## What does this PR do?

Makes it possible to set array attribute to empty array in Appwrite CLI.

Generated code:

```js
databases
    .command(`createDocument`)
    .description(`Create a new Document. Before using this route, you should create a new collection resource using either a [server integration](/docs/server/databases#databasesCreateCollection) API or directly from your database console.`)
    .requiredOption(`--databaseId <databaseId>`, `Database ID.`)
    .requiredOption(`--collectionId <collectionId>`, `Collection ID. You can create a new collection using the Database service [server integration](https://appwrite.io/docs/server/databases#databasesCreateCollection). Make sure to define attributes before creating documents.`)
    .requiredOption(`--documentId <documentId>`, `Document ID. Choose a custom ID or generate a random ID with 'ID.unique()'. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can't start with a special char. Max length is 36 chars.`)
    .requiredOption(`--data <data>`, `Document data as JSON object.`)
    .option(`--permissions [permissions...]`, `An array of permissions strings. By default, only the current user is granted all permissions. [Learn more about permissions](/docs/permissions).`)
    .action(actionRunner(databasesCreateDocument))
```

```js
const databasesCreateDocument = async ({ databaseId, collectionId, documentId, data, permissions, parseOutput = true, sdk = undefined}) => {
    /* @param {string} databaseId */
    /* @param {string} collectionId */
    /* @param {string} documentId */
    /* @param {object} data */
    /* @param {string[]} permissions */

    let client = !sdk ? await sdkForProject() : sdk;
    let path = '/databases/{databaseId}/collections/{collectionId}/documents'.replace('{databaseId}', databaseId).replace('{collectionId}', collectionId);
    let payload = {};
    
    /** Body Params */

    if (typeof documentId !== 'undefined') {
        payload['documentId'] = documentId;
    }

    if (typeof data !== 'undefined') {
        payload['data'] = JSON.parse(data);
    }

    permissions = permissions === true ? [] : permissions;

    if (typeof permissions !== 'undefined') {
        payload['permissions'] = permissions;
    }

    let response = undefined;
    response = await client.call('post', path, {
        'content-type': 'application/json',
    }, payload);
    
    if (parseOutput) {
        parse(response)
        success()
    }
    return response;
}
```

## Test Plan

- [x] Manual QA:

```
appwrite databases createDocument --permissions --databaseId 'default' --collectionId 'categories' --documentId 'cryptocurrency' --data '{"name":"Crypto","description":"Cryptocurrency coverage and news on Bitcoin, Ethereum and the blockchain startups building the future of crypto, web3 using tokens and NFTs."}'
```

<img width="798" alt="CleanShot 2023-03-17 at 12 19 37@2x" src="https://user-images.githubusercontent.com/19310830/225890627-93b73086-937c-4c3d-92a6-dd8ba8bddbf2.png">


## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes