### PR TITLE
Add type generation support for geometric types (point, linestring, polygon)

### DIFF
--- a/example.php
+++ b/example.php
@@ -94,8 +94,9 @@ try {
         // $platform = 'server';
     }
 
+    $branch = '1.8.x';
     $version = '1.8.x';
-    $spec = getSSLPage("https://raw.githubusercontent.com/appwrite/appwrite/{$version}/app/config/specs/swagger2-{$version}-{$platform}.json");
+    $spec = getSSLPage("https://raw.githubusercontent.com/appwrite/appwrite/{$branch}/app/config/specs/swagger2-{$version}-{$platform}.json");
 
     if(empty($spec)) {
         throw new Exception('Failed to fetch spec from Appwrite server');

--- a/templates/cli/lib/type-generation/attribute.js.twig
+++ b/templates/cli/lib/type-generation/attribute.js.twig
@@ -9,6 +9,9 @@ const AttributeType = {
     URL: "url",
     ENUM: "enum",
     RELATIONSHIP: "relationship",
+    POINT: "point",
+    LINESTRING: "linestring",
+    POLYGON: "polygon",
 };
 
  module.exports = {

--- a/templates/cli/lib/type-generation/languages/csharp.js.twig
+++ b/templates/cli/lib/type-generation/languages/csharp.js.twig
@@ -33,6 +33,15 @@ class CSharp extends LanguageMeta {
           type = `List<${type}>`;
         }
         break;
+      case AttributeType.POINT:
+        type = "List<double>";
+        break;
+      case AttributeType.LINESTRING:
+        type = "List<List<double>>";
+        break;
+      case AttributeType.POLYGON:
+        type = "List<List<List<double>>>";
+        break;
       default:
         throw new Error(`Unknown attribute type: ${attribute.type}`);
     }

--- a/templates/cli/lib/type-generation/languages/dart.js.twig
+++ b/templates/cli/lib/type-generation/languages/dart.js.twig
@@ -70,6 +70,15 @@ class Dart extends LanguageMeta {
           type = `List<${type}>`;
         }
         break;
+      case AttributeType.POINT:
+        type = "List<double>";
+        break;
+      case AttributeType.LINESTRING:
+        type = "List<List<double>>";
+        break;
+      case AttributeType.POLYGON:
+        type = "List<List<List<double>>>";
+        break;
       default:
         throw new Error(`Unknown attribute type: ${attribute.type}`);
     }

--- a/templates/cli/lib/type-generation/languages/java.js.twig
+++ b/templates/cli/lib/type-generation/languages/java.js.twig
@@ -33,6 +33,15 @@ class Java extends LanguageMeta {
           type = "List<" + type + ">";
         }
         break;
+      case AttributeType.POINT:
+        type = "List<Double>";
+        break;
+      case AttributeType.LINESTRING:
+        type = "List<List<Double>>";
+        break;
+      case AttributeType.POLYGON:
+        type = "List<List<List<Double>>>";
+        break;
       default:
         throw new Error(`Unknown attribute type: ${attribute.type}`);
     }

--- a/templates/cli/lib/type-generation/languages/javascript.js.twig
+++ b/templates/cli/lib/type-generation/languages/javascript.js.twig
@@ -38,6 +38,15 @@ class JavaScript extends LanguageMeta {
           type = `${type}[]`;
         }
         break;
+      case AttributeType.POINT:
+        type = "number[]";
+        break;
+      case AttributeType.LINESTRING:
+        type = "number[][]";
+        break;
+      case AttributeType.POLYGON:
+        type = "number[][][]";
+        break;
       default:
         throw new Error(`Unknown attribute type: ${attribute.type}`);
     }

--- a/templates/cli/lib/type-generation/languages/kotlin.js.twig
+++ b/templates/cli/lib/type-generation/languages/kotlin.js.twig
@@ -33,6 +33,15 @@ class Kotlin extends LanguageMeta {
           type = `List<${type}>`;
         }
         break;
+      case AttributeType.POINT:
+        type = "List<Double>";
+        break;
+      case AttributeType.LINESTRING:
+        type = "List<List<Double>>";
+        break;
+      case AttributeType.POLYGON:
+        type = "List<List<List<Double>>>";
+        break;
       default:
         throw new Error(`Unknown attribute type: ${attribute.type}`);
     }

--- a/templates/cli/lib/type-generation/languages/php.js.twig
+++ b/templates/cli/lib/type-generation/languages/php.js.twig
@@ -36,6 +36,11 @@ class PHP extends LanguageMeta {
           type = "array";
         }
         break;
+      case AttributeType.POINT:
+      case AttributeType.LINESTRING:
+      case AttributeType.POLYGON:
+        type = "array";
+        break;
       default:
         throw new Error(`Unknown attribute type: ${attribute.type}`);
     }

