### PR TITLE
Fixed file upload for .NET SDK

### DIFF
--- a/templates/dotnet/Package/Client.cs.twig
+++ b/templates/dotnet/Package/Client.cs.twig
@@ -154,6 +154,12 @@ namespace {{ spec.title | caseUcfirst }}
 
                 foreach (var parameter in parameters)
                 {
+                    // Skip parameters with no value
+                    if (parameter.Value == null)
+                    {
+                        continue;
+                    }
+
                     if (parameter.Key == "file")
                     {
                         form.Add(((MultipartFormDataContent)parameters["file"]).First()!);
@@ -377,14 +383,26 @@ namespace {{ spec.title | caseUcfirst }}
             if (!string.IsNullOrEmpty(idParamName) && (string)parameters[idParamName] != "unique()")
             {
                 // Make a request to check if a file already exists
-                var current = await Call<Dictionary<string, object?>>(
-                    method: "GET",
-                    path: "$path/${params[idParamName]}",
-                    headers,
-                    parameters = new Dictionary<string, object?>()
-                );
-                var chunksUploaded = (long)current["chunksUploaded"];
-                offset = chunksUploaded * ChunkSize;
+                var isIdAlreadyUsed = false;
+                try
+                {
+                    await Call<Dictionary<string, object?>>(
+                        method: "GET",
+                        path: $"{path}/{parameters[idParamName]}",
+                        headers,
+                        new Dictionary<string, object?>()
+                    );
+                    isIdAlreadyUsed = true;
+                }
+                catch (Exception)
+                {
+                    // ignored
+                }
+
+                if (isIdAlreadyUsed)
+                {
+                    throw new Exception("A file with this Id already exists.");
+                }
             }
 
             while (offset < size)


### PR DESCRIPTION
## What does this PR do?

This PR includes fixes to the 'CreateFile' flow while using the .NET SDK which was not working.
This changes were applied and tested directly to the SDK and then replicated to this template.

What was done:
  - ignored parameters with no value, which was causing a null object reference
  - fixed the logic regarding the GET method that checks for an already existing file with the same 'fileId'
  - fixed a malformed string (path for the GET method mentioned above)
  - fixed a wrong re-assignment of the 'parameters' variable (used in the GET method mentioned above)

## Test Plan

This changes were tested manually by using a locally fixed version of the SDK, using both self-hosted and cloud endpoints.
From what I found, if this is to be tested, it is using PHP, which I don't know.

Files used to test:
  - some .pdf (various sizes)
  - some .png (various sizes)

## Related PRs and Issues

Issue #963 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.