### PR TITLE
fix: encode + in parametersToQueryString

### DIFF
--- a/templates/apple/Sources/Client.swift.twig
+++ b/templates/apple/Sources/Client.swift.twig
@@ -9,6 +9,10 @@ import AsyncHTTPClient
 let DASHDASH = "--"
 let CRLF = "\r\n"
 
+extension CharacterSet {
+    static let rfc3986Unreserved = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+}
+
 open class Client {
 
     // MARK: Properties
@@ -214,7 +218,7 @@ open class Client {
        }
 
        return output.addingPercentEncoding(
-           withAllowedCharacters: .urlHostAllowed
+           withAllowedCharacters: .rfc3986Unreserved
        ) ?? ""
    }
 

--- a/templates/apple/Sources/Client.swift.twig
+++ b/templates/apple/Sources/Client.swift.twig
@@ -215,7 +215,7 @@ open class Client {
 
        return output.addingPercentEncoding(
            withAllowedCharacters: .urlHostAllowed
-       )?.replacingOccurrences(of: "+", with: "%2B") ?? ""
+       )?.replacingOccurrences(of: "+", with: "%2B") ?? "" // since urlHostAllowed doesn't include +
    }
 
     ///

--- a/templates/apple/Sources/Client.swift.twig
+++ b/templates/apple/Sources/Client.swift.twig
@@ -9,10 +9,6 @@ import AsyncHTTPClient
 let DASHDASH = "--"
 let CRLF = "\r\n"
 
-extension CharacterSet {
-    static let rfc3986Unreserved = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
-}
-
 open class Client {
 
     // MARK: Properties
@@ -218,8 +214,8 @@ open class Client {
        }
 
        return output.addingPercentEncoding(
-           withAllowedCharacters: .rfc3986Unreserved
-       ) ?? ""
+           withAllowedCharacters: .urlHostAllowed
+       )?.replacingOccurrences(of: "+", with: "%2B") ?? ""
    }
 
     ///

--- a/templates/swift/Sources/Client.swift.twig
+++ b/templates/swift/Sources/Client.swift.twig
@@ -192,7 +192,7 @@ open class Client {
 
        return output.addingPercentEncoding(
            withAllowedCharacters: .urlHostAllowed
-       )?.replacingOccurrences(of: "+", with: "%2B") ?? ""
+       )?.replacingOccurrences(of: "+", with: "%2B") ?? "" // since urlHostAllowed doesn't include +
    }
 
     ///

--- a/templates/swift/Sources/Client.swift.twig
+++ b/templates/swift/Sources/Client.swift.twig
@@ -9,6 +9,10 @@ import AsyncHTTPClient
 let DASHDASH = "--"
 let CRLF = "\r\n"
 
+extension CharacterSet {
+    static let rfc3986Unreserved = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+}
+
 open class Client {
 
     // MARK: Properties
@@ -191,7 +195,7 @@ open class Client {
        }
 
        return output.addingPercentEncoding(
-           withAllowedCharacters: .urlHostAllowed
+           withAllowedCharacters: .rfc3986Unreserved
        ) ?? ""
    }
 

--- a/templates/swift/Sources/Client.swift.twig
+++ b/templates/swift/Sources/Client.swift.twig
@@ -9,10 +9,6 @@ import AsyncHTTPClient
 let DASHDASH = "--"
 let CRLF = "\r\n"
 
-extension CharacterSet {
-    static let rfc3986Unreserved = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
-}
-
 open class Client {
 
     // MARK: Properties
@@ -195,8 +191,8 @@ open class Client {
        }
 
        return output.addingPercentEncoding(
-           withAllowedCharacters: .rfc3986Unreserved
-       ) ?? ""
+           withAllowedCharacters: .urlHostAllowed
+       )?.replacingOccurrences(of: "+", with: "%2B") ?? ""
    }
 
     ///


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

`CharacterSet.urlHostAllowed` contains the `+` symbol as allowed, leading to it not being encoded and errors in requests that contain it, specifically time based requests in Queries:

https://stackoverflow.com/questions/41561853/couldnt-encode-plus-character-in-url-swift 

The PR as the stack overflow thread suggests encodes the `+` symbol separately.

## Test Plan

## Related PRs and Issues

- https://github.com/appwrite/sdk-for-apple/issues/72

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.