### PR TITLE
fix: appwrite exception already read

### DIFF
--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -282,7 +282,13 @@ class Client {
         }
 
         if (400 <= response.status) {
-            throw new {{spec.title | caseUcfirst}}Exception(data?.message, response.status, data?.type, JSON.stringify(data));
+            let responseText = '';
+            if (response.headers.get('content-type')?.includes('application/json') || responseType === 'arrayBuffer') {
+                responseText = JSON.stringify(data);
+            } else {
+                responseText = data?.message;
+            }
+            throw new {{spec.title | caseUcfirst}}Exception(data?.message, response.status, data?.type, responseText);
         }
 
         return data;

--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -263,7 +263,6 @@ class Client {
         const { uri, options } = this.prepareRequest(method, url, headers, params);
 
         let data: any = null;
-        let text: string = '';
 
         const response = await fetch(uri, options);
 
@@ -274,18 +273,16 @@ class Client {
 
         if (response.headers.get('content-type')?.includes('application/json')) {
             data = await response.json();
-            text = JSON.stringify(data);
         } else if (responseType === 'arrayBuffer') {
             data = await response.arrayBuffer();
         } else {
-            text = await response.text();
             data = {
-                message: text
+                message: await response.text();
             };
         }
 
         if (400 <= response.status) {
-            throw new {{spec.title | caseUcfirst}}Exception(data?.message, response.status, data?.type, text);
+            throw new {{spec.title | caseUcfirst}}Exception(data?.message, response.status, data?.type, JSON.stringify(data));
         }
 
         return data;

--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -277,7 +277,7 @@ class Client {
             data = await response.arrayBuffer();
         } else {
             data = {
-                message: await response.text();
+                message: await response.text()
             };
         }
 

--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -414,7 +414,6 @@ class Client {
 
         try {
             let data = null;
-            let text: string = '';
 
             const response = await fetch(url.toString(), options);
 
@@ -425,16 +424,14 @@ class Client {
 
             if (response.headers.get('content-type')?.includes('application/json')) {
                 data = await response.json();
-                text = JSON.stringify(data);
             } else {
-                text = await response.text();
                 data = {
-                    message: text
+                    message: await response.text()
                 };
             }
 
             if (400 <= response.status) {
-                throw new {{spec.title | caseUcfirst}}Exception(data?.message, response.status, data?.type, text);
+                throw new {{spec.title | caseUcfirst}}Exception(data?.message, response.status, data?.type, JSON.stringify(data));
             }
 
             const cookieFallback = response.headers.get('X-Fallback-Cookies');

--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -414,8 +414,9 @@ class Client {
 
         try {
             let data = null;
+            let text: string = '';
+
             const response = await fetch(url.toString(), options);
-            const text = await response.text()
 
             const warnings = response.headers.get('x-{{ spec.title | lower }}-warning');
             if (warnings) {
@@ -424,7 +425,9 @@ class Client {
 
             if (response.headers.get('content-type')?.includes('application/json')) {
                 data = await response.json();
+                text = JSON.stringify(data);
             } else {
+                text = await response.text();
                 data = {
                     message: text
                 };

--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -431,7 +431,13 @@ class Client {
             }
 
             if (400 <= response.status) {
-                throw new {{spec.title | caseUcfirst}}Exception(data?.message, response.status, data?.type, JSON.stringify(data));
+                let responseText = '';
+                if (response.headers.get('content-type')?.includes('application/json') || responseType === 'arrayBuffer') {
+                    responseText = JSON.stringify(data);
+                } else {
+                    responseText = data?.message;
+                }
+                throw new {{spec.title | caseUcfirst}}Exception(data?.message, response.status, data?.type, responseText);
             }
 
             const cookieFallback = response.headers.get('X-Fallback-Cookies');

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -688,7 +688,13 @@ class Client {
         }
 
         if (400 <= response.status) {
-            throw new {{spec.title | caseUcfirst}}Exception(data?.message, response.status, data?.type, JSON.stringify(data));
+            let responseText = '';
+            if (response.headers.get('content-type')?.includes('application/json') || responseType === 'arrayBuffer') {
+                responseText = JSON.stringify(data);
+            } else {
+                responseText = data?.message;
+            }
+            throw new {{spec.title | caseUcfirst}}Exception(data?.message, response.status, data?.type, responseText);
         }
 
         const cookieFallback = response.headers.get('X-Fallback-Cookies');

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -669,7 +669,6 @@ class Client {
         const { uri, options } = this.prepareRequest(method, url, headers, params);
 
         let data: any = null;
-        let text: string = '';
 
         const response = await fetch(uri, options);
 
@@ -680,18 +679,16 @@ class Client {
 
         if (response.headers.get('content-type')?.includes('application/json')) {
             data = await response.json();
-            text = JSON.stringify(data);
         } else if (responseType === 'arrayBuffer') {
             data = await response.arrayBuffer();
         } else {
-            text = await response.text();
             data = {
-                message: text
+                message: await response.text();
             };
         }
 
         if (400 <= response.status) {
-            throw new {{spec.title | caseUcfirst}}Exception(data?.message, response.status, data?.type, text);
+            throw new {{spec.title | caseUcfirst}}Exception(data?.message, response.status, data?.type, JSON.stringify(data));
         }
 
         const cookieFallback = response.headers.get('X-Fallback-Cookies');

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -683,7 +683,7 @@ class Client {
             data = await response.arrayBuffer();
         } else {
             data = {
-                message: await response.text();
+                message: await response.text()
             };
         }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

A response stream can only be read once. That's why reading it for text and then reading it again for json gave error "Already read". The error was caught and fixed in web and node, but left in react-native. This PR makes the logic consistent across all three.

## Test Plan

## Related PRs and Issues

* https://github.com/appwrite/sdk-for-react-native/issues/49
* https://github.com/appwrite/sdk-for-react-native/issues/50

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.