### PR TITLE
Fix apple realtime socket cleanup

### DIFF
--- a/templates/swift/Sources/Services/Realtime.swift.twig
+++ b/templates/swift/Sources/Services/Realtime.swift.twig
@@ -23,6 +23,8 @@ open class Realtime : Service {
 
     private func createSocket() {
         guard activeChannels.count > 0 else {
+            reconnect = false
+            closeSocket()
             return
         }
 

--- a/templates/swift/Sources/Services/Realtime.swift.twig
+++ b/templates/swift/Sources/Services/Realtime.swift.twig
@@ -137,7 +137,7 @@ open class Realtime : Service {
             let subsWithChannel = activeSubscriptions.filter { callback in
                 return callback.value.channels.contains(channel)
             }
-            return subsWithChannel.isEmpty
+            return !subsWithChannel.isEmpty
         }
     }
 }

--- a/templates/swift/Sources/WebSockets/WebSocketClient.swift.twig
+++ b/templates/swift/Sources/WebSockets/WebSocketClient.swift.twig
@@ -408,5 +408,9 @@ public class WebSocketClient {
         } else {
             channel.write(frame, promise: nil)
         }
+        
+        if opcode == .connectionClose {
+            channel.close(mode: .all, promise: nil)
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
Fixes Apple realtime socket closing and cleanup - all subscription remained active all the time and closing socket never worked.

## Test Plan
Inspecting network, simple breakpoint in onMessage function and observing realtime count indicator in Appwrite dashboard revealed that realtime connection is still active and data is coming through even after disconnecting.
Whats more, if realtime subscription is called multiple times during the lifecycle of the app, all subscription were active and were never cleared properly.

## Related PRs and Issues
Similar issue found on sdk-for-web -> https://github.com/appwrite/sdk-generator/pull/809
and in sdk-for-android -> https://github.com/appwrite/sdk-generator/pull/814

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes