### PR TITLE
chore: remove cross-fetch and isomorphic-form-data

### DIFF
--- a/templates/web/package.json.twig
+++ b/templates/web/package.json.twig
@@ -32,10 +32,6 @@
     "tslib": "2.4.0",
     "typescript": "4.7.2"
   },
-  "dependencies": {
-    "cross-fetch": "3.1.5",
-    "isomorphic-form-data": "2.0.0"
-  },
   "jsdelivr": "dist/iife/sdk.js",
   "unpkg": "dist/iife/sdk.js"
 }

--- a/templates/web/rollup.config.js.twig
+++ b/templates/web/rollup.config.js.twig
@@ -2,7 +2,7 @@ import pkg from "./package.json";
 import typescript from "@rollup/plugin-typescript";
 
 export default {
-    external: Object.keys(pkg.dependencies),
+    external: Object.keys(pkg.dependencies ?? {}),
     input: "src/index.ts",
     plugins: [typescript()],
     output: [

--- a/templates/web/rollup.config.js.twig
+++ b/templates/web/rollup.config.js.twig
@@ -22,10 +22,6 @@ export default {
             file: pkg.jsdelivr,
             name: "Appwrite",
             extend: true,
-            globals: {
-                "cross-fetch": "window",
-                "FormData": "FormData",
-            },
         },
     ],
 };

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -1,5 +1,3 @@
-import 'isomorphic-form-data';
-import { fetch } from 'cross-fetch';
 import { Models } from './models';
 import { Service } from './service';
 


### PR DESCRIPTION
Removes `cross-fetch` and `isomorphic-form-data` from web SDK


Related Issues:

* https://github.com/vercel/next.js/issues/60687#issuecomment-1993484474
* https://github.com/appwrite/sdk-for-web/issues/85
* https://github.com/appwrite/sdk-for-web/issues/82
* https://github.com/appwrite/sdk-for-web/issues/53