### PR TITLE
Fix: byte array check to fix GetFileDownload function in .NET SDK

### DIFF
--- a/templates/dotnet/src/Appwrite/Client.cs.twig
+++ b/templates/dotnet/src/Appwrite/Client.cs.twig
@@ -221,7 +221,6 @@ namespace {{ spec.title | caseUcfirst }}
                 .FirstOrDefault() ?? string.Empty;
 
             var isJson = contentType.Contains("application/json");
-            var isBytes = contentType.Contains("application/octet-stream");
 
             if (code >= 400) {
                 var message = await response.Content.ReadAsStringAsync();
@@ -248,13 +247,9 @@ namespace {{ spec.title | caseUcfirst }}
 
                 return (dict as T)!;
             }
-            else if (isBytes)
-            {
-                return ((await response.Content.ReadAsByteArrayAsync()) as T)!;
-            }
             else
             {
-                return default!;
+                return ((await response.Content.ReadAsByteArrayAsync()) as T)!;
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Corrects the byte array check in the .NET SDK to prevent GetFileDownload/Preview/View functions from returning null values

## Test Plan

- Generate new .NET SDK
- Verify correctly generated code in `Call()` function in `Client.cs`
![image](https://github.com/appwrite/sdk-generator/assets/31401437/feed886a-6578-4a41-83ee-11f969f2a845)

- Use newly generated .NET SDK with the following C# code

```cs
using Appwrite;
using Appwrite.Services;

var client = new Client();
client
    .SetEndpoint("http://cloud.appwrite.io/v1")
    .SetProject("[PROJECT_ID]")
    .SetKey("[API_KEY]");

var storage = new Storage(client);

var download = await storage.GetFileDownload("[BUCKET_ID]t", "[FILE_ID]");

File.WriteAllBytes($"output-{Guid.NewGuid()}.png", download);
```

## Related PRs and Issues

No

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes