### PR TITLE
Fix error when no project set

### DIFF
--- a/templates/cli/lib/sdks.js.twig
+++ b/templates/cli/lib/sdks.js.twig
@@ -30,7 +30,7 @@ const sdkForProject = async () => {
   let selfSigned = globalConfig.getSelfSigned()
 
   if (!project) {
-    throw new Error("Project is not set. Please run `{{ language.params.executableName }} init` to initialize the current directory with an {{ spec.title|caseUcfirst }} project.");
+    throw new Error("Project is not set. Please run `{{ language.params.executableName }} init project` to initialize the current directory with an {{ spec.title|caseUcfirst }} project.");
   }
 
   client


### PR DESCRIPTION

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

The command should be `init project` and not just `init` as `init` will create some resource in a project

## Test Plan

Manual

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes