### PR TITLE
Move flutter service tests to dart

### DIFF
--- a/src/SDK/Language/Dart.php
+++ b/src/SDK/Language/Dart.php
@@ -402,6 +402,16 @@ class Dart extends Language
                 'template'      => 'dart/docs/example.md.twig',
             ],
             [
+                'scope'         => 'service',
+                'destination'   => '/test/services/{{service.name | caseDash}}_test.dart',
+                'template'      => 'dart/test/services/service_test.dart.twig',
+            ],
+            [
+                'scope'         => 'definition',
+                'destination'   => '/test/src/models/{{definition.name | caseSnake }}_test.dart',
+                'template'      => 'dart/test/src/models/model_test.dart.twig',
+            ],
+            [
                 'scope'         => 'default',
                 'destination'   => '/test/id_test.dart',
                 'template'      => 'dart/test/id_test.dart.twig',

--- a/src/SDK/Language/Flutter.php
+++ b/src/SDK/Language/Flutter.php
@@ -243,7 +243,7 @@ class Flutter extends Dart
             [
                 'scope'         => 'service',
                 'destination'   => '/test/services/{{service.name | caseDash}}_test.dart',
-                'template'      => 'flutter/test/services/service_test.dart.twig',
+                'template'      => 'dart/test/services/service_test.dart.twig',
             ],
             [
                 'scope'         => 'definition',

--- a/templates/dart/pubspec.yaml.twig
+++ b/templates/dart/pubspec.yaml.twig
@@ -13,3 +13,4 @@ dependencies:
 dev_dependencies:
   lints: ^2.0.1
   test: ^1.22.0
+  mockito: ^5.4.2

--- a/templates/dart/test/id_test.dart.twig
+++ b/templates/dart/test/id_test.dart.twig
@@ -1,5 +1,9 @@
 import 'package:{{ language.params.packageName }}/{{ language.params.packageName }}.dart';
+{% if 'dart' in language.params.packageName %}
+import 'package:test/test.dart';
+{% else %}
 import 'package:flutter_test/flutter_test.dart';
+{% endif %}
 
 void main() {
   group('unique()', () {

--- a/templates/dart/test/permission_test.dart.twig
+++ b/templates/dart/test/permission_test.dart.twig
@@ -1,5 +1,9 @@
 import 'package:{{ language.params.packageName }}/{{ language.params.packageName }}.dart';
+{% if 'dart' in language.params.packageName %}
+import 'package:test/test.dart';
+{% else %}
 import 'package:flutter_test/flutter_test.dart';
+{% endif %}
 
 void main() {
   group('read()', () {

--- a/templates/dart/test/query_test.dart.twig
+++ b/templates/dart/test/query_test.dart.twig
@@ -1,5 +1,9 @@
 import 'package:{{ language.params.packageName }}/{{ language.params.packageName }}.dart';
+{% if 'dart' in language.params.packageName %}
+import 'package:test/test.dart';
+{% else %}
 import 'package:flutter_test/flutter_test.dart';
+{% endif %}
 
 class BasicFilterQueryTest {
   final String description;

--- a/templates/dart/test/role_test.dart.twig
+++ b/templates/dart/test/role_test.dart.twig
@@ -1,5 +1,9 @@
 import 'package:{{ language.params.packageName }}/{{ language.params.packageName }}.dart';
+{% if 'dart' in language.params.packageName %}
+import 'package:test/test.dart';
+{% else %}
 import 'package:flutter_test/flutter_test.dart';
+{% endif %}
 
 void main() {
   group('any()', () {

--- a/templates/dart/test/services/service_test.dart.twig
+++ b/templates/dart/test/services/service_test.dart.twig
@@ -1,5 +1,9 @@
 {% import 'flutter/base/utils.twig' as utils %}
+{% if 'dart' in language.params.packageName %}
+import 'package:test/test.dart';
+{% else %}
 import 'package:flutter_test/flutter_test.dart';
+{% endif %}
 import 'package:mockito/mockito.dart';
 import 'package:{{ language.params.packageName }}/models.dart' as models;
 import 'package:{{ language.params.packageName }}/src/enums.dart';
@@ -65,7 +69,7 @@ void main() {
                 {%~ if method.responseModel and method.responseModel != 'any' ~%}
             final Map<String, dynamic> data = {
                 {%- for definition in spec.definitions ~%}{%~ if definition.name == method.responseModel -%}{%~ for property in definition.properties | filter((param) => param.required) ~%}
-                '{{property.name | escapeKeyword | escapeDollarSign}}': {% if property.type == 'object' %}<String, dynamic>{}{% elseif property.type == 'array' %}[]{% elseif property.type == 'string' %}'{{property.example}}'{% elseif property.type == 'boolean' %}true{% else %}{{property.example}}{% endif %},{%~ endfor ~%}{% set break = true %}{%- else -%}{% set continue = true %}{%- endif -%}{%~ endfor -%}
+                '{{property.name | escapeDollarSign}}': {% if property.type == 'object' %}<String, dynamic>{}{% elseif property.type == 'array' %}[]{% elseif property.type == 'string' %}'{{property.example | escapeDollarSign}}'{% elseif property.type == 'boolean' %}true{% else %}{{property.example}}{% endif %},{%~ endfor ~%}{% set break = true %}{%- else -%}{% set continue = true %}{%- endif -%}{%~ endfor -%}
 
             };
                 {%~ else ~%}
@@ -92,7 +96,7 @@ void main() {
             {%~ endif ~%}
 
             final response = await {{service.name | caseCamel}}.{{method.name | caseCamel}}({%~ for parameter in method.parameters.all | filter((param) => param.required) ~%}
-                {{parameter.name | escapeKeyword | caseCamel}}: {% if parameter.type == 'object' %}{}{% elseif parameter.type == 'file' %}InputFile.fromPath(path: './image.png'){% else %}'{{parameter.example}}'{%~ endif ~%},{%~ endfor ~%}
+                {{parameter.name | escapeKeyword | caseCamel}}: {% if parameter.type == 'object' %}{}{% elseif parameter.type == 'array' %}[]{% elseif parameter.type == 'file' %}InputFile.fromPath(path: './image.png'){% elseif parameter.type == 'boolean' %}true{% elseif parameter.type == 'string' %}'{% if parameter.example is not empty %}{{parameter.example | escapeDollarSign}}{% endif %}'{% elseif parameter.type == 'integer' and parameter['x-example'] is empty %}1{% elseif parameter.type == 'number' and parameter['x-example'] is empty %}1.0{% else %}{{parameter.example}}{%~ endif ~%},{%~ endfor ~%}
             );
 
         {%- if method.type == 'location' ~%}

--- a/templates/dart/test/src/enums_test.dart.twig
+++ b/templates/dart/test/src/enums_test.dart.twig
@@ -1,5 +1,9 @@
 import 'package:{{ language.params.packageName }}/src/enums.dart';
+{% if 'dart' in language.params.packageName %}
+import 'package:test/test.dart';
+{% else %}
 import 'package:flutter_test/flutter_test.dart';
+{% endif %}
 
 void main() {
   group('name()', () {

--- a/templates/dart/test/src/models/model_test.dart.twig
+++ b/templates/dart/test/src/models/model_test.dart.twig
@@ -1,6 +1,10 @@
 {% macro sub_schema(property) %}{% if property.sub_schema %}{% if property.type == 'array' %}List<{{property.sub_schema | caseUcfirst | overrideIdentifier}}>{% else %}{{property.sub_schema | caseUcfirst | overrideIdentifier }}{% endif %}{% else %}{% if property.type == 'object' and property.additionalProperties %}Map<String, dynamic>{% else %}{{property | typeName}}{% endif %}{% endif %}{% endmacro %}
 import 'package:{{ language.params.packageName }}/models.dart';
+{% if 'dart' in language.params.packageName %}
+import 'package:test/test.dart';
+{% else %}
 import 'package:flutter_test/flutter_test.dart';
+{% endif %}
 
 void main() {
   group('{{ definition.name | caseUcfirst | overrideIdentifier }}', () {

--- a/templates/dart/test/src/response_test.dart.twig
+++ b/templates/dart/test/src/response_test.dart.twig
@@ -1,5 +1,9 @@
 import 'package:{{ language.params.packageName }}/src/response.dart';
+{% if 'dart' in language.params.packageName %}
+import 'package:test/test.dart';
+{% else %}
 import 'package:flutter_test/flutter_test.dart';
+{% endif %}
 
 void main() {
   group('toString()', () {


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Moving it to dart allows them to be re-used between both SDKs.

Closes: https://github.com/appwrite/sdk-for-flutter/issues/90

## Test Plan

Manual Dart:

<img width="456" alt="Screen Shot 2023-06-20 at 5 38 30 PM" src="https://github.com/appwrite/sdk-generator/assets/1477010/4244370f-c65e-489e-b467-0f801c6de66e">

Manual Flutter:

<img width="538" alt="Screen Shot 2023-06-20 at 5 41 58 PM" src="https://github.com/appwrite/sdk-generator/assets/1477010/495900e8-8107-4bdc-b08d-15a7d2f02030">

## Related PRs and Issues

* https://github.com/appwrite/sdk-for-flutter/issues/90
* https://github.com/appwrite/sdk-generator/pull/673

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes