### PR TITLE
feat: add object param examples handling

### DIFF
--- a/example.php
+++ b/example.php
@@ -43,7 +43,7 @@ try {
     // $platform = 'server';
 
     $version = '1.8.x';
-    $spec = getSSLPage("https://raw.githubusercontent.com/appwrite/appwrite/{$version}/app/config/specs/swagger2-{$version}-{$platform}.json");
+    $spec = getSSLPage("https://raw.githubusercontent.com/appwrite/appwrite/add-param-examples/app/config/specs/swagger2-{$version}-{$platform}.json");
 
     if(empty($spec)) {
         throw new Exception('Failed to fetch spec from Appwrite server');

--- a/example.php
+++ b/example.php
@@ -43,7 +43,7 @@ try {
     // $platform = 'server';
 
     $version = '1.8.x';
-    $spec = getSSLPage("https://raw.githubusercontent.com/appwrite/appwrite/add-param-examples/app/config/specs/swagger2-{$version}-{$platform}.json");
+    $spec = getSSLPage("https://raw.githubusercontent.com/appwrite/appwrite/{$version}/app/config/specs/swagger2-{$version}-{$platform}.json");
 
     if(empty($spec)) {
         throw new Exception('Failed to fetch spec from Appwrite server');

--- a/src/SDK/Language/Dart.php
+++ b/src/SDK/Language/Dart.php
@@ -243,8 +243,8 @@ class Dart extends Language
             self::TYPE_ARRAY, self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
             self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
             self::TYPE_OBJECT => ($decoded = json_decode($example, true)) !== null
-            ? (empty($decoded) && $example === '{}' 
-                ? '{}' 
+            ? (empty($decoded) && $example === '{}'
+                ? '{}'
                 : preg_replace('/\n/', "\n    ", json_encode($decoded, JSON_PRETTY_PRINT)))
             : $example,
             self::TYPE_STRING => "'{$example}'",

--- a/src/SDK/Language/Dart.php
+++ b/src/SDK/Language/Dart.php
@@ -230,11 +230,11 @@ class Dart extends Language
 
         if (!$hasExample) {
             return match ($type) {
+                self::TYPE_OBJECT => '{}',
                 self::TYPE_ARRAY => '[]',
                 self::TYPE_BOOLEAN => 'false',
                 self::TYPE_FILE => 'InputFile(path: \'./path-to-files/image.jpg\', filename: \'image.jpg\')',
                 self::TYPE_INTEGER, self::TYPE_NUMBER => '0',
-                self::TYPE_OBJECT => '{}',
                 self::TYPE_STRING => "''",
             };
         }
@@ -242,8 +242,10 @@ class Dart extends Language
         return match ($type) {
             self::TYPE_ARRAY, self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
             self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
-            self::TYPE_OBJECT => ($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
-            ? preg_replace('/\n/', "\n    ", $formatted)
+            self::TYPE_OBJECT => ($decoded = json_decode($example, true)) !== null
+            ? (empty($decoded) && $example === '{}' 
+                ? '{}' 
+                : preg_replace('/\n/', "\n    ", json_encode($decoded, JSON_PRETTY_PRINT)))
             : $example,
             self::TYPE_STRING => "'{$example}'",
         };

--- a/src/SDK/Language/Dart.php
+++ b/src/SDK/Language/Dart.php
@@ -253,6 +253,22 @@ class Dart extends Language
         } else {
             switch ($type) {
                 case self::TYPE_OBJECT:
+                    $formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT);
+                    if ($formatted) {
+                        $lines = explode("\n", $formatted);
+                        $indentedLines = [];
+                        foreach ($lines as $i => $line) {
+                            if ($i === 0) {
+                                $indentedLines[] = $line; // First line doesn't need extra indent
+                            } else {
+                                $indentedLines[] = '    ' . $line; // Add 4 spaces for indentation
+                            }
+                        }
+                        $output .= implode("\n", $indentedLines);
+                    } else {
+                        $output .= $example;
+                    }
+                    break;
                 case self::TYPE_FILE:
                 case self::TYPE_NUMBER:
                 case self::TYPE_INTEGER:

--- a/src/SDK/Language/Dart.php
+++ b/src/SDK/Language/Dart.php
@@ -226,65 +226,27 @@ class Dart extends Language
         $type       = $param['type'] ?? '';
         $example    = $param['example'] ?? '';
 
-        $output = '';
+        $hasExample = !empty($example) || $example === 0 || $example === false;
 
-        if (empty($example) && $example !== 0 && $example !== false) {
-            switch ($type) {
-                case self::TYPE_FILE:
-                    $output .= 'InputFile(path: \'./path-to-files/image.jpg\', filename: \'image.jpg\')';
-                    break;
-                case self::TYPE_NUMBER:
-                case self::TYPE_INTEGER:
-                    $output .= '0';
-                    break;
-                case self::TYPE_BOOLEAN:
-                    $output .= 'false';
-                    break;
-                case self::TYPE_STRING:
-                    $output .= "''";
-                    break;
-                case self::TYPE_OBJECT:
-                    $output .= '{}';
-                    break;
-                case self::TYPE_ARRAY:
-                    $output .= '[]';
-                    break;
-            }
-        } else {
-            switch ($type) {
-                case self::TYPE_OBJECT:
-                    $formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT);
-                    if ($formatted) {
-                        $lines = explode("\n", $formatted);
-                        $indentedLines = [];
-                        foreach ($lines as $i => $line) {
-                            if ($i === 0) {
-                                $indentedLines[] = $line; // First line doesn't need extra indent
-                            } else {
-                                $indentedLines[] = '    ' . $line; // Add 4 spaces for indentation
-                            }
-                        }
-                        $output .= implode("\n", $indentedLines);
-                    } else {
-                        $output .= $example;
-                    }
-                    break;
-                case self::TYPE_FILE:
-                case self::TYPE_NUMBER:
-                case self::TYPE_INTEGER:
-                case self::TYPE_ARRAY:
-                    $output .= $example;
-                    break;
-                case self::TYPE_BOOLEAN:
-                    $output .= ($example) ? 'true' : 'false';
-                    break;
-                case self::TYPE_STRING:
-                    $output .= "'{$example}'";
-                    break;
-            }
+        if (!$hasExample) {
+            return match ($type) {
+                self::TYPE_FILE => 'InputFile(path: \'./path-to-files/image.jpg\', filename: \'image.jpg\')',
+                self::TYPE_NUMBER, self::TYPE_INTEGER => '0',
+                self::TYPE_BOOLEAN => 'false',
+                self::TYPE_STRING => "''",
+                self::TYPE_OBJECT => '{}',
+                self::TYPE_ARRAY => '[]',
+            };
         }
 
-        return $output;
+        return match ($type) {
+            self::TYPE_OBJECT => ($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
+            ? preg_replace('/\n/', "\n    ", $formatted)
+            : $example,
+            self::TYPE_FILE, self::TYPE_NUMBER, self::TYPE_INTEGER, self::TYPE_ARRAY => $example,
+            self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
+            self::TYPE_STRING => "'{$example}'",
+        };
     }
 
     /**

--- a/src/SDK/Language/Dart.php
+++ b/src/SDK/Language/Dart.php
@@ -230,21 +230,21 @@ class Dart extends Language
 
         if (!$hasExample) {
             return match ($type) {
-                self::TYPE_FILE => 'InputFile(path: \'./path-to-files/image.jpg\', filename: \'image.jpg\')',
-                self::TYPE_NUMBER, self::TYPE_INTEGER => '0',
-                self::TYPE_BOOLEAN => 'false',
-                self::TYPE_STRING => "''",
-                self::TYPE_OBJECT => '{}',
                 self::TYPE_ARRAY => '[]',
+                self::TYPE_BOOLEAN => 'false',
+                self::TYPE_FILE => 'InputFile(path: \'./path-to-files/image.jpg\', filename: \'image.jpg\')',
+                self::TYPE_INTEGER, self::TYPE_NUMBER => '0',
+                self::TYPE_OBJECT => '{}',
+                self::TYPE_STRING => "''",
             };
         }
 
         return match ($type) {
+            self::TYPE_ARRAY, self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
+            self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
             self::TYPE_OBJECT => ($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
             ? preg_replace('/\n/', "\n    ", $formatted)
             : $example,
-            self::TYPE_FILE, self::TYPE_NUMBER, self::TYPE_INTEGER, self::TYPE_ARRAY => $example,
-            self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
             self::TYPE_STRING => "'{$example}'",
         };
     }

--- a/src/SDK/Language/Deno.php
+++ b/src/SDK/Language/Deno.php
@@ -167,21 +167,21 @@ class Deno extends JS
 
         if (!$hasExample) {
             return match ($type) {
-                self::TYPE_FILE => 'InputFile(path: \'./path-to-files/image.jpg\', filename: \'image.jpg\')',
-                self::TYPE_NUMBER, self::TYPE_INTEGER => '0',
-                self::TYPE_BOOLEAN => 'false',
-                self::TYPE_STRING => "''",
-                self::TYPE_OBJECT => '{}',
                 self::TYPE_ARRAY => '[]',
+                self::TYPE_BOOLEAN => 'false',
+                self::TYPE_FILE => 'InputFile(path: \'./path-to-files/image.jpg\', filename: \'image.jpg\')',
+                self::TYPE_INTEGER, self::TYPE_NUMBER => '0',
+                self::TYPE_OBJECT => '{}',
+                self::TYPE_STRING => "''",
             };
         }
 
         return match ($type) {
+            self::TYPE_ARRAY, self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
+            self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
             self::TYPE_OBJECT => ($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
             ? preg_replace('/\n/', "\n    ", $formatted)
             : $example,
-            self::TYPE_FILE, self::TYPE_NUMBER, self::TYPE_INTEGER, self::TYPE_ARRAY => $example,
-            self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
             self::TYPE_STRING => "'{$example}'",
         };
     }

--- a/src/SDK/Language/Deno.php
+++ b/src/SDK/Language/Deno.php
@@ -179,7 +179,7 @@ class Deno extends JS
             self::TYPE_ARRAY, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
             self::TYPE_FILE => 'InputFile.fromPath(\'/path/to/file.png\', \'file.png\')',
             self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
-            self::TYPE_OBJECT => ($example === '{}') 
+            self::TYPE_OBJECT => ($example === '{}')
             ? '{}'
             : (($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
                 ? preg_replace('/\n/', "\n    ", $formatted)

--- a/src/SDK/Language/Deno.php
+++ b/src/SDK/Language/Deno.php
@@ -177,7 +177,8 @@ class Deno extends JS
         }
 
         return match ($type) {
-            self::TYPE_ARRAY, self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
+            self::TYPE_ARRAY, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
+            self::TYPE_FILE => 'InputFile.fromPath(\'/path/to/file.png\', \'file.png\')',
             self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
             self::TYPE_OBJECT => ($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
             ? preg_replace('/\n/', "\n    ", $formatted)

--- a/src/SDK/Language/Deno.php
+++ b/src/SDK/Language/Deno.php
@@ -169,7 +169,7 @@ class Deno extends JS
             return match ($type) {
                 self::TYPE_ARRAY => '[]',
                 self::TYPE_BOOLEAN => 'false',
-                self::TYPE_FILE => 'InputFile(path: \'./path-to-files/image.jpg\', filename: \'image.jpg\')',
+                self::TYPE_FILE => 'InputFile.fromPath(\'/path/to/file.png\', \'file.png\')',
                 self::TYPE_INTEGER, self::TYPE_NUMBER => '0',
                 self::TYPE_OBJECT => '{}',
                 self::TYPE_STRING => "''",

--- a/src/SDK/Language/Deno.php
+++ b/src/SDK/Language/Deno.php
@@ -190,8 +190,24 @@ class Deno extends JS
                 case self::TYPE_NUMBER:
                 case self::TYPE_INTEGER:
                 case self::TYPE_ARRAY:
-                case self::TYPE_OBJECT:
                     $output .= $example;
+                    break;
+                case self::TYPE_OBJECT:
+                    $formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT);
+                    if ($formatted) {
+                        $lines = explode("\n", $formatted);
+                        $indentedLines = [];
+                        foreach ($lines as $i => $line) {
+                            if ($i === 0) {
+                                $indentedLines[] = $line; // First line doesn't need extra indent
+                            } else {
+                                $indentedLines[] = '    ' . $line; // Add 4 spaces for indentation
+                            }
+                        }
+                        $output .= implode("\n", $indentedLines);
+                    } else {
+                        $output .= $example;
+                    }
                     break;
                 case self::TYPE_BOOLEAN:
                     $output .= ($example) ? 'true' : 'false';

--- a/src/SDK/Language/Deno.php
+++ b/src/SDK/Language/Deno.php
@@ -168,9 +168,8 @@ class Deno extends JS
         if (!$hasExample) {
             return match ($type) {
                 self::TYPE_ARRAY => '[]',
-                self::TYPE_BOOLEAN => 'false',
                 self::TYPE_FILE => 'InputFile.fromPath(\'/path/to/file.png\', \'file.png\')',
-                self::TYPE_INTEGER, self::TYPE_NUMBER => '0',
+                self::TYPE_INTEGER, self::TYPE_NUMBER, self::TYPE_BOOLEAN => 'null',
                 self::TYPE_OBJECT => '{}',
                 self::TYPE_STRING => "''",
             };
@@ -180,9 +179,11 @@ class Deno extends JS
             self::TYPE_ARRAY, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
             self::TYPE_FILE => 'InputFile.fromPath(\'/path/to/file.png\', \'file.png\')',
             self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
-            self::TYPE_OBJECT => ($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
-            ? preg_replace('/\n/', "\n    ", $formatted)
-            : $example,
+            self::TYPE_OBJECT => ($example === '{}') 
+            ? '{}'
+            : (($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
+                ? preg_replace('/\n/', "\n    ", $formatted)
+                : $example),
             self::TYPE_STRING => "'{$example}'",
         };
     }

--- a/src/SDK/Language/DotNet.php
+++ b/src/SDK/Language/DotNet.php
@@ -285,7 +285,11 @@ class DotNet extends Language
                     $output .= $example;
                     break;
                 case self::TYPE_OBJECT:
-                    $output .= '[object]';
+                    $output .= ($example === '{}')
+                    ? '[object]'
+                    : (($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
+                    ? 'new ' . preg_replace('/\n/', "\n    ", $formatted)
+                    : 'new ' . $example);
                     break;
                 case self::TYPE_BOOLEAN:
                     $output .= ($example) ? 'true' : 'false';

--- a/src/SDK/Language/DotNet.php
+++ b/src/SDK/Language/DotNet.php
@@ -285,11 +285,17 @@ class DotNet extends Language
                     $output .= $example;
                     break;
                 case self::TYPE_OBJECT:
-                    $output .= ($example === '{}')
-                    ? '[object]'
-                    : (($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
-                    ? 'new ' . preg_replace('/\n/', "\n    ", $formatted)
-                    : 'new ' . $example);
+                    if ($example === '{}') {
+                        $output .= '[object]';
+                    } else {
+                        $decoded = json_decode($example, true);
+                        if ($decoded && is_array($decoded)) {
+                            $csharpObject = $this->formatCSharpAnonymousObject($decoded, 1);
+                            $output .= 'new ' . $csharpObject;
+                        } else {
+                            $output .= 'new ' . $example;
+                        }
+                    }
                     break;
                 case self::TYPE_BOOLEAN:
                     $output .= ($example) ? 'true' : 'false';
@@ -457,5 +463,49 @@ class DotNet extends Language
                 return $property;
             }),
         ];
+    }
+
+    /**
+     * Format a PHP array as a C# anonymous object
+     */
+    private function formatCSharpAnonymousObject(array $data, int $indentLevel = 0): string
+    {
+        $propertyIndent = str_repeat('    ', $indentLevel + 1);
+        $properties = [];
+
+        foreach ($data as $key => $value) {
+            $formattedValue = $this->formatCSharpValue($value, $indentLevel + 2);
+            $properties[] = $propertyIndent . $key . ' = ' . $formattedValue;
+        }
+
+        if (count($properties) === 1) {
+            return '{ ' . trim($properties[0]) . ' }';
+        }
+
+        $baseIndent = str_repeat('    ', $indentLevel);
+        return "{\n" . implode(",\n", $properties) . "\n" . $baseIndent . "}";
+    }
+
+    /**
+     * Format a value for C# anonymous object property
+     */
+    private function formatCSharpValue($value, int $indentLevel = 0): string
+    {
+        if (is_string($value)) {
+            return '"' . $value . '"';
+        } elseif (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        } elseif (is_numeric($value)) {
+            return (string) $value;
+        } elseif (is_array($value)) {
+            if (array_keys($value) !== range(0, count($value) - 1)) {
+                return $this->formatCSharpAnonymousObject($value, $indentLevel);
+            } else {
+                $items = array_map(fn($item) => $this->formatCSharpValue($item, $indentLevel), $value);
+                return 'new[] { ' . implode(', ', $items) . ' }';
+            }
+        } else {
+            return 'null';
+        }
     }
 }

--- a/src/SDK/Language/Go.php
+++ b/src/SDK/Language/Go.php
@@ -266,7 +266,7 @@ class Go extends Language
                     break;
                 case self::TYPE_OBJECT:
                     $output .= ($example === '{}')
-                    ? '{map[string]interface{}{}}'
+                    ? 'map[string]interface{}{}'
                     : (($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
                         ? 'map[string]interface{}' . preg_replace('/\n/', "\n    ", $formatted)
                         : 'map[string]interface{}' . $example);

--- a/src/SDK/Language/Go.php
+++ b/src/SDK/Language/Go.php
@@ -265,7 +265,11 @@ class Go extends Language
                     $output .= 'interface{}{' . $example . '}';
                     break;
                 case self::TYPE_OBJECT:
-                    $output .= 'map[string]interface{}{}';
+                    $output .= ($example === '{}')
+                    ? '{map[string]interface{}{}}'
+                    : (($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
+                        ? 'map[string]interface{}' . preg_replace('/\n/', "\n    ", $formatted)
+                        : 'map[string]interface{}' . $example);
                     break;
                 case self::TYPE_BOOLEAN:
                     $output .= ($example) ? 'true' : 'false';

--- a/src/SDK/Language/GraphQL.php
+++ b/src/SDK/Language/GraphQL.php
@@ -137,7 +137,7 @@ class GraphQL extends HTTP
             self::TYPE_ARRAY, self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
             self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
             self::TYPE_OBJECT => ($example === '{}')
-            ? '{}'
+            ? '"{}"'
             : (($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
                 ? preg_replace('/\n/', "\n        ", $formatted)
                 : $example),

--- a/src/SDK/Language/GraphQL.php
+++ b/src/SDK/Language/GraphQL.php
@@ -141,7 +141,7 @@ class GraphQL extends HTTP
             : (($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
                 ? preg_replace('/\n/', "\n        ", $formatted)
                 : $example),
-            self::TYPE_STRING => "{$example}",
+            self::TYPE_STRING => '"' . $example . '"',
         };
     }
 

--- a/src/SDK/Language/GraphQL.php
+++ b/src/SDK/Language/GraphQL.php
@@ -126,7 +126,7 @@ class GraphQL extends HTTP
             return match ($type) {
                 self::TYPE_ARRAY => '[]',
                 self::TYPE_BOOLEAN => 'false',
-                self::TYPE_FILE => 'InputFile(path: \'./path-to-files/image.jpg\', filename: \'image.jpg\')',
+                self::TYPE_FILE => 'null',
                 self::TYPE_INTEGER, self::TYPE_NUMBER => '0',
                 self::TYPE_OBJECT => '{}',
                 self::TYPE_STRING => "''",

--- a/src/SDK/Language/GraphQL.php
+++ b/src/SDK/Language/GraphQL.php
@@ -136,7 +136,7 @@ class GraphQL extends HTTP
         return match ($type) {
             self::TYPE_ARRAY, self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
             self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
-            self::TYPE_OBJECT => ($example === '{}') 
+            self::TYPE_OBJECT => ($example === '{}')
             ? '{}'
             : (($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
                 ? preg_replace('/\n/', "\n        ", $formatted)

--- a/src/SDK/Language/GraphQL.php
+++ b/src/SDK/Language/GraphQL.php
@@ -129,17 +129,19 @@ class GraphQL extends HTTP
                 self::TYPE_FILE => 'null',
                 self::TYPE_INTEGER, self::TYPE_NUMBER => '0',
                 self::TYPE_OBJECT => '{}',
-                self::TYPE_STRING => "''",
+                self::TYPE_STRING => '""',
             };
         }
 
         return match ($type) {
             self::TYPE_ARRAY, self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
             self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
-            self::TYPE_OBJECT => ($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
-            ? preg_replace('/\n/', "\n        ", $formatted)
-            : $example,
-            self::TYPE_STRING => "'{$example}'",
+            self::TYPE_OBJECT => ($example === '{}') 
+            ? '{}'
+            : (($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
+                ? preg_replace('/\n/', "\n        ", $formatted)
+                : $example),
+            self::TYPE_STRING => "{$example}",
         };
     }
 

--- a/src/SDK/Language/GraphQL.php
+++ b/src/SDK/Language/GraphQL.php
@@ -137,10 +137,8 @@ class GraphQL extends HTTP
             self::TYPE_ARRAY, self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
             self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
             self::TYPE_OBJECT => ($example === '{}')
-            ? '"{}"'
-            : (($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
-                ? preg_replace('/\n/', "\n        ", $formatted)
-                : $example),
+                ? '"{}"'
+                : '"' . str_replace('"', '\\"', json_encode(json_decode($example, true))) . '"',
             self::TYPE_STRING => '"' . $example . '"',
         };
     }

--- a/src/SDK/Language/GraphQL.php
+++ b/src/SDK/Language/GraphQL.php
@@ -120,65 +120,27 @@ class GraphQL extends HTTP
         $type       = $param['type'] ?? '';
         $example    = $param['example'] ?? '';
 
-        $output = '';
+        $hasExample = !empty($example) || $example === 0 || $example === false;
 
-        if (empty($example) && $example !== 0 && $example !== false) {
-            switch ($type) {
-                case self::TYPE_FILE:
-                    $output .= 'null';
-                    break;
-                case self::TYPE_NUMBER:
-                case self::TYPE_INTEGER:
-                    $output .= '0';
-                    break;
-                case self::TYPE_BOOLEAN:
-                    $output .= 'false';
-                    break;
-                case self::TYPE_STRING:
-                    $output .= '""';
-                    break;
-                case self::TYPE_OBJECT:
-                    $output .= '"{}"';
-                    break;
-                case self::TYPE_ARRAY:
-                    $output .= '[]';
-                    break;
-            }
-        } else {
-            switch ($type) {
-                case self::TYPE_FILE:
-                case self::TYPE_NUMBER:
-                case self::TYPE_INTEGER:
-                case self::TYPE_ARRAY:
-                    $output .= $example;
-                    break;
-                case self::TYPE_STRING:
-                    $output .= '"' . $example . '"';
-                    break;
-                case self::TYPE_OBJECT:
-                    $formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT);
-                    if ($formatted) {
-                        $lines = explode("\n", $formatted);
-                        $indentedLines = [];
-                        foreach ($lines as $i => $line) {
-                            if ($i === 0) {
-                                $indentedLines[] = $line; // First line doesn't need extra indent
-                            } else {
-                                $indentedLines[] = '        ' . $line; // Add 8 spaces for indentation
-                            }
-                        }
-                        $output .= implode("\n", $indentedLines);
-                    } else {
-                        $output .= $example;
-                    }
-                    break;
-                case self::TYPE_BOOLEAN:
-                    $output .= ($example) ? 'true' : 'false';
-                    break;
-            }
+        if (!$hasExample) {
+            return match ($type) {
+                self::TYPE_ARRAY => '[]',
+                self::TYPE_BOOLEAN => 'false',
+                self::TYPE_FILE => 'InputFile(path: \'./path-to-files/image.jpg\', filename: \'image.jpg\')',
+                self::TYPE_INTEGER, self::TYPE_NUMBER => '0',
+                self::TYPE_OBJECT => '{}',
+                self::TYPE_STRING => "''",
+            };
         }
 
-        return $output;
+        return match ($type) {
+            self::TYPE_ARRAY, self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
+            self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
+            self::TYPE_OBJECT => ($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
+            ? preg_replace('/\n/', "\n        ", $formatted)
+            : $example,
+            self::TYPE_STRING => "'{$example}'",
+        };
     }
 
     /**

--- a/src/SDK/Language/GraphQL.php
+++ b/src/SDK/Language/GraphQL.php
@@ -153,8 +153,24 @@ class GraphQL extends HTTP
                     $output .= $example;
                     break;
                 case self::TYPE_STRING:
-                case self::TYPE_OBJECT:
                     $output .= '"' . $example . '"';
+                    break;
+                case self::TYPE_OBJECT:
+                    $formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT);
+                    if ($formatted) {
+                        $lines = explode("\n", $formatted);
+                        $indentedLines = [];
+                        foreach ($lines as $i => $line) {
+                            if ($i === 0) {
+                                $indentedLines[] = $line; // First line doesn't need extra indent
+                            } else {
+                                $indentedLines[] = '        ' . $line; // Add 8 spaces for indentation
+                            }
+                        }
+                        $output .= implode("\n", $indentedLines);
+                    } else {
+                        $output .= $example;
+                    }
                     break;
                 case self::TYPE_BOOLEAN:
                     $output .= ($example) ? 'true' : 'false';

--- a/src/SDK/Language/Kotlin.php
+++ b/src/SDK/Language/Kotlin.php
@@ -224,7 +224,32 @@ class Kotlin extends Language
         } else {
             switch ($type) {
                 case self::TYPE_OBJECT:
-                    $output .= 'mapOf( "a" to "b" )';
+                    $decoded = json_decode($example, true);
+                    if ($decoded && is_array($decoded)) {
+                        $mapEntries = [];
+                        foreach ($decoded as $key => $value) {
+                            $formattedKey = '"' . $key . '"';
+                            if (is_string($value)) {
+                                $formattedValue = '"' . $value . '"';
+                            } elseif (is_bool($value)) {
+                                $formattedValue = $value ? 'true' : 'false';
+                            } elseif (is_null($value)) {
+                                $formattedValue = 'null';
+                            } elseif (is_array($value)) {
+                                $formattedValue = 'listOf()'; // Simplified for nested arrays
+                            } else {
+                                $formattedValue = (string)$value;
+                            }
+                            $mapEntries[] = '        ' . $formattedKey . ' to ' . $formattedValue;
+                        }
+                        if (count($mapEntries) > 0) {
+                            $output .= "mapOf(\n" . implode(",\n", $mapEntries) . "\n    )";
+                        } else {
+                            $output .= 'mapOf()';
+                        }
+                    } else {
+                        $output .= 'mapOf()';
+                    }
                     break;
                 case self::TYPE_FILE:
                 case self::TYPE_NUMBER:

--- a/src/SDK/Language/Kotlin.php
+++ b/src/SDK/Language/Kotlin.php
@@ -245,10 +245,10 @@ class Kotlin extends Language
                         if (count($mapEntries) > 0) {
                             $output .= "mapOf(\n" . implode(",\n", $mapEntries) . "\n    )";
                         } else {
-                            $output .= 'mapOf("a" to "b")';
+                            $output .= 'mapOf( "a" to "b" )';
                         }
                     } else {
-                        $output .= 'mapOf("a" to "b")';
+                        $output .= 'mapOf( "a" to "b" )';
                     }
                     break;
                 case self::TYPE_FILE:

--- a/src/SDK/Language/Kotlin.php
+++ b/src/SDK/Language/Kotlin.php
@@ -245,10 +245,10 @@ class Kotlin extends Language
                         if (count($mapEntries) > 0) {
                             $output .= "mapOf(\n" . implode(",\n", $mapEntries) . "\n    )";
                         } else {
-                            $output .= 'mapOf()';
+                            $output .= 'mapOf("a" to "b")';
                         }
                     } else {
-                        $output .= 'mapOf()';
+                        $output .= 'mapOf("a" to "b")';
                     }
                     break;
                 case self::TYPE_FILE:

--- a/src/SDK/Language/Node.php
+++ b/src/SDK/Language/Node.php
@@ -142,9 +142,11 @@ class Node extends Web
         return match ($type) {
             self::TYPE_ARRAY, self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
             self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
-            self::TYPE_OBJECT => ($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
-            ? preg_replace('/\n/', "\n    ", $formatted)
-            : $example,
+            self::TYPE_OBJECT => ($example === '{}') 
+            ? '{}'
+            : (($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
+                ? preg_replace('/\n/', "\n    ", $formatted)
+                : $example),
             self::TYPE_STRING => "'{$example}'",
         };
     }

--- a/src/SDK/Language/Node.php
+++ b/src/SDK/Language/Node.php
@@ -133,7 +133,7 @@ class Node extends Web
             return match ($type) {
                 self::TYPE_ARRAY => '[]',
                 self::TYPE_BOOLEAN => 'false',
-                self::TYPE_FILE => 'InputFile(path: \'./path-to-files/image.jpg\', filename: \'image.jpg\')',
+                self::TYPE_FILE => 'InputFile.fromPath(\'/path/to/file\', \'filename\')',
                 self::TYPE_INTEGER, self::TYPE_NUMBER => '0',
                 self::TYPE_OBJECT => '{}',
                 self::TYPE_STRING => "''",

--- a/src/SDK/Language/Node.php
+++ b/src/SDK/Language/Node.php
@@ -127,65 +127,27 @@ class Node extends Web
         $type       = $param['type'] ?? '';
         $example    = $param['example'] ?? '';
 
-        $output = '';
+        $hasExample = !empty($example) || $example === 0 || $example === false;
 
-        if (empty($example) && $example !== 0 && $example !== false) {
-            switch ($type) {
-                case self::TYPE_NUMBER:
-                case self::TYPE_INTEGER:
-                case self::TYPE_BOOLEAN:
-                    $output .= 'null';
-                    break;
-                case self::TYPE_STRING:
-                    $output .= "''";
-                    break;
-                case self::TYPE_ARRAY:
-                    $output .= '[]';
-                    break;
-                case self::TYPE_OBJECT:
-                    $output .= '{}';
-                    break;
-                case self::TYPE_FILE:
-                    $output .= "InputFile.fromPath('/path/to/file', 'filename')";
-                    break;
-            }
-        } else {
-            switch ($type) {
-                case self::TYPE_NUMBER:
-                case self::TYPE_INTEGER:
-                case self::TYPE_ARRAY:
-                    $output .= $example;
-                    break;
-                case self::TYPE_OBJECT:
-                    $formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT);
-                    if ($formatted) {
-                        $lines = explode("\n", $formatted);
-                        $indentedLines = [];
-                        foreach ($lines as $i => $line) {
-                            if ($i === 0) {
-                                $indentedLines[] = $line; // First line doesn't need extra indent
-                            } else {
-                                $indentedLines[] = '    ' . $line; // Add 4 spaces for indentation
-                            }
-                        }
-                        $output .= implode("\n", $indentedLines);
-                    } else {
-                        $output .= $example;
-                    }
-                    break;
-                case self::TYPE_BOOLEAN:
-                    $output .= ($example) ? 'true' : 'false';
-                    break;
-                case self::TYPE_STRING:
-                    $output .= "'{$example}'";
-                    break;
-                case self::TYPE_FILE:
-                    $output .= "InputFile.fromPath('/path/to/file', 'filename')";
-                    break;
-            }
+        if (!$hasExample) {
+            return match ($type) {
+                self::TYPE_ARRAY => '[]',
+                self::TYPE_BOOLEAN => 'false',
+                self::TYPE_FILE => 'InputFile(path: \'./path-to-files/image.jpg\', filename: \'image.jpg\')',
+                self::TYPE_INTEGER, self::TYPE_NUMBER => '0',
+                self::TYPE_OBJECT => '{}',
+                self::TYPE_STRING => "''",
+            };
         }
 
-        return $output;
+        return match ($type) {
+            self::TYPE_ARRAY, self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
+            self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
+            self::TYPE_OBJECT => ($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
+            ? preg_replace('/\n/', "\n    ", $formatted)
+            : $example,
+            self::TYPE_STRING => "'{$example}'",
+        };
     }
 
     /**

--- a/src/SDK/Language/Node.php
+++ b/src/SDK/Language/Node.php
@@ -154,8 +154,24 @@ class Node extends Web
                 case self::TYPE_NUMBER:
                 case self::TYPE_INTEGER:
                 case self::TYPE_ARRAY:
-                case self::TYPE_OBJECT:
                     $output .= $example;
+                    break;
+                case self::TYPE_OBJECT:
+                    $formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT);
+                    if ($formatted) {
+                        $lines = explode("\n", $formatted);
+                        $indentedLines = [];
+                        foreach ($lines as $i => $line) {
+                            if ($i === 0) {
+                                $indentedLines[] = $line; // First line doesn't need extra indent
+                            } else {
+                                $indentedLines[] = '    ' . $line; // Add 4 spaces for indentation
+                            }
+                        }
+                        $output .= implode("\n", $indentedLines);
+                    } else {
+                        $output .= $example;
+                    }
                     break;
                 case self::TYPE_BOOLEAN:
                     $output .= ($example) ? 'true' : 'false';

--- a/src/SDK/Language/Node.php
+++ b/src/SDK/Language/Node.php
@@ -142,7 +142,7 @@ class Node extends Web
         return match ($type) {
             self::TYPE_ARRAY, self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
             self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
-            self::TYPE_OBJECT => ($example === '{}') 
+            self::TYPE_OBJECT => ($example === '{}')
             ? '{}'
             : (($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
                 ? preg_replace('/\n/', "\n    ", $formatted)

--- a/src/SDK/Language/Node.php
+++ b/src/SDK/Language/Node.php
@@ -132,9 +132,8 @@ class Node extends Web
         if (!$hasExample) {
             return match ($type) {
                 self::TYPE_ARRAY => '[]',
-                self::TYPE_BOOLEAN => 'false',
                 self::TYPE_FILE => 'InputFile.fromPath(\'/path/to/file\', \'filename\')',
-                self::TYPE_INTEGER, self::TYPE_NUMBER => '0',
+                self::TYPE_INTEGER, self::TYPE_NUMBER, self::TYPE_BOOLEAN => 'null',
                 self::TYPE_OBJECT => '{}',
                 self::TYPE_STRING => "''",
             };

--- a/src/SDK/Language/PHP.php
+++ b/src/SDK/Language/PHP.php
@@ -382,16 +382,37 @@ class PHP extends Language
      *
      * @var $data array
      */
-    protected function jsonToAssoc(array $data): string
+    protected function jsonToAssoc(array $data, int $indent = 0): string
     {
-        $output = '[';
-
-        foreach ($data as $key => $node) {
-            $value = (is_array($node)) ? $this->jsonToAssoc($node) : $node;
-            $output .= '\'' . $key . '\' => ' . ((is_string($node)) ? '\'' . $value . '\'' : $value) . (($key !== \array_key_last($data)) ? ', ' : '');
+        if (empty($data)) {
+            return '[]';
         }
 
-        $output .= ']';
+        $baseIndent = str_repeat('    ', $indent);
+        $itemIndent = str_repeat('    ', $indent + 1);
+        $output = "[\n";
+
+        $keys = array_keys($data);
+        foreach ($keys as $index => $key) {
+            $node = $data[$key];
+
+            if (is_array($node)) {
+                $value = $this->jsonToAssoc($node, $indent + 1);
+            } elseif (is_string($node)) {
+                $value = '\'' . $node . '\'';
+            } elseif (is_bool($node)) {
+                $value = $node ? 'true' : 'false';
+            } elseif (is_null($node)) {
+                $value = 'null';
+            } else {
+                $value = $node;
+            }
+
+            $comma = ($index < count($keys) - 1) ? ',' : '';
+            $output .= '    ' . $itemIndent . '\'' . $key . '\' => ' . $value . $comma . "\n";
+        }
+
+        $output .= $baseIndent . '    ]';
 
         return $output;
     }

--- a/src/SDK/Language/Python.php
+++ b/src/SDK/Language/Python.php
@@ -334,9 +334,11 @@ class Python extends Language
         return match ($type) {
             self::TYPE_ARRAY, self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
             self::TYPE_BOOLEAN => ($example) ? 'True' : 'False',
-            self::TYPE_OBJECT => ($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
-            ? preg_replace('/\n/', "\n    ", str_replace(['true', 'false'], ['True', 'False'], $formatted))
-            : $example,
+            self::TYPE_OBJECT => ($example === '{}')
+            ? '{}'
+            : (($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
+                ? preg_replace('/\n/', "\n    ", str_replace(['true', 'false'], ['True', 'False'], $formatted))
+                : $example),
             self::TYPE_STRING => "'{$example}'",
         };
     }

--- a/src/SDK/Language/Python.php
+++ b/src/SDK/Language/Python.php
@@ -324,9 +324,8 @@ class Python extends Language
         if (!$hasExample) {
             return match ($type) {
                 self::TYPE_ARRAY => '[]',
-                self::TYPE_BOOLEAN => 'False',
                 self::TYPE_FILE => 'InputFile.from_path(\'file.png\')',
-                self::TYPE_INTEGER, self::TYPE_NUMBER => '0',
+                self::TYPE_INTEGER, self::TYPE_NUMBER , self::TYPE_BOOLEAN => 'None',
                 self::TYPE_OBJECT => '{}',
                 self::TYPE_STRING => "''",
             };

--- a/src/SDK/Language/Python.php
+++ b/src/SDK/Language/Python.php
@@ -325,7 +325,7 @@ class Python extends Language
             return match ($type) {
                 self::TYPE_ARRAY => '[]',
                 self::TYPE_BOOLEAN => 'False',
-                self::TYPE_FILE => 'InputFile(path: \'./path-to-files/image.jpg\', filename: \'image.jpg\')',
+                self::TYPE_FILE => 'InputFile.from_path(\'file.png\')',
                 self::TYPE_INTEGER, self::TYPE_NUMBER => '0',
                 self::TYPE_OBJECT => '{}',
                 self::TYPE_STRING => "''",

--- a/src/SDK/Language/Python.php
+++ b/src/SDK/Language/Python.php
@@ -346,8 +346,26 @@ class Python extends Language
                 case self::TYPE_NUMBER:
                 case self::TYPE_INTEGER:
                 case self::TYPE_ARRAY:
-                case self::TYPE_OBJECT:
                     $output .= $example;
+                    break;
+                case self::TYPE_OBJECT:
+                    $formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT);
+                    if ($formatted) {
+                        $formatted = str_replace(['true', 'false'], ['True', 'False'], $formatted);
+
+                        $lines = explode("\n", $formatted);
+                        $indentedLines = [];
+                        foreach ($lines as $i => $line) {
+                            if ($i === 0) {
+                                $indentedLines[] = $line; // First line doesn't need extra indent
+                            } else {
+                                $indentedLines[] = '    ' . $line; // Add 4 spaces for indentation
+                            }
+                        }
+                        $output .= implode("\n", $indentedLines);
+                    } else {
+                        $output .= $example;
+                    }
                     break;
                 case self::TYPE_BOOLEAN:
                     $output .= ($example) ? 'True' : 'False';

--- a/src/SDK/Language/Python.php
+++ b/src/SDK/Language/Python.php
@@ -319,67 +319,27 @@ class Python extends Language
         $type = $param['type'] ?? '';
         $example = $param['example'] ?? '';
 
-        $output = '';
+        $hasExample = !empty($example) || $example === 0 || $example === false;
 
-        if (empty($example) && $example !== 0 && $example !== false) {
-            switch ($type) {
-                case self::TYPE_NUMBER:
-                case self::TYPE_INTEGER:
-                case self::TYPE_BOOLEAN:
-                    $output .= 'None';
-                    break;
-                case self::TYPE_STRING:
-                    $output .= "''";
-                    break;
-                case self::TYPE_ARRAY:
-                    $output .= '[]';
-                    break;
-                case self::TYPE_OBJECT:
-                    $output .= '{}';
-                    break;
-                case self::TYPE_FILE:
-                    $output .= "InputFile.from_path('file.png')";
-                    break;
-            }
-        } else {
-            switch ($type) {
-                case self::TYPE_NUMBER:
-                case self::TYPE_INTEGER:
-                case self::TYPE_ARRAY:
-                    $output .= $example;
-                    break;
-                case self::TYPE_OBJECT:
-                    $formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT);
-                    if ($formatted) {
-                        $formatted = str_replace(['true', 'false'], ['True', 'False'], $formatted);
-
-                        $lines = explode("\n", $formatted);
-                        $indentedLines = [];
-                        foreach ($lines as $i => $line) {
-                            if ($i === 0) {
-                                $indentedLines[] = $line; // First line doesn't need extra indent
-                            } else {
-                                $indentedLines[] = '    ' . $line; // Add 4 spaces for indentation
-                            }
-                        }
-                        $output .= implode("\n", $indentedLines);
-                    } else {
-                        $output .= $example;
-                    }
-                    break;
-                case self::TYPE_BOOLEAN:
-                    $output .= ($example) ? 'True' : 'False';
-                    break;
-                case self::TYPE_STRING:
-                    $output .= "'{$example}'";
-                    break;
-                case self::TYPE_FILE:
-                    $output .= "InputFile.from_path('file.png')";
-                    break;
-            }
+        if (!$hasExample) {
+            return match ($type) {
+                self::TYPE_ARRAY => '[]',
+                self::TYPE_BOOLEAN => 'False',
+                self::TYPE_FILE => 'InputFile(path: \'./path-to-files/image.jpg\', filename: \'image.jpg\')',
+                self::TYPE_INTEGER, self::TYPE_NUMBER => '0',
+                self::TYPE_OBJECT => '{}',
+                self::TYPE_STRING => "''",
+            };
         }
 
-        return $output;
+        return match ($type) {
+            self::TYPE_ARRAY, self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
+            self::TYPE_BOOLEAN => ($example) ? 'True' : 'False',
+            self::TYPE_OBJECT => ($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
+            ? preg_replace('/\n/', "\n    ", str_replace(['true', 'false'], ['True', 'False'], $formatted))
+            : $example,
+            self::TYPE_STRING => "'{$example}'",
+        };
     }
 
     public function getFilters(): array

--- a/src/SDK/Language/REST.php
+++ b/src/SDK/Language/REST.php
@@ -104,6 +104,22 @@ e8 ee 55 94 29 e7 94 89 19 26 28 01 26 29 3f 16...';
         } else {
             switch ($type) {
                 case self::TYPE_OBJECT:
+                    $formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT);
+                    if ($formatted) {
+                        $lines = explode("\n", $formatted);
+                        $indentedLines = [];
+                        foreach ($lines as $i => $line) {
+                            if ($i === count($lines) - 1) { // just add space in last line
+                                $indentedLines[] = '  ' . $line;
+                            } else {
+                                $indentedLines[] = $line;
+                            }
+                        }
+                        $output .= implode("\n", $indentedLines);
+                    } else {
+                        $output .= $example;
+                    }
+                    break;
                 case self::TYPE_FILE:
                 case self::TYPE_NUMBER:
                 case self::TYPE_INTEGER:

--- a/src/SDK/Language/REST.php
+++ b/src/SDK/Language/REST.php
@@ -90,7 +90,19 @@ class REST extends HTTP
         }
 
         return match ($type) {
-            self::TYPE_ARRAY, self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
+            self::TYPE_ARRAY => (function () use ($example) {
+                // If array of strings, make sure any sub-strings are escaped
+                if (\substr($example, 1, 1) === '"') {
+                    $start = \substr($example, 0, 2);
+                    $end = \substr($example, -2);
+                    $contents = \substr($example, 2, -2);
+                    $contents = \addslashes($contents);
+                    return $start . $contents . $end;
+                } else {
+                    return $example;
+                }
+            })(),
+            self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
             self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
             self::TYPE_OBJECT => ($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
                 ? (function () use ($formatted) {

--- a/src/SDK/Language/REST.php
+++ b/src/SDK/Language/REST.php
@@ -85,7 +85,7 @@ class REST extends HTTP
                 self::TYPE_FILE => 'cf 94 84 24 8d c4 91 10 0f dc 54 26 6c 8e 4b bc e8 ee 55 94 29 e7 94 89 19 26 28 01 26 29 3f 16...',
                 self::TYPE_INTEGER, self::TYPE_NUMBER => '0',
                 self::TYPE_OBJECT => '{}',
-                self::TYPE_STRING => "''",
+                self::TYPE_STRING => '""',
             };
         }
 
@@ -93,9 +93,15 @@ class REST extends HTTP
             self::TYPE_ARRAY, self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
             self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
             self::TYPE_OBJECT => ($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
-            ? preg_replace(['/^    /m', '/\n(?=[^}]*}$)/'], ['  ', "\n  "], $formatted)
-            : $example,
-            self::TYPE_STRING => "'{$example}'",
+                ? (function () use ($formatted) {
+                    // Replace leading four spaces with two spaces for indentation
+                    $formatted = preg_replace('/^    /m', '  ', $formatted);
+                    // Add two spaces before the closing brace if it's on a new line at the end
+                    $formatted = preg_replace('/\n(?=[^}]*}$)/', "\n  ", $formatted);
+                    return $formatted;
+                })()
+                : $example,
+            self::TYPE_STRING => "\"{$example}\"",
         };
     }
 

--- a/src/SDK/Language/REST.php
+++ b/src/SDK/Language/REST.php
@@ -104,15 +104,17 @@ class REST extends HTTP
             })(),
             self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
             self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
-            self::TYPE_OBJECT => ($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
-                ? (function () use ($formatted) {
-                    // Replace leading four spaces with two spaces for indentation
-                    $formatted = preg_replace('/^    /m', '  ', $formatted);
-                    // Add two spaces before the closing brace if it's on a new line at the end
-                    $formatted = preg_replace('/\n(?=[^}]*}$)/', "\n  ", $formatted);
-                    return $formatted;
-                })()
-                : $example,
+            self::TYPE_OBJECT => ($example === '{}') 
+                ? '{}'
+                : (($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
+                    ? (function () use ($formatted) {
+                        // Replace leading four spaces with two spaces for indentation
+                        $formatted = preg_replace('/^    /m', '  ', $formatted);
+                        // Add two spaces before the closing brace if it's on a new line at the end
+                        $formatted = preg_replace('/\n(?=[^}]*}$)/', "\n  ", $formatted);
+                        return $formatted;
+                    })()
+                    : $example),
             self::TYPE_STRING => "\"{$example}\"",
         };
     }

--- a/src/SDK/Language/REST.php
+++ b/src/SDK/Language/REST.php
@@ -104,7 +104,7 @@ class REST extends HTTP
             })(),
             self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
             self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
-            self::TYPE_OBJECT => ($example === '{}') 
+            self::TYPE_OBJECT => ($example === '{}')
                 ? '{}'
                 : (($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
                     ? (function () use ($formatted) {

--- a/src/SDK/Language/ReactNative.php
+++ b/src/SDK/Language/ReactNative.php
@@ -190,65 +190,27 @@ class ReactNative extends Web
         $type       = $param['type'] ?? '';
         $example    = $param['example'] ?? '';
 
-        $output = '';
+        $hasExample = !empty($example) || $example === 0 || $example === false;
 
-        if (empty($example) && $example !== 0 && $example !== false) {
-            switch ($type) {
-                case self::TYPE_NUMBER:
-                case self::TYPE_INTEGER:
-                case self::TYPE_BOOLEAN:
-                    $output .= 'null';
-                    break;
-                case self::TYPE_STRING:
-                    $output .= "''";
-                    break;
-                case self::TYPE_ARRAY:
-                    $output .= '[]';
-                    break;
-                case self::TYPE_OBJECT:
-                    $output .= '{}';
-                    break;
-                case self::TYPE_FILE:
-                    $output .= "await pickSingle()";
-                    break;
-            }
-        } else {
-            switch ($type) {
-                case self::TYPE_NUMBER:
-                case self::TYPE_INTEGER:
-                case self::TYPE_ARRAY:
-                    $output .= $example;
-                    break;
-                case self::TYPE_OBJECT:
-                    $formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT);
-                    if ($formatted) {
-                        $lines = explode("\n", $formatted);
-                        $indentedLines = [];
-                        foreach ($lines as $i => $line) {
-                            if ($i === 0) {
-                                $indentedLines[] = $line; // First line doesn't need extra indent
-                            } else {
-                                $indentedLines[] = '    ' . $line; // Add 4 spaces for indentation
-                            }
-                        }
-                        $output .= implode("\n", $indentedLines);
-                    } else {
-                        $output .= $example;
-                    }
-                    break;
-                case self::TYPE_BOOLEAN:
-                    $output .= ($example) ? 'true' : 'false';
-                    break;
-                case self::TYPE_STRING:
-                    $output .= "'{$example}'";
-                    break;
-                case self::TYPE_FILE:
-                    $output .= "await pickSingle()";
-                    break;
-            }
+        if (!$hasExample) {
+            return match ($type) {
+                self::TYPE_ARRAY => '[]',
+                self::TYPE_BOOLEAN => 'false',
+                self::TYPE_FILE => 'InputFile(path: \'./path-to-files/image.jpg\', filename: \'image.jpg\')',
+                self::TYPE_INTEGER, self::TYPE_NUMBER => '0',
+                self::TYPE_OBJECT => '{}',
+                self::TYPE_STRING => "''",
+            };
         }
 
-        return $output;
+        return match ($type) {
+            self::TYPE_ARRAY, self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
+            self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
+            self::TYPE_OBJECT => ($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
+            ? preg_replace('/\n/', "\n    ", $formatted)
+            : $example,
+            self::TYPE_STRING => "'{$example}'",
+        };
     }
 
     public function getReturn(array $method, array $spec): string

--- a/src/SDK/Language/ReactNative.php
+++ b/src/SDK/Language/ReactNative.php
@@ -196,7 +196,7 @@ class ReactNative extends Web
             return match ($type) {
                 self::TYPE_ARRAY => '[]',
                 self::TYPE_BOOLEAN => 'false',
-                self::TYPE_FILE => 'InputFile(path: \'./path-to-files/image.jpg\', filename: \'image.jpg\')',
+                self::TYPE_FILE => 'InputFile.fromPath(\'/path/to/file\', \'filename\')',
                 self::TYPE_INTEGER, self::TYPE_NUMBER => '0',
                 self::TYPE_OBJECT => '{}',
                 self::TYPE_STRING => "''",

--- a/src/SDK/Language/ReactNative.php
+++ b/src/SDK/Language/ReactNative.php
@@ -217,8 +217,24 @@ class ReactNative extends Web
                 case self::TYPE_NUMBER:
                 case self::TYPE_INTEGER:
                 case self::TYPE_ARRAY:
-                case self::TYPE_OBJECT:
                     $output .= $example;
+                    break;
+                case self::TYPE_OBJECT:
+                    $formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT);
+                    if ($formatted) {
+                        $lines = explode("\n", $formatted);
+                        $indentedLines = [];
+                        foreach ($lines as $i => $line) {
+                            if ($i === 0) {
+                                $indentedLines[] = $line; // First line doesn't need extra indent
+                            } else {
+                                $indentedLines[] = '    ' . $line; // Add 4 spaces for indentation
+                            }
+                        }
+                        $output .= implode("\n", $indentedLines);
+                    } else {
+                        $output .= $example;
+                    }
                     break;
                 case self::TYPE_BOOLEAN:
                     $output .= ($example) ? 'true' : 'false';

--- a/src/SDK/Language/ReactNative.php
+++ b/src/SDK/Language/ReactNative.php
@@ -206,7 +206,7 @@ class ReactNative extends Web
         return match ($type) {
             self::TYPE_ARRAY, self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
             self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
-            self::TYPE_OBJECT => ($example === '{}') 
+            self::TYPE_OBJECT => ($example === '{}')
             ? '{}'
             : (($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
                 ? preg_replace('/\n/', "\n    ", $formatted)

--- a/src/SDK/Language/ReactNative.php
+++ b/src/SDK/Language/ReactNative.php
@@ -206,9 +206,11 @@ class ReactNative extends Web
         return match ($type) {
             self::TYPE_ARRAY, self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
             self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
-            self::TYPE_OBJECT => ($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
-            ? preg_replace('/\n/', "\n    ", $formatted)
-            : $example,
+            self::TYPE_OBJECT => ($example === '{}') 
+            ? '{}'
+            : (($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
+                ? preg_replace('/\n/', "\n    ", $formatted)
+                : $example),
             self::TYPE_STRING => "'{$example}'",
         };
     }

--- a/src/SDK/Language/Ruby.php
+++ b/src/SDK/Language/Ruby.php
@@ -338,7 +338,7 @@ class Ruby extends Language
         $output = "{\n";
         $indentStr = str_repeat('  ', $indent + 4);
         $keys = array_keys($data);
-        
+
         foreach ($data as $key => $node) {
             if (is_array($node)) {
                 $value = $this->jsonToHash($node, $indent + 1);
@@ -349,14 +349,14 @@ class Ruby extends Language
             } else {
                 $value = $node;
             }
-            
+
             $output .= $indentStr . '"' . $key . '" => ' . $value;
-            
+
             // Add comma if not the last item
             if ($key !== end($keys)) {
                 $output .= ',';
             }
-            
+
             $output .= "\n";
         }
 

--- a/src/SDK/Language/Ruby.php
+++ b/src/SDK/Language/Ruby.php
@@ -329,16 +329,38 @@ class Ruby extends Language
      * @return string
      * @var $data array
      */
-    protected function jsonToHash(array $data): string
+    protected function jsonToHash(array $data, int $indent = 0): string
     {
-        $output = '{';
-
-        foreach ($data as $key => $node) {
-            $value = (is_array($node)) ? $this->jsonToHash($node) : $node;
-            $output .= '"' . $key . '" => ' . ((is_string($node)) ? '"' . $value . '"' : $value) . (($key !== array_key_last($data)) ? ', ' : '');
+        if (empty($data)) {
+            return '{}';
         }
 
-        $output .= '}';
+        $output = "{\n";
+        $indentStr = str_repeat('  ', $indent + 4);
+        $keys = array_keys($data);
+        
+        foreach ($data as $key => $node) {
+            if (is_array($node)) {
+                $value = $this->jsonToHash($node, $indent + 1);
+            } elseif (is_bool($node)) {
+                $value = $node ? 'true' : 'false';
+            } elseif (is_string($node)) {
+                $value = '"' . $node . '"';
+            } else {
+                $value = $node;
+            }
+            
+            $output .= $indentStr . '"' . $key . '" => ' . $value;
+            
+            // Add comma if not the last item
+            if ($key !== end($keys)) {
+                $output .= ',';
+            }
+            
+            $output .= "\n";
+        }
+
+        $output .= str_repeat('  ', $indent + 2) . '}';
 
         return $output;
     }

--- a/src/SDK/Language/Swift.php
+++ b/src/SDK/Language/Swift.php
@@ -435,10 +435,57 @@ class Swift extends Language
                     $output .= "\"{$example}\"";
                     break;
                 case self::TYPE_OBJECT:
-                    $output .= '[:]';
+                    $decoded = json_decode($example, true);
+                    if ($decoded && is_array($decoded)) {
+                        $output .= $this->jsonToSwiftDict($decoded);
+                    } else {
+                        $output .= '[:]';
+                    }
                     break;
             }
         }
+
+        return $output;
+    }
+
+    /**
+     * Converts JSON Object To Swift Native Dictionary
+     *
+     * @param array $data
+     * @param int $indent
+     * @return string
+     */
+    protected function jsonToSwiftDict(array $data, int $indent = 0): string
+    {
+        if (empty($data)) {
+            return '[:]';
+        }
+
+        $baseIndent = str_repeat('    ', $indent);
+        $itemIndent = str_repeat('    ', $indent + 1);
+        $output = "[\n";
+
+        $keys = array_keys($data);
+        foreach ($keys as $index => $key) {
+            $node = $data[$key];
+
+            if (is_array($node)) {
+                $value = $this->jsonToSwiftDict($node, $indent + 1);
+            } elseif (is_string($node)) {
+                $value = '"' . $node . '"';
+            } elseif (is_bool($node)) {
+                $value = $node ? 'true' : 'false';
+            } elseif (is_null($node)) {
+                $value = 'nil';
+            } else {
+                $value = $node;
+            }
+
+            $comma = ($index < count($keys) - 1) ? ',' : '';
+            $output .= '    ' . $itemIndent . '"' . $key . '": ' . $value . $comma . "\n";
+        }
+
+        $output .= '    ' . $baseIndent . ']';
 
         return $output;
     }

--- a/src/SDK/Language/Web.php
+++ b/src/SDK/Language/Web.php
@@ -148,7 +148,7 @@ class Web extends JS
             self::TYPE_ARRAY, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
             self::TYPE_FILE => 'document.getElementById(\'uploader/\').files[0]',
             self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
-            self::TYPE_OBJECT => ($example === '{}') 
+            self::TYPE_OBJECT => ($example === '{}')
             ? '{}'
             : (($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
                 ? preg_replace('/\n/', "\n    ", $formatted)

--- a/src/SDK/Language/Web.php
+++ b/src/SDK/Language/Web.php
@@ -138,7 +138,7 @@ class Web extends JS
             return match ($type) {
                 self::TYPE_ARRAY => '[]',
                 self::TYPE_BOOLEAN => 'false',
-                self::TYPE_FILE => 'InputFile.fromPath(\'/path/to/file\', \'filename\')',
+                self::TYPE_FILE => 'document.getElementById(\'uploader/\').files[0]',
                 self::TYPE_INTEGER, self::TYPE_NUMBER => '0',
                 self::TYPE_OBJECT => '{}',
                 self::TYPE_STRING => "''",
@@ -146,7 +146,8 @@ class Web extends JS
         }
 
         return match ($type) {
-            self::TYPE_ARRAY, self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
+            self::TYPE_ARRAY, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
+            self::TYPE_FILE => 'document.getElementById(\'uploader/\').files[0]',
             self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
             self::TYPE_OBJECT => ($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
             ? preg_replace('/\n/', "\n    ", $formatted)

--- a/src/SDK/Language/Web.php
+++ b/src/SDK/Language/Web.php
@@ -137,9 +137,8 @@ class Web extends JS
         if (!$hasExample) {
             return match ($type) {
                 self::TYPE_ARRAY => '[]',
-                self::TYPE_BOOLEAN => 'false',
                 self::TYPE_FILE => 'document.getElementById(\'uploader/\').files[0]',
-                self::TYPE_INTEGER, self::TYPE_NUMBER => '0',
+                self::TYPE_INTEGER, self::TYPE_NUMBER, self::TYPE_BOOLEAN => 'null',
                 self::TYPE_OBJECT => '{}',
                 self::TYPE_STRING => "''",
             };
@@ -149,9 +148,11 @@ class Web extends JS
             self::TYPE_ARRAY, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
             self::TYPE_FILE => 'document.getElementById(\'uploader/\').files[0]',
             self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
-            self::TYPE_OBJECT => ($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
-            ? preg_replace('/\n/', "\n    ", $formatted)
-            : $example,
+            self::TYPE_OBJECT => ($example === '{}') 
+            ? '{}'
+            : (($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
+                ? preg_replace('/\n/', "\n    ", $formatted)
+                : $example),
             self::TYPE_STRING => "'{$example}'",
         };
     }

--- a/src/SDK/Language/Web.php
+++ b/src/SDK/Language/Web.php
@@ -138,7 +138,7 @@ class Web extends JS
             return match ($type) {
                 self::TYPE_ARRAY => '[]',
                 self::TYPE_BOOLEAN => 'false',
-                self::TYPE_FILE => 'InputFile(path: \'./path-to-files/image.jpg\', filename: \'image.jpg\')',
+                self::TYPE_FILE => 'InputFile.fromPath(\'/path/to/file\', \'filename\')',
                 self::TYPE_INTEGER, self::TYPE_NUMBER => '0',
                 self::TYPE_OBJECT => '{}',
                 self::TYPE_STRING => "''",

--- a/src/SDK/Language/Web.php
+++ b/src/SDK/Language/Web.php
@@ -159,8 +159,24 @@ class Web extends JS
                 case self::TYPE_NUMBER:
                 case self::TYPE_INTEGER:
                 case self::TYPE_ARRAY:
-                case self::TYPE_OBJECT:
                     $output .= $example;
+                    break;
+                case self::TYPE_OBJECT:
+                    $formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT);
+                    if ($formatted) {
+                        $lines = explode("\n", $formatted);
+                        $indentedLines = [];
+                        foreach ($lines as $i => $line) {
+                            if ($i === 0) {
+                                $indentedLines[] = $line; // First line doesn't need extra indent
+                            } else {
+                                $indentedLines[] = '    ' . $line; // Add 4 spaces for indentation
+                            }
+                        }
+                        $output .= implode("\n", $indentedLines);
+                    } else {
+                        $output .= $example;
+                    }
                     break;
                 case self::TYPE_BOOLEAN:
                     $output .= ($example) ? 'true' : 'false';

--- a/src/SDK/Language/Web.php
+++ b/src/SDK/Language/Web.php
@@ -132,65 +132,27 @@ class Web extends JS
         $type       = $param['type'] ?? '';
         $example    = $param['example'] ?? '';
 
-        $output = '';
+        $hasExample = !empty($example) || $example === 0 || $example === false;
 
-        if (empty($example) && $example !== 0 && $example !== false) {
-            switch ($type) {
-                case self::TYPE_NUMBER:
-                case self::TYPE_INTEGER:
-                case self::TYPE_BOOLEAN:
-                    $output .= 'null';
-                    break;
-                case self::TYPE_STRING:
-                    $output .= "''";
-                    break;
-                case self::TYPE_ARRAY:
-                    $output .= '[]';
-                    break;
-                case self::TYPE_OBJECT:
-                    $output .= '{}';
-                    break;
-                case self::TYPE_FILE:
-                    $output .= "document.getElementById('uploader').files[0]";
-                    break;
-            }
-        } else {
-            switch ($type) {
-                case self::TYPE_NUMBER:
-                case self::TYPE_INTEGER:
-                case self::TYPE_ARRAY:
-                    $output .= $example;
-                    break;
-                case self::TYPE_OBJECT:
-                    $formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT);
-                    if ($formatted) {
-                        $lines = explode("\n", $formatted);
-                        $indentedLines = [];
-                        foreach ($lines as $i => $line) {
-                            if ($i === 0) {
-                                $indentedLines[] = $line; // First line doesn't need extra indent
-                            } else {
-                                $indentedLines[] = '    ' . $line; // Add 4 spaces for indentation
-                            }
-                        }
-                        $output .= implode("\n", $indentedLines);
-                    } else {
-                        $output .= $example;
-                    }
-                    break;
-                case self::TYPE_BOOLEAN:
-                    $output .= ($example) ? 'true' : 'false';
-                    break;
-                case self::TYPE_STRING:
-                    $output .= "'{$example}'";
-                    break;
-                case self::TYPE_FILE:
-                    $output .= "document.getElementById('uploader').files[0]";
-                    break;
-            }
+        if (!$hasExample) {
+            return match ($type) {
+                self::TYPE_ARRAY => '[]',
+                self::TYPE_BOOLEAN => 'false',
+                self::TYPE_FILE => 'InputFile(path: \'./path-to-files/image.jpg\', filename: \'image.jpg\')',
+                self::TYPE_INTEGER, self::TYPE_NUMBER => '0',
+                self::TYPE_OBJECT => '{}',
+                self::TYPE_STRING => "''",
+            };
         }
 
-        return $output;
+        return match ($type) {
+            self::TYPE_ARRAY, self::TYPE_FILE, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
+            self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
+            self::TYPE_OBJECT => ($formatted = json_encode(json_decode($example, true), JSON_PRETTY_PRINT))
+            ? preg_replace('/\n/', "\n    ", $formatted)
+            : $example,
+            self::TYPE_STRING => "'{$example}'",
+        };
     }
 
     public function getReadOnlyProperties(array $parameter, string $responseModel, array $spec = []): array

--- a/src/SDK/Language/Web.php
+++ b/src/SDK/Language/Web.php
@@ -137,7 +137,7 @@ class Web extends JS
         if (!$hasExample) {
             return match ($type) {
                 self::TYPE_ARRAY => '[]',
-                self::TYPE_FILE => 'document.getElementById(\'uploader/\').files[0]',
+                self::TYPE_FILE => 'document.getElementById(\'uploader\').files[0]',
                 self::TYPE_INTEGER, self::TYPE_NUMBER, self::TYPE_BOOLEAN => 'null',
                 self::TYPE_OBJECT => '{}',
                 self::TYPE_STRING => "''",
@@ -146,7 +146,7 @@ class Web extends JS
 
         return match ($type) {
             self::TYPE_ARRAY, self::TYPE_INTEGER, self::TYPE_NUMBER => $example,
-            self::TYPE_FILE => 'document.getElementById(\'uploader/\').files[0]',
+            self::TYPE_FILE => 'document.getElementById(\'uploader\').files[0]',
             self::TYPE_BOOLEAN => ($example) ? 'true' : 'false',
             self::TYPE_OBJECT => ($example === '{}')
             ? '{}'


### PR DESCRIPTION
## Summary by CodeRabbit

* **Style**
  * Object parameter examples in generated snippets are now pretty-printed and indented across SDKs (Dart, Deno, GraphQL, Kotlin, Node, PHP, Python, REST, React Native, Web) for improved readability.
* **Documentation**
  * Updated the API specification source URL used to build the SSL page, ensuring examples and formatting reflect the latest specification content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consistent, pretty-printed multi-line object examples across many SDKs; strings and booleans rendered predictably.
  * Clear per-type defaults when examples are missing (arrays, booleans, files, numbers, objects, strings).
  * Kotlin: dynamic mapOf generation from JSON examples.

* **Refactor**
  * Unified guard-and-match example generation with consistent indentation and robust formatting fallbacks; small internal helper signature additions to support indentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->