### PR TITLE
Feat: MFA support for CLI

### DIFF
--- a/example.php
+++ b/example.php
@@ -41,7 +41,7 @@ try {
      $platform = 'console';
     // $platform = 'server';
 
-    $spec = getSSLPage("https://raw.githubusercontent.com/appwrite/appwrite/feat-rc-sdks/app/config/specs/swagger2-latest-{$platform}.json");
+    $spec = getSSLPage("https://raw.githubusercontent.com/appwrite/appwrite/1.5.x/app/config/specs/swagger2-latest-{$platform}.json");
 
     if(empty($spec)) {
         throw new Exception('Failed to fetch spec from Appwrite server');

--- a/templates/cli/lib/commands/generic.js.twig
+++ b/templates/cli/lib/commands/generic.js.twig
@@ -5,8 +5,8 @@ const { sdkForConsole } = require("../sdks");
 const { globalConfig, localConfig } = require("../config");
 const { actionRunner, success, parseBool, commandDescriptions, log, parse } = require("../parser");
 {% if sdk.test != "true" %}
-const { questionsLogin } = require("../questions");
-const { accountCreateEmailPasswordSession, accountDeleteSession } = require("./account");
+const { questionsLogin, questionsListFactors, questionsMfaChallenge } = require("../questions");
+const { accountUpdateMfaChallenge, accountCreateMfaChallenge, accountGet, accountCreateEmailPasswordSession, accountDeleteSession } = require("./account");
 
 const login = new Command("login")
     .description(commandDescriptions['login'])
@@ -25,7 +25,44 @@ const login = new Command("login")
             sdk: client
         })
 
-        success()
+        client.setCookie(globalConfig.getCookie());
+
+        let account;
+
+        try {
+            account = await accountGet({
+                sdk: client,
+                parseOutput: false
+            });
+        } catch(error) {
+            if (error.response === 'user_more_factors_required') {
+                const { factor } = await inquirer.prompt(questionsListFactors);
+
+                const challenge = await accountCreateMfaChallenge({
+                    factor,
+                    parseOutput: false,
+                    sdk: client
+                });
+
+                const { otp } = await inquirer.prompt(questionsMfaChallenge);
+
+                await accountUpdateMfaChallenge({
+                    challengeId: challenge.$id,
+                    otp,
+                    parseOutput: false,
+                    sdk: client
+                });
+
+                account = await accountGet({
+                    sdk: client,
+                    parseOutput: false
+                });
+            } else {
+                throw error;
+            }
+        }
+
+        success("Signed in as user with ID: " + account.$id);
     }));
 
 const logout = new Command("logout")

--- a/templates/cli/lib/questions.js.twig
+++ b/templates/cli/lib/questions.js.twig
@@ -416,13 +416,12 @@ const questionsListFactors = [
                 {
                     name: `Phone (SMS)`,
                     value: 'phone'
+                },
+                {
+                    name: `Recovery code`,
+                    value: 'recoveryCode'
                 }
             ].filter((ch) => factors[ch.value] === true);
-
-            choices.push({
-                name: `Recovery code`,
-                value: 'recoveryCode'
-            });
 
             return choices;
         }

--- a/templates/cli/lib/questions.js.twig
+++ b/templates/cli/lib/questions.js.twig
@@ -1,6 +1,9 @@
 const { localConfig } = require('./config');
 const { projectsList } = require('./commands/projects');
 const { functionsListRuntimes } = require('./commands/functions');
+const { accountListMfaFactors } = require("./commands/account");
+const { sdkForConsole } = require("./sdks");
+
 const { databasesList } = require('./commands/databases');
 const JSONbig = require("json-bigint")({ storeAsString: false });
 
@@ -387,7 +390,58 @@ const questionsDeployTeams = [
         name: "override",
         message: 'Are you sure you want to override this team? This can lead to loss of data! Type "YES" to confirm.'
     },
-]
+];
+
+const questionsListFactors = [
+    {
+        type: "list",
+        name: "factor",
+        message: "Your account is protected by multiple factors. Which factor would you like to use to authenticate?",
+        choices: async () => {
+            let client = await sdkForConsole(false);
+            const factors = await accountListMfaFactors({
+                sdk: client,
+                parseOutput: false
+            });
+                
+            const choices = [
+                {
+                    name: `TOTP (Time-based One-time Password)`,
+                    value: 'totp'
+                },
+                {
+                    name: `E-mail`,
+                    value: 'email'
+                },
+                {
+                    name: `Phone (SMS)`,
+                    value: 'phone'
+                }
+            ].filter((ch) => factors[ch.value] === true);
+
+            choices.push({
+                name: `Recovery code`,
+                value: 'recoveryCode'
+            });
+
+            return choices;
+        }
+    }
+];
+
+const questionsMfaChallenge = [
+    {
+        type: "input",
+        name: "otp",
+        message: "Enter OTP",
+        validate(value) {
+            if (!value) {
+                return "Please enter OTP";
+            }
+            return true;
+        },
+    }
+];
 
 module.exports = {
     questionsInitProject,
@@ -398,5 +452,7 @@ module.exports = {
     questionsDeployCollections,
     questionsDeployBuckets,
     questionsDeployTeams,
-    questionsGetEntrypoint
+    questionsGetEntrypoint,
+    questionsListFactors,
+    questionsMfaChallenge
 };


### PR DESCRIPTION
## What does this PR do?

Accounts with MFA enabled cannot signing using `appwrite login` (they can, but cannot do any actions)

## Test Plan

- [x] Manual QA

TOTP sign in:

![CleanShot 2024-04-10 at 12 34 43@2x](https://github.com/appwrite/sdk-generator/assets/19310830/48ec1772-54e9-4025-b066-4294f1de9348)

Sessison object:

![CleanShot 2024-04-10 at 12 35 03@2x](https://github.com/appwrite/sdk-generator/assets/19310830/dc5ad14d-1edb-45ac-a6c3-2f3c953528cd)

Recovery code sign-in:

![CleanShot 2024-04-10 at 13 30 15@2x](https://github.com/appwrite/sdk-generator/assets/19310830/290123a4-6677-4829-bc26-bf378367c541)

## Related PRs and Issues

* https://github.com/appwrite/sdk-for-cli/issues/122

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes