### PR TITLE
Update flutter SDK supported platforms list

### DIFF
--- a/templates/flutter/pubspec.yaml.twig
+++ b/templates/flutter/pubspec.yaml.twig
@@ -5,6 +5,13 @@ homepage: {{sdk.url}}
 repository: https://github.com/{{sdk.gitUserName}}/{{sdk.gitRepoName}}
 issue_tracker: https://github.com/appwrite/sdk-generator/issues
 documentation: {{ spec.contactURL }}
+platforms:
+  android:
+  ios:
+  linux:
+  macos:
+  web:
+  windows:
 environment:
   sdk: ">=2.17.0 <3.0.0"
 


### PR DESCRIPTION
## What does this PR do?

pub.dev incorrectly shows that the appwrite flutter SDK doesn't support web when it does. This overrides what pub.dev detects to explicitly include web as supported.

## Test Plan

Manual:

<img width="1059" alt="image" src="https://user-images.githubusercontent.com/1477010/228977997-83d308e6-0988-4cc0-9248-7c3358491eae.png">

## Related PRs and Issues

* https://github.com/appwrite/sdk-for-flutter/issues/138

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes