### PR TITLE
fix: renaming teamUpdate function the refactored one

### DIFF
--- a/templates/cli/lib/commands/deploy.js.twig
+++ b/templates/cli/lib/commands/deploy.js.twig
@@ -34,7 +34,7 @@ const {
 } = require("./storage");
 const {
     teamsGet,
-    teamsUpdate,
+    teamsUpdateName,
     teamsCreate
 } = require("./teams");
 
@@ -353,7 +353,7 @@ const deployFunction = async ({ functionId, all, yes } = {}) => {
                     functionId: func['$id'],
                     parseOutput: false
                 }, 100, 'variables');
-    
+
                 await Promise.all(variables.map(async variable => {
                     await functionsDeleteVariable({
                         functionId: func['$id'],
@@ -361,7 +361,7 @@ const deployFunction = async ({ functionId, all, yes } = {}) => {
                         parseOutput: false
                     });
                 }));
-    
+
                 let result = await awaitPools.wipeVariables(func['$id']);
                 if (!result) {
                     throw new Error("Variable deletion timed out.");
@@ -882,7 +882,7 @@ const deployTeam = async ({ all, yes } = {}) => {
 
             log(`Updating team ...`)
 
-            await teamsUpdate({
+            await teamsUpdateName({
                 teamId: team['$id'],
                 name: team.name,
                 parseOutput: false


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
Renaming the `teamUpdate` function name in deployment to the [updated](https://github.com/appwrite/appwrite/pull/5196)  `teamUpdateName` one 

## Test Plan

Locally against `1.5.5` instance

## Related PRs and Issues

N/A

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
Yes