### PR TITLE
Prevent clearing fallback header in Web SDK

### DIFF
--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -353,7 +353,10 @@ class Client {
         };
 
         if (typeof window !== 'undefined' && window.localStorage) {
-            headers['X-Fallback-Cookies'] = window.localStorage.getItem('cookieFallback') ?? '';
+            const cookieFallback = window.localStorage.getItem('cookieFallback');
+            if (cookieFallback) {
+                headers['X-Fallback-Cookies'] = cookieFallback;
+            }
         }
 
         if (method === 'GET') {


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

If the cookie fallback isn't set in local storage, the X-Fallback-Cookies header is set to empty even if the default header has some value set. This change will only set the header if there's a value in local storage to allow developer to set the fallback header if they have a value from somewhere else.

Fixes https://github.com/appwrite/sdk-for-web/issues/64

## Test Plan

TBD

## Related PRs and Issues

* https://github.com/appwrite/sdk-for-web/issues/64

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes