### PR TITLE
fix: use platform.uname() instead of os.uname() so it works across pl…

### DIFF
--- a/templates/python/package/client.py.twig
+++ b/templates/python/package/client.py.twig
@@ -1,6 +1,7 @@
 import io
 import json
 import os
+import platform
 import requests
 from .input_file import InputFile
 from .exception import {{spec.title | caseUcfirst}}Exception
@@ -13,7 +14,7 @@ class Client:
         self._endpoint = '{{spec.endpoint}}'
         self._global_headers = {
             'content-type': '',
-            'user-agent' : f'{{spec.title | caseUcfirst}}{{ language.name | caseUcfirst }}SDK/{{ sdk.version }} ({os.uname().sysname}; {os.uname().version}; {os.uname().machine})',
+            'user-agent' : f'{{spec.title | caseUcfirst}}{{ language.name | caseUcfirst }}SDK/{{ sdk.version }} ({platform.uname().system}; {platform.uname().version}; {platform.uname().machine})',
             'x-sdk-name': '{{ sdk.name }}',
             'x-sdk-platform': '{{ sdk.platform }}',
             'x-sdk-language': '{{ language.name | caseLower }}',


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

![image](https://github.com/user-attachments/assets/6ccf26e3-953a-48a1-a34e-4384b279110f)

Related  - https://stackoverflow.com/questions/62798371/os-uname-function-not-working-in-windows

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)