### PR TITLE
fix: ruby create deployment

### DIFF
--- a/templates/ruby/lib/container/client.rb.twig
+++ b/templates/ruby/lib/container/client.rb.twig
@@ -213,7 +213,7 @@ module {{ spec.title | caseUcfirst }}
                     when 'application/json'
                         payload = params.to_json
                     when 'multipart/form-data'
-                        payload = encode_form_data(params) + "\r\n--#{@boundary}--"
+                        payload = encode_form_data(params) + "--#{@boundary}--\r\n"
                         headers[:'content-type'] = "multipart/form-data; boundary=#{@boundary}"
                     else
                         payload = encode(params)
@@ -284,17 +284,18 @@ module {{ spec.title | caseUcfirst }}
             else
                 post_body = []
                 if value.instance_of? InputFile
-                    post_body << "--#{@boundary}\r\n"
-                    post_body << "Content-Disposition: form-data; name=\"#{key}\"; filename=\"#{value.filename}\"\r\n"
-                    post_body << "Content-Type: #{value.mime_type}\r\n\r\n"
+                    post_body << "--#{@boundary}"
+                    post_body << "Content-Disposition: form-data; name=\"#{key}\"; filename=\"#{value.filename}\""
+                    post_body << "Content-Type: #{value.mime_type}"
+                    post_body << ""
                     post_body << value.data
-                    
                 else
-                    post_body << "--#{@boundary}\r\n"
-                    post_body << "Content-Disposition: form-data; name=\"#{key}\"\r\n\r\n"
-                    post_body << "#{value.to_s}" 
+                    post_body << "--#{@boundary}"
+                    post_body << "Content-Disposition: form-data; name=\"#{key}\""
+                    post_body << ""
+                    post_body << value.to_s
                 end
-                post_body.join
+                post_body.join("\r\n") + "\r\n"
             end
         end
 

--- a/templates/ruby/lib/container/client.rb.twig
+++ b/templates/ruby/lib/container/client.rb.twig
@@ -213,7 +213,7 @@ module {{ spec.title | caseUcfirst }}
                     when 'application/json'
                         payload = params.to_json
                     when 'multipart/form-data'
-                        payload = encode_form_data(params) + "--#{@boundary}--"
+                        payload = encode_form_data(params) + "\r\n--#{@boundary}--"
                         headers[:'content-type'] = "multipart/form-data; boundary=#{@boundary}"
                     else
                         payload = encode(params)

--- a/templates/ruby/lib/container/client.rb.twig
+++ b/templates/ruby/lib/container/client.rb.twig
@@ -213,7 +213,7 @@ module {{ spec.title | caseUcfirst }}
                     when 'application/json'
                         payload = params.to_json
                     when 'multipart/form-data'
-                        payload = "--#{@boundary}\r\n" + encode_form_data(params)
+                        payload = encode_form_data(params) + "--#{@boundary}--"
                         headers[:'content-type'] = "multipart/form-data; boundary=#{@boundary}"
                     else
                         payload = encode(params)
@@ -284,14 +284,15 @@ module {{ spec.title | caseUcfirst }}
             else
                 post_body = []
                 if value.instance_of? InputFile
+                    post_body << "--#{@boundary}\r\n"
                     post_body << "Content-Disposition: form-data; name=\"#{key}\"; filename=\"#{value.filename}\"\r\n"
                     post_body << "Content-Type: #{value.mime_type}\r\n\r\n"
                     post_body << value.data
-                    post_body << "\r\n--#{@boundary}--\r\n"
-                else          
+                    
+                else
+                    post_body << "--#{@boundary}\r\n"
                     post_body << "Content-Disposition: form-data; name=\"#{key}\"\r\n\r\n"
                     post_body << "#{value.to_s}" 
-                    post_body << "\r\n--#{@boundary}\r\n"
                 end
                 post_body.join
             end


### PR DESCRIPTION
Ruby SDK had a bug where payload for create deployment looked like this:
```
------A30#3ad1
Content-Disposition: form-data; name="entrypoint"

index.rb
------A30#3ad1
Content-Disposition: form-data; name="code"; filename="index.rb"
Content-Type: application/x-ruby

require "appwrite"

def main(context)
    return context.res.json(
        {
          "motto": "Build like a team of hundreds_",
          "learn": "https://appwrite.io/docs",
          "connect": "https://appwrite.io/discord",
          "getInspired": "https://builtwith.appwrite.io",
        }
      )
end
------A30#3ad1--  <----- THIS IS A THE PROBLEM, `--` TERMINATES THE MULTIPART
Content-Disposition: form-data; name="activate"

true
------A30#3ad1
```