--- a/templates/cli/lib/type-generation/languages/swift.js.twig
+++ b/templates/cli/lib/type-generation/languages/swift.js.twig
@@ -33,6 +33,15 @@ class Swift extends LanguageMeta {
           type = `[${type}]`;
         }
         break;
+      case AttributeType.POINT:
+        type = "[Double]";
+        break;
+      case AttributeType.LINESTRING:
+        type = "[[Double]]";
+        break;
+      case AttributeType.POLYGON:
+        type = "[[[Double]]]";
+        break;
       default:
         throw new Error(`Unknown attribute type: ${attribute.type}`);
     }

--- a/templates/cli/lib/type-generation/languages/typescript.js.twig
+++ b/templates/cli/lib/type-generation/languages/typescript.js.twig
@@ -38,6 +38,15 @@ class TypeScript extends LanguageMeta {
           type = `${type}[]`;
         }
         break;
+      case AttributeType.POINT:
+        type = "Array<number>";
+        break;
+      case AttributeType.LINESTRING:
+        type = "Array<Array<number>>";
+        break;
+      case AttributeType.POLYGON:
+        type = "Array<Array<Array<number>>>";
+        break;
       default:
         throw new Error(`Unknown attribute type: ${attribute.type}`);
     }

--- a/templates/react-native/package.json.twig
+++ b/templates/react-native/package.json.twig
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "8.3.2",
-    "playwright": "1.15.0",
+    "playwright": "1.56.1",
     "rollup": "2.75.4",
     "serve-handler": "6.1.0",
     "tslib": "2.4.0",

--- a/templates/web/package.json.twig
+++ b/templates/web/package.json.twig
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "8.3.2",
-    "playwright": "1.15.0",
+    "playwright": "1.56.1",
     "rollup": "2.79.2",
     "serve-handler": "6.1.0",
     "tslib": "2.4.0",

--- a/tests/WebChromiumTest.php
+++ b/tests/WebChromiumTest.php
@@ -15,10 +15,10 @@ class WebChromiumTest extends Base
         'cp tests/languages/web/tests.js tests/sdks/web/tests.js',
         'cp tests/languages/web/node.js tests/sdks/web/node.js',
         'cp tests/languages/web/index.html tests/sdks/web/index.html',
-        'docker run --rm -v $(pwd):/app -w /app/tests/sdks/web mcr.microsoft.com/playwright:v1.15.0-focal sh -c "npm install && npm run build"',
+        'docker run --rm -v $(pwd):/app -w /app/tests/sdks/web mcr.microsoft.com/playwright:v1.56.1-jammy sh -c "npm install && npm run build"',
     ];
     protected string $command =
-        'docker run --network="mockapi" --rm -v $(pwd):/app -e BROWSER=chromium -w /app/tests/sdks/web mcr.microsoft.com/playwright:v1.15.0-focal node tests.js';
+        'docker run --network="mockapi" --rm -v $(pwd):/app -e BROWSER=chromium -w /app/tests/sdks/web mcr.microsoft.com/playwright:v1.56.1-jammy node tests.js';
 
     protected array $expectedOutput = [
         ...Base::PING_RESPONSE,


### PR DESCRIPTION
## Summary
This PR adds support for generating types for geometric attributes (POINT, LINESTRING, POLYGON) across all supported languages in the CLI type generation feature.

## Changes
- Added `POINT`, `LINESTRING`, and `POLYGON` to the `AttributeType` enum in `attribute.js.twig`
- Implemented type mapping logic for all language generators:
  - **TypeScript**: `Array<number>`, `Array<Array<number>>`, `Array<Array<Array<number>>>`
  - **JavaScript**: `number[]`, `number[][]`, `number[][][]`
  - **C#**: `List<double>`, `List<List<double>>`, `List<List<List<double>>>`
  - **Dart**: `List<double>`, `List<List<double>>`, `List<List<List<double>>>`
  - **Java**: `List<Double>`, `List<List<Double>>`, `List<List<List<Double>>>`
  - **Kotlin**: `List<Double>`, `List<List<Double>>`, `List<List<List<Double>>>`
  - **PHP**: `array` (for all geometric types)
  - **Swift**: `[Double]`, `[[Double]]`, `[[[Double]]]`

## Type Structure
- **POINT**: Array of numbers representing coordinates `[longitude, latitude]`
- **LINESTRING**: Array of points (array of arrays) representing a line
- **POLYGON**: Array of linestrings (array of array of arrays) representing a polygon with optional holes

## Test plan
- [ ] Verify type generation works correctly for POINT attributes
- [ ] Verify type generation works correctly for LINESTRING attributes
- [ ] Verify type generation works correctly for POLYGON attributes
- [ ] Test with all supported languages (TypeScript, JavaScript, C#, Dart, Java, Kotlin, PHP, Swift)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for geometric attribute types: POINT, LINESTRING, POLYGON across code generators — mapped to nested numeric array types in generated SDKs.

* **Chores**
  * Updated development tooling in templates (Playwright version bumped).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->