### PR TITLE
Use string interpolation instead of concatenation in Dart/Flutter

### DIFF
--- a/templates/dart/lib/src/client_browser.dart.twig
+++ b/templates/dart/lib/src/client_browser.dart.twig
@@ -122,7 +122,7 @@ class ClientBrowser extends ClientBase with ClientMixin {
       try {
         res = await call(
           HttpMethod.get,
-          path: path + '/' + params[idParamName],
+          path: '$path/${params[idParamName]}',
           headers: headers,
         );
         final int chunksUploaded = res.data['chunksUploaded'] as int;

--- a/templates/dart/lib/src/client_io.dart.twig
+++ b/templates/dart/lib/src/client_io.dart.twig
@@ -143,7 +143,7 @@ class ClientIO extends ClientBase with ClientMixin {
       try {
         res = await call(
           HttpMethod.get,
-          path: path + '/' + params[idParamName],
+          path: '$path/${params[idParamName]}',
           headers: headers,
         );
         final int chunksUploaded = res.data['chunksUploaded'] as int;

--- a/templates/flutter/lib/src/client_browser.dart.twig
+++ b/templates/flutter/lib/src/client_browser.dart.twig
@@ -150,7 +150,7 @@ class ClientBrowser extends ClientBase with ClientMixin {
       try {
         res = await call(
           HttpMethod.get,
-          path: path + '/' + params[idParamName],
+          path: '$path/${params[idParamName]}',
           headers: headers,
         );
         final int chunksUploaded = res.data['chunksUploaded'] as int;
@@ -243,7 +243,7 @@ class ClientBrowser extends ClientBase with ClientMixin {
   Future webAuth(Uri url, {String? callbackUrlScheme}) {
     return FlutterWebAuth2.authenticate(
       url: url.toString(),
-      callbackUrlScheme: "{{spec.title | caseLower}}-callback-" + config['project']!,
+      callbackUrlScheme: "{{spec.title | caseLower}}-callback-${config['project']!}",
       options: const FlutterWebAuth2Options(useWebview: false),
     );
   }

--- a/templates/flutter/lib/src/client_io.dart.twig
+++ b/templates/flutter/lib/src/client_io.dart.twig
@@ -272,7 +272,7 @@ class ClientIO extends ClientBase with ClientMixin {
       try {
         res = await call(
           HttpMethod.get,
-          path: path + '/' + params[idParamName],
+          path: '$path/${params[idParamName]}',
           headers: headers,
         );
         final int chunksUploaded = res.data['chunksUploaded'] as int;
@@ -333,7 +333,7 @@ class ClientIO extends ClientBase with ClientMixin {
       url: url.toString(),
       callbackUrlScheme: callbackUrlScheme != null && _customSchemeAllowed
           ? callbackUrlScheme
-          : "{{spec.title | caseLower}}-callback-" + config['project']!,
+          : "{{spec.title | caseLower}}-callback-${config['project']!}",
       options: const FlutterWebAuth2Options(
         intentFlags: ephemeralIntentFlags,
         useWebview: false,


### PR DESCRIPTION
## Summary
- Replaced string concatenation using `+` operator with string interpolation
- Resolves `prefer_interpolation_to_compose_strings` lint warnings
- Applied to both Flutter and Dart templates

## Why This Change is Needed
According to the [Dart Linter Rules](https://dart.dev/tools/linter-rules/prefer_interpolation_to_compose_strings):

> **DO** use interpolation to compose strings and values.
> 
> Using interpolation when composing strings and values is usually easier to read and less error-prone than concatenation.

String interpolation (`"$variable"` or `"${expression}"`) is preferred over concatenation (`"text" + variable`) in Dart.

## Changes Made
1. **Path concatenation**: `path + '/' + params[idParamName]` → `'$path/${params[idParamName]}'`
2. **Callback URL scheme**: `"prefix-" + config['project']!` → `"prefix-${config['project']!}"`

## Files Changed
- `templates/flutter/lib/src/client_browser.dart.twig`
- `templates/flutter/lib/src/client_io.dart.twig`
- `templates/dart/lib/src/client_browser.dart.twig`
- `templates/dart/lib/src/client_io.dart.twig`

## Impact
This is a non-breaking change that improves code quality by:
- Eliminating `prefer_interpolation_to_compose_strings` lint warnings
- Making the code more idiomatic and easier to read
- Following Dart best practices

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized string interpolation for building URL paths across Dart and Flutter clients (browser and IO), replacing manual concatenation.
  * Unified construction of callback URL schemes using interpolation for greater consistency.
  * No changes to behavior, APIs, or error handling; improvements are internal for readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->