### PR TITLE
fix(cli): prevent shadowed error function

### DIFF
--- a/templates/cli/lib/commands/generic.js.twig
+++ b/templates/cli/lib/commands/generic.js.twig
@@ -122,7 +122,7 @@ const whoami = new Command("whoami")
                 sdk: client,
                 parseOutput: false
             });
-        } catch (error) {
+        } catch (_) {
             error("No user is signed in. To sign in, run 'appwrite login'");
             return;
         }


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Because the error function was shadowed by the caught error, you'd see an error like:

Error: error is not a function

This prevents the error function from being shadowed so that it is still callable.

## Test Plan

Tested manually

Before:

<img width="572" alt="image" src="https://github.com/user-attachments/assets/2d98eae4-867e-48e6-a197-3f2ace0286c5" />

After:

<img width="586" alt="image" src="https://github.com/user-attachments/assets/36840722-5b2d-4888-9706-8ea57abde884" />


## Related PRs and Issues

None

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes