### PR TITLE
Add new query methods and tests

### DIFF
--- a/templates/android/library/src/main/java/io/package/Query.kt.twig
+++ b/templates/android/library/src/main/java/io/package/Query.kt.twig
@@ -193,6 +193,84 @@ class Query(
         fun contains(attribute: String, value: Any) = Query("contains", attribute, parseValue(value)).toJson()
 
         /**
+         * Filter resources where attribute does not contain the specified value.
+         *
+         * @param attribute The attribute to filter on.
+         * @param value The value to compare against.
+         * @returns The query string.
+         */
+        fun notContains(attribute: String, value: Any) = Query("notContains", attribute, parseValue(value)).toJson()
+
+        /**
+         * Filter resources by searching attribute for value (inverse of search).
+         *
+         * @param attribute The attribute to filter on.
+         * @param value The search value to match against.
+         * @returns The query string.
+         */
+        fun notSearch(attribute: String, value: String) = Query("notSearch", attribute, listOf(value)).toJson()
+
+        /**
+         * Filter resources where attribute is not between start and end (exclusive).
+         *
+         * @param attribute The attribute to filter on.
+         * @param start The start value of the range.
+         * @param end The end value of the range.
+         * @returns The query string.
+         */
+        fun notBetween(attribute: String, start: Any, end: Any) = Query("notBetween", attribute, listOf(start, end)).toJson()
+
+        /**
+         * Filter resources where attribute does not start with value.
+         *
+         * @param attribute The attribute to filter on.
+         * @param value The value to compare against.
+         * @returns The query string.
+         */
+        fun notStartsWith(attribute: String, value: String) = Query("notStartsWith", attribute, listOf(value)).toJson()
+
+        /**
+         * Filter resources where attribute does not end with value.
+         *
+         * @param attribute The attribute to filter on.
+         * @param value The value to compare against.
+         * @returns The query string.
+         */
+        fun notEndsWith(attribute: String, value: String) = Query("notEndsWith", attribute, listOf(value)).toJson()
+
+        /**
+         * Filter resources where document was created before date.
+         *
+         * @param value The date value to compare against.
+         * @returns The query string.
+         */
+        fun createdBefore(value: String) = Query("createdBefore", null, listOf(value)).toJson()
+
+        /**
+         * Filter resources where document was created after date.
+         *
+         * @param value The date value to compare against.
+         * @returns The query string.
+         */
+        fun createdAfter(value: String) = Query("createdAfter", null, listOf(value)).toJson()
+
+        /**
+         * Filter resources where document was updated before date.
+         *
+         * @param value The date value to compare against.
+         * @returns The query string.
+         */
+        fun updatedBefore(value: String) = Query("updatedBefore", null, listOf(value)).toJson()
+
+        /**
+         * Filter resources where document was updated after date.
+         *
+         * @param value The date value to compare against.
+         * @returns The query string.
+         */
+        fun updatedAfter(value: String) = Query("updatedAfter", null, listOf(value)).toJson()
+
+        /**
          * Combine multiple queries using logical OR operator.
          *
          * @param queries The list of query strings to combine.

--- a/templates/dart/lib/query.dart.twig
+++ b/templates/dart/lib/query.dart.twig
@@ -83,6 +83,39 @@ class Query {
   static String contains(String attribute, dynamic value) =>
       Query._('contains', attribute, value).toString();
 
+  /// Filter resources where [attribute] does not contain [value]
+  /// [value] can be a single value or a list.
+  static String notContains(String attribute, dynamic value) =>
+      Query._('notContains', attribute, value).toString();
+
+  /// Filter resources by searching [attribute] for [value] (inverse of search).
+  static String notSearch(String attribute, String value) =>
+      Query._('notSearch', attribute, value).toString();
+
+  /// Filter resources where [attribute] is not between [start] and [end] (exclusive).
+  static String notBetween(String attribute, dynamic start, dynamic end) =>
+      Query._('notBetween', attribute, [start, end]).toString();
+
+  /// Filter resources where [attribute] does not start with [value].
+  static String notStartsWith(String attribute, String value) =>
+      Query._('notStartsWith', attribute, value).toString();
+
+  /// Filter resources where [attribute] does not end with [value].
+  static String notEndsWith(String attribute, String value) =>
+      Query._('notEndsWith', attribute, value).toString();
+
+  /// Filter resources where document was created before [value].
+  static String createdBefore(String value) => Query._('createdBefore', null, value).toString();
+
+  /// Filter resources where document was created after [value].
+  static String createdAfter(String value) => Query._('createdAfter', null, value).toString();
+
+  /// Filter resources where document was updated before [value].
+  static String updatedBefore(String value) => Query._('updatedBefore', null, value).toString();
+
+  /// Filter resources where document was updated after [value].
+  static String updatedAfter(String value) => Query._('updatedAfter', null, value).toString();
+
   static String or(List<String> queries) =>
     Query._('or', null, queries.map((query) => jsonDecode(query)).toList()).toString();
 

--- a/templates/dart/test/query_test.dart.twig
+++ b/templates/dart/test/query_test.dart.twig
@@ -211,5 +211,84 @@ void main() {
     expect(query['values'], 1);
     expect(query['method'], 'offset');
   });
+
+  test('returns notContains', () {
+    final query = Query.notContains('attr', 'value').toJson();
+    expect(query['attribute'], 'attr');
+    expect(query['values'], ['value']);
+    expect(query['method'], 'notContains');
+  });
+
+  test('returns notSearch', () {
+    final query = Query.notSearch('attr', 'keyword1 keyword2').toJson();
+    expect(query['attribute'], 'attr');
+    expect(query['values'], ['keyword1 keyword2']);
+    expect(query['method'], 'notSearch');
+  });
+
+  group('notBetween()', () {
+    test('with integers', () {
+      final query = Query.notBetween('attr', 1, 2).toJson();
+      expect(query['attribute'], 'attr');
+      expect(query['values'], [1, 2]);
+      expect(query['method'], 'notBetween');
+    });
+
+    test('with doubles', () {
+      final query = Query.notBetween('attr', 1.0, 2.0).toJson();
+      expect(query['attribute'], 'attr');
+      expect(query['values'], [1.0, 2.0]);
+      expect(query['method'], 'notBetween');
+    });
+
+    test('with strings', () {
+      final query = Query.notBetween('attr', 'a', 'z').toJson();
+      expect(query['attribute'], 'attr');
+      expect(query['values'], ['a', 'z']);
+      expect(query['method'], 'notBetween');
+    });
+  });
+
+  test('returns notStartsWith', () {
+    final query = Query.notStartsWith('attr', 'prefix').toJson();
+    expect(query['attribute'], 'attr');
+    expect(query['values'], ['prefix']);
+    expect(query['method'], 'notStartsWith');
+  });
+
+  test('returns notEndsWith', () {
+    final query = Query.notEndsWith('attr', 'suffix').toJson();
+    expect(query['attribute'], 'attr');
+    expect(query['values'], ['suffix']);
+    expect(query['method'], 'notEndsWith');
+  });
+
+  test('returns createdBefore', () {
+    final query = Query.createdBefore('2023-01-01').toJson();
+    expect(query['attribute'], null);
+    expect(query['values'], '2023-01-01');
+    expect(query['method'], 'createdBefore');
+  });
+
+  test('returns createdAfter', () {
+    final query = Query.createdAfter('2023-01-01').toJson();
+    expect(query['attribute'], null);
+    expect(query['values'], '2023-01-01');
+    expect(query['method'], 'createdAfter');
+  });
+
+  test('returns updatedBefore', () {
+    final query = Query.updatedBefore('2023-01-01').toJson();
+    expect(query['attribute'], null);
+    expect(query['values'], '2023-01-01');
+    expect(query['method'], 'updatedBefore');
+  });
+
+  test('returns updatedAfter', () {
+    final query = Query.updatedAfter('2023-01-01').toJson();
+    expect(query['attribute'], null);
+    expect(query['values'], '2023-01-01');
+    expect(query['method'], 'updatedAfter');
+  });
 }
 

--- a/templates/deno/src/query.ts.twig
+++ b/templates/deno/src/query.ts.twig
@@ -93,8 +93,103 @@ export class Query {
   static offset = (offset: number): string =>
     new Query("offset", undefined, offset).toString();
 
+  /**
+   * Filter resources where attribute contains the specified value.
+   *
+   * @param {string} attribute
+   * @param {string | string[]} value
+   * @returns {string}
+   */
   static contains = (attribute: string, value: string | string[]): string =>
     new Query("contains", attribute, value).toString();
+
+  /**
+   * Filter resources where attribute does not contain the specified value.
+   *
+   * @param {string} attribute
+   * @param {string | string[]} value
+   * @returns {string}
+   */
+  static notContains = (attribute: string, value: string | string[]): string =>
+    new Query("notContains", attribute, value).toString();
+
+  /**
+   * Filter resources by searching attribute for value (inverse of search).
+   * A fulltext index on attribute is required for this query to work.
+   *
+   * @param {string} attribute
+   * @param {string} value
+   * @returns {string}
+   */
+  static notSearch = (attribute: string, value: string): string =>
+    new Query("notSearch", attribute, value).toString();
+
+  /**
+   * Filter resources where attribute is not between start and end (exclusive).
+   *
+   * @param {string} attribute
+   * @param {string | number} start
+   * @param {string | number} end
+   * @returns {string}
+   */
+  static notBetween = (attribute: string, start: string | number, end: string | number): string =>
+    new Query("notBetween", attribute, [start, end] as QueryTypesList).toString();
+
+  /**
+   * Filter resources where attribute does not start with value.
+   *
+   * @param {string} attribute
+   * @param {string} value
+   * @returns {string}
+   */
+  static notStartsWith = (attribute: string, value: string): string =>
+    new Query("notStartsWith", attribute, value).toString();
+
+  /**
+   * Filter resources where attribute does not end with value.
+   *
+   * @param {string} attribute
+   * @param {string} value
+   * @returns {string}
+   */
+  static notEndsWith = (attribute: string, value: string): string =>
+    new Query("notEndsWith", attribute, value).toString();
+
+  /**
+   * Filter resources where document was created before date.
+   *
+   * @param {string} value
+   * @returns {string}
+   */
+  static createdBefore = (value: string): string =>
+    new Query("createdBefore", undefined, value).toString();
+
+  /**
+   * Filter resources where document was created after date.
+   *
+   * @param {string} value
+   * @returns {string}
+   */
+  static createdAfter = (value: string): string =>
+    new Query("createdAfter", undefined, value).toString();
+
+  /**
+   * Filter resources where document was updated before date.
+   *
+   * @param {string} value
+   * @returns {string}
+   */
+  static updatedBefore = (value: string): string =>
+    new Query("updatedBefore", undefined, value).toString();
+
+  /**
+   * Filter resources where document was updated after date.
+   *
+   * @param {string} value
+   * @returns {string}
+   */
+  static updatedAfter = (value: string): string =>
+    new Query("updatedAfter", undefined, value).toString();
 
   static or = (queries: string[]) =>
       new Query("or", undefined, queries.map((query) => JSON.parse(query))).toString();

--- a/templates/deno/test/query.test.ts.twig
+++ b/templates/deno/test/query.test.ts.twig
@@ -172,4 +172,59 @@ describe('Query', () => {
         Query.offset(1).toString(),
         `{"method":"offset","values":[1]}`,
     ));
+
+    test('notContains', () => assertEquals(
+        Query.notContains('attr', 'value').toString(),
+        `{"method":"notContains","attribute":"attr","values":["value"]}`,
+    ));
+
+    test('notSearch', () => assertEquals(
+        Query.notSearch('attr', 'keyword1 keyword2').toString(),
+        '{"method":"notSearch","attribute":"attr","values":["keyword1 keyword2"]}',
+    ));
+
+    describe('notBetween', () => {
+        test('with integers', () => assertEquals(
+            Query.notBetween('attr', 1, 2).toString(),
+            `{"method":"notBetween","attribute":"attr","values":[1,2]}`,
+        ));
+        test('with doubles', () => assertEquals(
+            Query.notBetween('attr', 1.2, 2.2).toString(),
+            `{"method":"notBetween","attribute":"attr","values":[1.2,2.2]}`,
+        ));
+        test('with strings', () => assertEquals(
+            Query.notBetween('attr', "a", "z").toString(),
+            `{"method":"notBetween","attribute":"attr","values":["a","z"]}`,
+        ));
+    });
+
+    test('notStartsWith', () => assertEquals(
+        Query.notStartsWith('attr', 'prefix').toString(),
+        `{"method":"notStartsWith","attribute":"attr","values":["prefix"]}`,
+    ));
+
+    test('notEndsWith', () => assertEquals(
+        Query.notEndsWith('attr', 'suffix').toString(),
+        `{"method":"notEndsWith","attribute":"attr","values":["suffix"]}`,
+    ));
+
+    test('createdBefore', () => assertEquals(
+        Query.createdBefore('2023-01-01').toString(),
+        `{"method":"createdBefore","values":["2023-01-01"]}`,
+    ));
+
+    test('createdAfter', () => assertEquals(
+        Query.createdAfter('2023-01-01').toString(),
+        `{"method":"createdAfter","values":["2023-01-01"]}`,
+    ));
+
+    test('updatedBefore', () => assertEquals(
+        Query.updatedBefore('2023-01-01').toString(),
+        `{"method":"updatedBefore","values":["2023-01-01"]}`,
+    ));
+
+    test('updatedAfter', () => assertEquals(
+        Query.updatedAfter('2023-01-01').toString(),
+        `{"method":"updatedAfter","values":["2023-01-01"]}`,
+    ));
 })

--- a/templates/dotnet/Package/Query.cs.twig
+++ b/templates/dotnet/Package/Query.cs.twig
@@ -150,6 +150,50 @@ namespace {{ spec.title | caseUcfirst }}
             return new Query("contains", attribute, value).ToString();
         }
 
+        public static string NotContains(string attribute, object value) {
+            return new Query("notContains", attribute, value).ToString();
+        }
+
+        public static string NotSearch(string attribute, string value) {
+            return new Query("notSearch", attribute, value).ToString();
+        }
+
+        public static string NotBetween(string attribute, string start, string end) {
+            return new Query("notBetween", attribute, new List<string> { start, end }).ToString();
+        }
+
+        public static string NotBetween(string attribute, int start, int end) {
+            return new Query("notBetween", attribute, new List<int> { start, end }).ToString();
+        }
+
+        public static string NotBetween(string attribute, double start, double end) {
+            return new Query("notBetween", attribute, new List<double> { start, end }).ToString();
+        }
+
+        public static string NotStartsWith(string attribute, string value) {
+            return new Query("notStartsWith", attribute, value).ToString();
+        }
+
+        public static string NotEndsWith(string attribute, string value) {
+            return new Query("notEndsWith", attribute, value).ToString();
+        }
+
+        public static string CreatedBefore(string value) {
+            return new Query("createdBefore", null, value).ToString();
+        }
+
+        public static string CreatedAfter(string value) {
+            return new Query("createdAfter", null, value).ToString();
+        }
+
+        public static string UpdatedBefore(string value) {
+            return new Query("updatedBefore", null, value).ToString();
+        }
+
+        public static string UpdatedAfter(string value) {
+            return new Query("updatedAfter", null, value).ToString();
+        }
+
         public static string Or(List<string> queries) {
             return new Query("or", null, queries.Select(q => JsonSerializer.Deserialize<Query>(q, Client.DeserializerOptions)).ToList()).ToString();
         }

--- a/templates/go/query.go.twig
+++ b/templates/go/query.go.twig
@@ -156,6 +156,83 @@ func Contains(attribute string, value interface{}) string {
 	})
 }
 
+func NotContains(attribute string, value interface{}) string {
+	values := toArray(value)
+	return parseQuery(queryOptions{
+		Method:    "notContains",
+		Attribute: &attribute,
+		Values:    &values,
+	})
+}
+
+func NotSearch(attribute string, value interface{}) string {
+	values := toArray(value)
+	return parseQuery(queryOptions{
+		Method:    "notSearch",
+		Attribute: &attribute,
+		Values:    &values,
+	})
+}
+
+func NotBetween(attribute string, start, end interface{}) string {
+	values := []interface{}{start, end}
+	return parseQuery(queryOptions{
+		Method:    "notBetween",
+		Attribute: &attribute,
+		Values:    &values,
+	})
+}
+
+func NotStartsWith(attribute string, value interface{}) string {
+	values := toArray(value)
+	return parseQuery(queryOptions{
+		Method:    "notStartsWith",
+		Attribute: &attribute,
+		Values:    &values,
+	})
+}
+
+func NotEndsWith(attribute string, value interface{}) string {
+	values := toArray(value)
+	return parseQuery(queryOptions{
+		Method:    "notEndsWith",
+		Attribute: &attribute,
+		Values:    &values,
+	})
+}
+
+func CreatedBefore(value interface{}) string {
+	values := toArray(value)
+	return parseQuery(queryOptions{
+		Method: "createdBefore",
+		Values: &values,
+	})
+}
+
+func CreatedAfter(value interface{}) string {
+	values := toArray(value)
+	return parseQuery(queryOptions{
+		Method: "createdAfter",
+		Values: &values,
+	})
+}
+
+func UpdatedBefore(value interface{}) string {
+	values := toArray(value)
+	return parseQuery(queryOptions{
+		Method: "updatedBefore",
+		Values: &values,
+	})
+}
+
+func UpdatedAfter(value interface{}) string {
+	values := toArray(value)
+	return parseQuery(queryOptions{
+		Method: "updatedAfter",
+		Values: &values,
+	})
+}
+
 func Select(attributes interface{}) string {
 	values := toArray(attributes)
 	return parseQuery(queryOptions{

--- a/templates/kotlin/src/main/kotlin/io/appwrite/Query.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/Query.kt.twig
@@ -51,6 +51,24 @@ class Query(
 
         fun contains(attribute: String, value: Any) = Query("contains", attribute, parseValue(value)).toJson()
 
+        fun notContains(attribute: String, value: Any) = Query("notContains", attribute, parseValue(value)).toJson()
+
+        fun notSearch(attribute: String, value: String) = Query("notSearch", attribute, listOf(value)).toJson()
+
+        fun notBetween(attribute: String, start: Any, end: Any) = Query("notBetween", attribute, listOf(start, end)).toJson()
+
+        fun notStartsWith(attribute: String, value: String) = Query("notStartsWith", attribute, listOf(value)).toJson()
+
+        fun notEndsWith(attribute: String, value: String) = Query("notEndsWith", attribute, listOf(value)).toJson()
+
+        fun createdBefore(value: String) = Query("createdBefore", null, listOf(value)).toJson()
+
+        fun createdAfter(value: String) = Query("createdAfter", null, listOf(value)).toJson()
+
+        fun updatedBefore(value: String) = Query("updatedBefore", null, listOf(value)).toJson()
+
+        fun updatedAfter(value: String) = Query("updatedAfter", null, listOf(value)).toJson()
+
         fun or(queries: List<String>) = Query("or", null, queries.map { it.fromJson<Query>() }).toJson()
 
         fun and(queries: List<String>) = Query("and", null, queries.map { it.fromJson<Query>() }).toJson()

--- a/templates/php/src/Query.php.twig
+++ b/templates/php/src/Query.php.twig
@@ -268,6 +268,111 @@ class Query implements \JsonSerializable
     }
 
     /**
+     * Not Contains
+     *
+     * @param string $attribute
+     * @param mixed $value
+     * @return string
+     */
+    public static function notContains(string $attribute, $value): string
+    {
+        return (new Query('notContains', $attribute, $value))->__toString();
+    }
+
+    /**
+     * Not Search
+     *
+     * @param string $attribute
+     * @param string $value
+     * @return string
+     */
+    public static function notSearch(string $attribute, string $value): string
+    {
+        return (new Query('notSearch', $attribute, $value))->__toString();
+    }
+
+    /**
+     * Not Between
+     *
+     * @param string $attribute
+     * @param string|int|float $start
+     * @param string|int|float $end
+     * @return string
+     */
+    public static function notBetween(string $attribute, mixed $start, mixed $end): string
+    {
+        return (new Query('notBetween', $attribute, [$start, $end]))->__toString();
+    }
+
+    /**
+     * Not Starts With
+     *
+     * @param string $attribute
+     * @param string $value
+     * @return string
+     */
+    public static function notStartsWith(string $attribute, string $value): string
+    {
+        return (new Query('notStartsWith', $attribute, $value))->__toString();
+    }
+
+    /**
+     * Not Ends With
+     *
+     * @param string $attribute
+     * @param string $value
+     * @return string
+     */
+    public static function notEndsWith(string $attribute, string $value): string
+    {
+        return (new Query('notEndsWith', $attribute, $value))->__toString();
+    }
+
+    /**
+     * Created Before
+     *
+     * @param string $value
+     * @return string
+     */
+    public static function createdBefore(string $value): string
+    {
+        return (new Query('createdBefore', null, $value))->__toString();
+    }
+
+    /**
+     * Created After
+     *
+     * @param string $value
+     * @return string
+     */
+    public static function createdAfter(string $value): string
+    {
+        return (new Query('createdAfter', null, $value))->__toString();
+    }
+
+    /**
+     * Updated Before
+     *
+     * @param string $value
+     * @return string
+     */
+    public static function updatedBefore(string $value): string
+    {
+        return (new Query('updatedBefore', null, $value))->__toString();
+    }
+
+    /**
+     * Updated After
+     *
+     * @param string $value
+     * @return string
+     */
+    public static function updatedAfter(string $value): string
+    {
+        return (new Query('updatedAfter', null, $value))->__toString();
+    }
+
+    /**
      * Or
      *
      * @param array<string> $queries

--- a/templates/php/tests/QueryTest.php.twig
+++ b/templates/php/tests/QueryTest.php.twig
@@ -146,4 +146,48 @@ final class QueryTest extends TestCase {
     public function testOffset(): void {
         $this->assertSame('offset(1)', Query::offset(1));
     }
+
+    public function testNotContains(): void {
+        $this->assertSame('notContains("attr", ["value"])', Query::notContains('attr', 'value'));
+    }
+
+    public function testNotSearch(): void {
+        $this->assertSame('notSearch("attr", ["keyword1 keyword2"])', Query::notSearch('attr', 'keyword1 keyword2'));
+    }
+
+    public function testNotBetweenWithIntegers(): void {
+        $this->assertSame('notBetween("attr", 1, 2)', Query::notBetween('attr', 1, 2));
+    }
+
+    public function testNotBetweenWithDoubles(): void {
+        $this->assertSame('notBetween("attr", 1, 2)', Query::notBetween('attr', 1.0, 2.0));
+    }
+
+    public function testNotBetweenWithStrings(): void {
+        $this->assertSame('notBetween("attr", "a", "z")', Query::notBetween('attr', 'a', 'z'));
+    }
+
+    public function testNotStartsWith(): void {
+        $this->assertSame('notStartsWith("attr", ["prefix"])', Query::notStartsWith('attr', 'prefix'));
+    }
+
+    public function testNotEndsWith(): void {
+        $this->assertSame('notEndsWith("attr", ["suffix"])', Query::notEndsWith('attr', 'suffix'));
+    }
+
+    public function testCreatedBefore(): void {
+        $this->assertSame('createdBefore("2023-01-01")', Query::createdBefore('2023-01-01'));
+    }
+
+    public function testCreatedAfter(): void {
+        $this->assertSame('createdAfter("2023-01-01")', Query::createdAfter('2023-01-01'));
+    }
+
+    public function testUpdatedBefore(): void {
+        $this->assertSame('updatedBefore("2023-01-01")', Query::updatedBefore('2023-01-01'));
+    }
+
+    public function testUpdatedAfter(): void {
+        $this->assertSame('updatedAfter("2023-01-01")', Query::updatedAfter('2023-01-01'));
+    }
 }

--- a/templates/python/package/query.py.twig
+++ b/templates/python/package/query.py.twig
@@ -100,6 +100,42 @@ class Query():
         return str(Query("contains", attribute, value))
 
     @staticmethod
+    def not_contains(attribute, value):
+        return str(Query("notContains", attribute, value))
+
+    @staticmethod
+    def not_search(attribute, value):
+        return str(Query("notSearch", attribute, value))
+
+    @staticmethod
+    def not_between(attribute, start, end):
+        return str(Query("notBetween", attribute, [start, end]))
+
+    @staticmethod
+    def not_starts_with(attribute, value):
+        return str(Query("notStartsWith", attribute, value))
+
+    @staticmethod
+    def not_ends_with(attribute, value):
+        return str(Query("notEndsWith", attribute, value))
+
+    @staticmethod
+    def created_before(value):
+        return str(Query("createdBefore", None, value))
+
+    @staticmethod
+    def created_after(value):
+        return str(Query("createdAfter", None, value))
+
+    @staticmethod
+    def updated_before(value):
+        return str(Query("updatedBefore", None, value))
+
+    @staticmethod
+    def updated_after(value):
+        return str(Query("updatedAfter", None, value))
+
+    @staticmethod
     def or_queries(queries):
         return str(Query("or", None, [json.loads(query) for query in queries]))
 

--- a/templates/react-native/src/query.ts.twig
+++ b/templates/react-native/src/query.ts.twig
@@ -90,8 +90,103 @@ export class Query {
   static offset = (offset: number): string =>
     new Query("offset", undefined, offset).toString();
 
+  /**
+   * Filter resources where attribute contains the specified value.
+   *
+   * @param {string} attribute
+   * @param {string | string[]} value
+   * @returns {string}
+   */
   static contains = (attribute: string, value: string | string[]): string =>
     new Query("contains", attribute, value).toString();
+
+  /**
+   * Filter resources where attribute does not contain the specified value.
+   *
+   * @param {string} attribute
+   * @param {string | string[]} value
+   * @returns {string}
+   */
+  static notContains = (attribute: string, value: string | string[]): string =>
+    new Query("notContains", attribute, value).toString();
+
+  /**
+   * Filter resources by searching attribute for value (inverse of search).
+   * A fulltext index on attribute is required for this query to work.
+   *
+   * @param {string} attribute
+   * @param {string} value
+   * @returns {string}
+   */
+  static notSearch = (attribute: string, value: string): string =>
+    new Query("notSearch", attribute, value).toString();
+
+  /**
+   * Filter resources where attribute is not between start and end (exclusive).
+   *
+   * @param {string} attribute
+   * @param {string | number} start
+   * @param {string | number} end
+   * @returns {string}
+   */
+  static notBetween = (attribute: string, start: string | number, end: string | number): string =>
+    new Query("notBetween", attribute, [start, end] as QueryTypesList).toString();
+
+  /**
+   * Filter resources where attribute does not start with value.
+   *
+   * @param {string} attribute
+   * @param {string} value
+   * @returns {string}
+   */
+  static notStartsWith = (attribute: string, value: string): string =>
+    new Query("notStartsWith", attribute, value).toString();
+
+  /**
+   * Filter resources where attribute does not end with value.
+   *
+   * @param {string} attribute
+   * @param {string} value
+   * @returns {string}
+   */
+  static notEndsWith = (attribute: string, value: string): string =>
+    new Query("notEndsWith", attribute, value).toString();
+
+  /**
+   * Filter resources where document was created before date.
+   *
+   * @param {string} value
+   * @returns {string}
+   */
+  static createdBefore = (value: string): string =>
+    new Query("createdBefore", undefined, value).toString();
+
+  /**
+   * Filter resources where document was created after date.
+   *
+   * @param {string} value
+   * @returns {string}
+   */
+  static createdAfter = (value: string): string =>
+    new Query("createdAfter", undefined, value).toString();
+
+  /**
+   * Filter resources where document was updated before date.
+   *
+   * @param {string} value
+   * @returns {string}
+   */
+  static updatedBefore = (value: string): string =>
+    new Query("updatedBefore", undefined, value).toString();
+
+  /**
+   * Filter resources where document was updated after date.
+   *
+   * @param {string} value
+   * @returns {string}
+   */
+  static updatedAfter = (value: string): string =>
+    new Query("updatedAfter", undefined, value).toString();
 
   static or = (queries: string[]) =>
     new Query("or", undefined, queries.map((query) => JSON.parse(query))).toString();

--- a/templates/ruby/lib/container/query.rb.twig
+++ b/templates/ruby/lib/container/query.rb.twig
@@ -108,6 +108,42 @@ module {{spec.title | caseUcfirst}}
                 return Query.new("contains", attribute, value).to_s
             end
 
+            def not_contains(attribute, value)
+                return Query.new("notContains", attribute, value).to_s
+            end
+
+            def not_search(attribute, value)
+                return Query.new("notSearch", attribute, value).to_s
+            end
+
+            def not_between(attribute, start, ending)
+                return Query.new("notBetween", attribute, [start, ending]).to_s
+            end
+
+            def not_starts_with(attribute, value)
+                return Query.new("notStartsWith", attribute, value).to_s
+            end
+
+            def not_ends_with(attribute, value)
+                return Query.new("notEndsWith", attribute, value).to_s
+            end
+
+            def created_before(value)
+                return Query.new("createdBefore", nil, value).to_s
+            end
+
+            def created_after(value)
+                return Query.new("createdAfter", nil, value).to_s
+            end
+
+            def updated_before(value)
+                return Query.new("updatedBefore", nil, value).to_s
+            end
+
+            def updated_after(value)
+                return Query.new("updatedAfter", nil, value).to_s
+            end
+
             def or(queries)
                 return Query.new("or", nil, queries.map { |query| JSON.parse(query) }).to_s
             end

--- a/templates/swift/Sources/Query.swift.twig
+++ b/templates/swift/Sources/Query.swift.twig
@@ -284,6 +284,90 @@ public struct Query : Codable, CustomStringConvertible {
         ).description
     }
 
+    public static func notContains(_ attribute: String, value: Any) -> String {
+        return Query(
+            method: "notContains",
+            attribute: attribute,
+            values: Query.parseValue(value)
+        ).description
+    }
+
+    public static func notSearch(_ attribute: String, value: String) -> String {
+        return Query(
+            method: "notSearch",
+            attribute: attribute,
+            values: [value]
+        ).description
+    }
+
+    public static func notBetween(_ attribute: String, start: Int, end: Int) -> String {
+        return Query(
+            method: "notBetween",
+            attribute: attribute,
+            values: [start, end]
+        ).description
+    }
+
+    public static func notBetween(_ attribute: String, start: Double, end: Double) -> String {
+        return Query(
+            method: "notBetween",
+            attribute: attribute,
+            values: [start, end]
+        ).description
+    }
+
+    public static func notBetween(_ attribute: String, start: String, end: String) -> String {
+        return Query(
+            method: "notBetween",
+            attribute: attribute,
+            values: [start, end]
+        ).description
+    }
+
+    public static func notStartsWith(_ attribute: String, value: String) -> String {
+        return Query(
+            method: "notStartsWith",
+            attribute: attribute,
+            values: [value]
+        ).description
+    }
+
+    public static func notEndsWith(_ attribute: String, value: String) -> String {
+        return Query(
+            method: "notEndsWith",
+            attribute: attribute,
+            values: [value]
+        ).description
+    }
+
+    public static func createdBefore(_ value: String) -> String {
+        return Query(
+            method: "createdBefore",
+            values: [value]
+        ).description
+    }
+
+    public static func createdAfter(_ value: String) -> String {
+        return Query(
+            method: "createdAfter",
+            values: [value]
+        ).description
+    }
+
+    public static func updatedBefore(_ value: String) -> String {
+        return Query(
+            method: "updatedBefore",
+            values: [value]
+        ).description
+    }
+
+    public static func updatedAfter(_ value: String) -> String {
+        return Query(
+            method: "updatedAfter",
+            values: [value]
+        ).description
+    }
+
     public static func or(_ queries: [String]) -> String {
         let decoder = JSONDecoder()
         let decodedQueries = queries.compactMap { queryStr -> Query? in

--- a/templates/web/src/query.ts.twig
+++ b/templates/web/src/query.ts.twig
@@ -242,6 +242,94 @@ export class Query {
     new Query("contains", attribute, value).toString();
 
   /**
+   * Filter resources where attribute does not contain the specified value.
+   *
+   * @param {string} attribute
+   * @param {string | string[]} value
+   * @returns {string}
+   */
+  static notContains = (attribute: string, value: string | string[]): string =>
+    new Query("notContains", attribute, value).toString();
+
+  /**
+   * Filter resources by searching attribute for value (inverse of search).
+   * A fulltext index on attribute is required for this query to work.
+   *
+   * @param {string} attribute
+   * @param {string} value
+   * @returns {string}
+   */
+  static notSearch = (attribute: string, value: string): string =>
+    new Query("notSearch", attribute, value).toString();
+
+  /**
+   * Filter resources where attribute is not between start and end (exclusive).
+   *
+   * @param {string} attribute
+   * @param {string | number} start
+   * @param {string | number} end
+   * @returns {string}
+   */
+  static notBetween = (attribute: string, start: string | number, end: string | number): string =>
+    new Query("notBetween", attribute, [start, end] as QueryTypesList).toString();
+
+  /**
+   * Filter resources where attribute does not start with value.
+   *
+   * @param {string} attribute
+   * @param {string} value
+   * @returns {string}
+   */
+  static notStartsWith = (attribute: string, value: string): string =>
+    new Query("notStartsWith", attribute, value).toString();
+
+  /**
+   * Filter resources where attribute does not end with value.
+   *
+   * @param {string} attribute
+   * @param {string} value
+   * @returns {string}
+   */
+  static notEndsWith = (attribute: string, value: string): string =>
+    new Query("notEndsWith", attribute, value).toString();
+
+  /**
+   * Filter resources where document was created before date.
+   *
+   * @param {string} value
+   * @returns {string}
+   */
+  static createdBefore = (value: string): string =>
+    new Query("createdBefore", undefined, value).toString();
+
+  /**
+   * Filter resources where document was created after date.
+   *
+   * @param {string} value
+   * @returns {string}
+   */
+  static createdAfter = (value: string): string =>
+    new Query("createdAfter", undefined, value).toString();
+
+  /**
+   * Filter resources where document was updated before date.
+   *
+   * @param {string} value
+   * @returns {string}
+   */
+  static updatedBefore = (value: string): string =>
+    new Query("updatedBefore", undefined, value).toString();
+
+  /**
+   * Filter resources where document was updated after date.
+   *
+   * @param {string} value
+   * @returns {string}
+   */
+  static updatedAfter = (value: string): string =>
+    new Query("updatedAfter", undefined, value).toString();
+
+  /**
    * Combine multiple queries using logical OR operator.
    *
    * @param {string[]} queries


### PR DESCRIPTION
Add support for new `Query` methods (`notContains`, `notSearch`, `notBetween`, `notStartsWith`, `notEndsWith`, `createdBefore`, `createdAfter`, `updatedBefore`, `updatedAfter`) across all language templates to enhance filtering capabilities.

---
<a href="https://cursor.com/background-agent?bcId=bc-92198962-ff3c-4bd2-9f98-38a832bde685">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-92198962-ff3c-4bd2-9f98-38a832bde685">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

