### PR TITLE
Downgrade mockito in Flutter and Dart SDKs

### DIFF
--- a/templates/dart/pubspec.yaml.twig
+++ b/templates/dart/pubspec.yaml.twig
@@ -13,4 +13,4 @@ dependencies:
 dev_dependencies:
   lints: ^2.0.1
   test: ^1.22.0
-  mockito: ^5.4.2
+  mockito: ^5.4.0

--- a/templates/flutter/pubspec.yaml.twig
+++ b/templates/flutter/pubspec.yaml.twig
@@ -32,4 +32,4 @@ dev_dependencies:
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
-  mockito: ^5.4.2
+  mockito: ^5.4.0


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This fixes the CI because the mockito 5.4.1 doesn't work with our version of flutter_test:

> Because mockito >=5.4.1 depends on matcher ^0.12.15 and every version of flutter_test from sdk depends on matcher 0.12.13, mockito >=5.4.1 is incompatible with flutter_test from sdk.

## Test Plan

CI tests for flutter should pass

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes