### PR TITLE
chore (breaking): update dart's fromMap constructor to accept use 'da…

### DIFF
--- a/templates/dart/lib/src/models/model.dart.twig
+++ b/templates/dart/lib/src/models/model.dart.twig
@@ -47,7 +47,7 @@ class {{ definition.name | caseUcfirst | overrideIdentifier }} implements Model 
             {%- endif -%},
 {% endfor %}
 {% if definition.additionalProperties %}
-            data: map,
+            data: map["data"],
 {% endif %}
         );
     }


### PR DESCRIPTION
…ta' key for Any models

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Right now dart accept's a flat object, but returns the object separated by a 'data' key. The existence of 'data' key is crucial for future generics support. Also current behaviour is causing confusions and incorrect serialisations, for eg. discovered by user @ugurcany that Preferences model does not correct serialize and deserialize when used with User model.

This change will make the behaviour match with what we do with other langauges like kotlin, for eg. here - https://github.com/appwrite/sdk-for-kotlin/blob/0a99330ed3a537fa1898027f7ae90eb0d759e397/src/main/kotlin/io/appwrite/models/Document.kt#L4

## Test Plan

## Related PRs and Issues

- https://github.com/appwrite/sdk-for-flutter/issues/271

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.