### PR TITLE
feat: added constants for Error Types

### DIFF
--- a/src/Spec/Swagger2.php
+++ b/src/Spec/Swagger2.php
@@ -312,6 +312,7 @@ class Swagger2 extends Spec
                 "name" => $key,
                 "properties" => $schema['properties'] ?? [],
                 "description" => $schema['description'] ?? [],
+                "error_types" => $schema['x-appwrite']['types'] ?? [],
                 "required" => $schema['required'] ?? [],
                 "additionalProperties" => $schema['additionalProperties'] ?? []
             ];
@@ -336,6 +337,18 @@ class Swagger2 extends Spec
                         $sch['properties'][$name]['sub_schemas'] = \array_map(fn($schema) => str_replace('#/definitions/', '', $schema['$ref']), $def['items']['x-oneOf']);
                     }
                 }
+            }
+            if (isset($sch['error_types'])) {
+                $types = [];
+                foreach ($sch['error_types'] as $type) {
+
+                    $types[] = [
+                        'code' => $type['code'],
+                        'type' => $type['type'],
+                        'description' => $type['description']
+                    ];
+                }
+                $sch['error_types'] = $types;
             }
             $list[$key] = $sch;
         }

--- a/templates/android/library/src/main/java/io/appwrite/exceptions/Exception.kt.twig
+++ b/templates/android/library/src/main/java/io/appwrite/exceptions/Exception.kt.twig
@@ -2,9 +2,18 @@ package {{ sdk.namespace | caseDot }}.exceptions
 
 import java.lang.Exception
 
-class {{spec.title | caseUcfirst}}Exception(
+class {{spec.title | caseUcfirst}} Exception(
     override val message: String? = null,
     val code: Int? = null,
     val type: String? = null,
     val response: String? = null
 ) : Exception(message)
+
+enum class ErrorType(val value: String) {
+{% for error in spec.definitions.appwriteException.error_types %}
+    /**
+     * {{ error.description }}
+     */
+    {{ error.type|title|replace({'_': ''}) }}("{{ error.type }}"),
+{% endfor %}
+}

--- a/templates/dart/lib/src/exception.dart.twig
+++ b/templates/dart/lib/src/exception.dart.twig
@@ -21,3 +21,10 @@ class {{spec.title | caseUcfirst}}Exception implements Exception {
     return "{{spec.title | caseUcfirst}}Exception: ${type ?? ''}, $message (${code ?? 0})";
   }
 }
+
+enum ErrorType {
+{% for error in spec.definitions.appwriteException.error_types %}
+  /// {{ error.description }}
+  {{ error.type|title|replace({'_': ''}) }},
+{% endfor %}
+}

--- a/templates/deno/src/exception.ts.twig
+++ b/templates/deno/src/exception.ts.twig
@@ -15,3 +15,12 @@ export class {{ spec.title | caseUcfirst}}Exception {
         return `${this.message} - ${this.code} - ${this.type} - ${JSON.stringify(this.response)}`;
     }
 }
+
+enum ErrorType {
+{% for error in spec.definitions.appwriteException.error_types %}
+	/**
+	 * {{ error.description }}
+	 */
+    {{ error.type|title|replace({'_': ''}) }} = "{{ error.type }}",
+{% endfor %}
+}

--- a/templates/dotnet/src/Appwrite/Exception.cs.twig
+++ b/templates/dotnet/src/Appwrite/Exception.cs.twig
@@ -25,3 +25,11 @@ namespace {{spec.title | caseUcfirst}}
     }
 }
 
+public enum ErrorType {
+{% for error in spec.definitions.appwriteException.error_types %}
+    /// <summary>
+    /// {{ error.description }}
+    /// </summary>
+    {{ error.type|title|replace({'_': ''}) }},
+{% endfor %}
+}

--- a/templates/kotlin/src/main/kotlin/io/appwrite/exceptions/Exception.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/exceptions/Exception.kt.twig
@@ -8,3 +8,12 @@ class {{spec.title | caseUcfirst}}Exception(
     val type: String? = null,
     val response: String? = null
 ) : Exception(message)
+
+enum class ErrorType(val value: String) {
+{% for error in spec.definitions.appwriteException.error_types %}
+    /**
+     * {{ error.description }}
+     */
+    {{ error.type|title|replace({'_': ''}) }}("{{ error.type }}"),
+{% endfor %}
+}

--- a/templates/node/lib/exception.js.twig
+++ b/templates/node/lib/exception.js.twig
@@ -8,3 +8,14 @@ class {{spec.title | caseUcfirst}}Exception extends Error {
 }
 
 module.exports = {{spec.title | caseUcfirst}}Exception;
+
+enum ErrorType {
+{% for error in spec.definitions.appwriteException.error_types %}
+  /**
+   * {{ error.description }}
+   */
+  {{ error.type|title|replace({'_': ''}) }} = "{{ error.type }}",
+{% endfor %}
+}
+
+module.exports = ErrorType;

--- a/templates/php/src/Exception.php.twig
+++ b/templates/php/src/Exception.php.twig
@@ -44,3 +44,12 @@ class {{spec.title | caseUcfirst}}Exception extends Exception {
       return $this->response;
   }
 }
+
+class ErrorType {
+{% for error in spec.definitions.appwriteException.error_types %}
+    /**
+    * {{ error.description }}
+    */
+    const {{ error.type|title|replace({'_': ''}) }} = '{{ error.type }}';
+{% endfor %}
+}

--- a/templates/python/package/exception.py.twig
+++ b/templates/python/package/exception.py.twig
@@ -1,3 +1,6 @@
+from enum import Enum
+
+
 class {{spec.title | caseUcfirst}}Exception(Exception):
     def __init__(self, message, code = 0, type = None, response = None):
         self.message = message
@@ -5,3 +8,12 @@ class {{spec.title | caseUcfirst}}Exception(Exception):
         self.type = type
         self.response = response
         super().__init__(self.message)
+
+
+class ErrorType(Enum):
+{% for error in spec.definitions.appwriteException.error_types %}
+    """
+    {{ error.description }}
+    """
+    {{ error.type|title|replace({'_': ''}) }} = '{{ error.type }}'
+{% endfor %}

--- a/templates/ruby/lib/container/exception.rb.twig
+++ b/templates/ruby/lib/container/exception.rb.twig
@@ -12,3 +12,10 @@ module {{spec.title | caseUcfirst}}
         end
     end
 end
+
+class ErrorType
+{% for error in spec.definitions.appwriteException.error_types %}
+    # {{ error.description }}
+    {{ error.type|title|replace({'_': ''}) }} = '{{ error.type }}'
+{% endfor %}
+end


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?


- added logic in Swagger2.php to parse errors from APISpecs -> definitions->x-appwrite.
- added Error enums in twig templates.


## Related PRs and Issues

Closes #698 