### PR TITLE
fix: update document type handling and improve generics in TS

### DIFF
--- a/src/SDK/Language/Node.php
+++ b/src/SDK/Language/Node.php
@@ -57,10 +57,10 @@ class Node extends Web
                         return "Partial<Preferences>";
                     case 'document':
                         if ($method['method'] === 'post') {
-                            return "Omit<Document, keyof Models.Document>";
+                            return "Document extends Models.DefaultDocument ? Models.DataWithoutDocumentKeys : Omit<Document, keyof Models.Document>";
                         }
                         if ($method['method'] === 'patch') {
-                            return "Partial<Omit<Document, keyof Models.Document>>";
+                            return "Partial<Document extends Models.DefaultDocument ? Models.DataWithoutDocumentKeys : Omit<Document, keyof Models.Document>>";
                         }
                 }
                 break;

--- a/src/SDK/Language/Web.php
+++ b/src/SDK/Language/Web.php
@@ -222,10 +222,10 @@ class Web extends JS
                         return "Partial<Preferences>";
                     case 'document':
                         if ($method['method'] === 'post') {
-                            return "Omit<Document, keyof Models.Document>";
+                            return "Document extends Models.DefaultDocument ? Models.DataWithoutDocumentKeys : Omit<Document, keyof Models.Document>";
                         }
                         if ($method['method'] === 'patch') {
-                            return "Partial<Omit<Document, keyof Models.Document>>";
+                            return "Partial<Document extends Models.DefaultDocument ? Models.DataWithoutDocumentKeys : Omit<Document, keyof Models.Document>>";
                         }
                 }
                 break;
@@ -261,7 +261,7 @@ class Web extends JS
         }
 
         $generics = array_unique($generics);
-        $generics = array_map(fn ($type) => "{$type} extends Models.{$type}", $generics);
+        $generics = array_map(fn ($type) => "{$type} extends Models.{$type} = Models.Default{$type}", $generics);
 
         return '<' . implode(', ', $generics) . '>';
     }

--- a/templates/node/src/services/template.ts.twig
+++ b/templates/node/src/services/template.ts.twig
@@ -94,5 +94,8 @@ export class {{ service.name | caseUcfirst }} {
         );
         {%~ endif %}
     }
+{%~ if not loop.last %}
+
+{%~ endif %}
     {%~ endfor %}
 }

--- a/templates/web/src/models.ts.twig
+++ b/templates/web/src/models.ts.twig
@@ -2,7 +2,10 @@
  * {{spec.title | caseUcfirst}} Models
  */
 export namespace Models {
+
+    declare const __default: unique symbol;
 {% for definition in spec.definitions %}
+
     /**
      * {{ definition.description }}
      */
@@ -13,8 +16,19 @@ export namespace Models {
          */
         {{ property.name }}{% if not property.required %}?{% endif %}: {{ property | getSubSchema(spec) | raw }};
 {% endfor %}
-{% if definition.additionalProperties %}        [key: string]: any;
-{% endif %}
     }
+{% if definition.additionalProperties %}
+
+    export type Default{{ definition.name | caseUcfirst }}{{ definition.name | getGenerics(spec, true) | raw }} = {{ definition.name | caseUcfirst }}{{ definition.name | getGenerics(spec, true) | raw }} & {
+        [key: string]: any;
+        [__default]: true;
+    };
+
+    export type DataWithout{{ definition.name | caseUcfirst }}Keys{{ definition.name | getGenerics(spec, true) | raw }} = {
+        [K in string]: any;
+    } & {
+        [K in keyof {{ definition.name | caseUcfirst }}{{ definition.name | getGenerics(spec, true) | raw }}]?: never;
+    };
+{% endif %}
 {% endfor %}
 }

--- a/templates/web/src/services/template.ts.twig
+++ b/templates/web/src/services/template.ts.twig
@@ -108,5 +108,8 @@ export class {{ service.name | caseUcfirst }} {
         );
         {%~ endif %}
     }
+{%~ if not loop.last %}
+
+{%~ endif %}
     {%~ endfor %}
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes document typing by:
1. introducing default model and document without keys:
	```ts
    export type DefaultDocument = Document & {
        [key: string]: any;
        [__default]: true;
    };

    export type DataWithoutDocumentKeys = {
        [K in string]: any;
    } & {
        [K in keyof Document]?: never;
    };
	```

2. Update document methods to use it:
	```ts
	data: Document extends Models.DefaultDocument ? Models.DataWithoutDocumentKeys : Omit<Document, keyof Models.Document>
	```

## Test Plan

## Related PRs and Issues

- https://github.com/appwrite/sdk-for-web/issues/76

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.