### PR TITLE
(fix) double slash in path

### DIFF
--- a/templates/cli/lib/client.js.twig
+++ b/templates/cli/lib/client.js.twig
@@ -1,4 +1,5 @@
 const os = require('os');
+const join = require('path').join;
 const https = require("https");
 const { fetch, FormData, Agent } = require("undici");
 const JSONbig = require("json-bigint")({ storeAsString: false });
@@ -96,7 +97,7 @@ class Client {
 
   async call(method, path = "", headers = {}, params = {}, responseType = "json") {
     headers = {...this.headers, ...headers};
-    const url = new URL(this.endpoint + path);
+    const url = new URL(join(this.endpoint + path));
 
     let body = undefined;
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Provides a fix for https://github.com/appwrite/appwrite/issues/9042 causing project related CLI operations to not work (specifically on macOS and Windows for some reason)

## Test Plan

I build and tested with an existing project. Where before I was getting the error "Project with the requested ID could not be found. Please check the value of the X-Appwrite-Project header to ensure the correct project ID is being used." I now do not.

## Related PRs and Issues

https://github.com/appwrite/appwrite/issues/9042

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes