### PR TITLE
fix: Add type field to AppwriteException class to .NET SDK

### DIFF
--- a/templates/dotnet/src/Appwrite/Exception.cs.twig
+++ b/templates/dotnet/src/Appwrite/Exception.cs.twig
@@ -5,14 +5,17 @@ namespace {{spec.title | caseUcfirst}}
     public class {{spec.title | caseUcfirst}}Exception : Exception
     {
         public int? Code { get; set; }
+        public string? Type { get; set; } = null;
         public string? Response { get; set; } = null;
 
         public {{spec.title | caseUcfirst}}Exception(
             string? message = null,
             int? code = null,
+            string? type = null,
             string? response = null) : base(message)
         {
             this.Code = code;
+            this.Type = type
             this.Response = response;
         }
         public {{spec.title | caseUcfirst}}Exception(string message, Exception inner)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Adds missing type field to the AppwriteException class

## Test Plan

Generate example SDK using the `example.php` file in the repo

- Earlier

![image](https://github.com/appwrite/sdk-generator/assets/31401437/595c109f-69fc-4be8-b7e2-b75d568ff4c7)

- Now

![image](https://github.com/appwrite/sdk-generator/assets/31401437/c53f59d6-b70e-4cf8-84d0-470352237d3a)

## Related PRs and Issues

No

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes