### PR TITLE
fix: inference error for apiHeaders

### DIFF
--- a/example.php
+++ b/example.php
@@ -42,7 +42,7 @@ try {
      $platform = 'console';
     // $platform = 'server';
 
-    $spec = getSSLPage("https://raw.githubusercontent.com/appwrite/appwrite/fix-headers/app/config/specs/swagger2-latest-{$platform}.json");
+    $spec = getSSLPage("https://raw.githubusercontent.com/appwrite/appwrite/1.7.x/app/config/specs/swagger2-latest-{$platform}.json");
 
     if(empty($spec)) {
         throw new Exception('Failed to fetch spec from Appwrite server');

--- a/example.php
+++ b/example.php
@@ -42,7 +42,7 @@ try {
      $platform = 'console';
     // $platform = 'server';
 
-    $spec = getSSLPage("https://raw.githubusercontent.com/appwrite/appwrite/1.7.x/app/config/specs/swagger2-latest-{$platform}.json");
+    $spec = getSSLPage("https://raw.githubusercontent.com/appwrite/appwrite/fix-headers/app/config/specs/swagger2-latest-{$platform}.json");
 
     if(empty($spec)) {
         throw new Exception('Failed to fetch spec from Appwrite server');

--- a/templates/android/library/src/main/java/io/package/services/Service.kt.twig
+++ b/templates/android/library/src/main/java/io/package/services/Service.kt.twig
@@ -127,7 +127,7 @@ class {{ service.name | caseUcfirst }}(client: Client) : Service(client) {
             responseType = {{ method | returnType(spec, sdk.namespace | caseDot) | raw }}::class.java
         )
         {%~ else %}
-        val apiHeaders = mutableMapOf(
+        val apiHeaders = mutableMapOf<String, String>(
         {%~ for key, header in method.headers %}
             "{{ key }}" to "{{ header }}",
         {%~ endfor %}

--- a/templates/dotnet/Package/Client.cs.twig
+++ b/templates/dotnet/Package/Client.cs.twig
@@ -149,9 +149,8 @@ namespace {{ spec.title | caseUcfirst }}
                 new HttpMethod(method),
                 _endpoint + path + queryString);
 
-            if ("multipart/form-data".Equals(
-                headers["content-type"],
-                StringComparison.OrdinalIgnoreCase))
+            if (headers.TryGetValue("content-type", out var contentType) && 
+                "multipart/form-data".Equals(contentType, StringComparison.OrdinalIgnoreCase))
             {
                 var form = new MultipartFormDataContent();
 

--- a/templates/kotlin/src/main/kotlin/io/appwrite/services/ServiceTemplate.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/services/ServiceTemplate.kt.twig
@@ -55,7 +55,7 @@ class {{ service.name | caseUcfirst }}(client: Client) : Service(client) {
             "{{ parameter.name }}" to {{ parameter.name | caseCamel }},
         {%~ endfor %}
         )
-        val apiHeaders = mutableMapOf(
+        val apiHeaders = mutableMapOf<String, String>(
         {%~ for key, header in method.headers %}
             "{{ key }}" to "{{ header }}",
         {%~ endfor %}

--- a/tests/resources/spec.json
+++ b/tests/resources/spec.json
@@ -77,9 +77,7 @@
       "get": {
         "summary": "Get Bar",
         "operationId": "barGet",
-        "consumes": [
-          "application\/json"
-        ],
+        "consumes": [],
         "produces": [
           "application\/json"
         ],
@@ -521,9 +519,7 @@
       "get": {
         "summary": "Get Foo",
         "operationId": "fooGet",
-        "consumes": [
-          "application\/json"
-        ],
+        "consumes": [],
         "produces": [
           "application\/json"
         ],
@@ -965,9 +961,7 @@
       "get": {
         "summary": "400 Error",
         "operationId": "generalError400",
-        "consumes": [
-          "application\/json"
-        ],
+        "consumes": [],
         "produces": [
           "application\/json"
         ],
@@ -1020,9 +1014,7 @@
       "get": {
         "summary": "500 Error",
         "operationId": "generalError500",
-        "consumes": [
-          "application\/json"
-        ],
+        "consumes": [],
         "produces": [
           "application\/json"
         ],
@@ -1075,9 +1067,7 @@
       "get": {
         "summary": "502 Error",
         "operationId": "generalError502",
-        "consumes": [
-          "application\/json"
-        ],
+        "consumes": [],
         "produces": [
           "text\/plain"
         ],
@@ -1126,9 +1116,7 @@
       "get": {
         "summary": "Download File",
         "operationId": "generalDownload",
-        "consumes": [
-          "application\/json"
-        ],
+        "consumes": [],
         "produces": [
           "*\/*"
         ],
@@ -1181,9 +1169,7 @@
       "get": {
         "summary": "Empty Response",
         "operationId": "generalEmpty",
-        "consumes": [
-          "application\/json"
-        ],
+        "consumes": [],
         "produces": [],
         "tags": [
           "general"
@@ -1319,9 +1305,7 @@
       "get": {
         "summary": "Get Cookie",
         "operationId": "generalGetCookie",
-        "consumes": [
-          "application\/json"
-        ],
+        "consumes": [],
         "produces": [
           "application\/json"
         ],
@@ -1374,9 +1358,7 @@
       "get": {
         "summary": "Get headers",
         "operationId": "generalHeaders",
-        "consumes": [
-          "application\/json"
-        ],
+        "consumes": [],
         "produces": [],
         "tags": [
           "general"
@@ -1514,9 +1496,7 @@
       "get": {
         "summary": "Redirect",
         "operationId": "generalRedirect",
-        "consumes": [
-          "application\/json"
-        ],
+        "consumes": [],
         "produces": [
           "text\/html"
         ],
@@ -1566,9 +1546,7 @@
       "get": {
         "summary": "Redirected",
         "operationId": "generalRedirected",
-        "consumes": [
-          "application\/json"
-        ],
+        "consumes": [],
         "produces": [
           "application\/json"
         ],
@@ -1621,9 +1599,7 @@
       "get": {
         "summary": "Set Cookie",
         "operationId": "generalSetCookie",
-        "consumes": [
-          "application\/json"
-        ],
+        "consumes": [],
         "produces": [
           "application\/json"
         ],
@@ -1767,9 +1743,7 @@
       "get": {
         "summary": "OAuth2",
         "operationId": "generalOAuth2",
-        "consumes": [
-          "application\/json"
-        ],
+        "consumes": [],
         "produces": [
           "text\/plain"
         ],


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

For android and kotlin, before apiHeaders always contained a value. But due to recent change in specs, we now removed unnecessary header for content type in GET and HEAD methods. This lead to apiHeaders being blank, leading to build errors - 

<img width="351" alt="Screenshot 2025-04-22 at 5 33 14 PM" src="https://github.com/user-attachments/assets/ea7c119e-5b9a-4320-af4f-5287ad8655d8" />

The PR fixes this with explicit typing.

## Test Plan

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.