### PR TITLE
Fix swift double optional

### DIFF
--- a/src/SDK/Language/Swift.php
+++ b/src/SDK/Language/Swift.php
@@ -526,10 +526,6 @@ class Swift extends Language
             $type = $this->getTypeName($property);
         }
 
-        if (!$property['required']) {
-            $type .= '?';
-        }
-
         return $type;
     }
 

--- a/templates/swift/Sources/Models/Model.swift.twig
+++ b/templates/swift/Sources/Models/Model.swift.twig
@@ -9,7 +9,7 @@ public class {{ definition | modelType(spec) | raw }} {
 
     {%~ for property in definition.properties %}
     /// {{ property.description }}
-    public let {{ property.name | escapeSwiftKeyword | removeDollarSign }}: {{ property | propertyType(spec) | raw }}
+    public let {{ property.name | escapeSwiftKeyword | removeDollarSign }}: {{ property | propertyType(spec) | raw }}{% if not property.required %}?{% endif %}
 
 
     {%~ endfor %}

--- a/templates/swift/Sources/Models/Model.swift.twig
+++ b/templates/swift/Sources/Models/Model.swift.twig
@@ -20,7 +20,7 @@ public class {{ definition | modelType(spec) | raw }} {
 
     init(
         {%~ for property in definition.properties %}
-        {{ property.name | escapeSwiftKeyword | removeDollarSign }}: {{ property | propertyType(spec) | raw  }}{% if not loop.last or (loop.last and definition.additionalProperties) %},{% endif %}
+        {{ property.name | escapeSwiftKeyword | removeDollarSign }}: {{ property | propertyType(spec) | raw  }}{% if not property.required %}?{% endif %}{% if not loop.last or (loop.last and definition.additionalProperties) %},{% endif %}
 
         {%~ endfor %}
         {%~ if definition.additionalProperties %}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Revert previous fixes for double optional, remove optional added by get type filter instead. Because the optional is not required when casting with `as?` this caused a build error when the declared type was not a double-optional.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)