### PR TITLE
fix(dotnet): models formatting

### DIFF
--- a/templates/dotnet/Package/Models/Model.cs.twig
+++ b/templates/dotnet/Package/Models/Model.cs.twig
@@ -28,7 +28,8 @@ namespace {{ spec.title | caseUcfirst }}.Models
             {%~ if definition.additionalProperties %}
             Dictionary<string, object> data
             {%~ endif %}
-        ) {
+        )
+        {
             {%~ for property in definition.properties %}
             {{ property_name(definition, property) | overrideProperty(definition.name) }} = {{ property.name | caseCamel | escapeKeyword }};
             {%~ endfor %}
@@ -62,7 +63,7 @@ namespace {{ spec.title | caseUcfirst }}.Models
                         map["{{ property.name }}"].ConvertToList<{{ property | typeName | replace({'List<': '', '>': ''}) }}>()
                     {%- else %}
                         {%- if property.type == "integer" or property.type == "number" %}
-                            {%- if not property.required -%}map["{{ property.name }}"] == null ? null :{% endif %}Convert.To{% if property.type == "integer" %}Int64{% else %}Double{% endif %}(map["{{ property.name }}"])
+                            {%- if not property.required -%}map["{{ property.name }}"] == null ? null : {% endif %}Convert.To{% if property.type == "integer" %}Int64{% else %}Double{% endif %}(map["{{ property.name }}"])
                         {%- else %}
                             {%- if property.type == "boolean" -%}
                                 ({{ property | typeName }}{% if not property.required %}?{% endif %})map["{{ property.name }}"]
@@ -73,14 +74,16 @@ namespace {{ spec.title | caseUcfirst }}.Models
                                     map["{{ property.name }}"].ToString()
                                 {%- endif %}
                             {%- endif %}
-                        {%~ endif %}
-                    {%~ endif %}
+                        {%- endif %}
+                    {%- endif %}
                 {%~ endif %}
                 {%- if not loop.last or (loop.last and definition.additionalProperties) %},
                 {%~ endif %}
             {%~ endfor %}
             {%- if definition.additionalProperties %}
-            data: map.TryGetValue("data", out var dataValue) ? (Dictionary<string, object>)dataValue : map
+            data: map.TryGetValue("data", out var dataValue)
+                ? (Dictionary<string, object>)dataValue
+                : map
             {%- endif ~%}
         );
 


### PR DESCRIPTION
## Summary

This PR keeps the DotNet model formatting fix relevant after the current `master` changes to the DotNet generator.

The original PR was stale and conflicted with newer `System.Text.Json`, enum, and `ConvertToList` model parsing changes in `templates/dotnet/Package/Models/Model.cs.twig`. The branch has now been rebased onto the latest `master`, the conflict was resolved by preserving the newer parsing behavior, and the formatting-only changes were rechecked against generated DotNet output.

## What changed

- Formats generated model constructors with the opening brace on the next line, matching `dotnet format` whitespace expectations.
- Adds the missing space after the `:` in nullable numeric ternaries such as `null : Convert.ToInt64(...)`.
- Splits the additional-properties `data` fallback into a multiline conditional expression so generated models with `Data` are easier to scan.
- Keeps the existing cast spacing style used by `dotnet format`; the old PR's cast-space changes were intentionally not kept because the formatter rejects those spaces.

## Generated output examples

### Constructor brace formatting

Before:

```cs
public Addon(
    string id,
    string createdAt,
    string updatedAt,
    List<string> permissions,
    string key,
    string resourceType,
    string resourceId,
    string status,
    long currentValue,
    long? nextValue
) {
    Id = id;
    CreatedAt = createdAt;
    UpdatedAt = updatedAt;
}
```

After:

```cs
public Addon(
    string id,
    string createdAt,
    string updatedAt,
    List<string> permissions,
    string key,
    string resourceType,
    string resourceId,
    string status,
    long currentValue,
    long? nextValue
)
{
    Id = id;
    CreatedAt = createdAt;
    UpdatedAt = updatedAt;
}
```

### Nullable numeric ternary spacing

Before:

```cs
public static Addon From(Dictionary<string, object> map) => new Addon(
    id: map["$id"].ToString(),
    currentValue: Convert.ToInt64(map["currentValue"]),
    nextValue: map["nextValue"] == null ? null :Convert.ToInt64(map["nextValue"])
);
```

After:

```cs
public static Addon From(Dictionary<string, object> map) => new Addon(
    id: map["$id"].ToString(),
    currentValue: Convert.ToInt64(map["currentValue"]),
    nextValue: map["nextValue"] == null ? null : Convert.ToInt64(map["nextValue"])
);
```

### Additional properties `data` fallback formatting

Before:

```cs
public static Row From(Dictionary<string, object> map) => new Row(
    id: map["$id"].ToString(),
    permissions: map["$permissions"].ConvertToList<string>(),
    data: map.TryGetValue("data", out var dataValue) ? (Dictionary<string, object>)dataValue : map
);
```

After:

```cs
public static Row From(Dictionary<string, object> map) => new Row(
    id: map["$id"].ToString(),
    permissions: map["$permissions"].ConvertToList<string>(),
    data: map.TryGetValue("data", out var dataValue)
        ? (Dictionary<string, object>)dataValue
        : map
);
```

## Relevance check

This is still relevant on current `master`: generated DotNet model output still contained the compact constructor brace and `:Convert` formatting issue before this change. I generated DotNet SDK output from both current `master` and this branch, then compared the generated `examples/dotnet` trees to confirm the rendered changes are formatting-only in model output.

## Validation

- `docker run --rm -v /Users/chiragaggarwal/Desktop/appwrite/sdk-generator:/app -w /app php:8.3-cli php example.php dotnet`
- Generated DotNet output from current `master` in a temporary worktree and compared it with this branch's generated output.
- `dotnet format whitespace --include Appwrite/Models --verify-no-changes --verbosity minimal` from generated `examples/dotnet`.
- `composer lint-twig`
- `git diff --check`

`dotnet build` was also checked against the generated SDK output. It currently fails on both current `master` and this branch with the same pre-existing generated-model issues, including duplicate `From` definitions and missing/invalid model names (`AggregationTeam`, `Invoice`, `DomainsList`, `Review`, `Roles`, `Schedule`). The failure does not appear to be introduced by this formatting PR.

## Review comments

Greptile Review passed and posted a summary only: confidence `5/5`, safe to merge, no files requiring special attention. There are no unresolved review threads or actionable Greptile comments to address. The only existing human review is an approval from `christyjacob4`.
