### PR TITLE
Fix typing exports for web SDK

### DIFF
--- a/templates/web/package.json.twig
+++ b/templates/web/package.json.twig
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "import": "./dist/esm/sdk.js",
-      "require": "./dist/cjs/sdk.js"
+      "require": "./dist/cjs/sdk.js",
+      "types": "./types/index.d.ts"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
## What does this PR do?

For projects with moduleResolution set to bundler in tsconfig.json, the types must be exported in the package.json file.

Closes: https://github.com/appwrite/sdk-for-web/issues/54

## Test Plan

Manually added in a new project and I no longer see the error:

<img width="822" alt="image" src="https://user-images.githubusercontent.com/1477010/236688170-13c8661d-0dd1-4db6-9bb8-aca98c5530e7.png">

I also added it to another TS project of mine that has `moduleResolution` set to `node` and that still worked as expected:

<img width="894" alt="image" src="https://user-images.githubusercontent.com/1477010/236688228-415a683e-8537-4ecd-94a9-ef949c244cbc.png">

## Related PRs and Issues

* https://github.com/appwrite/sdk-for-web/issues/54

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes