### PR TITLE
chore: prevent deprecated resources from being auto pulled

### DIFF
--- a/templates/cli/lib/commands/init.js.twig
+++ b/templates/cli/lib/commands/init.js.twig
@@ -124,7 +124,9 @@ const initProject = async ({ organizationId, projectId, projectName } = {}) => {
         if(answers.autopull) {
             cliConfig.all = true;
             cliConfig.force = true;
-            await pullResources();
+            await pullResources({
+                skipDeprecated: true
+            });
         } else {
             log("You can run 'appwrite pull all' to synchronize all of your existing resources.");
         }

--- a/templates/cli/lib/commands/pull.js.twig
+++ b/templates/cli/lib/commands/pull.js.twig
@@ -378,7 +378,7 @@ const pullTable = async () => {
         total++;
         log(`Pulling all tables from ${chalk.bold(database['name'])} database ...`);
 
-        localConfig.addDatabase(database);
+        localConfig.addTablesDB(database);
 
         const { tables } = await paginate(tablesDBListTables, {
             databaseId,

--- a/templates/cli/lib/commands/pull.js.twig
+++ b/templates/cli/lib/commands/pull.js.twig
@@ -18,7 +18,7 @@ const { cliConfig, success, log, warn, actionRunner, commandDescriptions } = req
 
 const pullResources = async ({
     skipDeprecated = false
-}) => {
+} = {}) => {
     const actions = {
         settings: pullSettings,
         functions: pullFunctions,

--- a/templates/cli/lib/commands/pull.js.twig
+++ b/templates/cli/lib/commands/pull.js.twig
@@ -16,7 +16,9 @@ const { paginate } = require("../paginate");
 const { questionsPullCollection, questionsPullFunctions, questionsPullFunctionsCode, questionsPullSites, questionsPullSitesCode, questionsPullResources } = require("../questions");
 const { cliConfig, success, log, warn, actionRunner, commandDescriptions } = require("../parser");
 
-const pullResources = async () => {
+const pullResources = async ({
+    skipDeprecated = false
+}) => {
     const actions = {
         settings: pullSettings,
         functions: pullFunctions,
@@ -26,6 +28,10 @@ const pullResources = async () => {
         buckets: pullBucket,
         teams: pullTeam,
         messages: pullMessagingTopic
+    }
+
+    if (skipDeprecated) {
+        delete actions.collections;
     }
 
     if (cliConfig.all) {

--- a/templates/cli/lib/commands/push.js.twig
+++ b/templates/cli/lib/commands/push.js.twig
@@ -1711,7 +1711,7 @@ const pushTable = async ({ returnOnZero, attempts } = { returnOnZero: false }) =
 
     // Parallel db actions
     await Promise.all(databases.map(async (databaseId) => {
-        const localDatabase = localConfig.getDatabase(databaseId);
+        const localDatabase = localConfig.getTablesDB(databaseId);
 
         try {
             const database = await tablesDBGet({

--- a/templates/cli/lib/commands/push.js.twig
+++ b/templates/cli/lib/commands/push.js.twig
@@ -894,7 +894,7 @@ const createIndexes = async (indexes, collection) => {
     );
 
     if (!result) {
-        throw new Error("Index creation timed out.");
+        throw new Error('Index creation timed out.');
     }
 
     success(`Created ${indexes.length} indexes`);
@@ -1759,7 +1759,6 @@ const pushTable = async ({ returnOnZero, attempts } = { returnOnZero: false }) =
                     databaseId: table['databaseId'],
                     tableId: table['$id'],
                     name: table.name,
-                    name: table.name,
                     parseOutput: false
                 })
 
@@ -1901,7 +1900,6 @@ const pushCollection = async ({ returnOnZero, attempts } = { returnOnZero: false
                 await databasesUpdateCollection({
                     databaseId: collection['databaseId'],
                     collectionId: collection['$id'],
-                    name: collection.name,
                     name: collection.name,
                     parseOutput: false
                 })

--- a/templates/cli/lib/commands/push.js.twig
+++ b/templates/cli/lib/commands/push.js.twig
@@ -51,7 +51,9 @@ const {
 } = require("./databases");
 const {
     tablesDBGet,
-    tablesDBGetTable
+    tablesDBGetTable,
+    tablesDBUpdateTable,
+    tablesDBCreateTable
 } = require("./tables-db");
 const {
     storageGetBucket, storageUpdateBucket, storageCreateBucket
@@ -1753,7 +1755,7 @@ const pushTable = async ({ returnOnZero, attempts } = { returnOnZero: false }) =
             });
 
             if (remoteTable.name !== table.name) {
-                await databasesUpdateTable({
+                await tablesDBUpdateTable({
                     databaseId: table['databaseId'],
                     tableId: table['$id'],
                     name: table.name,
@@ -1770,7 +1772,7 @@ const pushTable = async ({ returnOnZero, attempts } = { returnOnZero: false }) =
             (e) {
             if (Number(e.code) === 404) {
                 log(`Table ${table.name} does not exist in the project. Creating ... `);
-                await databasesCreateTable({
+                await tablesDBCreateTable({
                     databaseId: table['databaseId'],
                     tableId: table['$id'],
                     name: table.name,

--- a/templates/cli/lib/config.js.twig
+++ b/templates/cli/lib/config.js.twig
@@ -150,6 +150,47 @@ class Config {
     toString() {
         return JSONbig.stringify(this.data, null, 4);
     }
+
+    _getDBEntities(entityType) {
+        if (!this.has(entityType)) {
+            return [];
+        }
+        return this.get(entityType);
+    }
+
+    _getDBEntity(entityType, $id) {
+        if (!this.has(entityType)) {
+            return {};
+        }
+
+        let entities = this.get(entityType);
+        for (let i = 0; i < entities.length; i++) {
+            if (entities[i]['$id'] == $id) {
+                return entities[i];
+            }
+        }
+
+        return {};
+    }
+
+    _addDBEntity(entityType, props, keysSet, nestedKeys = {}) {
+        props = whitelistKeys(props, keysSet, nestedKeys);
+
+        if (!this.has(entityType)) {
+            this.set(entityType, []);
+        }
+
+        let entities = this.get(entityType);
+        for (let i = 0; i < entities.length; i++) {
+            if (entities[i]['$id'] == props['$id']) {
+                entities[i] = props;
+                this.set(entityType, entities);
+                return;
+            }
+        }
+        entities.push(props);
+        this.set(entityType, entities);
+    }
 }
 
 class Local extends Config {
@@ -464,45 +505,28 @@ class Local extends Config {
         this.set("topics", topics);
     }
 
+    getTablesDBs() {
+        return this._getDBEntities("tablesDB");
+    }
+
+    getTablesDB($id) {
+        return this._getDBEntity("tablesDB", $id);
+    }
+    
+    addTablesDB(props) {
+        this._addDBEntity("tablesDB", props, KeysDatabase);
+    }
+
     getDatabases() {
-        if (!this.has("databases")) {
-            return [];
-        }
-        return this.get("databases");
+        return this._getDBEntities("databases");
     }
 
     getDatabase($id) {
-        if (!this.has("databases")) {
-            return {};
-        }
-
-        let databases = this.get("databases");
-        for (let i = 0; i < databases.length; i++) {
-            if (databases[i]['$id'] == $id) {
-                return databases[i];
-            }
-        }
-
-        return {};
+        return this._getDBEntity("databases", $id);
     }
 
     addDatabase(props) {
-        props = whitelistKeys(props, KeysDatabase);
-
-        if (!this.has("databases")) {
-            this.set("databases", []);
-        }
-
-        let databases = this.get("databases");
-        for (let i = 0; i < databases.length; i++) {
-            if (databases[i]['$id'] == props['$id']) {
-                databases[i] = props;
-                this.set("databases", databases);
-                return;
-            }
-        }
-        databases.push(props);
-        this.set("databases", databases);
+        this._addDBEntity("databases", props, KeysDatabase);
     }
 
     getTeams() {

--- a/templates/cli/lib/questions.js.twig
+++ b/templates/cli/lib/questions.js.twig
@@ -259,7 +259,7 @@ const questionsPullResources = [
             { name: `Buckets ${chalk.blackBright(`(Storage)`)}`, value: 'buckets' },
             { name: `Teams ${chalk.blackBright(`(Auth)`)}`, value: 'teams' },
             { name: `Topics ${chalk.blackBright(`(Messaging)`)}`, value: 'messages' },
-            { name: `Collections ${chalk.blackBright(`(Database)`)}`, value: 'collections' }
+            { name: `Collections ${chalk.blackBright(`(Legacy Databases)`)}`, value: 'collections' }
         ]
     }
 ]
@@ -671,7 +671,7 @@ const questionsPushResources = [
             { name: `Buckets ${chalk.blackBright(`(Storage)`)}`, value: 'buckets' },
             { name: `Teams ${chalk.blackBright(`(Auth)`)}`, value: 'teams' },
             { name: `Topics ${chalk.blackBright(`(Messaging)`)}`, value: 'messages' },
-            { name: `Collections ${chalk.blackBright(`(Database)`)}`, value: 'collections' }
+            { name: `Collections ${chalk.blackBright(`(Legacy Databases)`)}`, value: 'collections' }
         ]
     }
 ];


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Pull operations can now skip deprecated resources; autopull will skip them to streamline updates.

- Style
  - Interactive prompts: “Collections” now displays “(Legacy Databases)” for clearer wording.

- Refactor
  - Configuration for database-like entities centralized for consistent add/get behavior.
  - Push/pull now use table-specific handling and the unified config helpers, improving reliability when syncing tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->