### PR TITLE
Update how the node SDK handles self signed requests

### DIFF
--- a/templates/node/lib/client.js.twig
+++ b/templates/node/lib/client.js.twig
@@ -1,5 +1,6 @@
 const os = require('os');
 const URL = require('url').URL;
+const https = require("https");
 const axios = require('axios');
 const FormData = require('form-data');
 const {{spec.title | caseUcfirst}}Exception = require('./exception.js');
@@ -81,11 +82,6 @@ class Client {
     }
       
     async call(method, path = '', headers = {}, params = {}, responseType = 'json') {
-        if(this.selfSigned) { // Allow self signed requests
-            process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = 0;
-        }
-
-
         headers = Object.assign({}, this.headers, headers);
 
         let contentType = headers['content-type'].toLowerCase();
@@ -125,6 +121,10 @@ class Client {
             json: (contentType.startsWith('application/json')),
             responseType: responseType
         };
+        if (this.selfSigned) {
+            // Allow self signed requests
+            options.httpsAgent = new https.Agent({ rejectUnauthorized: false });
+        }
         try {
             let response = await axios(options);
             return response.data;


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The NODE_TLS_REJECT_UNAUTHORIZED env variable will disable SSL checks for all requests. This PR changes the node SDK to only disable SSL checks for Appwrite related requests by passing an option to axios.

Fixes https://github.com/appwrite/appwrite/issues/6832

## Test Plan

Before change:

<img width="1005" alt="image" src="https://github.com/appwrite/sdk-generator/assets/1477010/1a7a9c55-6cbc-40e2-88c9-0692df68f87c">

After change:

<img width="1003" alt="image" src="https://github.com/appwrite/sdk-generator/assets/1477010/10ec1600-83a9-48c8-8b59-160ec1ce6ed7">

Without calling setSelfSigned():

<img width="825" alt="image" src="https://github.com/appwrite/sdk-generator/assets/1477010/c153fda8-9c4a-4ab8-a77e-ec944636369a">

## Related PRs and Issues

* https://github.com/appwrite/appwrite/issues/6832

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes