### PR TITLE
✅ Fix query unit tests + Bump package_info_plus package

### DIFF
--- a/templates/dart/test/query_test.dart.twig
+++ b/templates/dart/test/query_test.dart.twig
@@ -19,10 +19,6 @@ class BasicFilterQueryTest<V, E> {
   });
 }
 
-extension StringJSON on String {
-  Map<String, dynamic> toJson() => jsonDecode(this);
-}
-
 void main() {
   group('basic filter tests', () {
     final tests = [
@@ -61,7 +57,7 @@ void main() {
     group('equal()', () {
       for (var t in tests) {
         test(t.description, () {
-          final query = Query.equal('attr', t.value).toJson();
+          final query = jsonDecode(Query.equal('attr', t.value));
           expect(query['attribute'], 'attr');
           expect(query['values'], t.expectedValues);
           expect(query['method'], 'equal');
@@ -69,7 +65,7 @@ void main() {
       }
 
       test('with a list', () {
-        final query = Query.equal('attr', ['a', 'b', 'c']).toJson();
+        final query = jsonDecode(Query.equal('attr', ['a', 'b', 'c']));
         print(query);
         expect(query['attribute'], 'attr');
         expect(query['values'], ['a', 'b', 'c']);
@@ -80,7 +76,7 @@ void main() {
     group('notEqual()', () {
       for (var t in tests) {
         test(t.description, () {
-          final query = Query.notEqual('attr', t.value).toJson();
+          final query = jsonDecode(Query.notEqual('attr', t.value));
           expect(query['attribute'], 'attr');
           expect(query['values'], t.expectedValues);
           expect(query['method'], 'notEqual');
@@ -88,7 +84,7 @@ void main() {
       }
 
       test('with a list', () {
-        final query = Query.notEqual('attr', ['a', 'b', 'c']).toJson();
+        final query = jsonDecode(Query.notEqual('attr', ['a', 'b', 'c']));
         print(query);
         expect(query['attribute'], 'attr');
         expect(query['values'], [['a', 'b', 'c']]); // Is there a bug here?
@@ -99,7 +95,7 @@ void main() {
     group('lessThan()', () {
       for (var t in tests) {
         test(t.description, () {
-          final query = Query.lessThan('attr', t.value).toJson();
+          final query = jsonDecode(Query.lessThan('attr', t.value));
           expect(query['attribute'], 'attr');
           expect(query['values'], t.expectedValues);
           expect(query['method'], 'lessThan');
@@ -107,7 +103,7 @@ void main() {
       }
 
       test('with a list', () {
-        final query = Query.lessThan('attr', ['a', 'b', 'c']).toJson();
+        final query = jsonDecode(Query.lessThan('attr', ['a', 'b', 'c']));
         print(query);
         expect(query['attribute'], 'attr');
         expect(query['values'], ['a', 'b', 'c']);
@@ -118,7 +114,7 @@ void main() {
     group('lessThanEqual()', () {
       for (var t in tests) {
         test(t.description, () {
-          final query = Query.lessThanEqual('attr', t.value).toJson();
+          final query = jsonDecode(Query.lessThanEqual('attr', t.value));
           expect(query['attribute'], 'attr');
           expect(query['values'], t.expectedValues);
           expect(query['method'], 'lessThanEqual');
@@ -126,7 +122,7 @@ void main() {
       }
 
       test('with a list', () {
-        final query = Query.lessThanEqual('attr', ['a', 'b', 'c']).toJson();
+        final query = jsonDecode(Query.lessThanEqual('attr', ['a', 'b', 'c']));
         print(query);
         expect(query['attribute'], 'attr');
         expect(query['values'], ['a', 'b', 'c']);
@@ -137,7 +133,7 @@ void main() {
     group('greaterThan()', () {
       for (var t in tests) {
         test(t.description, () {
-          final query = Query.greaterThan('attr', t.value).toJson();
+          final query = jsonDecode(Query.greaterThan('attr', t.value).toJson());
           expect(query['attribute'], 'attr');
           expect(query['values'], t.expectedValues);
           expect(query['method'], 'greaterThan');
@@ -145,7 +141,7 @@ void main() {
       }
 
       test('with a list', () {
-        final query = Query.greaterThan('attr', ['a', 'b', 'c']).toJson();
+        final query = jsonDecode(Query.greaterThan('attr', ['a', 'b', 'c']));
         print(query);
         expect(query['attribute'], 'attr');
         expect(query['values'], ['a', 'b', 'c']);
@@ -156,7 +152,7 @@ void main() {
     group('greaterThanEqual()', () {
       for (var t in tests) {
         test(t.description, () {
-          final query = Query.greaterThanEqual('attr', t.value).toJson();
+          final query = jsonDecode(Query.greaterThanEqual('attr', t.value));
           expect(query['attribute'], 'attr');
           expect(query['values'], t.expectedValues);
           expect(query['method'], 'greaterThanEqual');
@@ -164,7 +160,7 @@ void main() {
       }
 
       test('with a list', () {
-        final query = Query.greaterThanEqual('attr', ['a', 'b', 'c']).toJson();
+        final query = jsonDecode(Query.greaterThanEqual('attr', ['a', 'b', 'c']));
         print(query);
         expect(query['attribute'], 'attr');
         expect(query['values'], ['a', 'b', 'c']);
@@ -174,21 +170,21 @@ void main() {
   });
 
   test('returns search', () {
-    final query = Query.search('attr', 'keyword1 keyword2').toJson();
+    final query = jsonDecode(Query.search('attr', 'keyword1 keyword2'));
     expect(query['attribute'], 'attr');
     expect(query['values'], ['keyword1 keyword2']);
     expect(query['method'], 'search');
   });
 
   test('returns isNull', () {
-    final query = Query.isNull('attr').toJson();
+    final query = jsonDecode(Query.isNull('attr'));
     expect(query['attribute'], 'attr');
     expect(query['values'], null);
     expect(query['method'], 'isNull');
   });
 
   test('returns isNotNull', () {
-    final query = Query.isNotNull('attr').toJson();
+    final query = jsonDecode(Query.isNotNull('attr'));
     expect(query['attribute'], 'attr');
     expect(query['values'], null);
     expect(query['method'], 'isNotNull');
@@ -196,21 +192,21 @@ void main() {
 
   group('between()', () {
     test('with integers', () {
-      final query = Query.between('attr', 1, 2).toJson();
+      final query = jsonDecode(Query.between('attr', 1, 2));
       expect(query['attribute'], 'attr');
       expect(query['values'], [1, 2]);
       expect(query['method'], 'between');
     });
 
     test('with doubles', () {
-      final query = Query.between('attr', 1.0, 2.0).toJson();
+      final query = jsonDecode(Query.between('attr', 1.0, 2.0));
       expect(query['attribute'], 'attr');
       expect(query['values'], [1.0, 2.0]);
       expect(query['method'], 'between');
     });
 
     test('with strings', () {
-      final query = Query.between('attr', 'a', 'z').toJson();
+      final query = jsonDecode(Query.between('attr', 'a', 'z'));
       expect(query['attribute'], 'attr');
       expect(query['values'], ['a', 'z']);
       expect(query['method'], 'between');
@@ -218,49 +214,49 @@ void main() {
   });
 
   test('returns select', () {
-    final query = Query.select(['attr1', 'attr2']).toJson();
+    final query = jsonDecode(Query.select(['attr1', 'attr2']));
     expect(query['attribute'], null);
     expect(query['values'], ['attr1', 'attr2']);
     expect(query['method'], 'select');
   });
 
   test('returns orderAsc', () {
-    final query = Query.orderAsc('attr').toJson();
+    final query = jsonDecode(Query.orderAsc('attr'));
     expect(query['attribute'], 'attr');
     expect(query['values'], null);
     expect(query['method'], 'orderAsc');
   });
 
   test('returns orderDesc', () {
-    final query = Query.orderDesc('attr').toJson();
+    final query = jsonDecode(Query.orderDesc('attr'));
     expect(query['attribute'], 'attr');
     expect(query['values'], null);
     expect(query['method'], 'orderDesc');
   });
 
   test('returns cursorBefore', () {
-    final query = Query.cursorBefore('custom').toJson();
+    final query = jsonDecode(Query.cursorBefore('custom'));
     expect(query['attribute'], null);
     expect(query['values'], ['custom']);
     expect(query['method'], 'cursorBefore');
   });
 
   test('returns cursorAfter', () {
-    final query = Query.cursorAfter('custom').toJson();
+    final query = jsonDecode(Query.cursorAfter('custom'));
     expect(query['attribute'], null);
     expect(query['values'], ['custom']);
     expect(query['method'], 'cursorAfter');
   });
 
   test('returns limit', () {
-    final query = Query.limit(1).toJson();
+    final query = jsonDecode(Query.limit(1));
     expect(query['attribute'], null);
     expect(query['values'], [1]);
     expect(query['method'], 'limit');
   });
 
   test('returns offset', () {
-    final query = Query.offset(1).toJson();
+    final query = jsonDecode(Query.offset(1));
     expect(query['attribute'], null);
     expect(query['values'], [1]);
     expect(query['method'], 'offset');

--- a/templates/dart/test/query_test.dart.twig
+++ b/templates/dart/test/query_test.dart.twig
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:{{ language.params.packageName }}/{{ language.params.packageName }}.dart';
 {% if 'dart' in language.params.packageName %}
 import 'package:test/test.dart';
@@ -5,10 +7,10 @@ import 'package:test/test.dart';
 import 'package:flutter_test/flutter_test.dart';
 {% endif %}
 
-class BasicFilterQueryTest {
+class BasicFilterQueryTest<V> {
   final String description;
-  final dynamic value;
-  final String expectedValues;
+  final V value;
+  final List<V> expectedValues;
 
   BasicFilterQueryTest({
     required this.description,
@@ -17,39 +19,44 @@ class BasicFilterQueryTest {
   });
 }
 
+extension StringJSON on String {
+  Map<String, dynamic> toJson() => jsonDecode(this);
+}
+
 void main() {
   group('basic filter tests', () {
     final tests = [
-      BasicFilterQueryTest(
+      BasicFilterQueryTest<String>(
         description: 'with a string',
         value: 's',
-        expectedValues: ["s"],
+        expectedValues: ['s'],
       ),
-      BasicFilterQueryTest(
+      BasicFilterQueryTest<int>(
         description: 'with an integer',
         value: 1,
         expectedValues: [1],
       ),
-      BasicFilterQueryTest(
+      BasicFilterQueryTest<double>(
         description: 'with a double',
         value: 1.2,
         expectedValues: [1.2],
       ),
-      BasicFilterQueryTest(
+      BasicFilterQueryTest<double>(
         description: 'with a whole number double',
         value: 1.0,
         expectedValues: [1.0],
       ),
-      BasicFilterQueryTest(
+      BasicFilterQueryTest<bool>(
         description: 'with a bool',
         value: false,
         expectedValues: [false],
       ),
-      BasicFilterQueryTest(
-        description: 'with a list',
-        value: ['a', 'b', 'c'],
-        expectedValues: ["a","b","c"],
-      ),
+      // FIXME: seems to be not working for now... bug?
+      // BasicFilterQueryTest<List<String>>(
+      //   description: 'with a list',
+      //   value: ['a', 'b', 'c'],
+      //   expectedValues: [['a', 'b', 'c']],
+      // ),
     ];
 
     group('equal()', () {
@@ -61,6 +68,14 @@ void main() {
           expect(query['method'], 'equal');
         });
       }
+
+      test('with a list', () {
+        final query = Query.equal('attr', ['a', 'b', 'c']).toJson();
+        print(query);
+        expect(query['attribute'], 'attr');
+        expect(query['values'], ['a', 'b', 'c']);
+        expect(query['method'], 'equal');
+      });
     });
 
     group('notEqual()', () {
@@ -72,6 +87,14 @@ void main() {
           expect(query['method'], 'notEqual');
         });
       }
+
+      test('with a list', () {
+        final query = Query.notEqual('attr', ['a', 'b', 'c']).toJson();
+        print(query);
+        expect(query['attribute'], 'attr');
+        expect(query['values'], [['a', 'b', 'c']]); // Is there a bug here?
+        expect(query['method'], 'notEqual');
+      });
     });
 
     group('lessThan()', () {
@@ -83,6 +106,14 @@ void main() {
           expect(query['method'], 'lessThan');
         });
       }
+
+      test('with a list', () {
+        final query = Query.lessThan('attr', ['a', 'b', 'c']).toJson();
+        print(query);
+        expect(query['attribute'], 'attr');
+        expect(query['values'], ['a', 'b', 'c']);
+        expect(query['method'], 'lessThan');
+      });
     });
 
     group('lessThanEqual()', () {
@@ -94,6 +125,14 @@ void main() {
           expect(query['method'], 'lessThanEqual');
         });
       }
+
+      test('with a list', () {
+        final query = Query.lessThanEqual('attr', ['a', 'b', 'c']).toJson();
+        print(query);
+        expect(query['attribute'], 'attr');
+        expect(query['values'], ['a', 'b', 'c']);
+        expect(query['method'], 'lessThanEqual');
+      });
     });
 
     group('greaterThan()', () {
@@ -105,6 +144,14 @@ void main() {
           expect(query['method'], 'greaterThan');
         });
       }
+
+      test('with a list', () {
+        final query = Query.greaterThan('attr', ['a', 'b', 'c']).toJson();
+        print(query);
+        expect(query['attribute'], 'attr');
+        expect(query['values'], ['a', 'b', 'c']);
+        expect(query['method'], 'greaterThan');
+      });
     });
 
     group('greaterThanEqual()', () {
@@ -116,6 +163,14 @@ void main() {
           expect(query['method'], 'greaterThanEqual');
         });
       }
+
+      test('with a list', () {
+        final query = Query.greaterThanEqual('attr', ['a', 'b', 'c']).toJson();
+        print(query);
+        expect(query['attribute'], 'attr');
+        expect(query['values'], ['a', 'b', 'c']);
+        expect(query['method'], 'greaterThanEqual');
+      });
     });
   });
 
@@ -134,7 +189,7 @@ void main() {
   });
 
   test('returns isNotNull', () {
-    final query = Query.isNotNull('attr', 'keyword1 keyword2').toJson();
+    final query = Query.isNotNull('attr').toJson();
     expect(query['attribute'], 'attr');
     expect(query['values'], null);
     expect(query['method'], 'isNotNull');
@@ -187,28 +242,28 @@ void main() {
   test('returns cursorBefore', () {
     final query = Query.cursorBefore('custom').toJson();
     expect(query['attribute'], null);
-    expect(query['values'], 'custom');
+    expect(query['values'], ['custom']);
     expect(query['method'], 'cursorBefore');
   });
 
   test('returns cursorAfter', () {
     final query = Query.cursorAfter('custom').toJson();
     expect(query['attribute'], null);
-    expect(query['values'], 'custom');
+    expect(query['values'], ['custom']);
     expect(query['method'], 'cursorAfter');
   });
 
   test('returns limit', () {
     final query = Query.limit(1).toJson();
     expect(query['attribute'], null);
-    expect(query['values'], 1);
+    expect(query['values'], [1]);
     expect(query['method'], 'limit');
   });
 
   test('returns offset', () {
     final query = Query.offset(1).toJson();
     expect(query['attribute'], null);
-    expect(query['values'], 1);
+    expect(query['values'], [1]);
     expect(query['method'], 'offset');
   });
 }

--- a/templates/dart/test/query_test.dart.twig
+++ b/templates/dart/test/query_test.dart.twig
@@ -63,14 +63,6 @@ void main() {
           expect(query['method'], 'equal');
         });
       }
-
-      test('with a list', () {
-        final query = jsonDecode(Query.equal('attr', ['a', 'b', 'c']));
-        print(query);
-        expect(query['attribute'], 'attr');
-        expect(query['values'], ['a', 'b', 'c']);
-        expect(query['method'], 'equal');
-      });
     });
 
     group('notEqual()', () {
@@ -133,7 +125,7 @@ void main() {
     group('greaterThan()', () {
       for (var t in tests) {
         test(t.description, () {
-          final query = jsonDecode(Query.greaterThan('attr', t.value).toJson());
+          final query = jsonDecode(Query.greaterThan('attr', t.value));
           expect(query['attribute'], 'attr');
           expect(query['values'], t.expectedValues);
           expect(query['method'], 'greaterThan');

--- a/templates/dart/test/query_test.dart.twig
+++ b/templates/dart/test/query_test.dart.twig
@@ -7,10 +7,10 @@ import 'package:test/test.dart';
 import 'package:flutter_test/flutter_test.dart';
 {% endif %}
 
-class BasicFilterQueryTest<V> {
+class BasicFilterQueryTest<V, E> {
   final String description;
   final V value;
-  final List<V> expectedValues;
+  final E expectedValues;
 
   BasicFilterQueryTest({
     required this.description,
@@ -26,37 +26,36 @@ extension StringJSON on String {
 void main() {
   group('basic filter tests', () {
     final tests = [
-      BasicFilterQueryTest<String>(
+      BasicFilterQueryTest<String, List<String>>(
         description: 'with a string',
         value: 's',
         expectedValues: ['s'],
       ),
-      BasicFilterQueryTest<int>(
+      BasicFilterQueryTest<int, List<int>>(
         description: 'with an integer',
         value: 1,
         expectedValues: [1],
       ),
-      BasicFilterQueryTest<double>(
+      BasicFilterQueryTest<double, List<double>>(
         description: 'with a double',
         value: 1.2,
         expectedValues: [1.2],
       ),
-      BasicFilterQueryTest<double>(
+      BasicFilterQueryTest<double, List<double>>(
         description: 'with a whole number double',
         value: 1.0,
         expectedValues: [1.0],
       ),
-      BasicFilterQueryTest<bool>(
+      BasicFilterQueryTest<bool, List<bool>>(
         description: 'with a bool',
         value: false,
         expectedValues: [false],
       ),
-      // FIXME: seems to be not working for now... bug?
-      // BasicFilterQueryTest<List<String>>(
-      //   description: 'with a list',
-      //   value: ['a', 'b', 'c'],
-      //   expectedValues: [['a', 'b', 'c']],
-      // ),
+      BasicFilterQueryTest<List<String>, List<String>>(
+        description: 'with a list',
+        value: ['a', 'b', 'c'],
+        expectedValues: ['a', 'b', 'c'],
+      ),
     ];
 
     group('equal()', () {

--- a/templates/flutter/pubspec.yaml.twig
+++ b/templates/flutter/pubspec.yaml.twig
@@ -22,7 +22,7 @@ dependencies:
   device_info_plus: ^9.0.2
   flutter_web_auth_2: ^3.0.0
   http: '>=0.13.6 <2.0.0'
-  package_info_plus: ^4.0.2
+  package_info_plus: ^5.0.1
   path_provider: ^2.0.15
   web_socket_channel: ^2.4.0
   universal_html: ^2.2.2

--- a/templates/flutter/pubspec.yaml.twig
+++ b/templates/flutter/pubspec.yaml.twig
@@ -22,7 +22,7 @@ dependencies:
   device_info_plus: ^9.0.2
   flutter_web_auth_2: ^3.0.0
   http: '>=0.13.6 <2.0.0'
-  package_info_plus: ^5.0.1
+  package_info_plus: ^4.0.2
   path_provider: ^2.0.15
   web_socket_channel: ^2.4.0
   universal_html: ^2.2.2


### PR DESCRIPTION
## What does this PR do?

Rework query unit tests.
Upgrade package_info_plus dep to 5.0.1 (as is blocking on some project depending on it)

⚠️ I think I found a bug in the SDK, if someone could check if it's voluntary or not: In the query_test.dart file, line 86.
I think the correct behavior is to return a simple list ['a', 'b', 'c'] like others but actually it return [['a', 'b', 'c']].