### PR TITLE
fix: type generation with tablesdb

### DIFF
--- a/templates/cli/lib/commands/types.js.twig
+++ b/templates/cli/lib/commands/types.js.twig
@@ -141,15 +141,17 @@ const typesCommand = actionRunner(async (rawOutputDirectory, {language, strict})
 
   log(`Found ${dataItems.length} ${itemType}: ${dataItems.map(c => c.name).join(", ")}`);
 
+  // Use columns if available, otherwise use attributes
+  const resourceType = tables.length > 0 ? 'columns' : 'attributes';
+
   const totalAttributes = dataItems.reduce((count, item) => count + (item.attributes || []).length, 0);
-  log(`Found ${totalAttributes} attributes across all ${itemType}`);
+  log(`Found ${totalAttributes} ${resourceType} across all ${itemType}`);
 
   const templater = ejs.compile(meta.getTemplate());
 
   if (meta.isSingleFile()) {
     const content = templater({
       collections: dataItems,
-      tables: dataItems,
       strict,
       ...templateHelpers,
       getType: meta.getType,

--- a/templates/cli/lib/commands/types.js.twig
+++ b/templates/cli/lib/commands/types.js.twig
@@ -100,22 +100,56 @@ const typesCommand = actionRunner(async (rawOutputDirectory, {language, strict})
     fs.mkdirSync(outputDirectory, { recursive: true });
   }
 
-  const collections = localConfig.getCollections();
-  if (collections.length === 0) {
-    const configFileName = path.basename(localConfig.path);
-    throw new Error(`No collections found in configuration. Make sure ${configFileName} exists and contains collections.`);
+  // Try tables first, fallback to collections
+  let tables = localConfig.getTables();
+  let collections = [];
+  let dataSource = 'tables';
+  
+  if (tables.length === 0) {
+    collections = localConfig.getCollections();
+    dataSource = 'collections';
+    
+    if (collections.length === 0) {
+      const configFileName = path.basename(localConfig.path);
+      throw new Error(`No tables or collections found in configuration. Make sure ${configFileName} exists and contains tables or collections.`);
+    }
   }
 
-  log(`Found ${collections.length} collections: ${collections.map(c => c.name).join(", ")}`);
+  // Use tables if available, otherwise use collections
+  let dataItems = tables.length > 0 ? tables : collections;
+  const itemType = tables.length > 0 ? 'tables' : 'collections';
 
-  const totalAttributes = collections.reduce((count, collection) => count + collection.attributes.length, 0);
-  log(`Found ${totalAttributes} attributes across all collections`);
+  // Normalize tables data: rename 'columns' to 'attributes' for template compatibility
+  if (tables.length > 0) {
+    dataItems = dataItems.map(table => {
+      const { columns, ...rest } = table;
+      return {
+        ...rest,
+        attributes: (columns || []).map(column => {
+          if (column.relatedTable) {
+            const { relatedTable, ...columnRest } = column;
+            return {
+              ...columnRest,
+              relatedCollection: relatedTable
+            };
+          }
+          return column;
+        })
+      };
+    });
+  }
+
+  log(`Found ${dataItems.length} ${itemType}: ${dataItems.map(c => c.name).join(", ")}`);
+
+  const totalAttributes = dataItems.reduce((count, item) => count + (item.attributes || []).length, 0);
+  log(`Found ${totalAttributes} attributes across all ${itemType}`);
 
   const templater = ejs.compile(meta.getTemplate());
 
   if (meta.isSingleFile()) {
     const content = templater({
-      collections,
+      collections: dataItems,
+      tables: dataItems,
       strict,
       ...templateHelpers,
       getType: meta.getType,
@@ -126,23 +160,23 @@ const typesCommand = actionRunner(async (rawOutputDirectory, {language, strict})
     fs.writeFileSync(destination, content);
     log(`Added types to ${destination}`);
   } else {
-    for (const collection of collections) {
+    for (const item of dataItems) {
       const content = templater({
-        collections,
-        collection,
+        collections: dataItems,
+        collection: item,
         strict,
         ...templateHelpers,
         getType: meta.getType,
       });
   
-      const destination = path.join(outputDirectory, meta.getFileName(collection));
+      const destination = path.join(outputDirectory, meta.getFileName(item));
   
       fs.writeFileSync(destination, content);
-      log(`Added types for ${collection.name} to ${destination}`);
+      log(`Added types for ${item.name} to ${destination}`);
     }
   }
   
-  success(`Generated types for all the listed collections`);
+  success(`Generated types for all the listed ${itemType}`);
 });
 
 const types = new Command("types")

--- a/templates/cli/lib/config.js.twig
+++ b/templates/cli/lib/config.js.twig
@@ -55,7 +55,7 @@ const KeysColumns = new Set([
     // enum
     "elements",
     // relationship
-    "relatedCollection",
+    "relatedTable",
     "relationType",
     "twoWay",
     "twoWayKey",


### PR DESCRIPTION
## Test Plan
both tables and collections work:
<img width="853" height="191" alt="Screenshot 2025-09-05 at 10 16 14 AM" src="https://github.com/user-attachments/assets/bcfa8ae0-19f8-4aef-a06b-c82b1a3195c8" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support configuration via tables or collections, with clear errors when neither is provided.
  * Per-item generation for single- and multi-file templates, with destination names derived from each item.
  * Logs now show the actual data source and attribute counts; success messages reference the correct item type.
  * Columns configuration accepts an updated relationship key.

* **Refactor**
  * Unified processing across tables and collections to streamline generation and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->