### PR TITLE
Fix: Consistently Log ' result ' in API Call Template.

### DIFF
--- a/templates/react-native/docs/example.md.twig
+++ b/templates/react-native/docs/example.md.twig
@@ -22,5 +22,5 @@ const {{ service.name | caseCamel }} = new {{service.name | caseUcfirst}}(client
 {% endif %}
 
 {% if method.type != 'webAuth' %}
-console.log({% if method.type == 'location' %}result{% else %}response{% endif %});
+console.log(result);
 {% endif %}

--- a/templates/web/docs/example.md.twig
+++ b/templates/web/docs/example.md.twig
@@ -22,5 +22,5 @@ const {{ service.name | caseCamel }} = new {{service.name | caseUcfirst}}(client
 {% endif %}
 
 {% if method.type != 'webAuth' %}
-console.log({% if method.type == 'location' %}result{% else %}response{% endif %});
+console.log(result);
 {% endif %}


### PR DESCRIPTION
### Summary
This pull request fixes the issue where the `console.log` statement inconsistently logged the `response` variable instead of the `result` variable in the API call template. This ensures that the output is always correct and avoids any confusion that might arise from logging an undefined `response` variable.

### Changes Made
- Updated the `console.log` statement to always log `result` instead of `response`.

### Reason for Changes
The previous implementation had an inconsistency in the variable being logged after an API call. Depending on the method type, the `console.log` statement sometimes attempted to log an undefined `response` variable, leading to potential confusion and errors. By consistently logging the `result` variable, the output remains accurate and predictable.

### Related  issues
- https://github.com/appwrite/appwrite/issues/8328#issue-2373904477

### Testing
- Verified that the `console.log` statement now correctly logs the `result` variable.
- Ensured that the change does not affect other parts of the code template.

### Impact
This change should have no negative impact on the existing functionality but will improve the clarity and correctness of the logging in the generated code template.

@stnguyen90