### PR TITLE
Feat: In-App OAuth2 Sign-in

### DIFF
--- a/templates/apple/base/requests/oauth.twig
+++ b/templates/apple/base/requests/oauth.twig
@@ -3,9 +3,12 @@
         let callbackScheme = "appwrite-callback-\(client.config["project"] ?? "")"
 
         _ = try await withCheckedThrowingContinuation { continuation in
-            WebAuthComponent.authenticate(url: url, callbackScheme: callbackScheme) { result in
-                continuation.resume(with: result)
+            /// main thread for ASWebAuthenticationPresentationContextProviding
+            DispatchQueue.main.async {
+                WebAuthComponent.authenticate(url: url, callbackScheme: callbackScheme) { result in
+                    continuation.resume(with: result)
+                }
             }
         }
-        
+
         return true

--- a/templates/apple/base/requests/oauth.twig
+++ b/templates/apple/base/requests/oauth.twig
@@ -3,7 +3,7 @@
         let callbackScheme = "appwrite-callback-\(client.config["project"] ?? "")"
 
         _ = try await withCheckedThrowingContinuation { continuation in
-            /// main thread for ASWebAuthenticationPresentationContextProviding
+            /// main thread for PresentationContextProvider
             DispatchQueue.main.async {
                 WebAuthComponent.authenticate(url: url, callbackScheme: callbackScheme) { result in
                     continuation.resume(with: result)

--- a/templates/swift/Sources/OAuth/WebAuthComponent.swift.twig
+++ b/templates/swift/Sources/OAuth/WebAuthComponent.swift.twig
@@ -2,8 +2,8 @@ import AsyncHTTPClient
 import Foundation
 import NIO
 
-#if canImport(SwiftUI)
-import SwiftUI
+#if canImport(AuthenticationServices)
+import AuthenticationServices
 #endif
 
 ///
@@ -13,12 +13,10 @@ import SwiftUI
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, visionOS 1.0, *)
 public class WebAuthComponent {
 
-#if canImport(SwiftUI)
-    @Environment(\.openURL)
-    private static var openURL
-#endif
-
     private static var callbacks = [String: (Result<String, {{ spec.title | caseUcfirst}}Error>) -> Void]()
+    #if canImport(AuthenticationServices)
+    private static var currentAuthSession: ASWebAuthenticationSession?
+    #endif
 
     ///
     /// Authenticate Session with OAuth2
@@ -41,9 +39,29 @@ public class WebAuthComponent {
     ) {
         callbacks[callbackScheme] = onComplete
 
-    #if canImport(SwiftUI)
-        openURL(url)
-    #endif
+        #if canImport(AuthenticationServices)
+        currentAuthSession = ASWebAuthenticationSession(
+                url: url,
+                callbackURLScheme: callbackScheme
+            ) { callbackURL, error in
+                if let error = error {
+                    cleanUp()
+                } else if let callbackURL = callbackURL {
+                    // handle cookies here itself!
+                    WebAuthComponent.handleIncomingCookie(from: callbackURL)
+                    cleanUp()
+                }
+            }
+
+        if let session = currentAuthSession {
+            /// Indicates that the session should be a private session.
+            session.prefersEphemeralWebBrowserSession = true
+            session.presentationContextProvider = PresentationContextProvider.shared
+            session.start()
+        } else {
+            print("Failed to create ASWebAuthenticationSession")
+        }
+        #endif
     }
 
     ///
@@ -130,5 +148,20 @@ public class WebAuthComponent {
         callbacks.forEach { (_, callback) in
             callback(.failure({{ spec.title | caseUcfirst}}Error(message: "User cancelled login.")))
         }
+
+        #if canImport(AuthenticationServices)
+        currentAuthSession = nil
+        #endif
     }
 }
+
+#if canImport(AuthenticationServices)
+/// Presentation context for the ASWebAuthenticationSession.
+class PresentationContextProvider: NSObject, ASWebAuthenticationPresentationContextProviding {
+    static let shared = PresentationContextProvider()
+
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        return ASPresentationAnchor()
+    }
+}
+#endif

--- a/templates/swift/Sources/OAuth/WebAuthComponent.swift.twig
+++ b/templates/swift/Sources/OAuth/WebAuthComponent.swift.twig
@@ -161,10 +161,8 @@ class PresentationContextProvider: NSObject, ASWebAuthenticationPresentationCont
     static let shared = PresentationContextProvider()
 
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
-            if let mainWindow = windowScene.windows.first {
-                return mainWindow
-            }
+        if let mainWindow = OSApplication.shared.windows.first { $0.isKeyWindow } {
+            return mainWindow
         }
 
         return ASPresentationAnchor()

--- a/templates/swift/Sources/OAuth/WebAuthComponent.swift.twig
+++ b/templates/swift/Sources/OAuth/WebAuthComponent.swift.twig
@@ -161,6 +161,12 @@ class PresentationContextProvider: NSObject, ASWebAuthenticationPresentationCont
     static let shared = PresentationContextProvider()
 
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+            if let mainWindow = windowScene.windows.first {
+                return mainWindow
+            }
+        }
+
         return ASPresentationAnchor()
     }
 }


### PR DESCRIPTION
## What does this PR do?

This PR aads support for showing an InApp Safari ViewController or Apple's SignIn Native prompt [whichever is supported] instead of opening Safari externally.

## Test Plan

Manual.

## Related PRs and Issues

N/A.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.