### PR TITLE
Add typing for new Query methods in the Node SDK

### DIFF
--- a/templates/node/index.d.ts.twig
+++ b/templates/node/index.d.ts.twig
@@ -157,6 +157,18 @@ declare module "{{ language.params.npmPackage|caseDash }}" {
 
     static greaterThanEqual(attribute: string, value: QueryTypes): string;
 
+    static isNull(attribute: string): string;
+
+    static isNotNull(attribute: string): string;
+
+    static between<T extends string | number>(attribute: string, start: T, end: T): string;
+
+    static startsWith(attribute: string, value: string): string;
+
+    static endsWith(attribute: string, value: string): string;
+
+    static select(attributes: string[]): string;
+
     static search(attribute: string, value: string): string;
 
     static orderDesc(attribute: string): string;


### PR DESCRIPTION
## What does this PR do?

1.3.x introduced new Query methods and they were added to the Query class, but were missing from index.d.ts.

## Test Plan

Manually generated SDK:

<img width="691" alt="image" src="https://user-images.githubusercontent.com/1477010/235179810-5dbcdcdc-9738-484e-83c5-698bd6c59381.png">

## Related PRs and Issues

* https://github.com/appwrite/sdk-for-node/pull/55 - [Comment](https://github.com/appwrite/sdk-for-node/pull/55/files#r1180009818)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes