### PR TITLE
Fix: container start commands

### DIFF
--- a/templates/cli/lib/emulation/utils.js.twig
+++ b/templates/cli/lib/emulation/utils.js.twig
@@ -25,67 +25,67 @@ const runtimeNames = {
 const systemTools = {
     'node': {
         isCompiled: false,
-        startCommand: "node src/server.js",
+        startCommand: "sh helpers/server.sh",
         dependencyFiles: [ "package.json", "package-lock.json" ]
     },
     'php': {
         isCompiled: false,
-        startCommand: "php src/server.php",
+        startCommand: "sh helpers/server.sh",
         dependencyFiles: [ "composer.json", "composer.lock" ]
     },
     'ruby': {
         isCompiled: false,
-        startCommand: "bundle exec puma -b tcp://0.0.0.0:3000 -e production",
+        startCommand: "sh helpers/server.sh",
         dependencyFiles: [ "Gemfile", "Gemfile.lock" ]
     },
     'python': {
         isCompiled: false,
-        startCommand: "python3 src/server.py",
+        startCommand: "sh helpers/server.sh",
         dependencyFiles: [ "requirements.txt", "requirements.lock" ]
     },
     'python-ml': {
         isCompiled: false,
-        startCommand: "python3 src/server.py",
+        startCommand: "sh helpers/server.sh",
         dependencyFiles: [ "requirements.txt", "requirements.lock" ]
     },
     'deno': {
         isCompiled: false,
-        startCommand: "deno run --allow-run --allow-net --allow-write --allow-read --allow-env src/server.ts",
+        startCommand: "sh helpers/server.sh",
         dependencyFiles: [ ]
     },
     'dart': {
         isCompiled: true,
-        startCommand: "src/function/server",
+        startCommand: "sh helpers/server.sh",
         dependencyFiles: [ ]
     },
     'dotnet': {
         isCompiled: true,
-        startCommand: "dotnet src/function/DotNetRuntime.dll",
+        startCommand: "sh helpers/server.sh",
         dependencyFiles: [ ]
     },
     'java': {
         isCompiled: true,
-        startCommand: "java -jar src/function/java-runtime-1.0.0.jar",
+        startCommand: "sh helpers/server.sh",
         dependencyFiles: [ ]
     },
     'swift': {
         isCompiled: true,
-        startCommand: "src/function/Runtime serve --env production --hostname 0.0.0.0 --port 3000",
+        startCommand: "sh helpers/server.sh",
         dependencyFiles: [ ]
     },
     'kotlin': {
         isCompiled: true,
-        startCommand: "java -jar src/function/kotlin-runtime-1.0.0.jar",
+        startCommand: "sh helpers/server.sh",
         dependencyFiles: [ ]
     },
     'bun': {
         isCompiled: false,
-        startCommand: "bun src/server.ts",
+        startCommand: "sh helpers/server.sh",
         dependencyFiles: [ "package.json", "package-lock.json", "bun.lockb" ]
     },
     'go': {
         isCompiled: true,
-        startCommand: "src/function/server",
+        startCommand: "sh helpers/server.sh",
         dependencyFiles: [ ]
     },
 };


### PR DESCRIPTION
## What does this PR do?

In Python, we switched from Flask to asynciohttp library.
With that, start command changed. CLI has start-command hard-coded, so we need to update it.

What I did instead is used helper bash script. This resolves the problem, and also ensures it doesn't happen in future. Those start helpers are what Open Runtimes tests use, so they are always 100% reliable.

I only manually tested everything working properly with Python and Node, but start helper is used for all runtime tests in Open Runtimes, so it gives me confidence it's not breaking anything currently working fine.

## Test Plan

- [x] Manual QA

Before:
![CleanShot 2024-11-04 at 15 26 44@2x](https://github.com/user-attachments/assets/f1cc6830-8d28-44ab-85b9-d35a5eb4654c)


After:


![CleanShot 2024-11-04 at 15 29 04@2x](https://github.com/user-attachments/assets/3334f849-f470-48e0-a75c-d42f93f6e1a2)

![CleanShot 2024-11-04 at 15 29 30@2x](https://github.com/user-attachments/assets/0b27b9b9-b862-448b-be46-3eb1558f8b0e)

## Related PRs and Issues

- Discord discussion: https://discord.com/channels/564160730845151244/1297382564515942470

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes