### PR TITLE
  fix: 🐛 Handle null values for integer properties in Dart models

### DIFF
--- a/templates/dart/lib/src/models/model.dart.twig
+++ b/templates/dart/lib/src/models/model.dart.twig
@@ -44,6 +44,9 @@ class {{ definition.name | caseUcfirst | overrideIdentifier }} implements Model 
                     List.from(map['{{property.name | escapeDollarSign }}'] ?? [])
                 {%- else -%}
                     map['{{property.name | escapeDollarSign }}']
+                    {%- if property.type == "integer" -%}
+                        {%- if not property.required %}?{% endif %}.toInt()
+                    {%- endif -%}
                     {%- if property.type == "number" -%}
                         {%- if not property.required %}?{% endif %}.toDouble()
                     {%- endif -%}

--- a/templates/dart/lib/src/models/model.dart.twig
+++ b/templates/dart/lib/src/models/model.dart.twig
@@ -43,15 +43,14 @@ class {{ definition.name | caseUcfirst | overrideIdentifier }} implements Model 
                 {%- if property.type == 'array' -%}
                     List.from(map['{{property.name | escapeDollarSign }}'] ?? [])
                 {%- else -%}
-                    map['{{property.name | escapeDollarSign }}']
                     {%- if property.type == "integer" -%}
-                        {%- if not property.required %}?{% endif %}.toInt()
-                    {%- endif -%}
-                    {%- if property.type == "number" -%}
-                        {%- if not property.required %}?{% endif %}.toDouble()
-                    {%- endif -%}
-                    {%- if property.type == "string" -%}
-                        {%- if not property.required %}?{% endif %}.toString()
+                        (map['{{property.name | escapeDollarSign }}'] is int ? map['{{property.name | escapeDollarSign }}'] : {% if property.required %}int.parse(map['{{property.name | escapeDollarSign }}'].toString()){% else %}map['{{property.name | escapeDollarSign }}'] != null ? int.parse(map['{{property.name | escapeDollarSign }}'].toString()) : null{% endif %})
+                    {%- elseif property.type == "number" -%}
+                        (map['{{property.name | escapeDollarSign }}'] is double ? map['{{property.name | escapeDollarSign }}'] : {% if property.required %}double.parse(map['{{property.name | escapeDollarSign }}'].toString()){% else %}map['{{property.name | escapeDollarSign }}'] != null ? double.parse(map['{{property.name | escapeDollarSign }}'].toString()) : null{% endif %})
+                    {%- elseif property.type == "string" -%}
+                        map['{{property.name | escapeDollarSign }}']{% if not property.required %}?{% endif %}.toString()
+                    {%- else -%}
+                        map['{{property.name | escapeDollarSign }}']
                     {%- endif -%}
                 {%- endif -%}
             {%- endif -%},

--- a/templates/dart/lib/src/models/model.dart.twig
+++ b/templates/dart/lib/src/models/model.dart.twig
@@ -44,9 +44,6 @@ class {{ definition.name | caseUcfirst | overrideIdentifier }} implements Model 
                     List.from(map['{{property.name | escapeDollarSign }}'] ?? [])
                 {%- else -%}
                     map['{{property.name | escapeDollarSign }}']
-                    {%- if property.type == "integer" -%}
-                        {%- if not property.required %}?{% endif %}.toInt()
-                    {%- endif -%}
                     {%- if property.type == "number" -%}
                         {%- if not property.required %}?{% endif %}.toDouble()
                     {%- endif -%}

--- a/templates/dart/lib/src/models/model.dart.twig
+++ b/templates/dart/lib/src/models/model.dart.twig
@@ -43,12 +43,20 @@ class {{ definition.name | caseUcfirst | overrideIdentifier }} implements Model 
                 {%- if property.type == 'array' -%}
                     List.from(map['{{property.name | escapeDollarSign }}'] ?? [])
                 {%- else -%}
-                    map['{{property.name | escapeDollarSign }}']
-                    {%- if property.type == "number" -%}
-                        {%- if not property.required %}?{% endif %}.toDouble()
-                    {%- endif -%}
-                    {%- if property.type == "string" -%}
-                        {%- if not property.required %}?{% endif %}.toString()
+                    {%- if property.type == "integer" -%}
+                        {%- if property.required -%}
+                            (map['{{property.name | escapeDollarSign }}'] as int)
+                        {%- else -%}
+                            (map['{{property.name | escapeDollarSign }}'] as int?)
+                        {%- endif -%}
+                    {%- else -%}
+                        map['{{property.name | escapeDollarSign }}']
+                        {%- if property.type == "number" -%}
+                            {%- if not property.required %}?{% endif %}.toDouble()
+                        {%- endif -%}
+                        {%- if property.type == "string" -%}
+                            {%- if not property.required %}?{% endif %}.toString()
+                        {%- endif -%}
                     {%- endif -%}
                 {%- endif -%}
             {%- endif -%},

--- a/templates/dart/lib/src/models/model.dart.twig
+++ b/templates/dart/lib/src/models/model.dart.twig
@@ -43,14 +43,15 @@ class {{ definition.name | caseUcfirst | overrideIdentifier }} implements Model 
                 {%- if property.type == 'array' -%}
                     List.from(map['{{property.name | escapeDollarSign }}'] ?? [])
                 {%- else -%}
+                    map['{{property.name | escapeDollarSign }}']
                     {%- if property.type == "integer" -%}
-                        (map['{{property.name | escapeDollarSign }}'] is int ? map['{{property.name | escapeDollarSign }}'] : {% if property.required %}int.parse(map['{{property.name | escapeDollarSign }}'].toString()){% else %}map['{{property.name | escapeDollarSign }}'] != null ? int.parse(map['{{property.name | escapeDollarSign }}'].toString()) : null{% endif %})
-                    {%- elseif property.type == "number" -%}
-                        (map['{{property.name | escapeDollarSign }}'] is double ? map['{{property.name | escapeDollarSign }}'] : {% if property.required %}double.parse(map['{{property.name | escapeDollarSign }}'].toString()){% else %}map['{{property.name | escapeDollarSign }}'] != null ? double.parse(map['{{property.name | escapeDollarSign }}'].toString()) : null{% endif %})
-                    {%- elseif property.type == "string" -%}
-                        map['{{property.name | escapeDollarSign }}']{% if not property.required %}?{% endif %}.toString()
-                    {%- else -%}
-                        map['{{property.name | escapeDollarSign }}']
+                        {%- if not property.required %}?{% endif %}.toInt()
+                    {%- endif -%}
+                    {%- if property.type == "number" -%}
+                        {%- if not property.required %}?{% endif %}.toDouble()
+                    {%- endif -%}
+                    {%- if property.type == "string" -%}
+                        {%- if not property.required %}?{% endif %}.toString()
                     {%- endif -%}
                 {%- endif -%}
             {%- endif -%},


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

fix: 🐛 Handle null values for integer properties in Dart models
---
Fixes #1150 - Type 'Null' is not a subtype of type 'int'  by adding explicit type casting for integer properties to properly handle null values for optional & required fields.

## Test Plan

[x] Ran both Dart & Flutter tests (both passed)

## Related PRs and Issues

https://github.com/appwrite/sdk-generator/issues/1150

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes