### PR TITLE
Fix concurrent modification error when closing socket

### DIFF
--- a/templates/flutter/lib/src/realtime_mixin.dart.twig
+++ b/templates/flutter/lib/src/realtime_mixin.dart.twig
@@ -87,8 +87,8 @@ mixin RealtimeMixin {
             break;
         }
       }, onDone: () {
-        if (!_notifyDone || _creatingSocket) return;
-        for (var subscription in _subscriptions.values) {
+        final subscriptions = List.from(_subscriptions.values);
+        for (var subscription in subscriptions) {
           subscription.close();
         }
         _channels.clear();


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Since subscription.close() modifies _subscriptions, we need to create a separate list to avoid concurrent modification error.

Closes https://github.com/appwrite/sdk-for-flutter/issues/200

## Test Plan

Manually tested and confirmed subscribing and unsubscribing still works:

<img width="2033" alt="image" src="https://github.com/appwrite/sdk-generator/assets/1477010/1e09ba74-3a31-4f85-b5cb-929d5ec6a3c6">


## Related PRs and Issues

* https://github.com/appwrite/sdk-for-flutter/issues/200

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes