### PR TITLE
Fix: Scopes not pushed on function creation

### DIFF
--- a/templates/cli/lib/commands/push.js.twig
+++ b/templates/cli/lib/commands/push.js.twig
@@ -1134,6 +1134,7 @@ const pushFunction = async ({ functionId, async, code, withVariables } = { retur
                     logging: func.logging,
                     entrypoint: func.entrypoint,
                     commands: func.commands,
+                    scopes: func.scopes,
                     vars: JSON.stringify(func.vars),
                     parseOutput: false
                 });


### PR DESCRIPTION
## What does this PR do?

Scopes were not added to the functions on initial `appwrite push function`. This PR fixes that.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)