### PR TITLE
Fix variable names and logging in web and react-native docs templates #8328 

### DIFF
--- a/templates/react-native/docs/example.md.twig
+++ b/templates/react-native/docs/example.md.twig
@@ -22,6 +22,5 @@ const {{ service.name | caseCamel }} = new {{service.name | caseUcfirst}}(client
 {% endif %}
 
 {% if method.type != 'webAuth' %}
-{# console.log({% if method.type == 'location' %}result{% else %}response{% endif %}); #} //previous code
 console.log(result); // Updated to log the result variable
 {% endif %}

--- a/templates/react-native/docs/example.md.twig
+++ b/templates/react-native/docs/example.md.twig
@@ -22,5 +22,5 @@ const {{ service.name | caseCamel }} = new {{service.name | caseUcfirst}}(client
 {% endif %}
 
 {% if method.type != 'webAuth' %}
-console.log(result); // Updated to log the result variable
+console.log(result);
 {% endif %}

--- a/templates/react-native/docs/example.md.twig
+++ b/templates/react-native/docs/example.md.twig
@@ -22,5 +22,6 @@ const {{ service.name | caseCamel }} = new {{service.name | caseUcfirst}}(client
 {% endif %}
 
 {% if method.type != 'webAuth' %}
-console.log({% if method.type == 'location' %}result{% else %}response{% endif %});
+{# console.log({% if method.type == 'location' %}result{% else %}response{% endif %}); #} //previous code
+console.log(result); // Updated to log the result variable
 {% endif %}

--- a/templates/web/docs/example.md.twig
+++ b/templates/web/docs/example.md.twig
@@ -21,6 +21,6 @@ const {{ service.name | caseCamel }} = new {{service.name | caseUcfirst}}(client
 {% if method.parameters.all | length > 0 %});
 {% endif %}
 
-{% if method.type != 'webAuth' %} 
+{% if method.type != 'webAuth' %}
 console.log(result);
 {% endif %}

--- a/templates/web/docs/example.md.twig
+++ b/templates/web/docs/example.md.twig
@@ -22,6 +22,5 @@ const {{ service.name | caseCamel }} = new {{service.name | caseUcfirst}}(client
 {% endif %}
 
 {% if method.type != 'webAuth' %} 
-{# console.log({% if method.type == 'location' %}result{% else %}response{% endif %}); #} // previous code 
 console.log(result); // Updated to log the result variable
 {% endif %}

--- a/templates/web/docs/example.md.twig
+++ b/templates/web/docs/example.md.twig
@@ -21,6 +21,7 @@ const {{ service.name | caseCamel }} = new {{service.name | caseUcfirst}}(client
 {% if method.parameters.all | length > 0 %});
 {% endif %}
 
-{% if method.type != 'webAuth' %}
-console.log({% if method.type == 'location' %}result{% else %}response{% endif %});
+{% if method.type != 'webAuth' %} 
+{# console.log({% if method.type == 'location' %}result{% else %}response{% endif %}); #} // previous code 
+console.log(result); // Updated to log the result variable
 {% endif %}

--- a/templates/web/docs/example.md.twig
+++ b/templates/web/docs/example.md.twig
@@ -22,5 +22,5 @@ const {{ service.name | caseCamel }} = new {{service.name | caseUcfirst}}(client
 {% endif %}
 
 {% if method.type != 'webAuth' %} 
-console.log(result); // Updated to log the result variable
+console.log(result);
 {% endif %}


### PR DESCRIPTION
# Title: Fix Console Logging in Storage Client Example Templates

## Description:
This PR addresses an issue in the example templates for the Appwrite documentation where the console logging of API responses was incorrectly referencing the response variable instead of the result variable. This discrepancy could potentially confuse users following the examples.

## Changes Made:

Updated the console logging in the example templates for both the web and React Native clients to use the result variable consistently.

### Context:
The original templates incorrectly used response in the console.log statement, which does not align with the variable naming conventions in the example code provided. By changing this to result, we ensure clarity and accuracy in the displayed examples.

## Contributor Note:
This change aligns with the conventions observed throughout the documentation examples and improves the usability for developers integrating the Appwrite storage client in their applications.

### References:

Fixes: https://github.com/appwrite/appwrite/issues/8328

### Issue Link

* https://github.com/appwrite/appwrite/issues/8328)

This PR is ready for review. Your feedback is appreciated!