### PR TITLE
Fix: Android and Kotlin package name directory issues

### DIFF
--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -135,7 +135,7 @@ class SDK
             return strtolower(preg_replace('/(?<!^)([A-Z][a-z]|(?<=[a-z])[^a-z\s]|(?<=[A-Z])[0-9_])/', '-$1', $value));
         }));
         $this->twig->addFilter(new TwigFilter('caseSlash', function ($value) {
-            return str_replace([' ', '_'], '/', strtolower(preg_replace('/([a-zA-Z])(?=[A-Z])/', '$1/', $value)));
+            return str_replace([' ', '_', '.'], '/', strtolower(preg_replace('/([a-zA-Z])(?=[A-Z])/', '$1/', $value)));
         }));
         $this->twig->addFilter(new TwigFilter('caseDot', function ($value) {
             return str_replace([' ', '_'], '.', strtolower(preg_replace('/([a-zA-Z])(?=[A-Z])/', '$1.', $value)));


### PR DESCRIPTION
## What does this PR do?

Fixes `/io.appwrite/` to be `/io/appwrite/`

## Test Plan

Manual.

Before -
<img width="358" height="323" alt="Screenshot 2026-01-15 at 1 36 28 PM" src="https://github.com/user-attachments/assets/55e660f6-7d61-4604-8231-4aae9bb35ea0" />

After -

<img width="378" height="286" alt="Screenshot 2026-01-15 at 1 35 35 PM" src="https://github.com/user-attachments/assets/15be471e-0c55-4b4e-a165-92e40b995f51" />

## Related PRs and Issues

* https://github.com/appwrite/sdk-for-kotlin/pull/65/

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced string transformation to properly handle dots (.) alongside existing separators when converting camelCase to path-like formats, ensuring consistent behavior across all separator types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->