### PR TITLE
feat: add support for nullable parameters in API calls in python

### DIFF
--- a/templates/python/base/params.twig
+++ b/templates/python/base/params.twig
@@ -1,9 +1,15 @@
         api_params = {}
+        nullable_params = []
+
 {% if method.parameters.all | length %}
 {% for parameter in method.parameters.all  %}
 {% if parameter.required and not parameter.nullable %}
         if {{ parameter.name | escapeKeyword | caseSnake }} is None:
             raise {{spec.title | caseUcfirst}}Exception('Missing required parameter: "{{ parameter.name | escapeKeyword | caseSnake }}"')
+
+{% endif %}
+{% if parameter.nullable %}
+        nullable_params.append('{{ parameter.name }}')
 
 {% endif %}
 {% endfor %}

--- a/templates/python/base/requests/api.twig
+++ b/templates/python/base/requests/api.twig
@@ -5,4 +5,4 @@
 {% for key, header in method.headers %}
             '{{ key }}': '{{ header }}',
 {% endfor %}
-        }, api_params{% if method.type == 'webAuth' %}, response_type='location'{% endif %})
+        }, api_params, nullable_params{% if method.type == 'webAuth' %}, response_type='location'{% endif %})

--- a/templates/python/package/client.py.twig
+++ b/templates/python/package/client.py.twig
@@ -49,14 +49,18 @@ class Client:
         return self
 {% endfor %}
 
-    def call(self, method, path='', headers=None, params=None, response_type='json'):
+    def call(self, method, path='', headers=None, params=None, response_type='json', nullable_params=None):
         if headers is None:
             headers = {}
 
         if params is None:
             params = {}
 
-        params = {k: v for k, v in params.items() if v is not None}  # Remove None values from params dictionary
+        if nullable_params is None:
+            nullable_params = []
+
+        # Only filter out None values for non-nullable params
+        params = {k: v for k, v in params.items() if v is not None or k in nullable_params}
 
         data = {}
         files = {}

--- a/templates/python/package/client.py.twig
+++ b/templates/python/package/client.py.twig
@@ -49,7 +49,7 @@ class Client:
         return self
 {% endfor %}
 
-    def call(self, method, path='', headers=None, params=None, response_type='json', nullable_params=None):
+    def call(self, method, path='', headers=None, params=None, nullable_params=None, response_type='json'):
         if headers is None:
             headers = {}
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

currently python sdk filters out all `None` values from api requests. but attributes like `default` can be nullable, and hence should not be filtered out

## Test Plan

<img width="457" alt="Screenshot 2025-07-01 at 6 17 30 PM" src="https://github.com/user-attachments/assets/2da35d1c-6c68-4f5f-a3a3-1c857a0352f8" />

## Related PRs and Issues

- https://github.com/appwrite/sdk-for-python/issues/111
- https://github.com/appwrite/sdk-generator/pull/687

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.