### PR TITLE
Make dependencies more robust

### DIFF
--- a/templates/react-native/package.json.twig
+++ b/templates/react-native/package.json.twig
@@ -33,11 +33,10 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "expo-file-system": "~18.0.11",
-    "react-native": "0.76.7"
+    "expo-file-system": "^18.0.11",
+    "react-native": "~0.76.7"
   },
   "peerDependencies": {
-    "expo": "*",
-    "react-native": "*"
+    "expo": "*"
   }
 }


### PR DESCRIPTION
## What does this PR do?

Current dependencies are triggering version conflicts when SDK is installed in Expo React Native app.

## Test Plan

Run `npx expo-doctor` without issues.

## Related PRs and Issues

[Bug Report: Issue with Expo](https://github.com/appwrite/sdk-for-react-native/issues/43)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes