### PR TITLE
fix(cli): Removing VCS fields

### DIFF
--- a/templates/cli/lib/commands/push.js.twig
+++ b/templates/cli/lib/commands/push.js.twig
@@ -1088,11 +1088,6 @@ const pushFunction = async ({ functionId, async, code, withVariables } = { retur
                 entrypoint: func.entrypoint,
                 commands: func.commands,
                 scopes: func.scopes,
-                providerRepositoryId: func.providerRepositoryId ?? "",
-                installationId: func.installationId ?? '',
-                providerBranch: func.providerBranch ?? '',
-                providerRootDirectory: func.providerRootDirectory ?? '',
-                providerSilentMode: func.providerSilentMode ?? false,
                 vars: JSON.stringify(response.vars),
                 parseOutput: false
             });


### PR DESCRIPTION
## What does this PR do?

Removing vcs fields when deploying function so they will be empty

## Test Plan
Locally

## Related PRs and Issues
https://github.com/appwrite/appwrite/pull/8500