### PR TITLE
fix: enum usage for body params

### DIFF
--- a/templates/dart/base/utils.twig
+++ b/templates/dart/base/utils.twig
@@ -1,6 +1,6 @@
 {% macro map_parameter(parameters) %}
 {% for parameter in parameters %}
-'{{ parameter.name }}': {{ parameter.name | caseCamel | overrideIdentifier }},
+'{{ parameter.name }}': {{ parameter.name | caseCamel | overrideIdentifier }}{% if parameter.enumValues | length > 0  %}{% if not parameter.required %}?{% endif %}.value{% endif %},
 {% endfor %}
 {% endmacro %}
 

--- a/templates/flutter/base/utils.twig
+++ b/templates/flutter/base/utils.twig
@@ -1,6 +1,6 @@
 {%- macro map_parameter(parameters) -%}
 {%- for parameter in parameters ~%}
-            '{{ parameter.name }}': {{ parameter.name | caseCamel | overrideIdentifier }},
+            '{{ parameter.name }}': {{ parameter.name | caseCamel | overrideIdentifier }}{% if parameter.enumValues | length > 0  %}{% if not parameter.required %}?{% endif %}.value{% endif %},
 {%- endfor ~%}
 {%- endmacro ~%}
 


### PR DESCRIPTION
## What does this PR do?

- uses the `enum.value` on enums for body params
- use `enum?.value` on optional enum params

## Test Plan

- n/a

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

✅ 