### PR TITLE
Fix: Go data in generics

### DIFF
--- a/templates/go/base/requests/api.twig
+++ b/templates/go/base/requests/api.twig
@@ -2,14 +2,29 @@
 	if err != nil {
 		return nil, err
 	}
-	var parsed {{ method | returnType(spec, spec.title | caseLower) }}
 	if strings.HasPrefix(resp.Type, "application/json") {
-		err = json.Unmarshal([]byte(resp.Result.(string)), &parsed)
+		bytes := []byte(resp.Result.(string))
+
+{%~ if method | returnType(spec, spec.title | caseLower) != 'interface{}' and method | returnType(spec, spec.title | caseLower) != '[]byte' and method | returnType(spec, spec.title | caseLower) != 'bool' %}
+		parsed := {{ method | returnType(spec, spec.title | caseLower) }}{}.New(bytes)
+
+		err = json.Unmarshal(bytes, parsed)
+		if err != nil {
+			return nil, err
+		}
+
+		return parsed, nil
+{%~ else %}
+		var parsed {{ method | returnType(spec, spec.title | caseLower) }}
+
+		err = json.Unmarshal(bytes, &parsed)
 		if err != nil {
 			return nil, err
 		}
 		return &parsed, nil
+{%~ endif %}
 	}
+	var parsed {{ method | returnType(spec, spec.title | caseLower) }}
 	parsed, ok := resp.Result.({{ method | returnType(spec, spec.title | caseLower) }})
 	if !ok {
 		return nil, errors.New("unexpected response type")

--- a/templates/go/models/model.go.twig
+++ b/templates/go/models/model.go.twig
@@ -1,5 +1,6 @@
 package models
 
+import "encoding/json"
 
 {{ ((definition.description | caseUcfirst) ~ " Model") | godocComment }}
 type {{ definition.name | caseUcfirst }} struct {
@@ -8,8 +9,23 @@ type {{ definition.name | caseUcfirst }} struct {
     {{ property.name | caseUcfirst  }} {{ property | propertyType(spec) }} `json:"{{ property.name | escapeKeyword }}"`
     {%~ endfor %}
 
-    {%~ if definition.additionalProperties %}
-    // Additional properties
-    Data map[string]interface{}
-    {%~ endif %}
+    // Used by Decode() method
+    data []byte
+}
+
+func (model {{ definition.name | caseUcfirst }}) New(data []byte) *{{ definition.name | caseUcfirst }} {
+    model.data = data
+    return &model
+}
+
+{%~ if definition.additionalProperties %}
+// Use this method to get response in desired type
+{%~ endif %}
+func (model *{{ definition.name | caseUcfirst }}) Decode(value *any) error {
+    err := json.Unmarshal(model.data, value)
+    if err != nil {
+        return err
+    }
+
+    return nil
 }

--- a/templates/go/models/model.go.twig
+++ b/templates/go/models/model.go.twig
@@ -26,7 +26,7 @@ func (model {{ definition.name | caseUcfirst }}) New(data []byte) *{{ definition
 {%~ endif %}
 func (model *{{ definition.name | caseUcfirst }}) Decode(value interface{}) error {
     if len(model.data) <= 0 {
-        return errors.New("method Decode() cannot be used on nested structs.")
+        return errors.New("method Decode() cannot be used on nested struct")
     }
 
     err := json.Unmarshal(model.data, value)

--- a/templates/go/models/model.go.twig
+++ b/templates/go/models/model.go.twig
@@ -1,6 +1,9 @@
 package models
 
-import "encoding/json"
+import (
+    "encoding/json"
+    "errors"
+)
 
 {{ ((definition.description | caseUcfirst) ~ " Model") | godocComment }}
 type {{ definition.name | caseUcfirst }} struct {
@@ -21,7 +24,11 @@ func (model {{ definition.name | caseUcfirst }}) New(data []byte) *{{ definition
 {%~ if definition.additionalProperties %}
 // Use this method to get response in desired type
 {%~ endif %}
-func (model *{{ definition.name | caseUcfirst }}) Decode(value *any) error {
+func (model *{{ definition.name | caseUcfirst }}) Decode(value interface{}) error {
+    if len(model.data) <= 0 {
+        return errors.New("method Decode() cannot be used on nested structs.")
+    }
+
     err := json.Unmarshal(model.data, value)
     if err != nil {
         return err


### PR DESCRIPTION
## What does this PR do?

Switches from `.Data.(type)` to `.Decode(&varOfType)`

## Test Plan

- [x] Manual QA

![CleanShot 2024-07-24 at 17 03 14@2x](https://github.com/user-attachments/assets/6ce4c98b-ea11-4b30-b4a6-88523edf7162)



## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes