### PR TITLE
refactor(cli): use function name as destination folder

### DIFF
--- a/templates/cli/lib/commands/init.js.twig
+++ b/templates/cli/lib/commands/init.js.twig
@@ -203,12 +203,13 @@ const initFunction = async () => {
     }
 
     const functionId = answers.id === 'unique()' ? ID.unique() : answers.id;
-    const functionDir = path.join(functionFolder, functionId);
+    const functionName = answers.name;
+    const functionDir = path.join(functionFolder, functionName);
     const templatesDir = path.join(functionFolder, `${functionId}-templates`);
     const runtimeDir = path.join(templatesDir, answers.runtime.name);
 
     if (fs.existsSync(functionDir)) {
-        throw new Error(`( ${functionId} ) already exists in the current directory. Please choose another name.`);
+        throw new Error(`( ${functionName} ) already exists in the current directory. Please choose another name.`);
     }
 
     if (!answers.runtime.entrypoint) {
@@ -285,7 +286,7 @@ const initFunction = async () => {
 
     fs.rmSync(templatesDir, { recursive: true, force: true });
 
-    const readmePath = path.join(process.cwd(), 'functions', functionId, 'README.md');
+    const readmePath = path.join(process.cwd(), 'functions', functionName, 'README.md');
     const readmeFile = fs.readFileSync(readmePath).toString();
     const newReadmeFile = readmeFile.split('\n');
     newReadmeFile[0] = `# ${answers.name}`;
@@ -306,7 +307,7 @@ const initFunction = async () => {
         entrypoint: answers.runtime.entrypoint || '',
         commands: answers.runtime.commands || '',
         ignore: answers.runtime.ignore || null,
-        path: `functions/${functionId}`,
+        path: `functions/${functionName}`,
     };
 
     localConfig.addFunction(data);

--- a/templates/cli/lib/commands/pull.js.twig
+++ b/templates/cli/lib/commands/pull.js.twig
@@ -84,7 +84,7 @@ const pullFunctions = async ({ code, withVariables }) => {
 
         func['path'] = localFunction['path'];
         if (!localFunction['path']) {
-            func['path'] = `functions/${func.$id}`;
+            func['path'] = `functions/${func.name}`;
         }
         if (!withVariables) {
             delete func['vars'];


### PR DESCRIPTION
## What does this PR do?

When creating/pulling function it will placed in a folder named with the function's name

## Test Plan
![image](https://github.com/user-attachments/assets/9b118069-db52-4139-9609-0a5f65bf8231)
