### PR TITLE
fix: example generation for php for enums

### DIFF
--- a/templates/php/docs/example.md.twig
+++ b/templates/php/docs/example.md.twig
@@ -7,7 +7,6 @@ use {{ spec.title | caseUcfirst }}\InputFile;
 use {{ spec.title | caseUcfirst }}\Services\{{ service.name | caseUcfirst }};
 {% set added = [] %}
 {% for parameter in method.parameters.all %}
-{% if method == parameter.required %}
 {% if parameter.enumValues is not empty %}
 {% if parameter.enumName is not empty %}
 {% set name = parameter.enumName %}
@@ -15,9 +14,8 @@ use {{ spec.title | caseUcfirst }}\Services\{{ service.name | caseUcfirst }};
 {% set name = parameter.name %}
 {% endif %}
 {% if name not in added %}
-use {{ spec.title | caseUcfirst }}\Enums\{{parameter.enumName | caseUcfirst}};
+use {{ spec.title | caseUcfirst }}\Enums\{{ name | caseUcfirst }};
 {% set added = added|merge([name]) %}
-{% endif %}
 {% endif %}
 {% endif %}
 {% endfor %}
@@ -41,7 +39,7 @@ ${{ service.name | caseCamel }} = new {{ service.name | caseUcfirst }}($client);
 $result = ${{ service.name | caseCamel }}->{{ method.name | caseCamel }}({% if method.parameters.all | length == 0 %});{% endif %}
 
     {%~ for parameter in method.parameters.all %}
-    {{ parameter.name | caseCamel }}: {% if parameter.enumValues | length > 0%}{{ parameter.enumName }}::{{ (parameter.enumKeys[0] ?? parameter.enumValues[0]) | caseEnumKey }}(){% else%}{{ parameter | paramExample }}{% endif %}{% if not loop.last %},{% endif %}{% if not parameter.required %} // optional{% endif %}
+    {{ parameter.name | caseCamel }}: {% if parameter.enumValues | length > 0%}{% if parameter.enumName is not empty %}{{ parameter.enumName | caseUcfirst }}{% else %}{{ parameter.name | caseUcfirst }}{% endif %}::{{ (parameter.enumKeys[0] ?? parameter.enumValues[0]) | caseEnumKey }}(){% else%}{{ parameter | paramExample }}{% endif %}{% if not loop.last %},{% endif %}{% if not parameter.required %} // optional{% endif %}
 
     {%~ endfor -%}
 {% if method.parameters.all | length > 0 %});{% endif %}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated duplicate enum imports in generated PHP code
  * Corrected template logic affecting parameter rendering

* **New Features**
  * Improved enum name derivation for more consistent handling across generated code
  * Added Role import generation alongside Permission imports when needed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->