### PR TITLE
Fix Flutter constant naming: CHUNK_SIZE to chunkSize

### DIFF
--- a/templates/flutter/lib/src/client.dart.twig
+++ b/templates/flutter/lib/src/client.dart.twig
@@ -10,7 +10,7 @@ import 'upload_progress.dart';
 /// The [Client] is also responsible for managing user's sessions.
 abstract class Client {
   /// The size for cunked uploads in bytes.
-  static const int CHUNK_SIZE = 5 * 1024 * 1024;
+  static const int chunkSize = 5 * 1024 * 1024;
 
   /// Holds configuration such as project.
   late Map<String, String> config;

--- a/templates/flutter/lib/src/client_browser.dart.twig
+++ b/templates/flutter/lib/src/client_browser.dart.twig
@@ -16,7 +16,7 @@ ClientBase createClient({required String endPoint, required bool selfSigned}) =>
     ClientBrowser(endPoint: endPoint, selfSigned: selfSigned);
 
 class ClientBrowser extends ClientBase with ClientMixin {
-  static const int CHUNK_SIZE = 5 * 1024 * 1024;
+  static const int chunkSize = 5 * 1024 * 1024;
   String _endPoint;
   Map<String, String>? _headers;
   @override
@@ -130,7 +130,7 @@ class ClientBrowser extends ClientBase with ClientMixin {
     int size = file.bytes!.length;
 
     late Response res;
-    if (size <= CHUNK_SIZE) {
+    if (size <= chunkSize) {
       params[paramName] = http.MultipartFile.fromBytes(
         paramName,
         file.bytes!,
@@ -154,13 +154,13 @@ class ClientBrowser extends ClientBase with ClientMixin {
           headers: headers,
         );
         final int chunksUploaded = res.data['chunksUploaded'] as int;
-        offset = chunksUploaded * CHUNK_SIZE;
+        offset = chunksUploaded * chunkSize;
       } on {{spec.title | caseUcfirst}}Exception catch (_) {}
     }
 
     while (offset < size) {
       List<int> chunk = [];
-      final end = min(offset + CHUNK_SIZE, size);
+      final end = min(offset + chunkSize, size);
       chunk = file.bytes!.getRange(offset, end).toList();
       params[paramName] = http.MultipartFile.fromBytes(
         paramName,
@@ -168,14 +168,14 @@ class ClientBrowser extends ClientBase with ClientMixin {
         filename: file.filename,
       );
       headers['content-range'] =
-          'bytes $offset-${min<int>((offset + CHUNK_SIZE - 1), size - 1)}/$size';
+          'bytes $offset-${min<int>((offset + chunkSize - 1), size - 1)}/$size';
       res = await call(
         HttpMethod.post,
         path: path,
         headers: headers,
         params: params,
       );
-      offset += CHUNK_SIZE;
+      offset += chunkSize;
       if (offset < size) {
         headers['x-{{spec.title | caseLower }}-id'] = res.data['\$id'];
       }

--- a/templates/flutter/lib/src/client_io.dart.twig
+++ b/templates/flutter/lib/src/client_io.dart.twig
@@ -22,7 +22,7 @@ ClientBase createClient({required String endPoint, required bool selfSigned}) =>
     ClientIO(endPoint: endPoint, selfSigned: selfSigned);
 
 class ClientIO extends ClientBase with ClientMixin {
-  static const int CHUNK_SIZE = 5 * 1024 * 1024;
+  static const int chunkSize = 5 * 1024 * 1024;
   String _endPoint;
   Map<String, String>? _headers;
   @override
@@ -244,7 +244,7 @@ class ClientIO extends ClientBase with ClientMixin {
     }
 
     late Response res;
-    if (size <= CHUNK_SIZE) {
+    if (size <= chunkSize) {
       if (file.path != null) {
         params[paramName] = await http.MultipartFile.fromPath(
           paramName,
@@ -276,7 +276,7 @@ class ClientIO extends ClientBase with ClientMixin {
           headers: headers,
         );
         final int chunksUploaded = res.data['chunksUploaded'] as int;
-        offset = chunksUploaded * CHUNK_SIZE;
+        offset = chunksUploaded * chunkSize;
       } on {{spec.title | caseUcfirst}}Exception catch (_) {}
     }
 
@@ -289,11 +289,11 @@ class ClientIO extends ClientBase with ClientMixin {
     while (offset < size) {
       List<int> chunk = [];
       if (file.bytes != null) {
-        final end = min(offset + CHUNK_SIZE, size);
+        final end = min(offset + chunkSize, size);
         chunk = file.bytes!.getRange(offset, end).toList();
       } else {
         raf!.setPositionSync(offset);
-        chunk = raf.readSync(CHUNK_SIZE);
+        chunk = raf.readSync(chunkSize);
       }
       params[paramName] = http.MultipartFile.fromBytes(
         paramName,
@@ -301,14 +301,14 @@ class ClientIO extends ClientBase with ClientMixin {
         filename: file.filename,
       );
       headers['content-range'] =
-          'bytes $offset-${min<int>((offset + CHUNK_SIZE - 1), size - 1)}/$size';
+          'bytes $offset-${min<int>((offset + chunkSize - 1), size - 1)}/$size';
       res = await call(
         HttpMethod.post,
         path: path,
         headers: headers,
         params: params,
       );
-      offset += CHUNK_SIZE;
+      offset += chunkSize;
       if (offset < size) {
         headers['x-{{spec.title | caseLower }}-id'] = res.data['\$id'];
       }


### PR DESCRIPTION
## Summary
- Changed `CHUNK_SIZE` constant to `chunkSize` in Flutter SDK templates to follow Dart's lowerCamelCase naming convention
- Resolves the `constant_identifier_names` lint warning

## Why This Change is Needed
According to the [Dart Style Guide](https://dart.dev/effective-dart/style#do-name-constants-using-lowercamelcase), constants should use lowerCamelCase naming:

> **DO** name constants using lowerCamelCase.
> 
> In new code, use `lowerCamelCase` for constant variables, including enum values.

The current `CHUNK_SIZE` constant uses SCREAMING_CAPS, which was an older convention. Modern Dart code should use `chunkSize` instead.

## Files Changed
- `templates/flutter/lib/src/client.dart.twig`
- `templates/flutter/lib/src/client_browser.dart.twig`
- `templates/flutter/lib/src/client_io.dart.twig`

## Impact
This change affects the generated Flutter SDK and will eliminate the `constant_identifier_names` lint warnings in the generated code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)