### PR TITLE
Fix CLI missing command descriptions

### DIFF
--- a/templates/cli/lib/parser.js.twig
+++ b/templates/cli/lib/parser.js.twig
@@ -169,6 +169,11 @@ const commandDescriptions = {
     "login": `The login command allows you to authenticate and manage a user account.`,
     "logout": `The logout command allows you to logout of your {{ spec.title|caseUcfirst }} account.`,
     "console" : `The console command allows gives you access to the APIs used by the Appwrite console.`,
+    "assistant": `The assistant command allows you to interact with the Appwrite Assistant AI`,
+    "migrations": `The migrations command allows you to migrate data between services.`,
+    "project": `The project command is for overall project administration.`,
+    "proxy": `The proxy command allows you to configure behavior for your attached domains.`,
+    "vcs": `The vcs command allows you to interact with VCS providers and manage your code repositories.`,
     "main": chalk.redBright(`${logo}${description}`),
 {% if sdk.test == "true" %}
 {% for service in spec.services %}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fix errors like:

```
appwrite -v                                                          
pkg/prelude/bootstrap.js:1740
      throw error;
      ^

TypeError: (intermediate value).description(...).configureHelp is not a function
    at Object.<anonymous> (/snapshot/sdk-for-cli/lib/commands/assistant.js:13:90)
    at Module._compile (pkg/prelude/bootstrap.js:1794:22)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at Module.require (pkg/prelude/bootstrap.js:1719:31)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/snapshot/sdk-for-cli/index.js:18:23)
    at Module._compile (pkg/prelude/bootstrap.js:1794:22)
```

## Test Plan

Manual:

Checking version:

<img width="165" alt="image" src="https://github.com/appwrite/sdk-generator/assets/1477010/f95e8c01-9418-4ccf-a6e0-5ff7b9865977">

help:

<img width="745" alt="image" src="https://github.com/appwrite/sdk-generator/assets/1477010/7971165c-1899-4943-b128-64cf2f5cb0bb">

## Related PRs and Issues

- https://github.com/appwrite/sdk-for-cli/issues/93

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes