### PR TITLE
fix: python chunked upload

### DIFF
--- a/templates/python/package/client.py.twig
+++ b/templates/python/package/client.py.twig
@@ -166,7 +166,7 @@ class Client:
                 if offset + self._chunk_size < size:
                     end = offset + self._chunk_size
                 else:
-                    end = size - offset
+                    end = size
                 input_file.data = input[offset:end]
 
             params[param_name] = input_file


### PR DESCRIPTION
Fixes an issue with the final chunk upload calculation when using byte-based file sources. Changes the end index of the last chunk from `size - offset` to `size` to ensure all remaining bytes are included. 

Related:
* https://github.com/appwrite/sdk-for-python/issues/100
