### PR TITLE
Fix "attributes" typing for Node and Web SDKs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ sdk-generator/blob/master/example.php:
 Run the following command (make sure you have an updated docker version on your machine):
 
 ```bash
-docker run --rm -v $(pwd):/app -w /app php:8.1-cli php example.php
+docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php
 ```
 
 >Note: You can just add the new language next to the other languages in the `example.php` file. You don't need to rewrite the file completely.
@@ -252,7 +252,7 @@ Also in `.travis.yml` add new env `SDK=[Language]` so that travis will run a tes
 
 Finally, you can run tests using:
 ```sh
-docker run --rm -v $(pwd):$(pwd):rw -w $(pwd) -v /var/run/docker.sock:/var/run/docker.sock  php:8.1-cli-alpine sh -c "apk add docker-cli && vendor/bin/phpunit"
+docker run --rm -v $(pwd):$(pwd):rw -w $(pwd) -v /var/run/docker.sock:/var/run/docker.sock  php:8.3-cli-alpine sh -c "apk add docker-cli && vendor/bin/phpunit"
 ```
 
 ## SDK Generator Interface

--- a/src/SDK/Language/Node.php
+++ b/src/SDK/Language/Node.php
@@ -29,6 +29,19 @@ class Node extends Web
             case self::TYPE_NUMBER:
                 return 'number';
             case self::TYPE_ARRAY:
+                if (!empty($parameter['array']['x-anyOf'] ?? [])) {
+                    $unionTypes = [];
+                    foreach ($parameter['array']['x-anyOf'] as $refType) {
+                        if (isset($refType['$ref'])) {
+                            $refParts = explode('/', $refType['$ref']);
+                            $modelName = end($refParts);
+                            $unionTypes[] = 'Models.' . $this->toPascalCase($modelName);
+                        }
+                    }
+                    if (!empty($unionTypes)) {
+                        return '(' . implode(' | ', $unionTypes) . ')[]';
+                    }
+                }
                 if (!empty(($parameter['array'] ?? [])['type']) && !\is_array($parameter['array']['type'])) {
                     return $this->getTypeName($parameter['array']) . '[]';
                 }

--- a/src/SDK/Language/Web.php
+++ b/src/SDK/Language/Web.php
@@ -194,6 +194,19 @@ class Web extends JS
             case self::TYPE_NUMBER:
                 return 'number';
             case self::TYPE_ARRAY:
+                if (!empty($parameter['array']['x-anyOf'] ?? [])) {
+                    $unionTypes = [];
+                    foreach ($parameter['array']['x-anyOf'] as $refType) {
+                        if (isset($refType['$ref'])) {
+                            $refParts = explode('/', $refType['$ref']);
+                            $modelName = end($refParts);
+                            $unionTypes[] = 'Models.' . $this->toPascalCase($modelName);
+                        }
+                    }
+                    if (!empty($unionTypes)) {
+                        return '(' . implode(' | ', $unionTypes) . ')[]';
+                    }
+                }
                 if (!empty(($parameter['array'] ?? [])['type']) && !\is_array($parameter['array']['type'])) {
                     return $this->getTypeName($parameter['array']) . '[]';
                 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

In our swagger specs, we have defined the typings for an attribute to be attributeBoolean, attributeInteger and so on... but in SDK generator although we have the typings defined, we default `attribute`'s typing to an array of strings instead of using the defined typings.

This PR adds check if typings exist in "anyOf" field of the spec, and use those as a union.

## Test Plan

Before:

```
attribute: string[]
```

After:

```
attributes: (Models.AttributeBoolean | Models.AttributeInteger | Models.AttributeFloat | Models.AttributeEmail | Models.AttributeEnum | Models.AttributeUrl | Models.AttributeIp | Models.AttributeDatetime | Models.AttributeRelationship | Models.AttributeString)[];
```

## Related PRs and Issues

- https://github.com/appwrite/sdk-for-node/issues/87

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.