### PR TITLE
Close Android realtime socket properly on unsubscribe

### DIFF
--- a/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
+++ b/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
@@ -44,6 +44,8 @@ class Realtime(client: Client) : Service(client), CoroutineScope {
 
     private fun createSocket() {
         if (activeChannels.isEmpty()) {
+            reconnect = false
+            closeSocket()
             return
         }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
Fixes Android realtime socket cleanup - last subscription was always active even after unsubscribing. 

## Test Plan
Inspecting network, simple breakpoint in onMessage function and observing realtime count indicator in Appwrite dashboard revealed that realtime connection is still active and data is coming through even after disconnecting.
After the fix, socket is closed properly and Appwrite dashboard confirms it as well.

## Related PRs and Issues
Similar issue found on sdk-for-web -> https://github.com/appwrite/sdk-generator/pull/809
### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes