### PR TITLE
Fix Ruby not mapping document data properly

### DIFF
--- a/templates/ruby/lib/container/models/model.rb.twig
+++ b/templates/ruby/lib/container/models/model.rb.twig
@@ -32,7 +32,7 @@ module {{ spec.title | caseUcfirst }}
 
 {% endfor %}
 {% if definition.additionalProperties %}
-                    data: map.reject { |k,_| k.start_with?("$") }
+                    data: map
 {% endif %}
                 )
             end

--- a/templates/ruby/lib/container/models/model.rb.twig
+++ b/templates/ruby/lib/container/models/model.rb.twig
@@ -32,7 +32,7 @@ module {{ spec.title | caseUcfirst }}
 
 {% endfor %}
 {% if definition.additionalProperties %}
-                    data: map["data"]
+                    data: map.reject { |k,_| k.start_with?("$") }
 {% endif %}
                 )
             end


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The generated model references map['data'], which is not defined because 'data' is not passed in from the API.

Instead, the API passes in user-defined attribute at the same level as system attributes that start with `$`

See: https://github.com/appwrite/sdk-for-ruby/blob/dd56d3d4a0ff469ab19c7728ac4f508daa7b8d42/lib/appwrite/models/document.rb#L39C1-L40C1

This fixes the issue by dynamically creating this `data` map from the `map` directly.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)