### PR TITLE
revert: remove conversion of attribute keys to camel case

### DIFF
--- a/templates/cli/lib/type-generation/languages/dart.js.twig
+++ b/templates/cli/lib/type-generation/languages/dart.js.twig
@@ -60,19 +60,19 @@ enum <%- toPascalCase(attribute.key) %> {
 <% } -%>
 class <%= toPascalCase(collection.name) %> {
 <% for (const [index, attribute] of Object.entries(collection.attributes)) { -%>
-  <%- getType(attribute) %> <%- attribute.key %>;
+  <%- getType(attribute) %> <%= toCamelCase(attribute.key) %>;
 <% } -%>
 
   <%= toPascalCase(collection.name) %>({
   <% for (const [index, attribute] of Object.entries(collection.attributes)) { -%>
-  <% if (attribute.required) { %>required <% } %>this.<%- attribute.key %>,
+  <% if (attribute.required) { %>required <% } %>this.<%= toCamelCase(attribute.key) %>,
   <% } -%>
 });
 
   factory <%= toPascalCase(collection.name) %>.fromMap(Map<String, dynamic> map) {
     return <%= toPascalCase(collection.name) %>(
 <% for (const [index, attribute] of Object.entries(collection.attributes)) { -%>
-      <%- attribute.key %>: <% if (attribute.type === 'string' || attribute.type === 'email' || attribute.type === 'datetime') { -%>
+      <%= toCamelCase(attribute.key) %>: <% if (attribute.type === 'string' || attribute.type === 'email' || attribute.type === 'datetime') { -%>
 <% if (attribute.format === 'enum') { -%>
 <% if (attribute.array) { -%>
 (map['<%= attribute.key %>'] as List<dynamic>?)?.map((e) => <%- toPascalCase(attribute.key) %>.values.firstWhere((element) => element.name == e)).toList()<% if (!attribute.required) { %> ?? []<% } -%>
@@ -124,18 +124,18 @@ map['<%= attribute.key %>'] != null ? <%- toPascalCase(attribute.relatedCollecti
 <% for (const [index, attribute] of Object.entries(collection.attributes)) { -%>
       "<%= attribute.key %>": <% if (attribute.type === 'relationship') { -%>
 <% if ((attribute.relationType === 'oneToMany' && attribute.side === 'parent') || (attribute.relationType === 'manyToOne' && attribute.side === 'child') || attribute.relationType === 'manyToMany') { -%>
-<%- attribute.key %><% if (!attribute.required) { %>?<% } %>.map((e) => e.toMap()).toList()<% if (!attribute.required) { %> ?? []<% } -%>
+<%= toCamelCase(attribute.key) %><% if (!attribute.required) { %>?<% } %>.map((e) => e.toMap()).toList()<% if (!attribute.required) { %> ?? []<% } -%>
 <% } else { -%>
-<%- attribute.key %><% if (!attribute.required) { %>?<% } %>.toMap()<% if (!attribute.required) { %> ?? {}<% } -%>
+<%= toCamelCase(attribute.key) %><% if (!attribute.required) { %>?<% } %>.toMap()<% if (!attribute.required) { %> ?? {}<% } -%>
 <% } -%>
 <% } else if (attribute.format === 'enum') { -%>
 <% if (attribute.array) { -%>
-<%- attribute.key %><% if (!attribute.required) { %>?<% } %>.map((e) => e.name).toList()<% if (!attribute.required) { %> ?? []<% } -%>
+<%= toCamelCase(attribute.key) %><% if (!attribute.required) { %>?<% } %>.map((e) => e.name).toList()<% if (!attribute.required) { %> ?? []<% } -%>
 <% } else { -%>
-<%- attribute.key %><% if (!attribute.required) { %>?<% } %>.name<% if (!attribute.required) { %> ?? null<% } -%>
+<%= toCamelCase(attribute.key) %><% if (!attribute.required) { %>?<% } %>.name<% if (!attribute.required) { %> ?? null<% } -%>
 <% } -%>
 <% } else { -%>
-<%- attribute.key -%>
+<%= toCamelCase(attribute.key) -%>
 <% } -%>,
 <% } -%>
     };

--- a/templates/cli/lib/type-generation/languages/java.js.twig
+++ b/templates/cli/lib/type-generation/languages/java.js.twig
@@ -61,7 +61,7 @@ public class <%- toPascalCase(collection.name) %> {
 <% } -%>
 <% } -%>
 <% for (const attribute of collection.attributes) { -%>
-    private <%- getType(attribute) %> <%- attribute.key %>;
+    private <%- getType(attribute) %> <%- toCamelCase(attribute.key) %>;
 <% } -%>
 
     public <%- toPascalCase(collection.name) %>() {
@@ -69,21 +69,21 @@ public class <%- toPascalCase(collection.name) %> {
 
     public <%- toPascalCase(collection.name) %>(
 <% for (const [index, attribute] of Object.entries(collection.attributes)) { -%>
-        <%- getType(attribute) %> <%- attribute.key %><%- index < collection.attributes.length - 1 ? ',' : '' %>
+        <%- getType(attribute) %> <%= toCamelCase(attribute.key) %><%- index < collection.attributes.length - 1 ? ',' : '' %>
 <% } -%>
     ) {
 <% for (const attribute of collection.attributes) { -%>
-        this.<%- attribute.key %> = <%- attribute.key %>;
+        this.<%= toCamelCase(attribute.key) %> = <%= toCamelCase(attribute.key) %>;
 <% } -%>
     }
 
 <% for (const attribute of collection.attributes) { -%>
     public <%- getType(attribute) %> get<%- toPascalCase(attribute.key) %>() {
-        return <%- attribute.key %>;
+        return <%= toCamelCase(attribute.key) %>;
     }
 
-    public void set<%- toPascalCase(attribute.key) %>(<%- getType(attribute) %> <%- attribute.key %>) {
-        this.<%- attribute.key %> = <%- attribute.key %>;
+    public void set<%- toPascalCase(attribute.key) %>(<%- getType(attribute) %> <%= toCamelCase(attribute.key) %>) {
+        this.<%= toCamelCase(attribute.key) %> = <%= toCamelCase(attribute.key) %>;
     }
 
 <% } -%>
@@ -92,20 +92,20 @@ public class <%- toPascalCase(collection.name) %> {
         if (this == obj) return true;
         if (obj == null || getClass() != obj.getClass()) return false;
         <%- toPascalCase(collection.name) %> that = (<%- toPascalCase(collection.name) %>) obj;
-        return <% collection.attributes.forEach((attr, index) => { %>Objects.equals(<%- attr.key %>, that.<%- attr.key %>)<% if (index < collection.attributes.length - 1) { %> &&
+        return <% collection.attributes.forEach((attr, index) => { %>Objects.equals(<%= toCamelCase(attr.key) %>, that.<%= toCamelCase(attr.key) %>)<% if (index < collection.attributes.length - 1) { %> &&
               <% } }); %>;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(<%- collection.attributes.map(attr => attr.key).join(', ') %>);
+        return Objects.hash(<%= collection.attributes.map(attr => toCamelCase(attr.key)).join(', ') %>);
     }
 
     @Override
     public String toString() {
         return "<%- toPascalCase(collection.name) %>{" +
 <% for (const [index, attribute] of Object.entries(collection.attributes)) { -%>
-                "<%- attribute.key %>=" + <%- attribute.key %> +
+                "<%= toCamelCase(attribute.key) %>=" + <%= toCamelCase(attribute.key) %> +
 <% } -%>
                 '}';
     }

--- a/templates/cli/lib/type-generation/languages/javascript.js.twig
+++ b/templates/cli/lib/type-generation/languages/javascript.js.twig
@@ -69,7 +69,7 @@ class JavaScript extends LanguageMeta {
 /**
  * @typedef {Object} <%- toPascalCase(collection.name) %>
 <% for (const attribute of collection.attributes) { -%>
- * @property {<%- getType(attribute) %>} <%- attribute.key %>
+ * @property {<%- getType(attribute) %>} <%- toCamelCase(attribute.key) %>
 <% } -%>
  */
 

--- a/templates/cli/lib/type-generation/languages/kotlin.js.twig
+++ b/templates/cli/lib/type-generation/languages/kotlin.js.twig
@@ -62,7 +62,7 @@ enum class <%- toPascalCase(attribute.key) %> {
 <% } -%>
 data class <%- toPascalCase(collection.name) %>(
 <% for (const attribute of collection.attributes) { -%>
-    val <%- attribute.key %>: <%- getType(attribute) %>,
+    val <%- toCamelCase(attribute.key) %>: <%- getType(attribute) %>,
 <% } -%>
 )`;
   }

--- a/templates/cli/lib/type-generation/languages/php.js.twig
+++ b/templates/cli/lib/type-generation/languages/php.js.twig
@@ -55,7 +55,7 @@ use Appwrite\\Models\\<%- toPascalCase(attribute.relatedCollection) %>;
 <% if (attribute.format === 'enum') { -%>
 enum <%- toPascalCase(attribute.key) %> {
 <% for (const [index, element] of Object.entries(attribute.elements)) { -%>
-  case <%- toUpperSnakeCase(element) %> = '<%- element %>';
+  case <%- toUpperSnakeCase(element) %> = "<%- element %>";
 <% } -%>
 }
 

--- a/templates/cli/lib/type-generation/languages/php.js.twig
+++ b/templates/cli/lib/type-generation/languages/php.js.twig
@@ -63,30 +63,30 @@ enum <%- toPascalCase(attribute.key) %> {
 <% } -%>
 class <%- toPascalCase(collection.name) %> {
 <% for (const attribute of collection.attributes ){ -%>
-  private <%- getType(attribute) %> $<%- attribute.key %>;
+  private <%- getType(attribute) %> $<%- toCamelCase(attribute.key) %>;
 <% } -%>
 
   public function __construct(
 <% for (const attribute of collection.attributes ){ -%>
 <% if (attribute.required) { -%>
-    <%- getType(attribute).replace('|null', '') %> $<%- attribute.key %><% if (collection.attributes.indexOf(attribute) < collection.attributes.length - 1) { %>,<% } %>
+    <%- getType(attribute).replace('|null', '') %> $<%- toCamelCase(attribute.key) %><% if (collection.attributes.indexOf(attribute) < collection.attributes.length - 1) { %>,<% } %>
 <% } else { -%>
-    ?<%- getType(attribute).replace('|null', '') %> $<%- attribute.key %> = null<% if (collection.attributes.indexOf(attribute) < collection.attributes.length - 1) { %>,<% } %>
+    ?<%- getType(attribute).replace('|null', '') %> $<%- toCamelCase(attribute.key) %> = null<% if (collection.attributes.indexOf(attribute) < collection.attributes.length - 1) { %>,<% } %>
 <% } -%>
 <% } -%>
   ) {
 <% for (const attribute of collection.attributes ){ -%>
-    $this-><%- attribute.key %> = $<%- attribute.key %>;
+    $this-><%- toCamelCase(attribute.key) %> = $<%- toCamelCase(attribute.key) %>;
 <% } -%>
   }
 
 <% for (const attribute of collection.attributes ){ -%>
   public function get<%- toPascalCase(attribute.key) %>(): <%- getType(attribute) %> {
-    return $this-><%- attribute.key %>;
+    return $this-><%- toCamelCase(attribute.key) %>;
   }
 
-  public function set<%- toPascalCase(attribute.key) %>(<%- getType(attribute) %> $<%- attribute.key %>): void {
-    $this-><%- attribute.key %> = $<%- attribute.key %>;
+  public function set<%- toPascalCase(attribute.key) %>(<%- getType(attribute) %> $<%- toCamelCase(attribute.key) %>): void {
+    $this-><%- toCamelCase(attribute.key) %> = $<%- toCamelCase(attribute.key) %>;
   }
 <% } -%>
 }`;

--- a/templates/cli/lib/type-generation/languages/php.js.twig
+++ b/templates/cli/lib/type-generation/languages/php.js.twig
@@ -53,9 +53,9 @@ use Appwrite\\Models\\<%- toPascalCase(attribute.relatedCollection) %>;
 <% } -%>
 <% for (const attribute of collection.attributes) { -%>
 <% if (attribute.format === 'enum') { -%>
-enum <%- toPascalCase(attribute.key) %> {
+enum <%- toPascalCase(attribute.key) %>: string {
 <% for (const [index, element] of Object.entries(attribute.elements)) { -%>
-  case <%- toUpperSnakeCase(element) %> = "<%- element %>";
+  case <%- toUpperSnakeCase(element) %> = '<%- element %>';
 <% } -%>
 }
 

--- a/templates/cli/lib/type-generation/languages/php.js.twig
+++ b/templates/cli/lib/type-generation/languages/php.js.twig
@@ -55,7 +55,7 @@ use Appwrite\\Models\\<%- toPascalCase(attribute.relatedCollection) %>;
 <% if (attribute.format === 'enum') { -%>
 enum <%- toPascalCase(attribute.key) %> {
 <% for (const [index, element] of Object.entries(attribute.elements)) { -%>
-  case <%- element.toUpperCase() %> = '<%- element %>';
+  case <%- toUpperSnakeCase(element) %> = '<%- element %>';
 <% } -%>
 }
 

--- a/templates/cli/lib/type-generation/languages/swift.js.twig
+++ b/templates/cli/lib/type-generation/languages/swift.js.twig
@@ -48,7 +48,7 @@ class Swift extends LanguageMeta {
 <% if (attribute.format === 'enum') { -%>
 public enum <%- toPascalCase(attribute.key) %>: String, Codable, CaseIterable {
 <% for (const [index, element] of Object.entries(attribute.elements)) { -%>
-  case <%- element %> = "<%- element %>"
+  case <%- toSnakeCase(element) %> = "<%- element %>"
 <% } -%>
 }
 

--- a/templates/cli/lib/type-generation/languages/swift.js.twig
+++ b/templates/cli/lib/type-generation/languages/swift.js.twig
@@ -56,21 +56,21 @@ public enum <%- toPascalCase(attribute.key) %>: String, Codable, CaseIterable {
 <% } -%>
 public class <%- toPascalCase(collection.name) %>: Codable {
 <% for (const attribute of collection.attributes) { -%>
-    public let <%- attribute.key %>: <%- getType(attribute) %>
+    public let <%- toCamelCase(attribute.key) %>: <%- getType(attribute) %>
 <% } %>
     enum CodingKeys: String, CodingKey {
 <% for (const attribute of collection.attributes) { -%>
-        case <%- attribute.key %> = "<%- attribute.key %>"
+        case <%- toCamelCase(attribute.key) %> = "<%- attribute.key %>"
 <% } -%>
     }
 
     init(
 <% for (const attribute of collection.attributes) { -%>
-        <%- attribute.key %>: <%- getType(attribute) %><% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
+        <%- toCamelCase(attribute.key) %>: <%- getType(attribute) %><% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
 <% } -%>
     ) {
 <% for (const attribute of collection.attributes) { -%>
-        self.<%- attribute.key %> = <%- attribute.key %>
+        self.<%- toCamelCase(attribute.key) %> = <%- toCamelCase(attribute.key) %>
 <% } -%>
     }
 
@@ -79,9 +79,9 @@ public class <%- toPascalCase(collection.name) %>: Codable {
 
 <% for (const attribute of collection.attributes) { -%>
 <% if (attribute.required) { -%>
-        self.<%- attribute.key %> = try container.decode(<%- getType(attribute).replace('?', '') %>.self, forKey: .<%- attribute.key %>)
+        self.<%- toCamelCase(attribute.key) %> = try container.decode(<%- getType(attribute).replace('?', '') %>.self, forKey: .<%- toCamelCase(attribute.key) %>)
 <% } else { -%>
-        self.<%- attribute.key %> = try container.decodeIfPresent(<%- getType(attribute).replace('?', '') %>.self, forKey: .<%- attribute.key %>)
+        self.<%- toCamelCase(attribute.key) %> = try container.decodeIfPresent(<%- getType(attribute).replace('?', '') %>.self, forKey: .<%- toCamelCase(attribute.key) %>)
 <% } -%>
 <% } -%>
     }
@@ -91,9 +91,9 @@ public class <%- toPascalCase(collection.name) %>: Codable {
 
 <% for (const attribute of collection.attributes) { -%>
 <% if (attribute.required) { -%>
-        try container.encode(<%- attribute.key %>, forKey: .<%- attribute.key %>)
+        try container.encode(<%- toCamelCase(attribute.key) %>, forKey: .<%- toCamelCase(attribute.key) %>)
 <% } else { -%>
-        try container.encodeIfPresent(<%- attribute.key %>, forKey: .<%- attribute.key %>)
+        try container.encodeIfPresent(<%- toCamelCase(attribute.key) %>, forKey: .<%- toCamelCase(attribute.key) %>)
 <% } -%>
 <% } -%>
     }
@@ -102,11 +102,11 @@ public class <%- toPascalCase(collection.name) %>: Codable {
         return [
 <% for (const attribute of collection.attributes) { -%>
 <% if (attribute.type === 'relationship') { -%>
-            "<%- attribute.key %>": <%- attribute.key %> as Any<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
+            "<%- attribute.key %>": <%- toCamelCase(attribute.key) %> as Any<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
 <% } else if (attribute.array && attribute.type !== 'string' && attribute.type !== 'integer' && attribute.type !== 'float' && attribute.type !== 'boolean') { -%>
-            "<%- attribute.key %>": <%- attribute.key %>?.map { $0.toMap() } as Any<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
+            "<%- attribute.key %>": <%- toCamelCase(attribute.key) %>?.map { $0.toMap() } as Any<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
 <% } else { -%>
-            "<%- attribute.key %>": <%- attribute.key %> as Any<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
+            "<%- attribute.key %>": <%- toCamelCase(attribute.key) %> as Any<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
 <% } -%>
 <% } -%>
         ]
@@ -116,30 +116,30 @@ public class <%- toPascalCase(collection.name) %>: Codable {
         return <%- toPascalCase(collection.name) %>(
 <% for (const attribute of collection.attributes) { -%>
 <% if (attribute.type === 'relationship') { -%>
-            <%- attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> <%- toPascalCase(attribute.relatedCollection) %><% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
+            <%- toCamelCase(attribute.key) %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> <%- toPascalCase(attribute.relatedCollection) %><% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
 <% } else if (attribute.array) { -%>
 <% if (attribute.type === 'string') { -%>
-            <%- attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [String]<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
+            <%- toCamelCase(attribute.key) %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [String]<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
 <% } else if (attribute.type === 'integer') { -%>
-            <%- attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [Int]<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
+            <%- toCamelCase(attribute.key) %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [Int]<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
 <% } else if (attribute.type === 'float') { -%>
-            <%- attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [Double]<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
+            <%- toCamelCase(attribute.key) %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [Double]<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
 <% } else if (attribute.type === 'boolean') { -%>
-            <%- attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [Bool]<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
+            <%- toCamelCase(attribute.key) %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [Bool]<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
 <% } else { -%>
-            <%- attribute.key %>: (map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [[String: Any]])<% if (!attribute.required) { %>?<% } %>.map { <%- toPascalCase(attribute.type) %>.from(map: $0) }<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
+            <%- toCamelCase(attribute.key) %>: (map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [[String: Any]])<% if (!attribute.required) { %>?<% } %>.map { <%- toPascalCase(attribute.type) %>.from(map: $0) }<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
 <% } -%>
 <% } else { -%>
 <% if (attribute.type === 'string' || attribute.type === 'email' || attribute.type === 'datetime' || attribute.type === 'enum') { -%>
-            <%- attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> String<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
+            <%- toCamelCase(attribute.key) %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> String<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
 <% } else if (attribute.type === 'integer') { -%>
-            <%- attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> Int<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
+            <%- toCamelCase(attribute.key) %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> Int<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
 <% } else if (attribute.type === 'float') { -%>
-            <%- attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> Double<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
+            <%- toCamelCase(attribute.key) %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> Double<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
 <% } else if (attribute.type === 'boolean') { -%>
-            <%- attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> Bool<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
+            <%- toCamelCase(attribute.key) %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> Bool<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
 <% } else { -%>
-            <%- attribute.key %>: <%- toPascalCase(attribute.type) %>.from(map: map["<%- attribute.key %>"] as! [String: Any])<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
+            <%- toCamelCase(attribute.key) %>: <%- toPascalCase(attribute.type) %>.from(map: map["<%- attribute.key %>"] as! [String: Any])<% if (attribute !== collection.attributes[collection.attributes.length - 1]) { %>,<% } %>
 <% } -%>
 <% } -%>
 <% } -%>

--- a/templates/cli/lib/type-generation/languages/typescript.js.twig
+++ b/templates/cli/lib/type-generation/languages/typescript.js.twig
@@ -79,10 +79,10 @@ export enum <%- toPascalCase(attribute.key) %> {
 <% } -%>
 <% } -%>
 <% } -%>
-<% for (const collection of collections) { -%>
+<% for (const collection of collections) { %>
 export type <%- toPascalCase(collection.name) %> = Models.Document & {
 <% for (const attribute of collection.attributes) { -%>
-  <%- attribute.key %>: <%- getType(attribute) %>;
+  <%- toCamelCase(attribute.key) %>: <%- getType(attribute) %>;
 <% } -%>
 }
 

--- a/templates/cli/lib/type-generation/languages/typescript.js.twig
+++ b/templates/cli/lib/type-generation/languages/typescript.js.twig
@@ -72,14 +72,14 @@ class TypeScript extends LanguageMeta {
 <% if (attribute.format === 'enum') { -%>
 export enum <%- toPascalCase(attribute.key) %> {
 <% for (const [index, element] of Object.entries(attribute.elements)) { -%>
-  <%- element.toUpperCase() %> = "<%- element %>",
+  <%- toUpperSnakeCase(element) %> = "<%- element %>",
 <% } -%>
 }
 
 <% } -%>
 <% } -%>
 <% } -%>
-<% for (const collection of collections) { %>
+<% for (const collection of collections) { -%>
 export type <%- toPascalCase(collection.name) %> = Models.Document & {
 <% for (const attribute of collection.attributes) { -%>
   <%- toCamelCase(attribute.key) %>: <%- getType(attribute) %>;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

reverts removal of camel casing, also fixes casing for enums:

<img width="222" alt="Screenshot 2025-06-12 at 4 39 14 PM" src="https://github.com/user-attachments/assets/367934b5-3da0-406a-aca4-d16d19b5f6eb" />

<img width="219" alt="Screenshot 2025-06-12 at 4 43 56 PM" src="https://github.com/user-attachments/assets/2abe97b8-1815-4b3d-a290-4002cbdab443" />

## Test Plan

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.