### PR TITLE
chore: only encode user-agent if set

### DIFF
--- a/templates/dart/lib/src/client_mixin.dart.twig
+++ b/templates/dart/lib/src/client_mixin.dart.twig
@@ -62,8 +62,12 @@ mixin ClientMixin {
       (request as http.Request).body = jsonEncode(params);
     }
 
-    headers['User-Agent'] = Uri.encodeFull(headers['User-Agent'] ?? '');
-    headers['X-Forwarded-User-Agent'] = Uri.encodeFull(headers['X-Forwarded-User-Agent'] ?? '');
+    if (headers['User-Agent'] != null) {
+      headers['User-Agent'] = Uri.encodeFull(headers['User-Agent']!);
+    }
+    if (headers['X-Forwarded-User-Agent'] != null) {
+      headers['X-Forwarded-User-Agent'] = Uri.encodeFull(headers['X-Forwarded-User-Agent']!);
+    }
 
     request.headers.addAll(headers);
     return request;

--- a/templates/flutter/lib/src/client_mixin.dart.twig
+++ b/templates/flutter/lib/src/client_mixin.dart.twig
@@ -62,8 +62,12 @@ mixin ClientMixin {
       (request as http.Request).body = jsonEncode(params);
     }
 
-    headers['User-Agent'] = Uri.encodeFull(headers['User-Agent'] ?? '');
-    headers['X-Forwarded-User-Agent'] = Uri.encodeFull(headers['X-Forwarded-User-Agent'] ?? '');
+    if (headers['User-Agent'] != null) {
+      headers['User-Agent'] = Uri.encodeFull(headers['User-Agent']!);
+    }
+    if (headers['X-Forwarded-User-Agent'] != null) {
+      headers['X-Forwarded-User-Agent'] = Uri.encodeFull(headers['X-Forwarded-User-Agent']!);
+    }
 
     request.headers.addAll(headers);
     return request;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Only encodes user-agent header if its set. Previously it would have set a empty string as user-agent which browsers like safari did not like.

## Test Plan

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.