### PR TITLE
feat: realtime heartbeat

### DIFF
--- a/templates/flutter/lib/src/realtime_mixin.dart.twig
+++ b/templates/flutter/lib/src/realtime_mixin.dart.twig
@@ -27,13 +27,31 @@ mixin RealtimeMixin {
   int _retries = 0;
   StreamSubscription? _websocketSubscription;
   bool _creatingSocket = false;
+  Timer? _heartbeatTimer;
 
   Future<dynamic> _closeConnection() async {
+    _stopHeartbeat();
     await _websocketSubscription?.cancel();
     await _websok?.sink.close(status.normalClosure, 'Ending session');
     _lastUrl = null;
     _retries = 0;
     _reconnect = false;
+  }
+
+  void _startHeartbeat() {
+    _stopHeartbeat();
+    _heartbeatTimer = Timer.periodic(Duration(seconds: 20), (_) {
+      if (_websok != null) {
+        _websok!.sink.add(jsonEncode({
+          "type": "ping"
+        }));
+      }
+    });
+  }
+
+  void _stopHeartbeat() {
+    _heartbeatTimer?.cancel();
+    _heartbeatTimer = null;
   }
 
   _createSocket() async {
@@ -78,6 +96,10 @@ mixin RealtimeMixin {
                 }));
               }
             }
+            _startHeartbeat(); // Start heartbeat after successful connection
+            break;
+          case 'pong':
+            debugPrint('Received heartbeat response from realtime server');
             break;
           case 'event':
             final message = RealtimeMessage.fromMap(data.data);
@@ -91,8 +113,10 @@ mixin RealtimeMixin {
             break;
         }
       }, onDone: () {
+        _stopHeartbeat();
         _retry();
       }, onError: (err, stack) {
+        _stopHeartbeat();
         for (var subscription in _subscriptions.values) {
           subscription.controller.addError(err, stack);
         }

--- a/templates/swift/Sources/Services/Realtime.swift.twig
+++ b/templates/swift/Sources/Services/Realtime.swift.twig
@@ -14,7 +14,7 @@ open class Realtime : Service {
     private var socketClient: WebSocketClient? = nil
     private var activeChannels = Set<String>()
     private var activeSubscriptions = [Int: RealtimeCallback]()
-    private var heartbeatTask: Task<Void, Error>? = nil
+    private var heartbeatTask: Task<Void, Swift.Error>? = nil
 
     let connectSync = DispatchQueue(label: "ConnectSync")
 
@@ -30,8 +30,8 @@ open class Realtime : Service {
                 while !Task.isCancelled {
                     if let client = socketClient, client.isConnected {
                         let pingMessage = ["type": "ping"]
-                        if let jsonData = try JSONSerialization.data(withJSONObject: pingMessage),
-                        let jsonString = String(data: jsonData, encoding: .utf8) {
+                        let jsonData = try JSONSerialization.data(withJSONObject: pingMessage)
+                        if let jsonString = String(data: jsonData, encoding: .utf8) {
                             client.send(text: jsonString)
                         }
                     }

--- a/templates/swift/Sources/Services/Realtime.swift.twig
+++ b/templates/swift/Sources/Services/Realtime.swift.twig
@@ -7,11 +7,14 @@ open class Realtime : Service {
 
     private let TYPE_ERROR = "error"
     private let TYPE_EVENT = "event"
+    private let TYPE_PONG = "pong"
     private let DEBOUNCE_NANOS = 1_000_000
+    private let HEARTBEAT_INTERVAL: UInt64 = 20_000_000_000 // 20 seconds in nanoseconds
 
     private var socketClient: WebSocketClient? = nil
     private var activeChannels = Set<String>()
     private var activeSubscriptions = [Int: RealtimeCallback]()
+    private var heartbeatTask: Task<Void, Error>? = nil
 
     let connectSync = DispatchQueue(label: "ConnectSync")
 
@@ -19,6 +22,33 @@ open class Realtime : Service {
     private var reconnectAttempts = 0
     private var subscriptionsCounter = 0
     private var reconnect = true
+
+    private func startHeartbeat() {
+        stopHeartbeat()
+        heartbeatTask = Task {
+            do {
+                while !Task.isCancelled {
+                    if let client = socketClient, client.isConnected {
+                        let pingMessage = ["type": "ping"]
+                        if let jsonData = try JSONSerialization.data(withJSONObject: pingMessage),
+                        let jsonString = String(data: jsonData, encoding: .utf8) {
+                            client.send(text: jsonString)
+                        }
+                    }
+                    try await Task.sleep(nanoseconds: HEARTBEAT_INTERVAL)
+                }
+            } catch {
+                if !Task.isCancelled {
+                    print("Heartbeat task failed: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
+    private func stopHeartbeat() {
+        heartbeatTask?.cancel()
+        heartbeatTask = nil
+    }
 
     private func createSocket() async throws {
         guard activeChannels.count > 0 else {
@@ -50,6 +80,8 @@ open class Realtime : Service {
     }
 
     private func closeSocket() async throws {
+        stopHeartbeat()
+        
         guard let client = socketClient,
               let group = client.threadGroup else {
             return
@@ -163,6 +195,7 @@ extension Realtime: WebSocketClientDelegate {
 
     public func onOpen(channel: Channel) {
         self.reconnectAttempts = 0
+        startHeartbeat()
     }
 
     public func onMessage(text: String) {
@@ -172,6 +205,7 @@ extension Realtime: WebSocketClientDelegate {
                 switch type {
                 case TYPE_ERROR: try! handleResponseError(from: json)
                 case TYPE_EVENT: handleResponseEvent(from: json)
+                case TYPE_PONG: break  // Handle pong response if needed
                 default: break
                 }
             }
@@ -179,6 +213,8 @@ extension Realtime: WebSocketClientDelegate {
     }
 
     public func onClose(channel: Channel, data: Data) async throws {
+        stopHeartbeat()
+        
         if (!reconnect) {
             reconnect = true
             return
@@ -196,6 +232,7 @@ extension Realtime: WebSocketClientDelegate {
     }
 
     public func onError(error: Swift.Error?, status: HTTPResponseStatus?) {
+        stopHeartbeat()
         print(error?.localizedDescription ?? "Unknown error")
     }
 

--- a/templates/swift/Sources/Services/Realtime.swift.twig
+++ b/templates/swift/Sources/Services/Realtime.swift.twig
@@ -29,11 +29,7 @@ open class Realtime : Service {
             do {
                 while !Task.isCancelled {
                     if let client = socketClient, client.isConnected {
-                        let pingMessage = ["type": "ping"]
-                        let jsonData = try JSONSerialization.data(withJSONObject: pingMessage)
-                        if let jsonString = String(data: jsonData, encoding: .utf8) {
-                            client.send(text: jsonString)
-                        }
+                        client.send(text: #"{"type": "ping"}"#)
                     }
                     try await Task.sleep(nanoseconds: HEARTBEAT_INTERVAL)
                 }


### PR DESCRIPTION
- Add realtime connection heartbeat
- Adds ping/pong heartbeat mechanism to maintain realtime connections on Android, Flutter, and Swift platforms. 
- Sends ping every 20s and handles cleanup.