### PR TITLE
Fix: Rename to use new method

### DIFF
--- a/templates/cli/lib/commands/pull.js.twig
+++ b/templates/cli/lib/commands/pull.js.twig
@@ -6,7 +6,7 @@ const inquirer = require("inquirer");
 const { messagingListTopics } = require("./messaging");
 const { teamsList } = require("./teams");
 const { projectsGet } = require("./projects");
-const { functionsList, functionsDownloadDeployment, functionsListDeployments } = require("./functions");
+const { functionsList, functionsGetDeploymentDownload, functionsListDeployments } = require("./functions");
 const { databasesGet, databasesListCollections, databasesList } = require("./databases");
 const { storageListBuckets } = require("./storage");
 const { localConfig } = require("../config");
@@ -136,7 +136,7 @@ const pullFunctions = async ({ code, withVariables }) => {
         log("Pulling latest deployment code ...");
 
         const compressedFileName = `${func['$id']}-${+new Date()}.tar.gz`
-        await functionsDownloadDeployment({
+        await functionsGetDeploymentDownload({
             functionId: func['$id'],
             deploymentId,
             destination: compressedFileName,


### PR DESCRIPTION
## What does this PR do?

Uses new method name from 1.6.x

## Test Plan

- [x] Generated code looks good, method exists

![CleanShot 2024-08-08 at 10 46 30@2x](https://github.com/user-attachments/assets/6b767437-77d6-4a4e-a9b5-8554aa3709ca)

## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes