### PR TITLE
fix: wrap invalid variable names in quotes in ts type generation

### DIFF
--- a/templates/cli/lib/type-generation/languages/typescript.js.twig
+++ b/templates/cli/lib/type-generation/languages/typescript.js.twig
@@ -90,7 +90,9 @@ export enum <%- toPascalCase(attribute.key) %> {
 <% for (const [index, collection] of Object.entries(collections)) { -%>
 export type <%- toPascalCase(collection.name) %> = Models.Row & {
 <% for (const attribute of collection.attributes) { -%>
-    <%- strict ? toCamelCase(attribute.key) : attribute.key %>: <%- getType(attribute, collections) %>;
+<% const propertyName = strict ? toCamelCase(attribute.key) : attribute.key; -%>
+<% const isValidIdentifier = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(propertyName); -%>
+    <% if (isValidIdentifier) { %><%- propertyName %><% } else { %>"<%- propertyName %>"<% } %>: <%- getType(attribute, collections) %>;
 <% } -%>
 }<% if (index < collections.length - 1) { %>
 <% } %>


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Generated TypeScript definitions now correctly quote collection attribute keys that aren’t valid identifiers, preventing syntax errors in appwrite.d.ts.
  - Improves compatibility with keys containing spaces, dashes, or other non-alphanumeric characters without altering the underlying types.
  - Affects only how keys are declared in exported collection types; existing type mappings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->