### PR TITLE
Fix: Add missing specification in CLI

### DIFF
--- a/templates/cli/lib/commands/push.js.twig
+++ b/templates/cli/lib/commands/push.js.twig
@@ -1095,6 +1095,7 @@ const pushFunction = async ({ functionId, async, code, withVariables } = { retur
             response = await functionsUpdate({
                 functionId: func['$id'],
                 name: func.name,
+                specification: func.specification,
                 execute: func.execute,
                 events: func.events,
                 schedule: func.schedule,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR adds specification to a section of `push.js` in the CLI that updates functions so you can edit the appwrite.json file and change specs.

## Test Plan

Test that updating a specification from the CLI is possible manually

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes