### PR TITLE
fix: added null checks for message.data & pong type checking

### DIFF
--- a/templates/android/library/src/main/java/io/package/models/RealtimeModels.kt.twig
+++ b/templates/android/library/src/main/java/io/package/models/RealtimeModels.kt.twig
@@ -17,7 +17,7 @@ data class RealtimeCallback(
 
 open class RealtimeResponse(
     val type: String,
-    val data: Any
+    val data: Any? = null
 )
 
 data class RealtimeResponseEvent<T>(

--- a/templates/android/library/src/main/java/io/package/models/RealtimeModels.kt.twig
+++ b/templates/android/library/src/main/java/io/package/models/RealtimeModels.kt.twig
@@ -17,7 +17,7 @@ data class RealtimeCallback(
 
 open class RealtimeResponse(
     val type: String,
-    val data: Any? = null
+    val data: Any?
 )
 
 data class RealtimeResponseEvent<T>(

--- a/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
+++ b/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
@@ -174,7 +174,8 @@ class Realtime(client: Client) : Service(client), CoroutineScope {
                 val message = text.fromJson<RealtimeResponse>()
                 when (message.type) {
                     TYPE_ERROR -> handleResponseError(message)
-                    TYPE_EVENT -> handleResponseEvent(message)
+                    TYPE_EVENT -> message.data?.let {handleResponseEvent(message)}
+                    TYPE_PONG -> {}
                 }
             }
         }

--- a/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
+++ b/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
@@ -174,7 +174,7 @@ class Realtime(client: Client) : Service(client), CoroutineScope {
                 val message = text.fromJson<RealtimeResponse>()
                 when (message.type) {
                     TYPE_ERROR -> handleResponseError(message)
-                    TYPE_EVENT -> message.data?.let {handleResponseEvent(message)}
+                    TYPE_EVENT -> message.data?.let {handleResponseEvent(message) ?: {}}
                     TYPE_PONG -> {}
                 }
             }

--- a/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
+++ b/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
@@ -181,11 +181,11 @@ class Realtime(client: Client) : Service(client), CoroutineScope {
         }
 
         private fun handleResponseError(message: RealtimeResponse) {
-            throw message.data.jsonCast<{{ spec.title | caseUcfirst }}Exception>()
+            throw message.data?.jsonCast<{{ spec.title | caseUcfirst }}Exception>() ?: RuntimeException("data is not present")
         }
 
         private suspend fun handleResponseEvent(message: RealtimeResponse) {
-            val event = message.data.jsonCast<RealtimeResponseEvent<Any>>()
+            val event = message.data?.jsonCast<RealtimeResponseEvent<Any>>() ?: return
             if (event.channels.isEmpty()) {
                 return
             }

--- a/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
+++ b/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
@@ -181,7 +181,7 @@ class Realtime(client: Client) : Service(client), CoroutineScope {
         }
 
         private fun handleResponseError(message: RealtimeResponse) {
-            throw message.data?.jsonCast<{{ spec.title | caseUcfirst }}Exception>() ?: RuntimeException("data is not present")
+            throw message.data?.jsonCast<{{ spec.title | caseUcfirst }}Exception>() ?: RuntimeException("Data is not present")
         }
 
         private suspend fun handleResponseEvent(message: RealtimeResponse) {

--- a/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
+++ b/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
@@ -174,7 +174,7 @@ class Realtime(client: Client) : Service(client), CoroutineScope {
                 val message = text.fromJson<RealtimeResponse>()
                 when (message.type) {
                     TYPE_ERROR -> handleResponseError(message)
-                    TYPE_EVENT -> message.data?.let {handleResponseEvent(message) ?: {}}
+                    TYPE_EVENT -> handleResponseEvent(message)
                     TYPE_PONG -> {}
                 }
             }

--- a/templates/flutter/lib/src/realtime_response.dart.twig
+++ b/templates/flutter/lib/src/realtime_response.dart.twig
@@ -29,7 +29,7 @@ class RealtimeResponse {
 
   factory RealtimeResponse.fromMap(Map<String, dynamic> map) {
     return RealtimeResponse(
-      type: map['type'] ?? '',
+      type: map['type'],
       data: Map<String, dynamic>.from(map['data'] ?? {}),
     );
   }

--- a/templates/flutter/lib/src/realtime_response.dart.twig
+++ b/templates/flutter/lib/src/realtime_response.dart.twig
@@ -29,8 +29,8 @@ class RealtimeResponse {
 
   factory RealtimeResponse.fromMap(Map<String, dynamic> map) {
     return RealtimeResponse(
-      type: map['type'],
-      data: Map<String, dynamic>.from(map['data']),
+      type: map['type'] ?? '',
+      data: (map.containsKey('data')) ? Map<String, dynamic>.from(map['data']) : {},
     );
   }
 

--- a/templates/flutter/lib/src/realtime_response.dart.twig
+++ b/templates/flutter/lib/src/realtime_response.dart.twig
@@ -30,7 +30,7 @@ class RealtimeResponse {
   factory RealtimeResponse.fromMap(Map<String, dynamic> map) {
     return RealtimeResponse(
       type: map['type'] ?? '',
-      data: (map.containsKey('data')) ? Map<String, dynamic>.from(map['data']) : {},
+      data: Map<String, dynamic>.from(map['data'] ?? {}),
     );
   }
 

--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -290,19 +290,16 @@ class Client {
                 this.realtime.lastMessage = message;
                 switch (message.type) {
                     case 'event':
-                        if(!message.data) return;
-                        
-                        const data = message.data as RealtimeResponseEvent<unknown>;
-                        if (!data?.channels) return;
-
-                        const isSubscribed = data.channels.some(channel => this.realtime.channels.has(channel));
-                        if (!isSubscribed) return;
-
-                        this.realtime.subscriptions.forEach(subscription => {
-                            if (data.channels.some(channel => subscription.channels.includes(channel))) {
-                                setTimeout(() => subscription.callback(data));
-                            }
-                        });
+                        let data = <RealtimeResponseEvent<unknown>>message.data;
+                        if (data?.channels) {
+                            const isSubscribed = data.channels.some(channel => this.realtime.channels.has(channel));
+                            if (!isSubscribed) return;
+                            this.realtime.subscriptions.forEach(subscription => {
+                                if (data.channels.some(channel => subscription.channels.includes(channel))) {
+                                    setTimeout(() => subscription.callback(data));
+                                }
+                            })
+                        }
                         break;
                     case 'pong':
                         break; // Handle pong response if needed

--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -12,7 +12,7 @@ type Headers = {
 
 type RealtimeResponse = {
     type: 'error' | 'event' | 'connected' | 'response' | 'pong';
-    data: RealtimeResponseAuthenticated | RealtimeResponseConnected | RealtimeResponseError | RealtimeResponseEvent<unknown>;
+    data: RealtimeResponseAuthenticated | RealtimeResponseConnected | RealtimeResponseError | RealtimeResponseEvent<unknown> | undefined;
 }
 
 type RealtimeRequest = {
@@ -291,16 +291,18 @@ class Client {
                 switch (message.type) {
                     case 'event':
                         if(!message.data) return;
-                        let data = <RealtimeResponseEvent<unknown>>message.data;
-                        if (data?.channels) {
-                            const isSubscribed = data.channels.some(channel => this.realtime.channels.has(channel));
-                            if (!isSubscribed) return;
-                            this.realtime.subscriptions.forEach(subscription => {
-                                if (data.channels.some(channel => subscription.channels.includes(channel))) {
-                                    setTimeout(() => subscription.callback(data));
-                                }
-                            })
-                        }
+                        
+                        const data = message.data as RealtimeResponseEvent<unknown>;
+                        if (!data?.channels) return;
+
+                        const isSubscribed = data.channels.some(channel => this.realtime.channels.has(channel));
+                        if (!isSubscribed) return;
+
+                        this.realtime.subscriptions.forEach(subscription => {
+                            if (data.channels.some(channel => subscription.channels.includes(channel))) {
+                                setTimeout(() => subscription.callback(data));
+                            }
+                        });
                         break;
                     case 'pong':
                         break; // Handle pong response if needed

--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -11,7 +11,7 @@ type Headers = {
 }
 
 type RealtimeResponse = {
-    type: 'error' | 'event' | 'connected' | 'response';
+    type: 'error' | 'event' | 'connected' | 'response' | 'pong';
     data: RealtimeResponseAuthenticated | RealtimeResponseConnected | RealtimeResponseError | RealtimeResponseEvent<unknown>;
 }
 
@@ -290,6 +290,7 @@ class Client {
                 this.realtime.lastMessage = message;
                 switch (message.type) {
                     case 'event':
+                        if(!message.data) return;
                         let data = <RealtimeResponseEvent<unknown>>message.data;
                         if (data?.channels) {
                             const isSubscribed = data.channels.some(channel => this.realtime.channels.has(channel));
@@ -301,6 +302,8 @@ class Client {
                             })
                         }
                         break;
+                    case 'pong':
+                        break; // Handle pong response if needed
                     case 'error':
                         throw message.data;
                     default:

--- a/templates/swift/Sources/Services/Realtime.swift.twig
+++ b/templates/swift/Sources/Services/Realtime.swift.twig
@@ -200,7 +200,7 @@ extension Realtime: WebSocketClientDelegate {
             if let type = json["type"] as? String {
                 switch type {
                 case TYPE_ERROR: try! handleResponseError(from: json)
-                case TYPE_EVENT: if json["data"] != nil {handleResponseEvent(from: json)}
+                case TYPE_EVENT: handleResponseEvent(from: json)
                 case TYPE_PONG: break  // Handle pong response if needed
                 default: break
                 }

--- a/templates/swift/Sources/Services/Realtime.swift.twig
+++ b/templates/swift/Sources/Services/Realtime.swift.twig
@@ -200,7 +200,7 @@ extension Realtime: WebSocketClientDelegate {
             if let type = json["type"] as? String {
                 switch type {
                 case TYPE_ERROR: try! handleResponseError(from: json)
-                case TYPE_EVENT: handleResponseEvent(from: json)
+                case TYPE_EVENT: if json["data"] != nil {handleResponseEvent(from: json)}
                 case TYPE_PONG: break  // Handle pong response if needed
                 default: break
                 }

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -485,6 +485,7 @@ class Client {
                         }
                         break;
                     case 'event':
+                        if (!message.data) return;
                         let data = <RealtimeResponseEvent<unknown>>message.data;
                         if (data?.channels) {
                             const isSubscribed = data.channels.some(channel => this.realtime.channels.has(channel));
@@ -496,6 +497,8 @@ class Client {
                             })
                         }
                         break;
+                    case 'pong':
+                        break; // Handle pong response if needed
                     case 'error':
                         throw message.data;
                     default:

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -486,16 +486,18 @@ class Client {
                         break;
                     case 'event':
                         if (!message.data) return;
-                        let data = <RealtimeResponseEvent<unknown>>message.data;
-                        if (data?.channels) {
-                            const isSubscribed = data.channels.some(channel => this.realtime.channels.has(channel));
-                            if (!isSubscribed) return;
-                            this.realtime.subscriptions.forEach(subscription => {
-                                if (data.channels.some(channel => subscription.channels.includes(channel))) {
-                                    setTimeout(() => subscription.callback(data));
-                                }
-                            })
-                        }
+
+                        const data = message.data as RealtimeResponseEvent<unknown>;
+                        if (!data?.channels) return;
+
+                        const isSubscribed = data.channels.some(channel => this.realtime.channels.has(channel));
+                        if (!isSubscribed) return;
+
+                        this.realtime.subscriptions.forEach(subscription => {
+                            if (data.channels.some(channel => subscription.channels.includes(channel))) {
+                                setTimeout(() => subscription.callback(data));
+                            }
+                        });
                         break;
                     case 'pong':
                         break; // Handle pong response if needed

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -485,19 +485,16 @@ class Client {
                         }
                         break;
                     case 'event':
-                        if (!message.data) return;
-
-                        const data = message.data as RealtimeResponseEvent<unknown>;
-                        if (!data?.channels) return;
-
-                        const isSubscribed = data.channels.some(channel => this.realtime.channels.has(channel));
-                        if (!isSubscribed) return;
-
-                        this.realtime.subscriptions.forEach(subscription => {
-                            if (data.channels.some(channel => subscription.channels.includes(channel))) {
-                                setTimeout(() => subscription.callback(data));
-                            }
-                        });
+                        let data = <RealtimeResponseEvent<unknown>>message.data;
+                        if (data?.channels) {
+                            const isSubscribed = data.channels.some(channel => this.realtime.channels.has(channel));
+                            if (!isSubscribed) return;
+                            this.realtime.subscriptions.forEach(subscription => {
+                                if (data.channels.some(channel => subscription.channels.includes(channel))) {
+                                    setTimeout(() => subscription.callback(data));
+                                }
+                            })
+                        }
                         break;
                     case 'pong':
                         break; // Handle pong response if needed

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -19,14 +19,14 @@ type Headers = {
  */
 type RealtimeResponse = {
     /**
-     * Type of the response: 'error', 'event', 'connected', 'pong', or 'response'.
+     * Type of the response: 'error', 'event', 'connected', 'response' or 'pong'.
      */
     type: 'error' | 'event' | 'connected' | 'response' | 'pong';
 
     /**
      * Data associated with the response based on the response type.
      */
-    data: RealtimeResponseAuthenticated | RealtimeResponseConnected | RealtimeResponseError | RealtimeResponseEvent<unknown>;
+    data: RealtimeResponseAuthenticated | RealtimeResponseConnected | RealtimeResponseError | RealtimeResponseEvent<unknown> | undefined;
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

During creation of heartbeat messages in realtime, the response is `{"type": "pong"}`. It does not contain the `data` attribute that the code does not account for, leading to error:

```
[ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception: type 'Null' is not a subtype of type 'Map<dynamic, dynamic>'
```

This PR adds null-safety checks for message event type in flutter, android, ios, web and react-native. it also makes accounting for `pong` type consistent.

## Test Plan

## Related PRs and Issues

* https://github.com/appwrite/sdk-generator/issues/1026

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.