### PR TITLE
Add missing service import for Python examples

### DIFF
--- a/templates/python/docs/example.md.twig
+++ b/templates/python/docs/example.md.twig
@@ -1,4 +1,5 @@
 from {{ spec.title | caseSnake }}.client import Client
+from {{ spec.title | caseSnake }}.services.{{ service.name | caseSnake }} import {{ service.name | caseUcfirst }}
 {% if method.parameters.all | filter((param) => param.type == 'file') | length > 0 %}
 from {{ spec.title | caseSnake }}.input_file import InputFile
 {% endif %}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

It looks like when we https://github.com/appwrite/sdk-generator/pull/700, we accidentally [deleted that import](https://github.com/appwrite/sdk-generator/commit/c6b568620a09c138ea82fcddc01880ce07cb3f6e#diff-5e6917afab7f018468629a5c5a64c13536c4a85f50e0af6b46304258c49e391c).

Fixes https://github.com/appwrite/sdk-for-python/issues/84

## Test Plan

Manually generated and inspected examples:

<img width="667" alt="image" src="https://github.com/user-attachments/assets/ffd89848-3092-4e53-9971-c5f810a221ee" />

## Related PRs and Issues

* https://github.com/appwrite/sdk-for-python/issues/84
* https://github.com/appwrite/sdk-generator/pull/700

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes