### PR TITLE
fix: deprecated warnings in cli leading to error

### DIFF
--- a/templates/cli/lib/client.js.twig
+++ b/templates/cli/lib/client.js.twig
@@ -139,7 +139,7 @@ class Client {
 
       const warnings = response.headers.get('x-{{ spec.title | lower }}-warning');
       if (warnings) {
-          warnings.split(';').forEach((warning) => console.log(`${chalk.yellow.bold("ℹ Warning:")} ${chalk.yellow(warning ?? "")}`));
+          warnings.split(';').forEach((warning) => console.log(`${chalk.yellow.bold("ℹ Warning:")} ${chalk.yellow(warning)}`));
       }
     } catch (error) {
       throw new {{spec.title | caseUcfirst}}Exception(error.message);

--- a/templates/cli/lib/client.js.twig
+++ b/templates/cli/lib/client.js.twig
@@ -139,7 +139,7 @@ class Client {
 
       const warnings = response.headers.get('x-{{ spec.title | lower }}-warning');
       if (warnings) {
-          warnings.split(';').forEach((warning) => console.warn(warning));
+          warnings.split(';').forEach((warning) => console.log(`${chalk.yellow.bold("ℹ Warning:")} ${chalk.yellow(warning ?? "")}`));
       }
     } catch (error) {
       throw new {{spec.title | caseUcfirst}}Exception(error.message);

--- a/templates/cli/lib/commands/command.js.twig
+++ b/templates/cli/lib/commands/command.js.twig
@@ -7,7 +7,7 @@ const libClient = require('../client.js');
 const { getAllFiles, showConsoleLink } = require('../utils.js');
 const { Command } = require('commander');
 const { sdkForProject, sdkForConsole } = require('../sdks')
-const { parse, actionRunner, parseInteger, parseBool, commandDescriptions, success, log } = require('../parser')
+const { parse, actionRunner, parseInteger, parseBool, commandDescriptions, success, log, warn } = require('../parser')
 const { localConfig, globalConfig } = require("../config");
 const { File } = require('undici');
 const { ReadableStream } = require('stream/web');
@@ -72,13 +72,6 @@ const {{ service.name | caseLower }}{{ method.name | caseUcfirst }} = async ({
         {%- if method.type == 'location' -%}, destination{%- endif -%}
         {% if hasConsolePreview(method.name,service.name) %}, console{%- endif -%}
 }) => {
-{% if method.deprecated %}
-{% if method.since and method.replaceWith %}
-    console.warn('Warning: This command is deprecated since {{ method.since }}.{% if method.replaceWith %} Please use "{{ method.replaceWith | replace({'.': ' '}) | caseKebab }}" instead.{% endif %}');
-{% else %}
-    console.warn('Warning: This command is deprecated.');
-{% endif %}
-{% endif %}
     let client = !sdk ? await {% if service.name == "projects" %}sdkForConsole(){% else %}sdkForProject(){% endif %} :
     sdk;
     let apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replace('{{ '{' }}{{ parameter.name | caseCamel }}{{ '}' }}', {{ parameter.name | caseCamel | escapeKeyword }}){% endfor %};


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

error that was caused:
<img width="640" height="163" alt="Screenshot 2025-07-25 at 3 16 12 PM" src="https://github.com/user-attachments/assets/edd10351-a0cf-42a2-8f13-148365664329" />

fix:
1. remove warnings from methods as a warning from `client` call will be returned via header
2. switched using `console.warn` as that method does not exist in CLI

## Test Plan

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.