### PR TITLE
refactor(cli): Changing commands from singular to plural when applicable

### DIFF
--- a/templates/cli/lib/commands/pull.js.twig
+++ b/templates/cli/lib/commands/pull.js.twig
@@ -13,15 +13,6 @@ const { paginate } = require("../paginate");
 const { questionsPullCollection, questionsPullFunctions } = require("../questions");
 const { success, log, actionRunner, commandDescriptions } = require("../parser");
 
-const pull = new Command("pull")
-    .description(commandDescriptions['pull'])
-    .configureHelp({
-        helpWidth: process.stdout.columns || 80
-    })
-    .action(actionRunner(async (_options, command) => {
-        command.help();
-    }));
-
 const pullProject = async () => {
     try {
         let response = await projectsGet({
@@ -170,36 +161,42 @@ const pullMessagingTopic = async () => {
     success();
 }
 
+const pull = new Command("pull")
+    .description(commandDescriptions['pull'])
+    .configureHelp({
+        helpWidth: process.stdout.columns || 80
+    });
+
 pull
     .command("project")
     .description("Pulling your {{ spec.title|caseUcfirst }} project name")
     .action(actionRunner(pullProject));
 
 pull
-    .command("function")
+    .command("functions")
     .description(`Pulling your {{ spec.title|caseUcfirst }} functions`)
     .option(`--all`, `Flag to pull all functions`)
     .action(actionRunner(pullFunctions));
 
 pull
-    .command("collection")
+    .command("collections")
     .description("Pulling your {{ spec.title|caseUcfirst }} collections")
     .option(`--databaseId <databaseId>`, `Database ID`)
     .option(`--all`, `Flag to pull all databases`)
     .action(actionRunner(pullCollection))
 
 pull
-    .command("bucket")
+    .command("buckets")
     .description("Pulling your {{ spec.title|caseUcfirst }} buckets")
     .action(actionRunner(pullBucket))
 
 pull
-    .command("team")
+    .command("teams")
     .description("Pulling your {{ spec.title|caseUcfirst }} teams")
     .action(actionRunner(pullTeam))
 
 pull
-    .command("topic")
+    .command("topics")
     .description("Initialise your Appwrite messaging topics")
     .action(actionRunner(pullMessagingTopic))
 

--- a/templates/cli/lib/commands/push.js.twig
+++ b/templates/cli/lib/commands/push.js.twig
@@ -1117,8 +1117,10 @@ const pushMessagingTopic = async ({ all, yes } = {}) => {
 const push = new Command("push")
     .alias('deploy')
     .description(commandDescriptions['push'])
-    .option(`--all`, `Flag to push all resources`)
-    .option(`--yes`, `Flag to confirm all warnings`)
+
+push
+    .command("all")
+    .description("Push all resource.")
     .action(actionRunner(pushResources));
 
 push
@@ -1127,7 +1129,7 @@ push
     .action(actionRunner(pushProject));
 
 push
-    .command("function")
+    .command("functions")
     .description("Push functions in the current directory.")
     .option(`--functionId <functionId>`, `Function ID`)
     .option(`--all`, `Flag to push all functions`)
@@ -1136,28 +1138,28 @@ push
     .action(actionRunner(pushFunction));
 
 push
-    .command("collection")
+    .command("collections")
     .description("Push collections in the current project.")
     .option(`--all`, `Flag to push all collections`)
     .option(`--yes`, `Flag to confirm all warnings`)
     .action(actionRunner(pushCollection));
 
 push
-    .command("bucket")
+    .command("buckets")
     .description("Push buckets in the current project.")
     .option(`--all`, `Flag to push all buckets`)
     .option(`--yes`, `Flag to confirm all warnings`)
     .action(actionRunner(pushBucket));
 
 push
-    .command("team")
+    .command("teams")
     .description("Push teams in the current project.")
     .option(`--all`, `Flag to push all teams`)
     .option(`--yes`, `Flag to confirm all warnings`)
     .action(actionRunner(pushTeam));
 
 push
-    .command("topic")
+    .command("topics")
     .description("Push messaging topics in the current project.")
     .option(`--all`, `Flag to deploy all topics`)
     .option(`--yes`, `Flag to confirm all warnings`)


### PR DESCRIPTION
## What does this PR do?

Changing command from singular to plural, for example: `appwrite pull collection` to `appwrite pull collections` .
CommanderJS will show errors like this automatically
```sh
error: unknown command 'collection'
(Did you mean collections?)
```
The change doesn't include `appwrite init` as this action is singular.

## Test Plan
![image](https://github.com/appwrite/sdk-generator/assets/316103/79d046ab-06f2-41dc-93ca-a80c1c01b921)

