### PR TITLE
Update accountCreateEmailSession to accountCreateEmailPasswordSession

### DIFF
--- a/templates/cli/lib/commands/generic.js.twig
+++ b/templates/cli/lib/commands/generic.js.twig
@@ -6,7 +6,7 @@ const { globalConfig, localConfig } = require("../config");
 const { actionRunner, success, parseBool, commandDescriptions, log, parse } = require("../parser");
 {% if sdk.test != "true" %}
 const { questionsLogin } = require("../questions");
-const { accountCreateEmailSession, accountDeleteSession } = require("./account");
+const { accountCreateEmailPasswordSession, accountDeleteSession } = require("./account");
 
 const login = new Command("login")
     .description(commandDescriptions['login'])
@@ -18,7 +18,7 @@ const login = new Command("login")
 
         let client = await sdkForConsole(false);
 
-        await accountCreateEmailSession({
+        await accountCreateEmailPasswordSession({
             email: answers.email,
             password: answers.password,
             parseOutput: false,


### PR DESCRIPTION
Update accountCreateEmailSession to accountCreateEmailPasswordSession in generic.js.twig

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes the error `Error accountCreateEmailSession is not a function` when running `appwrite login` cli command

## Test Plan

Tested logging into self-hosted appwrite instance successfully.

## Related PRs and Issues

https://github.com/appwrite/sdk-for-cli/issues/116
#796

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes