### PR TITLE
Fix model array subtypes

### DIFF
--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -287,6 +287,10 @@ class CLI extends Node
         if (!empty($parameter['enumValues'])) {
             return \ucfirst($parameter['name']);
         }
+        if (isset($parameter['items'])) {
+            // Map definition nested type to parameter nested type
+            $parameter['array'] = $parameter['items'];
+        }
         return match ($parameter['type']) {
             self::TYPE_INTEGER,
             self::TYPE_NUMBER => 'number',

--- a/src/SDK/Language/Dart.php
+++ b/src/SDK/Language/Dart.php
@@ -133,6 +133,10 @@ class Dart extends Language
         if (!empty($parameter['enumValues'])) {
             return 'enums.' . \ucfirst($parameter['name']);
         }
+        if (isset($parameter['items'])) {
+            // Map definition nested type to parameter nested type
+            $parameter['array'] = $parameter['items'];
+        }
         switch ($parameter['type'] ?? '') {
             case self::TYPE_INTEGER:
                 return 'int';

--- a/src/SDK/Language/Deno.php
+++ b/src/SDK/Language/Deno.php
@@ -140,6 +140,9 @@ class Deno extends JS
         if (!empty($parameter['enumValues'])) {
             return \ucfirst($parameter['name']);
         }
+        if (isset($parameter['items'])) {
+            $parameter['array'] = $parameter['items'];
+        }
         return match ($parameter['type']) {
             self::TYPE_INTEGER => 'number',
             self::TYPE_STRING => 'string',

--- a/src/SDK/Language/DotNet.php
+++ b/src/SDK/Language/DotNet.php
@@ -166,6 +166,10 @@ class DotNet extends Language
         if (!empty($parameter['enumValues'])) {
             return 'Appwrite.Enums.' . \ucfirst($parameter['name']);
         }
+        if (isset($parameter['items'])) {
+            // Map definition nested type to parameter nested type
+            $parameter['array'] = $parameter['items'];
+        }
         return match ($parameter['type']) {
             self::TYPE_INTEGER => 'long',
             self::TYPE_NUMBER => 'double',

--- a/src/SDK/Language/Go.php
+++ b/src/SDK/Language/Go.php
@@ -141,6 +141,10 @@ class Go extends Language
         if (str_contains($parameter['description'] ?? '', 'Collection attributes') || str_contains($parameter['description'] ?? '', 'List of attributes')) {
             return '[]map[string]any';
         }
+        if (isset($parameter['items'])) {
+            // Map definition nested type to parameter nested type
+            $parameter['array'] = $parameter['items'];
+        }
         return match ($parameter['type']) {
             self::TYPE_INTEGER => 'int',
             self::TYPE_NUMBER => 'float64',

--- a/src/SDK/Language/JS.php
+++ b/src/SDK/Language/JS.php
@@ -131,6 +131,10 @@ abstract class JS extends Language
         if (!empty($parameter['enumValues'])) {
             return \ucfirst($parameter['name']);
         }
+        if (isset($parameter['items'])) {
+            // Map definition nested type to parameter nested type
+            $parameter['array'] = $parameter['items'];
+        }
         switch ($parameter['type']) {
             case self::TYPE_INTEGER:
             case self::TYPE_NUMBER:

--- a/src/SDK/Language/Kotlin.php
+++ b/src/SDK/Language/Kotlin.php
@@ -112,6 +112,9 @@ class Kotlin extends Language
         if (!empty($parameter['enumValues'])) {
             return 'io.appwrite.enums.' . \ucfirst($parameter['name']);
         }
+        if (isset($parameter['items'])) {
+            $parameter['array'] = $parameter['items'];
+        }
         return match ($parameter['type']) {
             self::TYPE_INTEGER => 'Long',
             self::TYPE_NUMBER => 'Double',

--- a/src/SDK/Language/Node.php
+++ b/src/SDK/Language/Node.php
@@ -20,6 +20,10 @@ class Node extends Web
         if (!empty($parameter['enumValues'])) {
             return \ucfirst($parameter['name']);
         }
+        if (isset($parameter['items'])) {
+            // Map definition nested type to parameter nested type
+            $parameter['array'] = $parameter['items'];
+        }
         switch ($parameter['type']) {
             case self::TYPE_INTEGER:
             case self::TYPE_NUMBER:

--- a/src/SDK/Language/ReactNative.php
+++ b/src/SDK/Language/ReactNative.php
@@ -136,6 +136,10 @@ class ReactNative extends Web
         if (!empty($parameter['enumValues'])) {
             return \ucfirst($parameter['name']);
         }
+        if (isset($parameter['items'])) {
+            // Map definition nested type to parameter nested type
+            $parameter['array'] = $parameter['items'];
+        }
         switch ($parameter['type']) {
             case self::TYPE_INTEGER:
             case self::TYPE_NUMBER:

--- a/src/SDK/Language/Swift.php
+++ b/src/SDK/Language/Swift.php
@@ -307,6 +307,10 @@ class Swift extends Language
         if (!empty($parameter['enumValues'])) {
             return ($spec['title'] ?? '') . 'Enums.' . \ucfirst($parameter['name']);
         }
+        if (isset($parameter['items'])) {
+            // Map definition nested type to parameter nested type
+            $parameter['array'] = $parameter['items'];
+        }
         return match ($parameter['type']) {
             self::TYPE_INTEGER => 'Int',
             self::TYPE_NUMBER => 'Double',

--- a/src/SDK/Language/Web.php
+++ b/src/SDK/Language/Web.php
@@ -185,6 +185,10 @@ class Web extends JS
         if (!empty($parameter['enumValues'])) {
             return \ucfirst($parameter['name']);
         }
+        if (isset($parameter['items'])) {
+            // Map definition nested type to parameter nested type
+            $parameter['array'] = $parameter['items'];
+        }
         switch ($parameter['type']) {
             case self::TYPE_INTEGER:
             case self::TYPE_NUMBER:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Currently response model classes don't use the nested type for list types. This PR fixes that.

E.g. for Kotlin `Document.permissions` is currently `List<Any>`, when it should be `List<String>`

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)