### PR TITLE
Fix TypeScript setEndpoint validation for undefined values

### DIFF
--- a/templates/deno/src/client.ts.twig
+++ b/templates/deno/src/client.ts.twig
@@ -46,6 +46,10 @@ export class Client {
      * @return this
      */
     setEndpoint(endpoint: string): this {
+        if (!endpoint || typeof endpoint !== 'string') {
+            throw new {{spec.title | caseUcfirst}}Exception('Endpoint must be a valid string');
+        }
+
         if (!endpoint.startsWith('http://') && !endpoint.startsWith('https://')) {
             throw new {{spec.title | caseUcfirst}}Exception('Invalid endpoint URL: ' + endpoint);
         }

--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -96,6 +96,10 @@ class Client {
      * @returns {this}
      */
     setEndpoint(endpoint: string): this {
+        if (!endpoint || typeof endpoint !== 'string') {
+            throw new {{spec.title | caseUcfirst}}Exception('Endpoint must be a valid string');
+        }
+
         if (!endpoint.startsWith('http://') && !endpoint.startsWith('https://')) {
             throw new {{spec.title | caseUcfirst}}Exception('Invalid endpoint URL: ' + endpoint);
         }

--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -129,6 +129,10 @@ class Client {
      * @returns {this}
      */
     setEndpoint(endpoint: string): this {
+        if (!endpoint || typeof endpoint !== 'string') {
+            throw new {{spec.title | caseUcfirst}}Exception('Endpoint must be a valid string');
+        }
+
         if (!endpoint.startsWith('http://') && !endpoint.startsWith('https://')) {
             throw new {{spec.title | caseUcfirst}}Exception('Invalid endpoint URL: ' + endpoint);
         }
@@ -147,6 +151,10 @@ class Client {
      * @returns {this}
      */
     setEndpointRealtime(endpointRealtime: string): this {
+        if (!endpointRealtime || typeof endpointRealtime !== 'string') {
+            throw new {{spec.title | caseUcfirst}}Exception('Endpoint must be a valid string');
+        }
+
         if (!endpointRealtime.startsWith('ws://') && !endpointRealtime.startsWith('wss://')) {
             throw new {{spec.title | caseUcfirst}}Exception('Invalid realtime endpoint URL: ' + endpointRealtime);
         }

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -334,6 +334,10 @@ class Client {
      * @returns {this}
      */
     setEndpoint(endpoint: string): this {
+        if (!endpoint || typeof endpoint !== 'string') {
+            throw new {{spec.title | caseUcfirst}}Exception('Endpoint must be a valid string');
+        }
+
         if (!endpoint.startsWith('http://') && !endpoint.startsWith('https://')) {
             throw new {{spec.title | caseUcfirst}}Exception('Invalid endpoint URL: ' + endpoint);
         }
@@ -352,6 +356,10 @@ class Client {
      * @returns {this}
      */
     setEndpointRealtime(endpointRealtime: string): this {
+        if (!endpointRealtime || typeof endpointRealtime !== 'string') {
+            throw new {{spec.title | caseUcfirst}}Exception('Endpoint must be a valid string');
+        }
+
         if (!endpointRealtime.startsWith('ws://') && !endpointRealtime.startsWith('wss://')) {
             throw new {{spec.title | caseUcfirst}}Exception('Invalid realtime endpoint URL: ' + endpointRealtime);
         }


### PR DESCRIPTION
## Summary
Fixes the weird error thrown when `setEndpoint()` is called with `undefined` in TypeScript client SDKs.

## Problem
Previously, calling `setEndpoint(undefined)` would throw a confusing `TypeError` because the code tried to call `.startsWith()` on `undefined`:
```
TypeError: Cannot read property 'startsWith' of undefined
```

## Solution
Added proper validation to check if the endpoint parameter is:
- `null`
- `undefined` 
- Not a string

Before attempting to validate the URL format. Now users get a clear, descriptive error message:
```
Endpoint must be a valid string
```

## Changes
- Added endpoint existence and type validation before `.startsWith()` check
- Applied to all TypeScript client templates:
  - Node.js (`templates/node/src/client.ts.twig`)
  - Web (`templates/web/src/client.ts.twig`)
  - Deno (`templates/deno/src/client.ts.twig`)
  - React Native (`templates/react-native/src/client.ts.twig`)

## Test plan
- [ ] Test with `undefined`: `client.setEndpoint(undefined)` → Should throw "Endpoint must be a valid string"
- [ ] Test with `null`: `client.setEndpoint(null)` → Should throw "Endpoint must be a valid string"
- [ ] Test with invalid URL: `client.setEndpoint('invalid')` → Should throw "Invalid endpoint URL: invalid"
- [ ] Test with valid URL: `client.setEndpoint('https://cloud.appwrite.io/v1')` → Should work correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved endpoint validation across Deno, Node.js, React Native, and Web SDKs. Endpoint setters now reject empty or non-string inputs early, before URL-scheme checks, and surface clearer error messages. This prevents invalid endpoint values from progressing to downstream URL validation or runtime use.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->