### PR TITLE
Add support for vision os and fix warnings & errors

### DIFF
--- a/templates/apple/Sources/Client.swift.twig
+++ b/templates/apple/Sources/Client.swift.twig
@@ -542,6 +542,8 @@ extension Client {
         return "tvos"
         #elseif os(macOS)
         return "macos"
+        #elseif os(visionOS)
+        return "visionos"
         #elseif os(Linux)
         return "linux"
         #elseif os(Windows)

--- a/templates/swift/Sources/Client.swift.twig
+++ b/templates/swift/Sources/Client.swift.twig
@@ -578,6 +578,8 @@ extension Client {
         return "tvos"
         #elseif os(macOS)
         return "macos"
+        #elseif os(visionOS)
+        return "visionos"
         #elseif os(Linux)
         return "linux"
         #elseif os(Windows)
@@ -601,6 +603,9 @@ extension Client {
         #elseif os(macOS)
         let info = deviceInfo.macOSInfo
         device = "(Macintosh; \(info!.model))"
+        #elseif os(visionOS)
+        let info = deviceInfo.iOSInfo
+        device = "\(info!.modelIdentifier) visionOS/\(info!.systemVersion)"
         #elseif os(Linux)
         let info = deviceInfo.linuxInfo
         device = "(Linux; U; \(info!.id) \(info!.version))"

--- a/templates/swift/Sources/DeviceInfo/OSDeviceInfo.swift
+++ b/templates/swift/Sources/DeviceInfo/OSDeviceInfo.swift
@@ -2,7 +2,7 @@ import Foundation
 
 class OSDeviceInfo {
 
-    #if os(iOS) || os(tvOS)
+    #if os(iOS) || os(tvOS) || os(visionOS)
     var iOSInfo: IOSDeviceInfo?
     #elseif os(watchOS)
     var watchOSInfo: WatchOSDeviceInfo?
@@ -15,7 +15,7 @@ class OSDeviceInfo {
     #endif
 
     init() {
-        #if os(iOS) || os(tvOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
         self.iOSInfo = IOSDeviceInfo()
         #elseif os(watchOS)
         self.watchOSInfo = WatchOSDeviceInfo()

--- a/templates/swift/Sources/DeviceInfo/iOS/IOSDeviceInfo.swift
+++ b/templates/swift/Sources/DeviceInfo/iOS/IOSDeviceInfo.swift
@@ -1,4 +1,4 @@
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 import Foundation
 import UIKit
 

--- a/templates/swift/Sources/DeviceInfo/iOS/UIDevice+ModelName.swift
+++ b/templates/swift/Sources/DeviceInfo/iOS/UIDevice+ModelName.swift
@@ -1,4 +1,4 @@
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 import Foundation
 import UIKit
 
@@ -91,8 +91,12 @@ public extension UIDevice {
             case "AppleTV5,3":                                    return "Apple TV (4th generation)"
             case "AppleTV6,2":                                    return "Apple TV 4K (1st generation)"
             case "AppleTV11,1":                                   return "Apple TV 4K (2nd generation)"
-            case "i386", "x86_64": return "Simulator \(mapToDevice(identifier: ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "tvOS"))"
-            default: return identifier
+            case "i386", "x86_64":                                return "Simulator \(mapToDevice(identifier: ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "tvOS"))"
+            default:                                              return identifier
+            #elseif os(visionOS)
+            case "RealityDevice14,1":                             return "Apple Vision Pro"
+            case "i386", "x86_64":                                return "Simulator \(mapToDevice(identifier: ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "visionOS"))"
+            default:                                              return identifier
             #endif
             }
         }

--- a/templates/swift/Sources/DeviceInfo/iOS/UIDevice+ModelName.swift
+++ b/templates/swift/Sources/DeviceInfo/iOS/UIDevice+ModelName.swift
@@ -82,7 +82,7 @@ public extension UIDevice {
             case "iPad8,5", "iPad8,6", "iPad8,7", "iPad8,8":      return "iPad Pro (12.9-inch) (3rd generation)"
             case "iPad8,11", "iPad8,12":                          return "iPad Pro (12.9-inch) (4th generation)"
             case "iPad13,8", "iPad13,9", "iPad13,10", "iPad13,11":return "iPad Pro (12.9-inch) (5th generation)"
-            case "i386", "x86_64":                                return "Simulator \(mapToDevice(identifier: ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "iOS"))"
+            case "i386", "x86_64", "arm64":                       return "Simulator \(mapToDevice(identifier: ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "iOS"))"
             default:                                              return identifier
             #elseif os(tvOS)
             case "AppleTV1,1":                                    return "Apple TV (1st generation)"
@@ -91,11 +91,11 @@ public extension UIDevice {
             case "AppleTV5,3":                                    return "Apple TV (4th generation)"
             case "AppleTV6,2":                                    return "Apple TV 4K (1st generation)"
             case "AppleTV11,1":                                   return "Apple TV 4K (2nd generation)"
-            case "i386", "x86_64":                                return "Simulator \(mapToDevice(identifier: ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "tvOS"))"
+            case "i386", "x86_64", "arm64":                       return "Simulator \(mapToDevice(identifier: ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "tvOS"))"
             default:                                              return identifier
             #elseif os(visionOS)
             case "RealityDevice14,1":                             return "Apple Vision Pro"
-            case "i386", "x86_64":                                return "Simulator \(mapToDevice(identifier: ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "visionOS"))"
+            case "i386", "x86_64", "arm64":                       return "Simulator \(mapToDevice(identifier: ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] ?? "visionOS"))"
             default:                                              return identifier
             #endif
             }

--- a/templates/swift/Sources/OAuth/View+OAuth.swift.twig
+++ b/templates/swift/Sources/OAuth/View+OAuth.swift.twig
@@ -2,7 +2,7 @@
 typealias OSApplication = NSApplication
 typealias OSViewController = NSViewController
 let notificationType = NSApplication.willBecomeActiveNotification
-#elseif os(iOS) || os(tvOS)
+#elseif os(iOS) || os(tvOS) || os(visionOS)
 typealias OSApplication = UIApplication
 typealias OSViewController = UIViewController
 let notificationType = UIApplication.willEnterForegroundNotification
@@ -14,7 +14,7 @@ let notificationType = WKApplication.willEnterForegroundNotification
 
 #if canImport(SwiftUI)
 import SwiftUI
-@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, visionOS 1.0, *)
 extension View {
     public func registerOAuthHandler() -> some View {
         onOpenURL { url in
@@ -27,12 +27,12 @@ extension View {
 #endif
 
 #if canImport(OSViewController)
-@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, visionOS 1.0, *)
 extension OSViewController {
     public func registerOAuthHandler() {
         #if os(macOS)
         typealias OSHostingController = NSHostingController
-        #elseif os(iOS) || os(tvOS) || os(watchOS)
+        #elseif os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
         typealias OSHostingController = UIHostingController
         #endif
         self.addChild(OSHostingController(rootView: EmptyView().registerOAuthHandler()))

--- a/templates/swift/Sources/OAuth/WebAuthComponent.swift.twig
+++ b/templates/swift/Sources/OAuth/WebAuthComponent.swift.twig
@@ -10,7 +10,7 @@ import SwiftUI
 /// Used to authenticate with external OAuth2 providers. Launches browser windows and handles
 /// suspension until the user completes the process or otherwise returns to the app.
 ///
-@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, visionOS 1.0, *)
 public class WebAuthComponent {
 
 #if canImport(SwiftUI)

--- a/templates/swift/Sources/PackageInfo/OSPackageInfo.swift
+++ b/templates/swift/Sources/PackageInfo/OSPackageInfo.swift
@@ -3,7 +3,7 @@ import Foundation
 class OSPackageInfo {
 
     public static func get() -> PackageInfo {
-        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS)
+        #if os(iOS) || os(watchOS) || os(tvOS) || os(macOS) || os(visionOS)
         return PackageInfo.getApplePackage()
         #elseif os(Linux)
         return PackageInfo.getLinuxPackage()

--- a/templates/swift/Sources/WebSockets/WebSocketClient.swift.twig
+++ b/templates/swift/Sources/WebSockets/WebSocketClient.swift.twig
@@ -246,7 +246,9 @@ public class WebSocketClient {
         
         let basicUpgrader = NIOWebSocketClientUpgrader(
             requestKey: self.frameKey,
-            upgradePipelineHandler: self.upgradePipelineHandler
+            upgradePipelineHandler: { channel, response in
+                self.upgradePipelineHandler(channel: channel, response: response)
+            }
         )
         
         let config: NIOHTTPClientUpgradeConfiguration = (upgraders: [basicUpgrader], completionHandler: { context in

--- a/templates/swift/example-swiftui/Shared/ExampleView.swift
+++ b/templates/swift/example-swiftui/Shared/ExampleView.swift
@@ -49,7 +49,7 @@ struct ExampleView: View {
             ImagePicker.present()
         }
         #endif
-        #if os(iOS)
+        #if os(iOS) || os(visionOS)
         .sheet(isPresented: $viewModel.isShowPhotoLibrary) {
             ImagePicker(selectedImage: $imageToUpload)
         }

--- a/templates/swift/example-swiftui/Shared/Image/OSImage.swift
+++ b/templates/swift/example-swiftui/Shared/Image/OSImage.swift
@@ -9,7 +9,7 @@ import SwiftUI
 #if os(macOS)
 import AppKit
 public typealias OSImage = NSImage
-#elseif os(iOS) || os(tvOS) || os(watchOS)
+#elseif os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
 import UIKit
 public typealias OSImage = UIImage
 #endif
@@ -18,7 +18,7 @@ extension Image {
     public init(data: Data) {
         #if os(macOS)
         self.init(nsImage: NSImage(data: data)!)
-        #elseif os(iOS) || os(tvOS) || os(watchOS)
+        #elseif os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
         self.init(uiImage: UIImage(data: data)!)
         #endif
     }
@@ -28,7 +28,7 @@ extension OSImage {
     public var data: Data {
         #if os(macOS)
         return self.tiffRepresentation!
-        #elseif os(iOS) || os(tvOS) || os(watchOS)
+        #elseif os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
         return self.pngData()!
         #endif
     }


### PR DESCRIPTION
Add support for visionOS and arm64 simulator

Fix warnings:
1. use singleton instead of createNew
2. explicit ignore unused result
3. warning regarding sendable function closure

Fix error: WebAuthComponents was missing for swift-server target