### PR TITLE
fix(android): fix invalid encoding of scopes in query parameters

### DIFF
--- a/templates/android/library/src/main/java/io/package/services/Service.kt.twig
+++ b/templates/android/library/src/main/java/io/package/services/Service.kt.twig
@@ -84,7 +84,9 @@ class {{ service.name | caseUcfirst }}(client: Client) : Service(client) {
                     return@forEach
                 }
                 is List<*> -> {
-                    apiQuery.add("${it.key}[]=${it.value.toString()}")
+                    (it.value as List<*>).forEach { v ->
+                        apiQuery.add("${it.key}[]=${v.toString()}")
+                    }
                 }
                 else -> {
                    apiQuery.add("${it.key}=${it.value.toString()}")


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Before this, the `it.value.toString()` caused the list of scopes to be encoded like `scopes[]=[scope1, scope2]` which is invalid.

This change fixes the encoding to `scopes[]=scope1&scopes[]=scope2` as expected by the server.

## Test Plan

Tested running this code:

```kotlin
fun main() {
    val apiParams = mutableMapOf<String, Any?>(
        "scopes" to listOf("user.read", "user.write"),
    )
    val apiQuery = mutableListOf<String>()
    apiParams.forEach {
        when (it.value) {
            null -> {
                return@forEach
            }
            is List<*> -> { 
                (it.value as List<*>).forEach { v ->
                    apiQuery.add("${it.key}[]=${v.toString()}")
                }
            }
            else -> {
               apiQuery.add("${it.key}=${it.value.toString()}")
            }
        }
    }

    print(apiQuery)
}
```

in [Kotlin playground](https://play.kotlinlang.org/):

<img width="847" alt="image" src="https://github.com/user-attachments/assets/fb115bef-9d6f-4888-a2fd-26c4be475b97">


## Related PRs and Issues

* https://github.com/appwrite/sdk-for-android/issues/60

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes