### PR TITLE
fix: bump dependencies to resolve PlatformConstants error with Expo 53

### DIFF
--- a/templates/react-native/package.json.twig
+++ b/templates/react-native/package.json.twig
@@ -33,8 +33,8 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "expo-file-system": "~18.0.11",
-    "react-native": "0.76.7"
+    "expo-file-system": "18.*.*",
+    "react-native": ">=0.76.7 <1.0.0"
   },
   "peerDependencies": {
     "expo": "*",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Resolves the "PlatformConstants could not be found" invariant violation that occurs when using React Native SDK with Expo 53. Updates all necessary dependencies to ensure compatibility with the new Expo version.

## Test Plan

## Related PRs and Issues

- https://github.com/appwrite/sdk-for-react-native/issues/45

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.