### PR TITLE
fix(.NET): pass enum value as string in API params

### DIFF
--- a/templates/dotnet/base/utils.twig
+++ b/templates/dotnet/base/utils.twig
@@ -6,7 +6,7 @@
 {% if parameters.all|length > 0 %}{% for parameter in parameters.all | filter((param) => not param.isGlobal)  %}{{ _self.parameter(parameter) }}{% if not loop.last %}{{ ', ' }}{% endif %}{% endfor %}{% if 'multipart/form-data' in consumes %},{% endif %}{% endif %}{% if 'multipart/form-data' in consumes %} Action<UploadProgress>? onProgress = null{% endif %}
 {% endmacro %}
 {% macro map_parameter(parameter) %}
-{% if parameter.name == 'orderType' %}{{ parameter.name | caseCamel ~ '.ToString()'}}{% elseif parameter.isGlobal %}{{ parameter.name | caseUcfirst | escapeKeyword }}{% else %}{{ parameter.name | caseCamel | escapeKeyword }}{% endif %}
+{% if parameter.name == 'orderType' %}{{ parameter.name | caseCamel ~ '.ToString()'}}{% elseif parameter.isGlobal %}{{ parameter.name | caseUcfirst | escapeKeyword }}{% elseif parameter.enumValues is not empty %}{{ parameter.name | caseCamel | escapeKeyword }}?.Value{% else %}{{ parameter.name | caseCamel | escapeKeyword }}{% endif %}
 {% endmacro %}
 {% macro methodNeedsSecurityParameters(method) %}
 {% if (method.type == "webAuth" or method.type == "location") and method.auth|length > 0 %}{{ true }}{% else %}{{false}}{% endif %}


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Always send enum wrappers as string values in API parameters to prevent serialization issues.

generated sdk (1.7.x server)
<img width="1247" height="790" alt="{50FA8EA9-300F-42B2-BB8D-26489E2E0B2F}" src="https://github.com/user-attachments/assets/d8cf922f-e6c1-48ed-a527-44c58ea582ba" />

## Test Plan

In dart base/utils, there is a similar implementation for enum.
## Related PRs and Issues

https://github.com/appwrite/sdk-for-dotnet/issues/54
assign me?

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes