### PR TITLE
fix: Add missing semicolon in AppwriteException constructor in .NET SDK

### DIFF
--- a/templates/dotnet/src/Appwrite/Exception.cs.twig
+++ b/templates/dotnet/src/Appwrite/Exception.cs.twig
@@ -15,7 +15,7 @@ namespace {{spec.title | caseUcfirst}}
             string? response = null) : base(message)
         {
             this.Code = code;
-            this.Type = type
+            this.Type = type;
             this.Response = response;
         }
         public {{spec.title | caseUcfirst}}Exception(string message, Exception inner)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Add missing semicolon in constructor

## Test Plan


## Related PRs and Issues

#691 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes