### PR TITLE
fix: dotnet template issues

### DIFF
--- a/src/SDK/Language/DotNet.php
+++ b/src/SDK/Language/DotNet.php
@@ -478,13 +478,13 @@ class DotNet extends Language
 
                 if (isset($property['sub_schema']) && !empty($property['sub_schema'])) {
                     if ($property['type'] === 'array') {
-                        $result = 'List<' . \ucfirst($property['sub_schema']) . '>';
+                        $result = 'List<' . $this->toPascalCase($property['sub_schema']) . '>';
                     } else {
-                        $result = \ucfirst($property['sub_schema']);
+                        $result = $this->toPascalCase($property['sub_schema']);
                     }
                 } elseif (isset($property['enum']) && !empty($property['enum'])) {
                     $enumName = $property['enumName'] ?? $property['name'];
-                    $result = \ucfirst($enumName);
+                    $result = $this->toPascalCase($enumName);
                 } else {
                     $result = $this->getTypeName($property);
                 }
@@ -497,8 +497,8 @@ class DotNet extends Language
             }),
             new TwigFunction('property_name', function (array $definition, array $property) {
                 $name = $property['name'];
-                $name = \ucfirst($name);
                 $name = \str_replace('$', '', $name);
+                $name = $this->toPascalCase($name);
                 if (\in_array(\strtolower($name), $this->getKeywords())) {
                     $name = '@' . $name;
                 }

--- a/src/SDK/Language/DotNet.php
+++ b/src/SDK/Language/DotNet.php
@@ -499,7 +499,7 @@ class DotNet extends Language
                 $name = $property['name'];
                 $name = \str_replace('$', '', $name);
                 $name = $this->toPascalCase($name);
-                if (\in_array(\strtolower($name), $this->getKeywords())) {
+                if (\in_array($name, $this->getKeywords())) {
                     $name = '@' . $name;
                 }
                 return $name;

--- a/templates/dotnet/Package/Models/Model.cs.twig
+++ b/templates/dotnet/Package/Models/Model.cs.twig
@@ -1,3 +1,4 @@
+
 using System;
 using System.Linq;
 using System.Collections.Generic;
@@ -11,7 +12,7 @@ namespace {{ spec.title | caseUcfirst }}.Models
     {
         {%~ for property in definition.properties %}
         [JsonPropertyName("{{ property.name }}")]
-        public {{ sub_schema(property) }} {{ property_name(definition, property) | overrideProperty(definition.name) }} { get; private set; }
+        public {{ sub_schema(property) | raw }} {{ property_name(definition, property) | overrideProperty(definition.name) }} { get; private set; }
 
         {%~ endfor %}
         {%~ if definition.additionalProperties %}
@@ -20,7 +21,7 @@ namespace {{ spec.title | caseUcfirst }}.Models
         {%~ endif %}
         public {{ definition.name | caseUcfirst | overrideIdentifier }}(
             {%~ for property in definition.properties %}
-            {{ sub_schema(property) }} {{ property.name | caseCamel | escapeKeyword }}{% if not loop.last or (loop.last and definition.additionalProperties) %},{% endif %}
+            {{ sub_schema(property) | raw }} {{ property.name | caseCamel | escapeKeyword }}{% if not loop.last or (loop.last and definition.additionalProperties) %},{% endif %}
 
             {%~ endfor %}
             {%~ if definition.additionalProperties %}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * .NET identifiers (types, properties, enums) consistently use PascalCase to match .NET naming conventions.
  * Model property and constructor parameter types now render as raw type expressions to prevent formatting issues.

* **Refactor**
  * Name construction consolidated to a single PascalCase approach for consistent generated output without changing public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->