### PR TITLE
fix-805-change-GetValues-to-TryGetValues-when-parsing-content-type-header

### DIFF
--- a/templates/dotnet/src/Appwrite/Client.cs.twig
+++ b/templates/dotnet/src/Appwrite/Client.cs.twig
@@ -232,9 +232,11 @@ namespace {{ spec.title | caseUcfirst }}
             if (code >= 400) {
                 var message = await response.Content.ReadAsStringAsync();
 
-                var contentType = response.Content.Headers
-                    .GetValues("Content-Type")
-                    .FirstOrDefault() ?? string.Empty;
+                string contentType = string.Empty;
+                if (response.Content.Headers.TryGetValues("Content-Type", out var contentTypes))
+                {
+                    contentType = contentTypes.FirstOrDefault() ?? string.Empty;
+                }
 
                 if (contentType.Contains("application/json")) {
                     message = JObject.Parse(message)["message"]!.ToString();
@@ -267,9 +269,11 @@ namespace {{ spec.title | caseUcfirst }}
             var response = await _http.SendAsync(request);
             var code = (int)response.StatusCode;
 
-            var contentType = response.Content.Headers
-                .GetValues("Content-Type")
-                .FirstOrDefault() ?? string.Empty;
+            string contentType = string.Empty;
+            if (response.Content.Headers.TryGetValues("Content-Type", out var contentTypes))
+            {
+                contentType = contentTypes.FirstOrDefault() ?? string.Empty;
+            }
 
             var isJson = contentType.Contains("application/json");
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The DotNet SDK has a bug where the SDK throws an InvalidOperationException if the "Content-Type" header is not present in the response from Appwrite. This is the case if you for example delete a document.
This PR changes the code to use `TryGetValues` which returns a boolean if it could successfully parse the header.

Fixes #805 

## Test Plan

I checked out the repository of the dotnet-sdk, made the proposed changes and tested.

## Related PRs and Issues

* #805 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

I read the Contributing Guidelines