### PR TITLE
fix: cast string arrays

### DIFF
--- a/templates/dart/lib/src/models/model.dart.twig
+++ b/templates/dart/lib/src/models/model.dart.twig
@@ -32,18 +32,15 @@ class {{ definition.name | caseUcfirst | overrideIdentifier }} implements Model 
                     {{property.sub_schema | caseUcfirst | overrideIdentifier}}.fromMap(map['{{property.name | escapeDollarSign }}'])
                 {%- endif -%}
             {%- else -%}
-                map['{{property.name | escapeDollarSign }}']
-                {%- if property.type == "number" -%}
-                    {%- if not property.required %}?{% endif %}.toDouble()
-                {%- endif -%}
-                {%- if property.type == "string" -%}
-                    {%- if not property.required %}?{% endif %}.toString()
-                {%- endif -%}
                 {%- if property.type == 'array' -%}
-                    {%- if property.sub_schema -%}
-                        List<{{property.sub_schema | caseUcfirst | overrideIdentifier}}>.from(map['{{property.name | escapeDollarSign }}'].map((p) => {{property.sub_schema | caseUcfirst | overrideIdentifier}}.fromMap(p)))
-                    {%- else -%}
-                        List<{{ property | typeNameInner }}>.from(map['{{property.name | escapeDollarSign }}']?.map((x) => x{% if property.items.type == "string" %}.toString(){% endif %}) ?? [])
+                    List<{{ property.items.type | caseUcfirst }}>.from(map['{{property.name | escapeDollarSign }}']?.map((x) => x{% if property.items.type == "string" %}.toString(){% endif %}) ?? [])
+                {%- else -%}
+                    map['{{property.name | escapeDollarSign }}']
+                    {%- if property.type == "number" -%}
+                        {%- if not property.required %}?{% endif %}.toDouble()
+                    {%- endif -%}
+                    {%- if property.type == "string" -%}
+                        {%- if not property.required %}?{% endif %}.toString()
                     {%- endif -%}
                 {%- endif -%}
             {%- endif -%},

--- a/templates/dart/lib/src/models/model.dart.twig
+++ b/templates/dart/lib/src/models/model.dart.twig
@@ -39,8 +39,12 @@ class {{ definition.name | caseUcfirst | overrideIdentifier }} implements Model 
                 {%- if property.type == "string" -%}
                     {%- if not property.required %}?{% endif %}.toString()
                 {%- endif -%}
-                {%- if property.type == "array" -%}
-                    {% if property.required %} ?? []{% endif %}
+                {%- if property.type == 'array' -%}
+                    {%- if property.sub_schema -%}
+                        List<{{property.sub_schema | caseUcfirst | overrideIdentifier}}>.from(map['{{property.name | escapeDollarSign }}'].map((p) => {{property.sub_schema | caseUcfirst | overrideIdentifier}}.fromMap(p)))
+                    {%- else -%}
+                        List<{{ property | typeNameInner }}>.from(map['{{property.name | escapeDollarSign }}']?.map((x) => x{% if property.items.type == "string" %}.toString(){% endif %}) ?? [])
+                    {%- endif -%}
                 {%- endif -%}
             {%- endif -%},
 {% endfor %}


### PR DESCRIPTION
Fixes a type error where `List<dynamic>` was not properly converted to `List<String>` in generated model classes. The issue occurred because array elements weren't being explicitly converted to their target type. Added proper type conversion and null safety handling for array deserialization.

Related:
* https://github.com/appwrite/appwrite/issues/9119