### PR TITLE
fix: print sdk warnings to stderr instead of stdout

### DIFF
--- a/templates/android/library/src/main/java/io/package/Client.kt.twig
+++ b/templates/android/library/src/main/java/io/package/Client.kt.twig
@@ -507,7 +507,7 @@ class Client @JvmOverloads constructor(
                 val warnings = response.headers["x-{{ spec.title | lower }}-warning"]
                 if (warnings != null) {
                     warnings.split(";").forEach { warning ->
-                        println("Warning: $warning")
+                        System.err.println("Warning: $warning")
                     }
                 }
 

--- a/templates/apple/Sources/Client.swift.twig
+++ b/templates/apple/Sources/Client.swift.twig
@@ -304,7 +304,7 @@ open class Client {
 
         if let warning = response.headers["x-{{ spec.title | lower }}-warning"].first {
             warning.split(separator: ";").forEach { warning in
-                print("Warning: \(warning)")
+                fputs("Warning: \(warning)\n", stderr)
             }
         }
 

--- a/templates/dotnet/Package/Client.cs.twig
+++ b/templates/dotnet/Package/Client.cs.twig
@@ -293,7 +293,7 @@ namespace {{ spec.title | caseUcfirst }}
             {
                 foreach (var warning in warnings)
                 {
-                    Console.WriteLine("Warning: " + warning);
+                    Console.Error.WriteLine("Warning: " + warning);
                 }
             }
 

--- a/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
@@ -552,7 +552,7 @@ class Client @JvmOverloads constructor(
                 val warnings = response.headers["x-{{ spec.title | lower }}-warning"]
                 if (warnings != null) {
                     warnings.split(";").forEach { warning ->
-                        println("Warning: $warning")
+                        System.err.println("Warning: $warning")
                     }
                 }
 

--- a/templates/python/package/client.py.twig
+++ b/templates/python/package/client.py.twig
@@ -2,6 +2,7 @@ import io
 import json
 import os
 import platform
+import sys
 import requests
 from .input_file import InputFile
 from .exception import {{spec.title | caseUcfirst}}Exception
@@ -98,7 +99,7 @@ class Client:
             warnings = response.headers.get('x-{{ spec.title | lower }}-warning')
             if warnings:
                 for warning in warnings.split(';'):
-                    print(f'Warning: {warning}')
+                    print(f'Warning: {warning}', file=sys.stderr)
 
             content_type = response.headers['Content-Type']
 

--- a/templates/swift/Sources/Client.swift.twig
+++ b/templates/swift/Sources/Client.swift.twig
@@ -350,7 +350,7 @@ open class Client {
 
         if let warning = response.headers["x-{{ spec.title | lower }}-warning"].first {
             warning.split(separator: ";").forEach { warning in
-                print("Warning: \(warning)")
+                fputs("Warning: \(warning)\n", stderr)
             }
         }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

fixes the stdout issue

## Test Plan

## Related PRs and Issues

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime warnings are now written to standard error instead of standard output across Android, Kotlin, Swift (Apple), Swift, .NET, and Python clients. This keeps standard output clean for pipelines and improves compatibility with logging and shell scripting. Behavior and response handling remain unchanged aside from the output stream. No public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->