### PR TITLE
Ensure all attribute keys are pulled into appwrite.json

### DIFF
--- a/templates/cli/lib/config.js.twig
+++ b/templates/cli/lib/config.js.twig
@@ -4,15 +4,36 @@ const _path = require("path");
 const process = require("process");
 const JSONbig = require("json-bigint")({ storeAsString: false });
 
-const KeysFunction = ["path", "$id", "execute", "name", "enabled", "logging", "runtime", "scopes", "events", "schedule", "timeout", "entrypoint", "commands"];
-const KeysDatabase = ["$id", "name", "enabled"];
-const KeysCollection = ["$id", "$permissions", "databaseId", "name", "enabled", "documentSecurity", "attributes", "indexes"];
-const KeysStorage = ["$id", "$permissions", "fileSecurity", "name", "enabled", "maximumFileSize", "allowedFileExtensions", "compression", "encryption", "antivirus"];
-const KeyTopics = ["$id", "name", "subscribe"];
-const KeyAttributes = ["key", "type", "required", "array", "size", "default"];
-const KeyIndexes = ["key", "type", "status", "attributes", "orders"];
+const KeysFunction = new Set(["path", "$id", "execute", "name", "enabled", "logging", "runtime", "scopes", "events", "schedule", "timeout", "entrypoint", "commands"]);
+const KeysDatabase = new Set(["$id", "name", "enabled"]);
+const KeysCollection = new Set(["$id", "$permissions", "databaseId", "name", "enabled", "documentSecurity", "attributes", "indexes"]);
+const KeysStorage = new Set(["$id", "$permissions", "fileSecurity", "name", "enabled", "maximumFileSize", "allowedFileExtensions", "compression", "encryption", "antivirus"]);
+const KeyTopics = new Set(["$id", "name", "subscribe"]);
+const KeyAttributes = new Set([
+    "key",
+    "type",
+    "required",
+    "array",
+    "size",
+    "default",
+    // integer and float
+    "min", 
+    "max",
+    // email, enum, URL, IP, and datetime
+    "format",
+    // enum
+    "elements",
+    // relationship
+    "relatedCollection",
+    "relationType",
+    "twoWay",
+    "twoWayKey",
+    "onDelete",
+    "side"
+]);
+const KeyIndexes = new Set(["key", "type", "status", "attributes", "orders"]);
 
-function whitelistKeys(value, keys, nestedKeys = []) {
+function whitelistKeys(value, keys, nestedKeys = {}) {
     if(Array.isArray(value)) {
         const newValue = [];
 
@@ -25,7 +46,7 @@ function whitelistKeys(value, keys, nestedKeys = []) {
 
     const newValue = {};
     Object.keys(value).forEach((key) => {
-        if(keys.includes(key)) {
+        if(keys.has(key)) {
             if(nestedKeys[key]) {
                 newValue[key] = whitelistKeys(value[key], nestedKeys[key]);
             } else {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Keys were missing so they weren't stored in the appwrite.json. As such, they wouldn't be set when pushing.

## Test Plan

Manual:

Result after pulling includes keys like min and max:

<img width="1254" alt="image" src="https://github.com/appwrite/sdk-generator/assets/1477010/0f78b04b-1695-4bd2-a405-670b2e3c17b6">

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes