### PR TITLE
fix: hot swapping error in python ml function

### DIFF
--- a/templates/cli/lib/utils.js.twig
+++ b/templates/cli/lib/utils.js.twig
@@ -9,9 +9,10 @@ function getAllFiles(folder) {
     const files = [];
     for (const pathDir of fs.readdirSync(folder)) {
         const pathAbsolute = path.join(folder, pathDir);
-        if (fs.statSync(pathAbsolute).isDirectory()) {
+        const stats = fs.lstatSync(pathAbsolute);
+        if (stats.isDirectory() && !stats.isSymbolicLink()) {
             files.push(...getAllFiles(pathAbsolute));
-        } else {
+        } else if (stats.isFile() && !stats.isSymbolicLink()) {
             files.push(pathAbsolute);
         }
     }

--- a/templates/cli/lib/utils.js.twig
+++ b/templates/cli/lib/utils.js.twig
@@ -9,10 +9,15 @@ function getAllFiles(folder) {
     const files = [];
     for (const pathDir of fs.readdirSync(folder)) {
         const pathAbsolute = path.join(folder, pathDir);
-        const stats = fs.lstatSync(pathAbsolute);
-        if (stats.isDirectory() && !stats.isSymbolicLink()) {
+        let stats;
+        try {
+            stats = fs.statSync(pathAbsolute);
+        } catch (error) {
+            continue;
+        }
+        if (stats.isDirectory()) {
             files.push(...getAllFiles(pathAbsolute));
-        } else if (stats.isFile() && !stats.isSymbolicLink()) {
+        } else {
             files.push(pathAbsolute);
         }
     }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

In python-ml function, we copy over files to `runtime-env` here - https://github.com/open-runtimes/open-runtimes/blob/088ef387b097cc7bb29aff6602372ac1196c5925/runtimes/python/versions/latest/helpers/prepare-start.sh#L4

This folder contains various files, even including symlinks.

Symlinks when copied over won't be valid files anymore and hence the `getAllFiles` function in CLI throws an error trying to fetch absolute paths for it.

So the PR makes the function just skip any invalid symlinks.

## Test Plan

Before:

<img width="1018" alt="Screenshot 2025-03-29 at 5 44 07 PM" src="https://github.com/user-attachments/assets/29ed931c-374b-4d4a-b31c-3cab3aa97a83" />

After:

<img width="1002" alt="Screenshot 2025-03-29 at 5 44 36 PM" src="https://github.com/user-attachments/assets/66cda0e6-def3-41f2-8809-3e1a54645599" />

## Related PRs and Issues

- https://github.com/appwrite/sdk-for-cli/issues/150

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.