### PR TITLE
fix: update localConfig from appwrite.json to appwrite.config.json

### DIFF
--- a/templates/cli/lib/config.js.twig
+++ b/templates/cli/lib/config.js.twig
@@ -125,27 +125,39 @@ class Config {
 }
 
 class Local extends Config {
-    static CONFIG_FILE_PATH = "{{ spec.title|caseLower }}.json";
+    static CONFIG_FILE_PATH = "{{ spec.title|caseLower }}.config.json";
+    static CONFIG_FILE_PATH_LEGACY = "{{ spec.title|caseLower }}.json";
     configDirectoryPath = ""
 
-    constructor(path = Local.CONFIG_FILE_PATH) {
+    constructor(path = Local.CONFIG_FILE_PATH, legacyPath = Local.CONFIG_FILE_PATH_LEGACY) {
+        let absolutePath = Local.findConfigFile(path) || Local.findConfigFile(legacyPath);
+        
+        if (!absolutePath) {
+            absolutePath = `${process.cwd()}/${path}`;
+        }
+
+        super(absolutePath);
+        this.configDirectoryPath = _path.dirname(absolutePath);
+    }
+
+    static findConfigFile(filename) {
         let currentPath = process.cwd();
-        let absolutePath = `${currentPath}/${path}`;
 
         while (true) {
-            if (fs.existsSync(`${currentPath}/${path}`)) {
-                absolutePath = `${currentPath}/${path}`;
-                break
-            } else {
-                const parentDirectory = _path.dirname(currentPath);
-                if (parentDirectory === currentPath) { // we hit the top directory
-                    break;
-                }
-                currentPath = parentDirectory
+            const filePath = `${currentPath}/${filename}`;
+            
+            if (fs.existsSync(filePath)) {
+                return filePath;
             }
+            
+            const parentDirectory = _path.dirname(currentPath);
+            if (parentDirectory === currentPath) {
+                break;
+            }
+            currentPath = parentDirectory;
         }
-        super(absolutePath);
-        this.configDirectoryPath =_path.dirname(absolutePath);
+
+        return null;
     }
 
     getDirname() {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

since frameworks like vite allow direct import of json files, `appwrite.json` can be confused with the `appwrite` package import. this PR shifts default config to be `appwrite.config.json` while keeping backwards compatibility with appwrite.json

## Test Plan

## Related PRs and Issues

- https://github.com/appwrite/sdk-for-cli/issues/172

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.