### PR TITLE
chore: remove unnecessary async and spacing

### DIFF
--- a/src/SDK/Language/Web.php
+++ b/src/SDK/Language/Web.php
@@ -269,7 +269,7 @@ class Web extends JS
     public function getReturn(array $method, array $spec): string
     {
         if ($method['type'] === 'webAuth') {
-            return 'Promise<void | string>';
+            return 'void | string';
         }
 
         if ($method['type'] === 'location') {

--- a/templates/node/src/services/template.ts.twig
+++ b/templates/node/src/services/template.ts.twig
@@ -36,7 +36,7 @@ export class {{ service.name | caseUcfirst }} {
      * @throws {{ '{' }}{{ spec.title | caseUcfirst}}Exception}
      * @returns {{ '{' }}{{ method | getReturn(spec) | raw }}{{ '}' }}
      */
-     {{ method.name | caseCamel }}{{ method.responseModel | getGenerics(spec) | raw }}({% for parameter in method.parameters.all %}{{ parameter.name | caseCamel | escapeKeyword }}{% if not parameter.required or parameter.nullable %}?{% endif %}: {{ parameter | getPropertyType(method) | raw }}{% if not loop.last %}, {% endif %}{% endfor %}{% if 'multipart/form-data' in method.consumes %}, onProgress = (progress: UploadProgress) => {}{% endif %}): {{ method | getReturn(spec) | raw }} {
+    {{ method.name | caseCamel }}{{ method.responseModel | getGenerics(spec) | raw }}({% for parameter in method.parameters.all %}{{ parameter.name | caseCamel | escapeKeyword }}{% if not parameter.required or parameter.nullable %}?{% endif %}: {{ parameter | getPropertyType(method) | raw }}{% if not loop.last %}, {% endif %}{% endfor %}{% if 'multipart/form-data' in method.consumes %}, onProgress = (progress: UploadProgress) => {}{% endif %}): {{ method | getReturn(spec) | raw }} {
         {%~ for parameter in method.parameters.all %}
         {%~ if parameter.required %}
         if (typeof {{ parameter.name | caseCamel | escapeKeyword }} === 'undefined') {

--- a/templates/web/src/services/template.ts.twig
+++ b/templates/web/src/services/template.ts.twig
@@ -85,10 +85,10 @@ export class {{ service.name | caseUcfirst }} {
             window.location.href = uri.toString();
             return Promise.resolve();
         } else {
-            return Promise.resolve(uri.toString());
+            return uri.toString();
         }
         {%~ elseif method.type == 'location' %}
-        return Promise.resolve(uri.toString());
+        return uri.toString();
         {%~ elseif 'multipart/form-data' in method.consumes %}
         return this.client.chunkedUpload(
             '{{ method.method | caseLower }}',

--- a/templates/web/src/services/template.ts.twig
+++ b/templates/web/src/services/template.ts.twig
@@ -77,9 +77,9 @@ export class {{ service.name | caseUcfirst }} {
         {%~ if method.type == 'webAuth' %}
         if (typeof window !== 'undefined' && window?.location) {
             window.location.href = uri.toString();
-            return Promise.resolve();
+            return;
         } else {
-            return Promise.resolve(uri.toString());
+            return uri.toString();
         }
         {%~ elseif method.type == 'location' %}
         return uri.toString();

--- a/templates/web/src/services/template.ts.twig
+++ b/templates/web/src/services/template.ts.twig
@@ -83,12 +83,12 @@ export class {{ service.name | caseUcfirst }} {
         {%~ if method.type == 'webAuth' %}
         if (typeof window !== 'undefined' && window?.location) {
             window.location.href = uri.toString();
-            return;
+            return Promise.resolve();
         } else {
-            return uri.toString();
+            return Promise.resolve(uri.toString());
         }
         {%~ elseif method.type == 'location' %}
-        return uri.toString();
+        return Promise.resolve(uri.toString());
         {%~ elseif 'multipart/form-data' in method.consumes %}
         return this.client.chunkedUpload(
             '{{ method.method | caseLower }}',

--- a/templates/web/src/services/template.ts.twig
+++ b/templates/web/src/services/template.ts.twig
@@ -69,11 +69,19 @@ export class {{ service.name | caseUcfirst }} {
         }
 
         {%~ if method.type == 'location' or method.type == 'webAuth' %}
+        {%~ if method.auth|length > 0 %}
+        {%~ for node in method.auth %}
+        {%~ for key,header in node|keys %}
+        payload['{{header|caseLower}}'] = this.client.config.{{header|caseLower}};
+        {%~ endfor %}
+        {%~ endfor %}
+        {%~ endif %}
+
         for (const [key, value] of Object.entries(Service.flatten(payload))) {
             uri.searchParams.append(key, value);
         }
+        
         {%~ endif %}
-
         {%~ if method.type == 'webAuth' %}
         if (typeof window !== 'undefined' && window?.location) {
             window.location.href = uri.toString();

--- a/templates/web/src/services/template.ts.twig
+++ b/templates/web/src/services/template.ts.twig
@@ -68,12 +68,6 @@ export class {{ service.name | caseUcfirst }} {
             {%~ endfor %}
         }
 
-        {%~ for node in method.auth %}
-        {%~ for key,header in node|keys %}
-        payload['{{header|caseLower}}'] = this.client.config.{{header|caseLower}};
-        {%~ endfor %}
-        {%~ endfor %}
-
         {%~ if method.type == 'location' or method.type == 'webAuth' %}
         for (const [key, value] of Object.entries(Service.flatten(payload))) {
             uri.searchParams.append(key, value);

--- a/templates/web/src/services/template.ts.twig
+++ b/templates/web/src/services/template.ts.twig
@@ -85,7 +85,7 @@ export class {{ service.name | caseUcfirst }} {
             window.location.href = uri.toString();
             return Promise.resolve();
         } else {
-            return uri.toString();
+            return Promise.resolve(uri.toString());
         }
         {%~ elseif method.type == 'location' %}
         return uri.toString();

--- a/templates/web/src/services/template.ts.twig
+++ b/templates/web/src/services/template.ts.twig
@@ -37,7 +37,7 @@ export class {{ service.name | caseUcfirst }} {
      * @throws {{ '{' }}{{ spec.title | caseUcfirst}}Exception}
      * @returns {{ '{' }}{{ method | getReturn(spec) | raw }}{{ '}' }}
      */
-    {% if method.type != 'location' %}async {% endif %}{{ method.name | caseCamel }}{{ method.responseModel | getGenerics(spec) | raw }}({% for parameter in method.parameters.all %}{{ parameter.name | caseCamel | escapeKeyword }}{% if not parameter.required or parameter.nullable %}?{% endif %}: {{ parameter | getPropertyType(method) | raw }}{% if not loop.last %}, {% endif %}{% endfor %}{% if 'multipart/form-data' in method.consumes %}, onProgress = (progress: UploadProgress) => {}{% endif %}): {{ method | getReturn(spec) | raw }} {
+    {{ method.name | caseCamel }}{{ method.responseModel | getGenerics(spec) | raw }}({% for parameter in method.parameters.all %}{{ parameter.name | caseCamel | escapeKeyword }}{% if not parameter.required or parameter.nullable %}?{% endif %}: {{ parameter | getPropertyType(method) | raw }}{% if not loop.last %}, {% endif %}{% endfor %}{% if 'multipart/form-data' in method.consumes %}, onProgress = (progress: UploadProgress) => {}{% endif %}): {{ method | getReturn(spec) | raw }} {
         {%~ for parameter in method.parameters.all %}
         {%~ if parameter.required %}
         if (typeof {{ parameter.name | caseCamel | escapeKeyword }} === 'undefined') {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

1. fix spacing in sdk for web (there was one extra in front of method names).
2. remove unnecessary async in sdk for node.
3. make the return for `webAuth` be string or void instead of promise. this previously did not give an error since methods were async.
4. remove unnecessary adding of payload in web auth. it would just add project in the payload, which would already be added in headers:

<img width="753" alt="Screenshot 2025-03-07 at 2 10 23 PM" src="https://github.com/user-attachments/assets/6ca3f20e-e5fe-4e64-9224-58a8eb5a8f96" />


## Test Plan

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.