### PR TITLE
Add @override annotation to toMap method in Dart models

### DIFF
--- a/templates/dart/lib/src/models/model.dart.twig
+++ b/templates/dart/lib/src/models/model.dart.twig
@@ -59,6 +59,7 @@ class {{ definition.name | caseUcfirst | overrideIdentifier }} implements Model 
         );
     }
 
+    @override
     Map<String, dynamic> toMap() {
         return {
 {% for property in definition.properties %}


### PR DESCRIPTION
## Summary
- Added `@override` annotation to the `toMap()` method in the Dart model template
- Resolves all 74+ `annotate_overrides` lint warnings in generated Flutter SDK models

## Why This Change is Needed
According to the [Dart Linter Rules](https://dart.dev/tools/linter-rules/annotate_overrides):

> **DO** annotate overridden members.
> 
> This practice improves code readability and helps avoid unintentionally overriding members.

The `toMap()` method overrides the abstract method defined in the `Model` interface, so it should be annotated with `@override` to follow Dart best practices.

## Files Changed
- `templates/dart/lib/src/models/model.dart.twig`

## Impact
This is a non-breaking change that adds the `@override` annotation to all generated model classes. This change:
- Eliminates 74+ `annotate_overrides` lint warnings
- Improves code quality and maintainability
- Makes the inheritance relationship explicit
- Helps catch errors if the parent interface signature changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized override annotations in generated model methods to align with Dart conventions, improving code clarity and IDE tooling support.
  * No changes to functionality or behavior; existing features continue to work as before.
  * This update enhances maintainability and consistency across generated code without impacting performance or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->