### PR TITLE
Fix "settings is not defined" error

### DIFF
--- a/templates/cli/lib/config.js.twig
+++ b/templates/cli/lib/config.js.twig
@@ -403,7 +403,7 @@ class Local extends Config {
             return;
         }
 
-        this.set('settings', this.createSettingsObject(settings));
+        this.set('settings', this.createSettingsObject(projectSettings));
     }
 
     createSettingsObject(projectSettings) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

A mismatch in variable name caused the "settings is not defined" error. This updates the variable name to match the parameter passed in.

## Test Plan

Manually modified the CLI locally:

<img width="1069" alt="image" src="https://github.com/user-attachments/assets/aa490355-b88b-4e1f-aed2-81c88afee893">

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes