### PR TITLE
Fix: file deployment for functions and sites

### DIFF
--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -201,7 +201,7 @@ class Client {
     }
 
     async chunkedUpload(method: string, url: URL, headers: Headers = {}, originalPayload: Payload = {}, onProgress: (progress: UploadProgress) => void) {
-        const [fileParam, file] = Object.entries(originalPayload).find(([, value]) => value instanceof File) ?? [];
+        const [fileParam, file] = Object.entries(originalPayload).find(([_, value]) => value instanceof File) ?? [];
 
         if (!file) {
             throw new Error('File not found in payload');

--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -224,7 +224,7 @@ class Client {
             const chunk = file.slice(start, end);
 
             let payload = { ...originalPayload };
-            payload[fileParam] = new File([chunk], file.name);
+            payload[fileParam ?? ''] = new File([chunk], file.name);
 
             response = await this.call(method, url, headers, payload);
 

--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -202,7 +202,7 @@ class Client {
 
     async chunkedUpload(method: string, url: URL, headers: Headers = {}, originalPayload: Payload = {}, onProgress: (progress: UploadProgress) => void) {
         const fileIndex = Object.values(originalPayload).findIndex((value) => value instanceof File);
-        const fileParam = Object.values(originalPayload)[fileIndex];
+        const fileParam = Object.keys(originalPayload)[fileIndex];
         const file = originalPayload[fileParam];
 
         if (!file) {

--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -201,7 +201,9 @@ class Client {
     }
 
     async chunkedUpload(method: string, url: URL, headers: Headers = {}, originalPayload: Payload = {}, onProgress: (progress: UploadProgress) => void) {
-        const file = Object.values(originalPayload).find((value) => value instanceof File);
+        const fileIndex = Object.values(originalPayload).findIndex((value) => value instanceof File);
+        const fileParam = Object.values(originalPayload)[fileIndex];
+        const file = originalPayload[fileParam];
 
         if (!file) {
             throw new Error('File not found in payload');
@@ -223,7 +225,8 @@ class Client {
             headers['content-range'] = `bytes ${start}-${end-1}/${file.size}`;
             const chunk = file.slice(start, end);
 
-            let payload = { ...originalPayload, file: new File([chunk], file.name)};
+            let payload = { ...originalPayload };
+            payload[fileParam] = new File([chunk], file.name);
 
             response = await this.call(method, url, headers, payload);
 

--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -201,9 +201,7 @@ class Client {
     }
 
     async chunkedUpload(method: string, url: URL, headers: Headers = {}, originalPayload: Payload = {}, onProgress: (progress: UploadProgress) => void) {
-        const fileIndex = Object.values(originalPayload).findIndex((value) => value instanceof File);
-        const fileParam = Object.keys(originalPayload)[fileIndex];
-        const file = originalPayload[fileParam];
+        const [fileParam, file] = Object.entries(originalPayload).find(([, value]) => value instanceof File) ?? [];
 
         if (!file) {
             throw new Error('File not found in payload');

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -629,7 +629,7 @@ class Client {
     }
 
     async chunkedUpload(method: string, url: URL, headers: Headers = {}, originalPayload: Payload = {}, onProgress: (progress: UploadProgress) => void) {
-        const [fileParam, file] = Object.entries(originalPayload).find(([, value]) => value instanceof File) ?? [];
+        const [fileParam, file] = Object.entries(originalPayload).find(([_, value]) => value instanceof File) ?? [];
 
         if (!file) {
             throw new Error('File not found in payload');

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -629,9 +629,7 @@ class Client {
     }
 
     async chunkedUpload(method: string, url: URL, headers: Headers = {}, originalPayload: Payload = {}, onProgress: (progress: UploadProgress) => void) {
-        const fileIndex = Object.values(originalPayload).findIndex((value) => value instanceof File);
-        const fileParam = Object.keys(originalPayload)[fileIndex];
-        const file = originalPayload[fileParam];
+        const [fileParam, file] = Object.entries(originalPayload).find(([, value]) => value instanceof File) ?? [];
 
         if (!file) {
             throw new Error('File not found in payload');

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -652,7 +652,7 @@ class Client {
             const chunk = file.slice(start, end);
 
             let payload = { ...originalPayload };
-            payload[fileParam] = new File([chunk], file.name);
+            payload[fileParam ?? ''] = new File([chunk], file.name);
 
             response = await this.call(method, url, headers, payload);
 

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -630,7 +630,7 @@ class Client {
 
     async chunkedUpload(method: string, url: URL, headers: Headers = {}, originalPayload: Payload = {}, onProgress: (progress: UploadProgress) => void) {
         const fileIndex = Object.values(originalPayload).findIndex((value) => value instanceof File);
-        const fileParam = Object.values(originalPayload)[fileIndex];
+        const fileParam = Object.keys(originalPayload)[fileIndex];
         const file = originalPayload[fileParam];
 
         if (!file) {

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -629,7 +629,9 @@ class Client {
     }
 
     async chunkedUpload(method: string, url: URL, headers: Headers = {}, originalPayload: Payload = {}, onProgress: (progress: UploadProgress) => void) {
-        const file = Object.values(originalPayload).find((value) => value instanceof File);
+        const fileIndex = Object.values(originalPayload).findIndex((value) => value instanceof File);
+        const fileParam = Object.values(originalPayload)[fileIndex];
+        const file = originalPayload[fileParam];
 
         if (!file) {
             throw new Error('File not found in payload');
@@ -651,7 +653,8 @@ class Client {
             headers['content-range'] = `bytes ${start}-${end-1}/${file.size}`;
             const chunk = file.slice(start, end);
 
-            let payload = { ...originalPayload, file: new File([chunk], file.name)};
+            let payload = { ...originalPayload };
+            payload[fileParam] = new File([chunk], file.name);
 
             response = await this.call(method, url, headers, payload);
 


### PR DESCRIPTION
## What does this PR do?

Site and functions got `createDeployment` that have param called `code`, not `file`. This makes param dynamic, so it works properly for those scenarios. Until now it only worked well for Storage.

## Test Plan

![CleanShot 2025-05-24 at 23 56 24@2x](https://github.com/user-attachments/assets/9c5939de-93c0-40ab-94ac-8b775f351b20)

![CleanShot 2025-05-24 at 23 56 31@2x](https://github.com/user-attachments/assets/4ba68390-fe83-4d8a-b5a9-642e09cbec8a)







## Related PRs and Issues

https://github.com/appwrite/console/pull/1888

https://discord.com/channels/564160730845151244/1375865210279166113

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes