### PR TITLE
fix(web): credentials include

### DIFF
--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -554,6 +554,7 @@ class Client {
         let options: RequestInit = {
             method,
             headers,
+            credentials: 'include',
         };
 
         if (method === 'GET') {


### PR DESCRIPTION
Adds `credentials: 'include'` to fetch options ensure 3rd party cookies are sent