### PR TITLE
Fix node types

### DIFF
--- a/templates/node/index.d.ts.twig
+++ b/templates/node/index.d.ts.twig
@@ -131,7 +131,7 @@ declare module "{{ language.params.npmPackage|caseDash }}" {
 
     static fromBuffer(buffer: Buffer, filename: string): InputFile;
 
-    static fromBlob(blob: buffer.Blob, filename: string): Promise<InputFile>;
+    static fromBlob(blob: Blob, filename: string): Promise<InputFile>;
 
     static fromStream(stream: NodeJS.ReadableStream, filename: string, size: number): InputFile;
 

--- a/templates/node/index.d.ts.twig
+++ b/templates/node/index.d.ts.twig
@@ -237,7 +237,7 @@ declare module "{{ language.params.npmPackage|caseDash }}" {
      * @throws {{ '{' }}{{ spec.title | caseUcfirst}}Exception}
      * @returns {Promise}
      */
-    {{ method.name | caseCamel }}{% if generics %}<{{generics}}>{% endif %}({% for parameter in method.parameters.all %}{{ parameter.name | caseCamel | escapeKeyword }}{% if not parameter.required or parameter.nullable %}?{% endif %}: {{ parameter | typeName }}{% if not loop.last %}, {% endif %}{% endfor %}): Promise<{% if method.type == 'location' %}Buffer{% else %}{% if method.responseModel and method.responseModel != 'any' %}{% if not spec.definitions[method.responseModel].additionalProperties %}Models.{% endif %}{{method.responseModel | caseUcfirst}}{% if generics_return %}<{{generics_return}}>{% endif %}{% else %}string{% endif %}{% endif %}>;
+    {{ method.name | caseCamel }}{% if generics %}<{{generics}}>{% endif %}({% for parameter in method.parameters.all %}{{ parameter.name | caseCamel | escapeKeyword }}{% if not parameter.required or parameter.nullable %}?{% endif %}: {{ parameter | typeName }}{% if not loop.last %}, {% endif %}{% endfor %}): Promise<{% if method.type == 'location' %}Buffer{% else %}{% if method.responseModel and method.responseModel != 'any' %}{% if not spec.definitions[method.responseModel].additionalProperties %}Models.{% endif %}{{method.responseModel | caseUcfirst}}{% if generics_return %}<{{generics_return}}>{% endif %}{% else %}{% if method.method == 'delete' %}string{% else %}any{% endif %}{% endif %}{% endif %}>;
 {% endfor %}
   }
 {% endfor %}

--- a/templates/node/package.json.twig
+++ b/templates/node/package.json.twig
@@ -10,7 +10,9 @@
     "type": "git",
     "url": "{{ sdk.gitURL }}"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "@types/node": "^18.16.1"
+  },
   "dependencies": {
     "axios": "^1.3.6",
     "form-data": "^4.0.0"


### PR DESCRIPTION
## What does this PR do?

Delete methods return empty string so the type should be a string.

getAttribute() returns any one of the possible attributes so we'll use
any for now. In the future, we can look into supporting a union type.

Fix missing buffer type error

Fix missing NodeJS type

## Test Plan

delete method:

<img width="706" alt="image" src="https://user-images.githubusercontent.com/1477010/234963551-657eb462-c9ec-4e10-8cd4-bbc69ac24023.png">

getAttribute(): 

<img width="701" alt="image" src="https://user-images.githubusercontent.com/1477010/234963481-c991edcd-dc85-4470-80af-30c895a081ee.png">

fix buffer and nodejs type errors:

<img width="736" alt="image" src="https://user-images.githubusercontent.com/1477010/234964279-39b556e6-384e-48da-a9e9-33c6acf29d55.png">


## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes