### PR TITLE
fix: headers keyword for .net

### DIFF
--- a/templates/dotnet/base/params.twig
+++ b/templates/dotnet/base/params.twig
@@ -12,7 +12,7 @@
                 {%~ endfor %}
             };
 
-            var headers = new Dictionary<string, string>()
+            var apiHeaders = new Dictionary<string, string>()
             {
                 {%~ for key, header in method.headers %}
                 { "{{ key }}", "{{ header }}" }{% if not loop.last %},{% endif %}

--- a/templates/dotnet/base/requests/api.twig
+++ b/templates/dotnet/base/requests/api.twig
@@ -2,7 +2,7 @@
             return _client.Call{% if method.type != 'webAuth' %}<{{ utils.resultType(spec.title, method) }}>{% endif %}(
                 method: "{{ method.method | caseUpper }}",
                 path: apiPath,
-                headers: headers,
+                headers: apiHeaders,
                 {%~ if not method.responseModel %}
                 parameters: parameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!);
                 {%~ else %}

--- a/templates/dotnet/base/requests/file.twig
+++ b/templates/dotnet/base/requests/file.twig
@@ -8,7 +8,7 @@
 
             return _client.ChunkedUpload(
                 apiPath,
-                headers,
+                apiHeaders,
                 parameters,
                 {%~ if method.responseModel %}
                 Convert,

--- a/templates/dotnet/base/requests/location.twig
+++ b/templates/dotnet/base/requests/location.twig
@@ -1,5 +1,5 @@
             return _client.Call<byte[]>(
                 method: "{{ method.method | caseUpper }}",
                 path: apiPath,
-                headers: headers,
+                headers: apiHeaders,
                 parameters: parameters.Where(it => it.Value != null).ToDictionary(it => it.Key, it => it.Value)!);


### PR DESCRIPTION
- renames `headers` var to `apiHeaders` to avoid conflicts