### PR TITLE
[CLI] Use `||` instead of `??` because `getEndpoint()` can return ""

### DIFF
--- a/templates/cli/lib/commands/generic.js.twig
+++ b/templates/cli/lib/commands/generic.js.twig
@@ -14,7 +14,7 @@ const DEFAULT_ENDPOINT = 'https://cloud.appwrite.io/v1';
 const loginCommand = async ({ email, password, endpoint, mfa, code }) => {
     const oldCurrent = globalConfig.getCurrentSession();
 
-    const configEndpoint = endpoint ?? globalConfig.getEndpoint() ?? DEFAULT_ENDPOINT;
+    const configEndpoint = (endpoint ?? globalConfig.getEndpoint()) || DEFAULT_ENDPOINT;
 
     if (globalConfig.getCurrentSession() !== '') {
         log('You are currently signed in as ' + globalConfig.getEmail());


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Since the `??` operator only returns the right side if the left side is null or undefined, it will not work if `getEndpoint()` returns an empty string. `||`, however, will return the right side if the left side is an empty string.

Fixes https://github.com/appwrite/sdk-for-cli/issues/139

## Test Plan

Before:

<img width="475" alt="image" src="https://github.com/user-attachments/assets/01ddce67-4523-454e-b925-96af1395af25">

After:

<img width="509" alt="image" src="https://github.com/user-attachments/assets/bd64b11a-d717-4a6d-9f2b-ded1eff455be">


## Related PRs and Issues

* https://github.com/appwrite/sdk-for-cli/issues/139

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes