### PR TITLE
fix: python library version

### DIFF
--- a/templates/python/requirements.txt.twig
+++ b/templates/python/requirements.txt.twig
@@ -1,1 +1,1 @@
-requests==2.28.2
+requests==2.29.0


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Update `requests` to 2.29.0

The Python SDK build fails https://app.travis-ci.com/github/appwrite/sdk-for-python/builds/264332283

This is due to the requests library being incompatible with a specific version of OpenSSL

https://github.com/urllib3/urllib3/issues/2168#issuecomment-1607906183

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)