### PR TITLE
chore: use swift-native doc comments

### DIFF
--- a/templates/apple/Sources/Services/Service.swift.twig
+++ b/templates/apple/Sources/Services/Service.swift.twig
@@ -14,11 +14,15 @@ open class {{ service.name | caseUcfirst | overrideIdentifier }}: Service {
     {{~ method.description | swiftComment }}
     ///
     {%~ endif %}
+    {%~ if method.parameters.all | length > 0 %}
+    /// - Parameters:
+    {%~ endif %}
     {%~ for parameter in method.parameters.all %}
-    /// @param {{ parameter | typeName(spec) | raw}} {{ parameter.name | caseCamel }}
+    ///   - {{ parameter.name | caseCamel }}: {{ parameter | typeName(spec) | raw }}{% if not parameter.required or parameter.nullable %} (optional){% endif %}
+
     {%~ endfor %}
-    /// @throws Exception
-    /// @return array
+    /// - Throws: Exception if the request fails
+    /// - Returns: {{ method | returnType(spec) | raw }}
     ///
     {%~ if method.type == "webAuth" %}
     @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
@@ -78,11 +82,15 @@ open class {{ service.name | caseUcfirst | overrideIdentifier }}: Service {
     {{~ method.description | swiftComment }}
     ///
     {%~ endif %}
+    {%~ if method.parameters.all | length > 0 %}
+    /// - Parameters:
+    {%~ endif %}
     {%~ for parameter in method.parameters.all %}
-    /// @param {{ parameter | typeName(spec) | raw}} {{ parameter.name | caseCamel }}
+    ///   - {{ parameter.name | caseCamel }}: {{ parameter | typeName(spec) | raw }}{% if not parameter.required or parameter.nullable %} (optional){% endif %}
+
     {%~ endfor %}
-    /// @throws Exception
-    /// @return array
+    /// - Throws: Exception if the request fails
+    /// - Returns: {{ method | returnType(spec) | raw }}
     ///
     {%~ if method.type == "webAuth" %}
     @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)

--- a/templates/swift/Sources/Services/Service.swift.twig
+++ b/templates/swift/Sources/Services/Service.swift.twig
@@ -14,11 +14,15 @@ open class {{ service.name | caseUcfirst | overrideIdentifier }}: Service {
     {{~ method.description | swiftComment }}
     ///
     {%~ endif %}
+    {%~ if method.parameters.all | length > 0 %}
+    /// - Parameters:
+    {%~ endif %}
     {%~ for parameter in method.parameters.all %}
-    /// @param {{ parameter | typeName(spec) | raw}} {{ parameter.name | caseCamel }}
+    ///   - {{ parameter.name | caseCamel }}: {{ parameter | typeName(spec) | raw }}{% if not parameter.required or parameter.nullable %} (optional){% endif %}
+
     {%~ endfor %}
-    /// @throws Exception
-    /// @return array
+    /// - Throws: Exception if the request fails
+    /// - Returns: {{ method | returnType(spec) | raw }}
     ///
     open func {{ method.name | caseCamel | overrideIdentifier }}{% if method.responseModel | hasGenericType(spec) %}<T>{% endif %}(
         {%~ for parameter in method.parameters.all %}
@@ -75,11 +79,15 @@ open class {{ service.name | caseUcfirst | overrideIdentifier }}: Service {
     {{~ method.description | swiftComment }}
     ///
     {%~ endif %}
+    {%~ if method.parameters.all | length > 0 %}
+    /// - Parameters:
+    {%~ endif %}
     {%~ for parameter in method.parameters.all %}
-    /// @param {{ parameter | typeName(spec) | raw}} {{ parameter.name | caseCamel }}
+    ///   - {{ parameter.name | caseCamel }}: {{ parameter | typeName(spec) | raw }}{% if not parameter.required or parameter.nullable %} (optional){% endif %}
+
     {%~ endfor %}
-    /// @throws Exception
-    /// @return array
+    /// - Throws: Exception if the request fails
+    /// - Returns: {{ method | returnType(spec) | raw }}
     ///
     open func {{ method.name | caseCamel }}(
         {%~ for parameter in method.parameters.all %}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

uses swift-native doc comments instead of jsdoc styled comments for apple and swift sdks.

uses this doc as the reference from official swift repository - https://github.com/swiftlang/swift/blob/main/docs/DocumentationComments.md

## Test Plan

before:
![image](https://github.com/user-attachments/assets/5b08d267-3983-4893-9bc6-580df54e9df7)

after:
![image](https://github.com/user-attachments/assets/55d3839e-34cb-4eea-b066-726475e2b8cf)

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.