### PR TITLE
fix: devKeys support in flutter by conditionally including credentials

### DIFF
--- a/templates/flutter/lib/src/client_browser.dart.twig
+++ b/templates/flutter/lib/src/client_browser.dart.twig
@@ -112,7 +112,6 @@ class ClientBrowser extends ClientBase with ClientMixin {
     if (cookieFallback != null) {
       addHeader('x-fallback-cookies', cookieFallback);
     }
-    _httpClient.withCredentials = true;
   }
 
   @override
@@ -192,11 +191,21 @@ class ClientBrowser extends ClientBase with ClientMixin {
   }) async {
     await init();
 
+    // Combine headers to check for dev key
+    final combinedHeaders = {..._headers!, ...headers};
+    
+    // Only include credentials when dev key is not set
+    if (combinedHeaders['X-Appwrite-Dev-Key'] == null) {
+      _httpClient.withCredentials = true;
+    } else {
+      _httpClient.withCredentials = false;
+    }
+
     late http.Response res;
     http.BaseRequest request = prepareRequest(
       method,
       uri: Uri.parse(_endPoint + path),
-      headers: {..._headers!, ...headers},
+      headers: combinedHeaders,
       params: params,
     );
     try {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes devKeys support in flutter.

When devKeys is set, we treat the authentication method as "keys" based, and thus we should not include "credentials: include". This change was also implemented in web and react native, was left in flutter.

the following error is thrown otherwise:
![image](https://github.com/user-attachments/assets/5741295b-f161-427f-8da8-f215a7c58ae4)

## Test Plan

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.