### PR TITLE
chore: allow internal attributes partially in web and node

### DIFF
--- a/src/SDK/Language/Node.php
+++ b/src/SDK/Language/Node.php
@@ -57,7 +57,7 @@ class Node extends Web
                         return "Partial<Preferences>";
                     case 'document':
                         if ($method['method'] === 'post') {
-                            return "Document extends Models.DefaultDocument ? Partial<Models.Document> & Record<string, any> : Partial<Models.Document> & Partial<Omit<Document, keyof Models.Document>>";
+                            return "Document extends Models.DefaultDocument ? Partial<Models.Document> & Record<string, any> : Partial<Models.Document> & Omit<Document, keyof Models.Document>";
                         }
                         if ($method['method'] === 'patch') {
                             return "Document extends Models.DefaultDocument ? Partial<Models.Document> & Record<string, any> : Partial<Models.Document> & Partial<Omit<Document, keyof Models.Document>>";

--- a/src/SDK/Language/Node.php
+++ b/src/SDK/Language/Node.php
@@ -57,10 +57,10 @@ class Node extends Web
                         return "Partial<Preferences>";
                     case 'document':
                         if ($method['method'] === 'post') {
-                            return "Document extends Models.DefaultDocument ? Models.DataWithoutDocumentKeys : Omit<Document, keyof Models.Document>";
+                            return "Document extends Models.DefaultDocument ? Partial<Models.Document> & Record<string, any> : Partial<Models.Document> & Partial<Omit<Document, keyof Models.Document>>";
                         }
                         if ($method['method'] === 'patch') {
-                            return "Partial<Document extends Models.DefaultDocument ? Models.DataWithoutDocumentKeys : Omit<Document, keyof Models.Document>>";
+                            return "Document extends Models.DefaultDocument ? Partial<Models.Document> & Record<string, any> : Partial<Models.Document> & Partial<Omit<Document, keyof Models.Document>>";
                         }
                 }
                 break;

--- a/src/SDK/Language/Web.php
+++ b/src/SDK/Language/Web.php
@@ -222,7 +222,7 @@ class Web extends JS
                         return "Partial<Preferences>";
                     case 'document':
                         if ($method['method'] === 'post') {
-                            return "Document extends Models.DefaultDocument ? Partial<Models.Document> & Record<string, any> : Partial<Models.Document> & Partial<Omit<Document, keyof Models.Document>>";
+                            return "Document extends Models.DefaultDocument ? Partial<Models.Document> & Record<string, any> : Partial<Models.Document> & Omit<Document, keyof Models.Document>";
                         }
                         if ($method['method'] === 'patch') {
                             return "Document extends Models.DefaultDocument ? Partial<Models.Document> & Record<string, any> : Partial<Models.Document> & Partial<Omit<Document, keyof Models.Document>>";

--- a/src/SDK/Language/Web.php
+++ b/src/SDK/Language/Web.php
@@ -222,10 +222,10 @@ class Web extends JS
                         return "Partial<Preferences>";
                     case 'document':
                         if ($method['method'] === 'post') {
-                            return "Document extends Models.DefaultDocument ? Models.DataWithoutDocumentKeys : Omit<Document, keyof Models.Document>";
+                            return "Document extends Models.DefaultDocument ? Partial<Models.Document> & Record<string, any> : Partial<Models.Document> & Partial<Omit<Document, keyof Models.Document>>";
                         }
                         if ($method['method'] === 'patch') {
-                            return "Partial<Document extends Models.DefaultDocument ? Models.DataWithoutDocumentKeys : Omit<Document, keyof Models.Document>>";
+                            return "Document extends Models.DefaultDocument ? Partial<Models.Document> & Record<string, any> : Partial<Models.Document> & Partial<Omit<Document, keyof Models.Document>>";
                         }
                 }
                 break;

--- a/templates/react-native/src/models.ts.twig
+++ b/templates/react-native/src/models.ts.twig
@@ -20,12 +20,6 @@ export namespace Models {
         [key: string]: any;
         [__default]: true;
     };
-
-    export type DataWithout{{ definition.name | caseUcfirst }}Keys{{ definition.name | getGenerics(spec, true) | raw }} = {
-        [K in string]: any;
-    } & {
-        [K in keyof {{ definition.name | caseUcfirst }}{{ definition.name | getGenerics(spec, true) | raw }}]?: never;
-    };
 {% endif %}
 {% endfor %}
 }

--- a/templates/web/src/models.ts.twig
+++ b/templates/web/src/models.ts.twig
@@ -23,12 +23,6 @@ export namespace Models {
         [key: string]: any;
         [__default]: true;
     };
-
-    export type DataWithout{{ definition.name | caseUcfirst }}Keys{{ definition.name | getGenerics(spec, true) | raw }} = {
-        [K in string]: any;
-    } & {
-        [K in keyof {{ definition.name | caseUcfirst }}{{ definition.name | getGenerics(spec, true) | raw }}]?: never;
-    };
 {% endif %}
 {% endfor %}
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

breakdown:

1. case 1 - generic is not passed, i.e `Document extends Models.DefaultDocument` satisfies. then:
	```ts
	Partial<Models.Document> & Record<string, any>
	```
	meaning allow internal attributes like `$id`, `$collectionId` etc. but "partially", meaning you get type completion but not 	required. apart from that allow any key.
	**aka** allow any thing but get type completion on internal attributes

2. case 2 - generic is not passed, the condition fails and now it's `Document extends Models.Document = Models.DefaultDocument`. then it's:
	```ts
	Partial<Models.Document> & Omit<Document, keyof Models.Document>
	```
	meaning again allow type completion on internal attributes, but make keys of `Document` compulsory just omiting the internal attributes

for patch methods, we just wrap `Omit<Document, keyof Models.Document>` in partial to not make all the keys compulsory.

also remove `DataWithoutDocumentKeys` since no need for it now

## Test Plan
<img width="822" height="728" alt="Screenshot 2025-07-29 at 9 12 47 AM" src="https://github.com/user-attachments/assets/5e90b22b-ecdb-4698-a7b9-f2c5ccc2c7bf" />

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.