### PR TITLE
Fix CLI deploy function

### DIFF
--- a/templates/cli/lib/commands/deploy.js.twig
+++ b/templates/cli/lib/commands/deploy.js.twig
@@ -106,6 +106,35 @@ const awaitPools = {
             iteration + 1
         );
     },
+    wipeVariables: async (functionId, iteration = 1) => {
+        if (iteration > poolMaxDebounces) {
+            return false;
+        }
+
+        const { total } = await functionsListVariables({
+            functionId,
+            queries: ['limit(1)'],
+            parseOutput: false
+        });
+
+        if (total === 0) {
+            return true;
+        }
+
+        let steps = Math.max(1, Math.ceil(total / STEP_SIZE));
+        if (steps > 1 && iteration === 1) {
+            poolMaxDebounces *= steps;
+
+            log('Found a large number of variables, increasing timeout to ' + (poolMaxDebounces * POOL_DEBOUNCE / 1000 / 60) + ' minutes')
+        }
+
+        await new Promise(resolve => setTimeout(resolve, POOL_DEBOUNCE));
+
+        return await awaitPools.wipeVariables(
+            functionId,
+            iteration + 1
+        );
+    },
     expectAttributes: async (databaseId, collectionId, attributeKeys, iteration = 1) => {
         if (iteration > poolMaxDebounces) {
             return false;
@@ -310,7 +339,7 @@ const deployFunction = async ({ functionId, all, yes } = {}) => {
 
             if (total === 0) {
                 deployVariables = true;
-            } else if (remoteVariables.length > 0 && !yes) {
+            } else if (total > 0 && !yes) {
                 const variableAnswers = await inquirer.prompt(questionsDeployFunctions[1])
                 deployVariables = variableAnswers.override.toLowerCase() === "yes";
             }
@@ -320,13 +349,23 @@ const deployFunction = async ({ functionId, all, yes } = {}) => {
             } else {
                 log(`Deploying variables for ${func.name} ( ${func['$id']} )`);
 
-                await Promise.all(remoteVariables.map(async remoteVariable => {
+                const { variables } = await paginate(functionsListVariables, {
+                    functionId: func['$id'],
+                    parseOutput: false
+                }, 100, 'variables');
+    
+                await Promise.all(variables.map(async variable => {
                     await functionsDeleteVariable({
                         functionId: func['$id'],
-                        variableId: remoteVariable['$id'],
+                        variableId: variable['$id'],
                         parseOutput: false
                     });
                 }));
+    
+                let result = await awaitPools.wipeVariables(func['$id']);
+                if (!result) {
+                    throw new Error("Variable deletion timed out.");
+                }
 
                 // Deploy local variables
                 await Promise.all(Object.keys(func.variables).map(async localVariableKey => {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

remoteVariables was undefined so use total instead and make it match how it's done for wiping attributes and indexes.

Fixes: https://github.com/appwrite/sdk-for-cli/issues/112

## Test Plan

Manually created SDK and deployed:

<img width="885" alt="image" src="https://github.com/appwrite/sdk-generator/assets/1477010/8f46a47f-fda6-4465-9ca6-c15db0488808">

variable was successfully recreated:

![image](https://github.com/appwrite/sdk-generator/assets/1477010/ce0c4723-2a80-44e7-9ab8-c8ed786654b0)

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes