### PR TITLE
Chore: Remove APPWRITE_ENV

### DIFF
--- a/templates/cli/lib/emulation/docker.js.twig
+++ b/templates/cli/lib/emulation/docker.js.twig
@@ -54,7 +54,6 @@ async function dockerBuild(func, variables) {
     const params = [ 'run' ];
     params.push('--name', id);
     params.push('-v', `${tmpBuildPath}/:/mnt/code:rw`);
-    params.push('-e', 'APPWRITE_ENV=development');
     params.push('-e', 'OPEN_RUNTIMES_ENV=development');
     params.push('-e', 'OPEN_RUNTIMES_SECRET=');
     params.push('-e', `OPEN_RUNTIMES_ENTRYPOINT=${func.entrypoint}`);
@@ -171,7 +170,6 @@ async function dockerStart(func, variables, port) {
     params.push('--rm');
     params.push('--name', id);
     params.push('-p', `${port}:3000`);
-    params.push('-e', 'APPWRITE_ENV=development');
     params.push('-e', 'OPEN_RUNTIMES_ENV=development');
     params.push('-e', 'OPEN_RUNTIMES_SECRET=');
 


### PR DESCRIPTION
## What does this PR do?

Removes APPWRITE_ENV as its not good use case to support it.

## Test Plan

None

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes