### PR TITLE
chore: update flutter_web_auth_2 to 4.x

### DIFF
--- a/templates/flutter/lib/src/client_browser.dart.twig
+++ b/templates/flutter/lib/src/client_browser.dart.twig
@@ -224,6 +224,7 @@ class ClientBrowser extends ClientBase with ClientMixin {
   return FlutterWebAuth2.authenticate(
       url: url.toString(),
       callbackUrlScheme: "{{spec.title | caseLower}}-callback-" + config['project']!,
+      options: const FlutterWebAuth2Options(useWebview: false),
     );
   }
 }

--- a/templates/flutter/lib/src/client_io.dart.twig
+++ b/templates/flutter/lib/src/client_io.dart.twig
@@ -325,6 +325,7 @@ class ClientIO extends ClientBase with ClientMixin {
           : "{{spec.title | caseLower}}-callback-" + config['project']!,
       options: const FlutterWebAuth2Options(
         intentFlags: ephemeralIntentFlags,
+        useWebview: false,
       ),
     ).then((value) async {
       Uri url = Uri.parse(value);

--- a/templates/flutter/pubspec.yaml.twig
+++ b/templates/flutter/pubspec.yaml.twig
@@ -20,7 +20,7 @@ dependencies:
     sdk: flutter
   cookie_jar: ^4.0.8
   device_info_plus: ^10.1.2
-  flutter_web_auth_2: ^3.1.2
+  flutter_web_auth_2: ^4.1.0
   http: '>=0.13.6 <2.0.0'
   package_info_plus: ^8.0.2
   path_provider: ^2.1.4


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Migration guide followed - https://pub.dev/packages/flutter_web_auth_2#upgrading-to-4x

For now we are keeping the old behaviour and disabling usage of `webView` for linux and windows platforms. But in future we can introduce an option to enable it.

## Test Plan

## Related PRs and Issues

- https://github.com/appwrite/sdk-generator/issues/1064
- https://github.com/appwrite/sdk-for-flutter/issues/238
- https://github.com/appwrite/appwrite/pull/9858

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.