### PR TITLE
Filename should not be optional

### DIFF
--- a/templates/python/package/input_file.py.twig
+++ b/templates/python/package/input_file.py.twig
@@ -12,7 +12,7 @@ class InputFile:
         return instance
 
     @classmethod
-    def from_bytes(cls, bytes, filename = None, mime_type = None):
+    def from_bytes(cls, bytes, filename, mime_type = None):
         instance = cls()
         instance.data = bytes
         instance.filename = filename


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The file name is currently optional in our InputFile.from_bytes for Python. 

This will give you an error 100% of the time because you can't infer a filename from bytes.

The error message will be something like:
```
/Users/wen/PycharmProjects/test-scripts/venv/bin/python /Users/wen/PycharmProjects/test-scripts/main.py 
/Users/wen/PycharmProjects/test-scripts/venv/lib/python3.9/site-packages/urllib3/__init__.py:34: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
  warnings.warn(
Traceback (most recent call last):
  File "/Users/wen/PycharmProjects/test-scripts/venv/lib/python3.9/site-packages/appwrite/client.py", line 100, in call
    response.raise_for_status()
  File "/Users/wen/PycharmProjects/test-scripts/venv/lib/python3.9/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://cloud.appwrite.io/v1/storage/buckets/images/files

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/wen/PycharmProjects/test-scripts/main.py", line 46, in <module>
    main()
  File "/Users/wen/PycharmProjects/test-scripts/main.py", line 43, in main
    result = storage.create_file('images', ID.unique(), InputFile.from_bytes(byte_array, None, mime_type='image/jpeg'))
  File "/Users/wen/PycharmProjects/test-scripts/venv/lib/python3.9/site-packages/appwrite/services/storage.py", line 156, in create_file
    return self.client.chunked_upload(api_path, {
  File "/Users/wen/PycharmProjects/test-scripts/venv/lib/python3.9/site-packages/appwrite/client.py", line 142, in chunked_upload
    return self.call(
  File "/Users/wen/PycharmProjects/test-scripts/venv/lib/python3.9/site-packages/appwrite/client.py", line 112, in call
    raise AppwriteException(response.json()['message'], response.status_code, response.json().get('type'), response.json())
appwrite.exception.AppwriteException: Empty file passed to the endpoint.

Process finished with exit code 1

```

## Test Plan

Manual testing.

If you try to use no filename:
```
TypeError: from_bytes() missing 1 required positional argument: 'filename'
```

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)