### PR TITLE
fix(cli): add missing brace

### DIFF
--- a/templates/cli/lib/commands/pull.js.twig
+++ b/templates/cli/lib/commands/pull.js.twig
@@ -124,6 +124,7 @@ const pullFunctions = async ({ code }) => {
     
                 fs.rmSync(compressedFileName);
             }
+        }
     }
 
     success(`Successfully pulled ${chalk.bold(total)} functions.`);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

appwrite-cli@6.0.0-rc.3 is missing a brace which results in:

```
$ npx appwrite-cli@next
Need to install the following packages:
appwrite-cli@6.0.0-rc.3
Ok to proceed? (y) y
/Users/steven/.npm/_npx/dd4d371d4e547a11/node_modules/appwrite-cli/lib/commands/pull.js:311



SyntaxError: Unexpected end of input
    at internalCompileFunction (node:internal/vm:128:18)
    at wrapSafe (node:internal/modules/cjs/loader:1280:20)
    at Module._compile (node:internal/modules/cjs/loader:1332:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1427:10)
    at Module.load (node:internal/modules/cjs/loader:1206:32)
    at Module._load (node:internal/modules/cjs/loader:1022:12)
    at Module.require (node:internal/modules/cjs/loader:1231:19)
    at require (node:internal/modules/helpers:179:18)
    at Object.<anonymous> (/Users/steven/.npm/_npx/dd4d371d4e547a11/node_modules/appwrite-cli/lib/commands/init.js:12:27)
    at Module._compile (node:internal/modules/cjs/loader:1369:14)

Node.js v20.12.2
```

## Test Plan

After adding the brace, the code ran:

<img width="693" alt="image" src="https://github.com/appwrite/sdk-generator/assets/1477010/bde370ed-5bc2-4028-91bd-35fd4e9afa3b">

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes