### PR TITLE
Updated typescript template generator to use Models.DocumentBase

### DIFF
--- a/templates/cli/lib/type-generation/languages/typescript.js.twig
+++ b/templates/cli/lib/type-generation/languages/typescript.js.twig
@@ -88,7 +88,7 @@ export enum <%- toPascalCase(attribute.key) %> {
 <% } -%>
 <% } -%>
 <% for (const [index, collection] of Object.entries(collections)) { -%>
-export type <%- toPascalCase(collection.name) %> = Models.Document & {
+export type <%- toPascalCase(collection.name) %> = Models.DocumentBase & {
 <% for (const attribute of collection.attributes) { -%>
     <%- strict ? toCamelCase(attribute.key) : attribute.key %>: <%- getType(attribute) %>;
 <% } -%>


### PR DESCRIPTION
## What does this PR do?

The [appwrite-cli type generation](https://appwrite.io/docs/products/databases/type-generation) for TypeScript defined a Document type as:

```ts
import { Models } from 'appwrite';

export type Books = Models.Document & {
  name: string;
  author: string;
  releaseYear: string | null;
  ...
}
```

However, by extending `Models.Document`, the `[key: string]: any` still allows attributes that don't exist.

To solve this, PR https://github.com/appwrite/appwrite/pull/10171 adds the `DocumentBase` type that defines the default attributes of a Document.

The type-generator can then use this type to define the specific types for the collections.

## Test Plan

Did not write any tests (yet); Let me know if you think this is needed.

## Related PRs and Issues

- PR in appwrite: https://github.com/appwrite/appwrite/pull/10171
- PR in website: https://github.com/appwrite/website/pull/2202
- @ChiragAgg5k mentioned on Discord that there is an open issue tracking this, but I can't seem to find it.

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes