### PR TITLE
fix(cli): prevent session cookie from being wiped

### DIFF
--- a/templates/cli/lib/client.js.twig
+++ b/templates/cli/lib/client.js.twig
@@ -171,7 +171,11 @@ class Client {
 
     let cookies = response.headers.getSetCookie();
     if (cookies && cookies.length > 0) {
-      globalConfig.setCookie(cookies.join(";"));
+      for (const cookie of cookies) {
+        if (cookie.startsWith('a_session_console=')) {
+          globalConfig.setCookie(cookie);
+        }
+      }
     }
 
     const text = await response.text();


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Prior to this change, the CLI would replace the cookies in the config if the server returned any cookies, even when not authenticating.

This change makes it so we check for the Appwrite session cookie and only save that cookie if it's found in the response.

## Test Plan

This was happening when I was using the CLI against a codespaces instance I had. So, I manually tweaked the code and then successfully connected to the codespace without losing the session:

<img width="1149" alt="image" src="https://github.com/user-attachments/assets/a73dbe18-9a04-4114-9c70-2e13fa6b8dce" />

## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes