### PR TITLE
Use JSONbig to parse and stringify JSON

### DIFF
--- a/templates/cli/lib/client.js.twig
+++ b/templates/cli/lib/client.js.twig
@@ -118,7 +118,7 @@ class Client {
 
       body = formData;
     } else {
-      body = JSON.stringify(params);
+      body = JSONbig.stringify(params);
     }
 
     let response = undefined;
@@ -174,7 +174,7 @@ class Client {
     const text = await response.text();
     let json = undefined;
     try {
-      json = JSON.parse(text);
+      json = JSONbig.parse(text);
     } catch (error) {
       return text;
     }

--- a/templates/cli/lib/commands/push.js.twig
+++ b/templates/cli/lib/commands/push.js.twig
@@ -354,8 +354,8 @@ const createAttribute = async (databaseId, collectionId, attribute) => {
                 collectionId,
                 key: attribute.key,
                 required: attribute.required,
-                min: parseInt(attribute.min.toString()),
-                max: parseInt(attribute.max.toString()),
+                min: attribute.min,
+                max: attribute.max,
                 xdefault: attribute.default,
                 array: attribute.array,
                 parseOutput: false
@@ -366,8 +366,8 @@ const createAttribute = async (databaseId, collectionId, attribute) => {
                 collectionId,
                 key: attribute.key,
                 required: attribute.required,
-                min: parseFloat(attribute.min.toString()),
-                max: parseFloat(attribute.max.toString()),
+                min: attribute.min,
+                max: attribute.max,
                 xdefault: attribute.default,
                 array: attribute.array,
                 parseOutput: false
@@ -471,8 +471,8 @@ const updateAttribute = async (databaseId, collectionId, attribute) => {
                 collectionId,
                 key: attribute.key,
                 required: attribute.required,
-                min: parseInt(attribute.min.toString()),
-                max: parseInt(attribute.max.toString()),
+                min: attribute.min,
+                max: attribute.max,
                 xdefault: attribute.default,
                 array: attribute.array,
                 parseOutput: false
@@ -483,8 +483,8 @@ const updateAttribute = async (databaseId, collectionId, attribute) => {
                 collectionId,
                 key: attribute.key,
                 required: attribute.required,
-                min: parseFloat(attribute.min.toString()),
-                max: parseFloat(attribute.max.toString()),
+                min: attribute.min,
+                max: attribute.max,
                 xdefault: attribute.default,
                 array: attribute.array,
                 parseOutput: false


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Due to the way JavaScript handles numbers, the standard JSON parser will convert the max PHP int, 9223372036854775807, to
9223372036854776000. However, this is problematic because the resulting number is an invalid int in PHP so the integer validation fails.

This PR ensures we use JSONbig to parse and stringify JSON in the CLI to retain the precision of the numbers.

Fixes https://github.com/appwrite/sdk-for-cli/issues/124

## Test Plan

Manually pulled and pushed successfully

<img width="1243" alt="image" src="https://github.com/appwrite/sdk-generator/assets/1477010/c491abcc-16f0-4291-91f4-a1dc01a37062">


## Related PRs and Issues

* https://github.com/appwrite/sdk-for-cli/issues/124

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes