### PR TITLE
chore(cli): Allowing the use of `deploy` like `push`

### DIFF
--- a/templates/cli/lib/commands/push.js.twig
+++ b/templates/cli/lib/commands/push.js.twig
@@ -1115,6 +1115,7 @@ const pushMessagingTopic = async ({ all, yes } = {}) => {
 }
 
 const push = new Command("push")
+    .alias('deploy')
     .description(commandDescriptions['push'])
     .option(`--all`, `Flag to push all resources`)
     .option(`--yes`, `Flag to confirm all warnings`)


### PR DESCRIPTION
## What does this PR do?

Keeping the `deploy` command available for `push` actions.
Other commands can't have backwards-compatibility, as they are in use for new things (`init` for exampe)

## Test Plan
![image](https://github.com/appwrite/sdk-generator/assets/316103/5f828a13-c83d-40b6-aad6-0940ac00de1c)