### PR TITLE
Fix dart SDK not uploading correct length of chunks

### DIFF
--- a/templates/dart/lib/src/client_browser.dart.twig
+++ b/templates/dart/lib/src/client_browser.dart.twig
@@ -120,7 +120,7 @@ class ClientBrowser extends ClientBase with ClientMixin {
 
     while (offset < size) {
       var chunk;
-      final end = min(offset + CHUNK_SIZE - 1, size - 1);
+      final end = min(offset + CHUNK_SIZE, size);
       chunk = file.bytes!.getRange(offset, end).toList();
       params[paramName] =
           http.MultipartFile.fromBytes(paramName, chunk, filename: file.filename);

--- a/templates/dart/lib/src/client_io.dart.twig
+++ b/templates/dart/lib/src/client_io.dart.twig
@@ -156,7 +156,7 @@ class ClientIO extends ClientBase with ClientMixin {
     while (offset < size) {
       List<int> chunk = [];
       if (file.bytes != null) {
-        final end = min(offset + CHUNK_SIZE - 1, size - 1);
+        final end = min(offset + CHUNK_SIZE, size);
         chunk = file.bytes!.getRange(offset, end).toList();
       } else {
         raf!.setPositionSync(offset);

--- a/templates/flutter/lib/src/client_browser.dart.twig
+++ b/templates/flutter/lib/src/client_browser.dart.twig
@@ -149,7 +149,7 @@ class ClientBrowser extends ClientBase with ClientMixin {
 
     while (offset < size) {
       var chunk;
-      final end = min(offset + CHUNK_SIZE - 1, size - 1);
+      final end = min(offset + CHUNK_SIZE, size);
       chunk = file.bytes!.getRange(offset, end).toList();
       params[paramName] =
           http.MultipartFile.fromBytes(paramName, chunk, filename: file.filename);

--- a/templates/flutter/lib/src/client_io.dart.twig
+++ b/templates/flutter/lib/src/client_io.dart.twig
@@ -276,7 +276,7 @@ class ClientIO extends ClientBase with ClientMixin {
     while (offset < size) {
       List<int> chunk = [];
       if (file.bytes != null) {
-        final end = min(offset + CHUNK_SIZE - 1, size - 1);
+        final end = min(offset + CHUNK_SIZE, size);
         chunk = file.bytes!.getRange(offset, end).toList();
       } else {
         raf!.setPositionSync(offset);


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The chunk length is supposed to be equal to CHUNK_SIZE or whatever is left for the file, but the - 1 for the end made the chunk 1 less than the correct length (due to the way getRange works).

For example, see the chunk length when using fromBytes():

<img width="604" alt="fromBytes" src="https://github.com/appwrite/sdk-generator/assets/1477010/0f6168f5-f2ab-4f55-bd33-1d16e573a72b">

vs fromPath():

<img width="417" alt="fromPath" src="https://github.com/appwrite/sdk-generator/assets/1477010/1f7c384a-cb8a-459f-8f9c-f47e290d6164">

## Test Plan

Manually tested and was able to upload the file successfully:

<img width="930" alt="Screen Shot 2023-09-21 at 5 11 18 PM" src="https://github.com/appwrite/sdk-generator/assets/1477010/b5e714de-e55b-4c0c-92da-8e5b9457382d">

In addition, comparing the uploaded file with the original file showed they were the same:

<img width="431" alt="image" src="https://github.com/appwrite/sdk-generator/assets/1477010/c5f581e7-e35e-48cb-8d88-3535e4503874">

## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/6304

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes