### PR TITLE
appwrite/sdk-for-php#44 - write warnings to error log instead of stdout

### DIFF
--- a/templates/php/src/Client.php.twig
+++ b/templates/php/src/Client.php.twig
@@ -189,7 +189,7 @@ class Client
         $warnings = $responseHeaders['x-{{spec.title | caseLower}}-warning'] ?? '';
         if ($warnings) {
             foreach(explode(';', $warnings) as $warning) {
-                echo 'Warning: ' . $warning . PHP_EOL;
+                \trigger_error($warning, E_USER_WARNING);
             }
         }
         


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This changes the way how API warnings are handled within the php client.
Originally the warning was directly sent to stdout and so could cause unwanted output within apps or websites, that may break json / html output etc.
This now uses the trigger_error method, so warnings will be sent to the target that is configured within the php installation.

## Test Plan

I made a call to on of the current database endoints that contain a "deprecated" warnings message within the x-appwrite-waring header.

## Related PRs and Issues

https://github.com/appwrite/sdk-for-php/issues/44

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Warnings are no longer printed to standard output. They are now emitted via PHP’s error handling system, ensuring cleaner responses and proper routing to error logs/handlers.
  * No changes to public APIs or signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->