### PR TITLE
Fix: Deno commands

### DIFF
--- a/templates/cli/lib/emulation/utils.js.twig
+++ b/templates/cli/lib/emulation/utils.js.twig
@@ -50,7 +50,7 @@ const systemTools = {
     },
     'deno': {
         isCompiled: false,
-        startCommand: "deno start",
+        startCommand: "deno run --allow-run --allow-net --allow-write --allow-read --allow-env src/server.ts",
         dependencyFiles: [ ]
     },
     'dart': {

--- a/templates/cli/lib/questions.js.twig
+++ b/templates/cli/lib/questions.js.twig
@@ -94,7 +94,7 @@ const getInstallCommand = (runtime) => {
         case 'dart':
             return 'dart pub get';
         case 'deno':
-            return "deno install";
+            return "deno cache src/main.ts";
         case 'node':
             return 'npm install';
         case 'bun':


### PR DESCRIPTION
## What does this PR do?

- Applies proper build command for starters used in Appwrite CLI
- Uses proper command to start Deno during local devleopment

## Test Plan

- [x] Manual QA in Gitpod:

Before:

![CleanShot 2024-10-09 at 20 54 31@2x](https://github.com/user-attachments/assets/b8578e54-ebf1-4407-a895-5cff8e000b63)

AFter:


![CleanShot 2024-10-09 at 20 54 10@2x](https://github.com/user-attachments/assets/019690be-0780-49f6-bcba-c6d47b89f92e)


## Related PRs and Issues

x

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes