### PR TITLE
fix: resource name from attributes to columns for tablesdb indexes in…

### DIFF
--- a/templates/cli/lib/config.js.twig
+++ b/templates/cli/lib/config.js.twig
@@ -62,12 +62,13 @@ const KeysColumns = new Set([
     "onDelete",
     "side",
     // Indexes
-    "attributes",
+    "columns",
     "orders",
     // Strings
     "encrypt",
 ]);
 const KeyIndexes = new Set(["key", "type", "status", "attributes", "orders"]);
+const KeyIndexesColumns = new Set(["key", "type", "status", "columns", "orders"]);
 
 function whitelistKeys(value, keys, nestedKeys = {}) {
     if (Array.isArray(value)) {
@@ -404,7 +405,7 @@ class Local extends Config {
     addTable(props) {
         props = whitelistKeys(props, KeysTable, {
             columns: KeysColumns,
-            indexes: KeyIndexes
+            indexes: KeyIndexesColumns
         });
 
         if (!this.has("tables")) {


### PR DESCRIPTION
… cli

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?


## Test Plan

## Related PRs and Issues

- https://github.com/appwrite/sdk-for-cli/issues/200

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

yes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated table index configuration schema to use "columns" instead of "attributes".
  * Whitelist for index definitions now validates keys: key, type, status, columns, orders.

* **Chores**
  * Standardized index configuration naming for consistency across the CLI.

User impact: When defining table indexes in configuration, replace "attributes" with "columns" and include optional "orders" as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->