### PR TITLE
fix: handle BigInt and float JSON parsing correctly

### DIFF
--- a/templates/cli/lib/client.ts
+++ b/templates/cli/lib/client.ts
@@ -1,7 +1,7 @@
 import os from "os";
 import { fetch, FormData, Agent } from "undici";
 import JSONbigModule from 'json-bigint';
-import BigNumber from 'bignumber.js';
+import { BigNumber } from 'bignumber.js';
 import { AppwriteException } from "@appwrite.io/console";
 import { globalConfig } from "./config.js";
 import chalk from "chalk";
@@ -26,48 +26,23 @@ const JSONbigSerializer = JSONbigModule({ useNativeBigInt: true });
 const MAX_SAFE = BigInt(Number.MAX_SAFE_INTEGER);
 const MIN_SAFE = BigInt(Number.MIN_SAFE_INTEGER);
 
-/**
- * Converts BigNumber objects from json-bigint to native types.
- * - Integer BigNumbers → BigInt (if unsafe) or number (if safe)
- * - Float BigNumbers → number
- * - Strings remain strings (never converted to BigNumber by json-bigint)
- */
-function convertBigNumbers(value: any): any {
-  if (value === null || value === undefined) return value;
-
-  if (Array.isArray(value)) {
-      return value.map(convertBigNumbers);
-  }
-
+function reviver(_key: string, value: any): any {
   if (BigNumber.isBigNumber(value)) {
-      if (value.isInteger()) {
-          const str = value.toFixed();
-          const bi = BigInt(str);
-
-          if (bi >= MIN_SAFE && bi <= MAX_SAFE) {
-              return Number(str);
-          }
-
-          return bi;
+    if (value.isInteger()) {
+      const str = value.toFixed();
+      const bi = BigInt(str);
+      if (bi >= MIN_SAFE && bi <= MAX_SAFE) {
+        return Number(str);
       }
-
-      // float
-      return value.toNumber();
+      return bi;
+    }
+    return value.toNumber();
   }
-
-  if (typeof value === 'object') {
-      const result: any = {};
-      for (const [k, v] of Object.entries(value)) {
-          result[k] = convertBigNumbers(v);
-      }
-      return result;
-  }
-
   return value;
 }
 
 const JSONbig = {
-  parse: (text: string) => convertBigNumbers(JSONbigParser.parse(text)),
+  parse: (text: string) => JSONbigParser.parse(text, reviver),
   stringify: JSONbigSerializer.stringify
 };
 

--- a/templates/cli/package.json
+++ b/templates/cli/package.json
@@ -28,7 +28,8 @@
     "windows-arm64": "bun run build && esbuild dist/cli.js --bundle --platform=node --format=cjs --outfile=dist/bundle.cjs --external:@appwrite.io/console --external:fsevents && pkg dist/bundle.cjs -t node18-win-arm64 -o build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
-    "@appwrite.io/console": "^2.1.0",
+    "@appwrite.io/console": "^2.1.3",
+    "bignumber.js": "^9.0.0",
     "chalk": "4.1.2",
     "chokidar": "^3.6.0",
     "cli-progress": "^3.12.0",

--- a/templates/cli/package.json.twig
+++ b/templates/cli/package.json.twig
@@ -28,7 +28,8 @@
     "windows-arm64": "bun run build && esbuild dist/cli.js --bundle --platform=node --format=cjs --outfile=dist/bundle.cjs --external:@appwrite.io/console --external:fsevents && pkg dist/bundle.cjs -t node18-win-arm64 -o build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
-    "@appwrite.io/console": "^2.1.0",
+    "@appwrite.io/console": "^2.1.3",
+    "bignumber.js": "^9.0.0",
     "chalk": "4.1.2",
     "chokidar": "^3.6.0",
     "cli-progress": "^3.12.0",

--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -2,35 +2,46 @@ import { fetch, FormData, File } from 'node-fetch-native-with-agent';
 import { createAgent } from 'node-fetch-native-with-agent/agent';
 import { Models } from './models';
 import JSONbigModule from 'json-bigint';
-const JSONbigParser = JSONbigModule({ storeAsString: true });
+const JSONbigParser = JSONbigModule({ storeAsString: false });
 const JSONbigSerializer = JSONbigModule({ useNativeBigInt: true });
 
 /**
- * Converts numeric strings from json-bigint (storeAsString: true) to native types.
- * Large integers (16+ digits) become BigInt, large floats become number.
+ * Converts BigNumber objects from json-bigint to native types.
+ * - Integer BigNumbers → BigInt (if unsafe) or number (if safe)
+ * - Float BigNumbers → number
+ * - Strings remain strings (never converted to BigNumber by json-bigint)
  */
-function convertBigIntStrings(obj: any): any {
+function convertBigNumbers(obj: any): any {
     if (obj === null || obj === undefined) return obj;
-    if (Array.isArray(obj)) return obj.map(convertBigIntStrings);
+    if (Array.isArray(obj)) return obj.map(convertBigNumbers);
+
+    // Check if it's a BigNumber (has specific BigNumber methods)
+    if (typeof obj === 'object' && obj.constructor?.name === 'BigNumber') {
+        const str = obj.toString();
+        // Check if it's an integer (no decimal point)
+        if (obj.isInteger()) {
+            const num = obj.toNumber();
+            return Number.isSafeInteger(num) ? num : BigInt(str);
+        }
+        // It's a float
+        return obj.toNumber();
+    }
+
     if (typeof obj === 'object') {
         const result: any = {};
         for (const key in obj) {
             if (Object.prototype.hasOwnProperty.call(obj, key)) {
-                result[key] = convertBigIntStrings(obj[key]);
+                result[key] = convertBigNumbers(obj[key]);
             }
         }
         return result;
     }
-    // json-bigint stores numbers > 15 digits as strings
-    if (typeof obj === 'string' && /^-?\d+$/.test(obj)) {
-        const num = Number(obj);
-        return Number.isSafeInteger(num) ? num : BigInt(obj);
-    }
+
     return obj;
 }
 
 const JSONbig = {
-    parse: (text: string) => convertBigIntStrings(JSONbigParser.parse(text)),
+    parse: (text: string) => convertBigNumbers(JSONbigParser.parse(text)),
     stringify: JSONbigSerializer.stringify
 };
 

--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -22,12 +22,9 @@ function convertBigIntStrings(obj: any): any {
         return result;
     }
     // json-bigint stores numbers > 15 digits as strings
-    if (typeof obj === 'string' && obj.length > 15) {
+    if (typeof obj === 'string' && /^-?\d+$/.test(obj)) {
         const num = Number(obj);
-        if (!Number.isNaN(num)) {
-            // Has decimal point → float, No decimal → BigInt
-            return obj.includes('.') ? num : BigInt(obj);
-        }
+        return Number.isSafeInteger(num) ? num : BigInt(obj);
     }
     return obj;
 }

--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -9,48 +9,23 @@ const JSONbigSerializer = JSONbigModule({ useNativeBigInt: true });
 const MAX_SAFE = BigInt(Number.MAX_SAFE_INTEGER);
 const MIN_SAFE = BigInt(Number.MIN_SAFE_INTEGER);
 
-/**
- * Converts BigNumber objects from json-bigint to native types.
- * - Integer BigNumbers → BigInt (if unsafe) or number (if safe)
- * - Float BigNumbers → number
- * - Strings remain strings (never converted to BigNumber by json-bigint)
- */
-function convertBigNumbers(value: any): any {
-    if (value === null || value === undefined) return value;
-
-    if (Array.isArray(value)) {
-        return value.map(convertBigNumbers);
-    }
-
+function reviver(_key: string, value: any): any {
     if (BigNumber.isBigNumber(value)) {
         if (value.isInteger()) {
             const str = value.toFixed();
             const bi = BigInt(str);
-
             if (bi >= MIN_SAFE && bi <= MAX_SAFE) {
                 return Number(str);
             }
-
             return bi;
         }
-
-        // float
         return value.toNumber();
     }
-
-    if (typeof value === 'object') {
-        const result: any = {};
-        for (const [k, v] of Object.entries(value)) {
-            result[k] = convertBigNumbers(v);
-        }
-        return result;
-    }
-
     return value;
 }
 
 const JSONbig = {
-    parse: (text: string) => convertBigNumbers(JSONbigParser.parse(text)),
+    parse: (text: string) => JSONbigParser.parse(text, reviver),
     stringify: JSONbigSerializer.stringify
 };
 

--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -2,7 +2,40 @@ import { fetch, FormData, File } from 'node-fetch-native-with-agent';
 import { createAgent } from 'node-fetch-native-with-agent/agent';
 import { Models } from './models';
 import JSONbigModule from 'json-bigint';
-const JSONbig = JSONbigModule({ useNativeBigInt: true });
+const JSONbigParser = JSONbigModule({ storeAsString: true });
+const JSONbigSerializer = JSONbigModule({ useNativeBigInt: true });
+
+/**
+ * Converts numeric strings from json-bigint (storeAsString: true) to native types.
+ * Large integers (16+ digits) become BigInt, large floats become number.
+ */
+function convertBigIntStrings(obj: any): any {
+    if (obj === null || obj === undefined) return obj;
+    if (Array.isArray(obj)) return obj.map(convertBigIntStrings);
+    if (typeof obj === 'object') {
+        const result: any = {};
+        for (const key in obj) {
+            if (Object.prototype.hasOwnProperty.call(obj, key)) {
+                result[key] = convertBigIntStrings(obj[key]);
+            }
+        }
+        return result;
+    }
+    // json-bigint stores numbers > 15 digits as strings
+    if (typeof obj === 'string' && obj.length > 15) {
+        const num = Number(obj);
+        if (!Number.isNaN(num)) {
+            // Has decimal point → float, No decimal → BigInt
+            return obj.includes('.') ? num : BigInt(obj);
+        }
+    }
+    return obj;
+}
+
+const JSONbig = {
+    parse: (text: string) => convertBigIntStrings(JSONbigParser.parse(text)),
+    stringify: JSONbigSerializer.stringify
+};
 
 type Payload = {
     [key: string]: any;

--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -2,8 +2,12 @@ import { fetch, FormData, File } from 'node-fetch-native-with-agent';
 import { createAgent } from 'node-fetch-native-with-agent/agent';
 import { Models } from './models';
 import JSONbigModule from 'json-bigint';
+import BigNumber from 'bignumber.js';
 const JSONbigParser = JSONbigModule({ storeAsString: false });
 const JSONbigSerializer = JSONbigModule({ useNativeBigInt: true });
+
+const MAX_SAFE = BigInt(Number.MAX_SAFE_INTEGER);
+const MIN_SAFE = BigInt(Number.MIN_SAFE_INTEGER);
 
 /**
  * Converts BigNumber objects from json-bigint to native types.
@@ -11,33 +15,38 @@ const JSONbigSerializer = JSONbigModule({ useNativeBigInt: true });
  * - Float BigNumbers → number
  * - Strings remain strings (never converted to BigNumber by json-bigint)
  */
-function convertBigNumbers(obj: any): any {
-    if (obj === null || obj === undefined) return obj;
-    if (Array.isArray(obj)) return obj.map(convertBigNumbers);
+function convertBigNumbers(value: any): any {
+    if (value === null || value === undefined) return value;
 
-    // Check if it's a BigNumber (has specific BigNumber methods)
-    if (typeof obj === 'object' && obj.constructor?.name === 'BigNumber') {
-        const str = obj.toString();
-        // Check if it's an integer (no decimal point)
-        if (obj.isInteger()) {
-            const num = obj.toNumber();
-            return Number.isSafeInteger(num) ? num : BigInt(str);
-        }
-        // It's a float
-        return obj.toNumber();
+    if (Array.isArray(value)) {
+        return value.map(convertBigNumbers);
     }
 
-    if (typeof obj === 'object') {
-        const result: any = {};
-        for (const key in obj) {
-            if (Object.prototype.hasOwnProperty.call(obj, key)) {
-                result[key] = convertBigNumbers(obj[key]);
+    if (BigNumber.isBigNumber(value)) {
+        if (value.isInteger()) {
+            const str = value.toFixed();
+            const bi = BigInt(str);
+
+            if (bi >= MIN_SAFE && bi <= MAX_SAFE) {
+                return Number(str);
             }
+
+            return bi;
+        }
+
+        // float
+        return value.toNumber();
+    }
+
+    if (typeof value === 'object') {
+        const result: any = {};
+        for (const [k, v] of Object.entries(value)) {
+            result[k] = convertBigNumbers(v);
         }
         return result;
     }
 
-    return obj;
+    return value;
 }
 
 const JSONbig = {

--- a/templates/react-native/package.json.twig
+++ b/templates/react-native/package.json.twig
@@ -36,7 +36,8 @@
   "dependencies": {
     "expo-file-system": "18.*.*",
     "json-bigint": "1.0.0",
-    "react-native": ">=0.76.7 <1.0.0"
+    "react-native": ">=0.76.7 <1.0.0",
+    "bignumber.js": "^9.0.0"
   },
   "peerDependencies": {
     "expo": "*"

--- a/templates/react-native/rollup.config.js.twig
+++ b/templates/react-native/rollup.config.js.twig
@@ -1,9 +1,11 @@
 import pkg from "./package.json";
 import typescript from "@rollup/plugin-typescript";
 
+const external = Object.keys(pkg.dependencies ?? {});
+
 export default {
-    external: Object.keys(pkg.dependencies),
     input: "src/index.ts",
+    external,
     plugins: [typescript()],
     output: [
         {
@@ -24,6 +26,7 @@ export default {
             extend: true,
             globals: {
                 "json-bigint": "JSONbig",
+                "bignumber.js": "BigNumber",
             },
         },
     ],

--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -2,35 +2,46 @@ import { Models } from './models';
 import { Service } from './service';
 import { Platform } from 'react-native';
 import JSONbigModule from 'json-bigint';
-const JSONbigParser = JSONbigModule({ storeAsString: true });
+const JSONbigParser = JSONbigModule({ storeAsString: false });
 const JSONbigSerializer = JSONbigModule({ useNativeBigInt: true });
 
 /**
- * Converts numeric strings from json-bigint (storeAsString: true) to native types.
- * Large integers (16+ digits) become BigInt, large floats become number.
+ * Converts BigNumber objects from json-bigint to native types.
+ * - Integer BigNumbers → BigInt (if unsafe) or number (if safe)
+ * - Float BigNumbers → number
+ * - Strings remain strings (never converted to BigNumber by json-bigint)
  */
-function convertBigIntStrings(obj: any): any {
+function convertBigNumbers(obj: any): any {
     if (obj === null || obj === undefined) return obj;
-    if (Array.isArray(obj)) return obj.map(convertBigIntStrings);
+    if (Array.isArray(obj)) return obj.map(convertBigNumbers);
+
+    // Check if it's a BigNumber (has specific BigNumber methods)
+    if (typeof obj === 'object' && obj.constructor?.name === 'BigNumber') {
+        const str = obj.toString();
+        // Check if it's an integer (no decimal point)
+        if (obj.isInteger()) {
+            const num = obj.toNumber();
+            return Number.isSafeInteger(num) ? num : BigInt(str);
+        }
+        // It's a float
+        return obj.toNumber();
+    }
+
     if (typeof obj === 'object') {
         const result: any = {};
         for (const key in obj) {
             if (Object.prototype.hasOwnProperty.call(obj, key)) {
-                result[key] = convertBigIntStrings(obj[key]);
+                result[key] = convertBigNumbers(obj[key]);
             }
         }
         return result;
     }
-    // json-bigint stores numbers > 15 digits as strings
-    if (typeof obj === 'string' && /^-?\d+$/.test(obj)) {
-        const num = Number(obj);
-        return Number.isSafeInteger(num) ? num : BigInt(obj);
-    }
+
     return obj;
 }
 
 const JSONbig = {
-    parse: (text: string) => convertBigIntStrings(JSONbigParser.parse(text)),
+    parse: (text: string) => convertBigNumbers(JSONbigParser.parse(text)),
     stringify: JSONbigSerializer.stringify
 };
 

--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -2,8 +2,12 @@ import { Models } from './models';
 import { Service } from './service';
 import { Platform } from 'react-native';
 import JSONbigModule from 'json-bigint';
+import BigNumber from 'bignumber.js';
 const JSONbigParser = JSONbigModule({ storeAsString: false });
 const JSONbigSerializer = JSONbigModule({ useNativeBigInt: true });
+
+const MAX_SAFE = BigInt(Number.MAX_SAFE_INTEGER);
+const MIN_SAFE = BigInt(Number.MIN_SAFE_INTEGER);
 
 /**
  * Converts BigNumber objects from json-bigint to native types.
@@ -11,33 +15,38 @@ const JSONbigSerializer = JSONbigModule({ useNativeBigInt: true });
  * - Float BigNumbers → number
  * - Strings remain strings (never converted to BigNumber by json-bigint)
  */
-function convertBigNumbers(obj: any): any {
-    if (obj === null || obj === undefined) return obj;
-    if (Array.isArray(obj)) return obj.map(convertBigNumbers);
+function convertBigNumbers(value: any): any {
+    if (value === null || value === undefined) return value;
 
-    // Check if it's a BigNumber (has specific BigNumber methods)
-    if (typeof obj === 'object' && obj.constructor?.name === 'BigNumber') {
-        const str = obj.toString();
-        // Check if it's an integer (no decimal point)
-        if (obj.isInteger()) {
-            const num = obj.toNumber();
-            return Number.isSafeInteger(num) ? num : BigInt(str);
-        }
-        // It's a float
-        return obj.toNumber();
+    if (Array.isArray(value)) {
+        return value.map(convertBigNumbers);
     }
 
-    if (typeof obj === 'object') {
-        const result: any = {};
-        for (const key in obj) {
-            if (Object.prototype.hasOwnProperty.call(obj, key)) {
-                result[key] = convertBigNumbers(obj[key]);
+    if (BigNumber.isBigNumber(value)) {
+        if (value.isInteger()) {
+            const str = value.toFixed();
+            const bi = BigInt(str);
+
+            if (bi >= MIN_SAFE && bi <= MAX_SAFE) {
+                return Number(str);
             }
+
+            return bi;
+        }
+
+        // float
+        return value.toNumber();
+    }
+
+    if (typeof value === 'object') {
+        const result: any = {};
+        for (const [k, v] of Object.entries(value)) {
+            result[k] = convertBigNumbers(v);
         }
         return result;
     }
 
-    return obj;
+    return value;
 }
 
 const JSONbig = {

--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -2,7 +2,40 @@ import { Models } from './models';
 import { Service } from './service';
 import { Platform } from 'react-native';
 import JSONbigModule from 'json-bigint';
-const JSONbig = JSONbigModule({ useNativeBigInt: true });
+const JSONbigParser = JSONbigModule({ storeAsString: true });
+const JSONbigSerializer = JSONbigModule({ useNativeBigInt: true });
+
+/**
+ * Converts numeric strings from json-bigint (storeAsString: true) to native types.
+ * Large integers (16+ digits) become BigInt, large floats become number.
+ */
+function convertBigIntStrings(obj: any): any {
+    if (obj === null || obj === undefined) return obj;
+    if (Array.isArray(obj)) return obj.map(convertBigIntStrings);
+    if (typeof obj === 'object') {
+        const result: any = {};
+        for (const key in obj) {
+            if (Object.prototype.hasOwnProperty.call(obj, key)) {
+                result[key] = convertBigIntStrings(obj[key]);
+            }
+        }
+        return result;
+    }
+    // json-bigint stores numbers > 15 digits as strings
+    if (typeof obj === 'string' && obj.length > 15) {
+        const num = Number(obj);
+        if (!Number.isNaN(num)) {
+            // Has decimal point → float, No decimal → BigInt
+            return obj.includes('.') ? num : BigInt(obj);
+        }
+    }
+    return obj;
+}
+
+const JSONbig = {
+    parse: (text: string) => convertBigIntStrings(JSONbigParser.parse(text)),
+    stringify: JSONbigSerializer.stringify
+};
 
 type Payload = {
     [key: string]: any;

--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -22,12 +22,9 @@ function convertBigIntStrings(obj: any): any {
         return result;
     }
     // json-bigint stores numbers > 15 digits as strings
-    if (typeof obj === 'string' && obj.length > 15) {
+    if (typeof obj === 'string' && /^-?\d+$/.test(obj)) {
         const num = Number(obj);
-        if (!Number.isNaN(num)) {
-            // Has decimal point → float, No decimal → BigInt
-            return obj.includes('.') ? num : BigInt(obj);
-        }
+        return Number.isSafeInteger(num) ? num : BigInt(obj);
     }
     return obj;
 }

--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -9,48 +9,23 @@ const JSONbigSerializer = JSONbigModule({ useNativeBigInt: true });
 const MAX_SAFE = BigInt(Number.MAX_SAFE_INTEGER);
 const MIN_SAFE = BigInt(Number.MIN_SAFE_INTEGER);
 
-/**
- * Converts BigNumber objects from json-bigint to native types.
- * - Integer BigNumbers → BigInt (if unsafe) or number (if safe)
- * - Float BigNumbers → number
- * - Strings remain strings (never converted to BigNumber by json-bigint)
- */
-function convertBigNumbers(value: any): any {
-    if (value === null || value === undefined) return value;
-
-    if (Array.isArray(value)) {
-        return value.map(convertBigNumbers);
-    }
-
+function reviver(_key: string, value: any): any {
     if (BigNumber.isBigNumber(value)) {
         if (value.isInteger()) {
             const str = value.toFixed();
             const bi = BigInt(str);
-
             if (bi >= MIN_SAFE && bi <= MAX_SAFE) {
                 return Number(str);
             }
-
             return bi;
         }
-
-        // float
         return value.toNumber();
     }
-
-    if (typeof value === 'object') {
-        const result: any = {};
-        for (const [k, v] of Object.entries(value)) {
-            result[k] = convertBigNumbers(v);
-        }
-        return result;
-    }
-
     return value;
 }
 
 const JSONbig = {
-    parse: (text: string) => convertBigNumbers(JSONbigParser.parse(text)),
+    parse: (text: string) => JSONbigParser.parse(text, reviver),
     stringify: JSONbigSerializer.stringify
 };
 

--- a/templates/web/package.json.twig
+++ b/templates/web/package.json.twig
@@ -25,7 +25,8 @@
     "build:libs": "rollup -c"
   },
   "dependencies": {
-    "json-bigint": "1.0.0"
+    "json-bigint": "1.0.0",
+    "bignumber.js": "^9.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "22.0.0",

--- a/templates/web/package.json.twig
+++ b/templates/web/package.json.twig
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "json-bigint": "1.0.0",
-    "bignumber.js": "^9.0.0"
+    "bignumber.js": "9.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "22.0.0",

--- a/templates/web/rollup.config.js.twig
+++ b/templates/web/rollup.config.js.twig
@@ -26,7 +26,6 @@ export default [
     },
     {
         input: "src/index.ts",
-        external,
         plugins: [
             resolve({ browser: true }),
             commonjs(),
@@ -38,10 +37,6 @@ export default [
                 file: pkg.jsdelivr,
                 name: "Appwrite",
                 extend: true,
-                globals: {
-                    "json-bigint": "JSONbig",
-                    "bignumber.js": "BigNumber",
-                },
             },
         ],
     }

--- a/templates/web/rollup.config.js.twig
+++ b/templates/web/rollup.config.js.twig
@@ -26,6 +26,7 @@ export default [
     },
     {
         input: "src/index.ts",
+        external,
         plugins: [
             resolve({ browser: true }),
             commonjs(),
@@ -37,6 +38,10 @@ export default [
                 file: pkg.jsdelivr,
                 name: "Appwrite",
                 extend: true,
+                globals: {
+                    "json-bigint": "JSONbig",
+                    "bignumber.js": "BigNumber",
+                },
             },
         ],
     }

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -1,35 +1,46 @@
 import { Models } from './models';
 import { Channel, ActionableChannel, ResolvedChannel } from './channel';
 import JSONbigModule from 'json-bigint';
-const JSONbigParser = JSONbigModule({ storeAsString: true });
+const JSONbigParser = JSONbigModule({ storeAsString: false });
 const JSONbigSerializer = JSONbigModule({ useNativeBigInt: true });
 
 /**
- * Converts numeric strings from json-bigint (storeAsString: true) to native types.
- * Large integers (16+ digits) become BigInt, large floats become number.
+ * Converts BigNumber objects from json-bigint to native types.
+ * - Integer BigNumbers → BigInt (if unsafe) or number (if safe)
+ * - Float BigNumbers → number
+ * - Strings remain strings (never converted to BigNumber by json-bigint)
  */
-function convertBigIntStrings(obj: any): any {
+function convertBigNumbers(obj: any): any {
     if (obj === null || obj === undefined) return obj;
-    if (Array.isArray(obj)) return obj.map(convertBigIntStrings);
+    if (Array.isArray(obj)) return obj.map(convertBigNumbers);
+
+    // Check if it's a BigNumber (has specific BigNumber methods)
+    if (typeof obj === 'object' && obj.constructor?.name === 'BigNumber') {
+        const str = obj.toString();
+        // Check if it's an integer (no decimal point)
+        if (obj.isInteger()) {
+            const num = obj.toNumber();
+            return Number.isSafeInteger(num) ? num : BigInt(str);
+        }
+        // It's a float
+        return obj.toNumber();
+    }
+
     if (typeof obj === 'object') {
         const result: any = {};
         for (const key in obj) {
             if (Object.prototype.hasOwnProperty.call(obj, key)) {
-                result[key] = convertBigIntStrings(obj[key]);
+                result[key] = convertBigNumbers(obj[key]);
             }
         }
         return result;
     }
-    // json-bigint stores numbers > 15 digits as strings
-    if (typeof obj === 'string' && /^-?\d+$/.test(obj)) {
-        const num = Number(obj);
-        return Number.isSafeInteger(num) ? num : BigInt(obj);
-    }
+
     return obj;
 }
 
 const JSONbig = {
-    parse: (text: string) => convertBigIntStrings(JSONbigParser.parse(text)),
+    parse: (text: string) => convertBigNumbers(JSONbigParser.parse(text)),
     stringify: JSONbigSerializer.stringify
 };
 

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -5,15 +5,15 @@ import BigNumber from 'bignumber.js';
 const JSONbigParser = JSONbigModule({ storeAsString: false });
 const JSONbigSerializer = JSONbigModule({ useNativeBigInt: true });
 
+const MAX_SAFE = BigInt(Number.MAX_SAFE_INTEGER);
+const MIN_SAFE = BigInt(Number.MIN_SAFE_INTEGER);
+
 /**
  * Converts BigNumber objects from json-bigint to native types.
  * - Integer BigNumbers → BigInt (if unsafe) or number (if safe)
  * - Float BigNumbers → number
  * - Strings remain strings (never converted to BigNumber by json-bigint)
  */
-const MAX_SAFE = BigInt(Number.MAX_SAFE_INTEGER);
-const MIN_SAFE = BigInt(Number.MIN_SAFE_INTEGER);
-
 function convertBigNumbers(value: any): any {
     if (value === null || value === undefined) return value;
 

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -8,48 +8,23 @@ const JSONbigSerializer = JSONbigModule({ useNativeBigInt: true });
 const MAX_SAFE = BigInt(Number.MAX_SAFE_INTEGER);
 const MIN_SAFE = BigInt(Number.MIN_SAFE_INTEGER);
 
-/**
- * Converts BigNumber objects from json-bigint to native types.
- * - Integer BigNumbers → BigInt (if unsafe) or number (if safe)
- * - Float BigNumbers → number
- * - Strings remain strings (never converted to BigNumber by json-bigint)
- */
-function convertBigNumbers(value: any): any {
-    if (value === null || value === undefined) return value;
-
-    if (Array.isArray(value)) {
-        return value.map(convertBigNumbers);
-    }
-
+function reviver(_key: string, value: any): any {
     if (BigNumber.isBigNumber(value)) {
         if (value.isInteger()) {
             const str = value.toFixed();
             const bi = BigInt(str);
-
             if (bi >= MIN_SAFE && bi <= MAX_SAFE) {
                 return Number(str);
             }
-
             return bi;
         }
-
-        // float
         return value.toNumber();
     }
-
-    if (typeof value === 'object') {
-        const result: any = {};
-        for (const [k, v] of Object.entries(value)) {
-            result[k] = convertBigNumbers(v);
-        }
-        return result;
-    }
-
     return value;
 }
 
 const JSONbig = {
-    parse: (text: string) => convertBigNumbers(JSONbigParser.parse(text)),
+    parse: (text: string) => JSONbigParser.parse(text, reviver),
     stringify: JSONbigSerializer.stringify
 };
 

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -1,7 +1,42 @@
 import { Models } from './models';
 import { Channel, ActionableChannel, ResolvedChannel } from './channel';
 import JSONbigModule from 'json-bigint';
-const JSONbig = JSONbigModule({ useNativeBigInt: true });
+const JSONbigParser = JSONbigModule({ storeAsString: true });
+const JSONbigSerializer = JSONbigModule({ useNativeBigInt: true });
+
+/**
+ * Converts numeric strings from json-bigint (storeAsString: true) to native types.
+ * Large integers (16+ digits) become BigInt, large floats become number.
+ */
+function convertBigIntStrings(obj: any): any {
+    if (obj === null || obj === undefined) return obj;
+    if (Array.isArray(obj)) return obj.map(convertBigIntStrings);
+    if (typeof obj === 'object') {
+        const result: any = {};
+        for (const key in obj) {
+            if (Object.prototype.hasOwnProperty.call(obj, key)) {
+                result[key] = convertBigIntStrings(obj[key]);
+            }
+        }
+        return result;
+    }
+    // json-bigint stores numbers > 15 digits as strings
+    if (typeof obj === 'string' && obj.length > 15) {
+        // Check if it's a numeric string (doesn't start with 0 unless it's "0" or "0.x")
+        const num = Number(obj);
+        if (!Number.isNaN(num)) {
+            // Has decimal point → float, keep as number
+            // No decimal point → large integer, convert to BigInt
+            return obj.includes('.') ? num : BigInt(obj);
+        }
+    }
+    return obj;
+}
+
+const JSONbig = {
+    parse: (text: string) => convertBigIntStrings(JSONbigParser.parse(text)),
+    stringify: JSONbigSerializer.stringify
+};
 
 /**
  * Payload type representing a key-value pair with string keys and any values.

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -21,14 +21,9 @@ function convertBigIntStrings(obj: any): any {
         return result;
     }
     // json-bigint stores numbers > 15 digits as strings
-    if (typeof obj === 'string' && obj.length > 15) {
-        // Check if it's a numeric string (doesn't start with 0 unless it's "0" or "0.x")
+    if (typeof obj === 'string' && /^-?\d+$/.test(obj)) {
         const num = Number(obj);
-        if (!Number.isNaN(num)) {
-            // Has decimal point → float, keep as number
-            // No decimal point → large integer, convert to BigInt
-            return obj.includes('.') ? num : BigInt(obj);
-        }
+        return Number.isSafeInteger(num) ? num : BigInt(obj);
     }
     return obj;
 }


### PR DESCRIPTION
## Summary

Fixes the `Cannot convert 168.79998779296875 to a BigInt` error that occurs when parsing API responses containing floating-point numbers with more than 15 characters.

### Problem

The previous configuration used `useNativeBigInt: true` for JSON parsing:

```typescript
const JSONbig = JSONbigModule({ useNativeBigInt: true });
```

This caused `json-bigint` to attempt converting **all** numbers with more than 15 characters to native `BigInt`. However, `BigInt` only supports integers, so floats like `168.79998779296875` (18 characters) would crash:

```
SyntaxError: Cannot convert 168.79998779296875 to a BigInt
```

### Solution

Use `storeAsString: true` for parsing (safe for all number types), then post-process to convert strings to appropriate native types:

```typescript
const JSONbigParser = JSONbigModule({ storeAsString: true });
const JSONbigSerializer = JSONbigModule({ useNativeBigInt: true });

function convertBigIntStrings(obj: any): any {
    // ... recursion for arrays/objects ...
    if (typeof obj === 'string' && obj.length > 15) {
        const num = Number(obj);
        if (!Number.isNaN(num)) {
            return obj.includes('.') ? num : BigInt(obj);
        }
    }
    return obj;
}

const JSONbig = {
    parse: (text) => convertBigIntStrings(JSONbigParser.parse(text)),
    stringify: JSONbigSerializer.stringify
};
```

## Test Cases

| Input JSON | Parsed Type | Parsed Value | Status |
|------------|-------------|--------------|--------|
| `168.79998779296875` | `number` | `168.79998779296875` | ✅ (was crashing) |
| `9007199254740993` | `bigint` | `9007199254740993n` | ✅ |
| `12345` | `number` | `12345` | ✅ |
| `-9007199254740993` | `bigint` | `-9007199254740993n` | ✅ |
| `-9223372036854775808` | `bigint` | `-9223372036854775808n` | ✅ (int64 min) |
| `9223372036854775807` | `bigint` | `9223372036854775807n` | ✅ (int64 max) |
| `"hello"` | `string` | `"hello"` | ✅ |
| `0.0` | `number` | `0` | ✅ |
| `999.99` | `number` | `999.99` | ✅ |
| `{"id": 9007199254740993n}` (stringify) | - | `{"id":9007199254740993}` | ✅ |

### Nested Object Example

```json
{"user": {"id": 9007199254740993, "score": 168.79998779296875, "name": "test"}}
```

Result:
- `user.id` → `bigint` ✅
- `user.score` → `number` ✅
- `user.name` → `string` ✅

## Files Changed

- `templates/web/src/client.ts.twig`
- `templates/node/src/client.ts.twig`
- `templates/react-native/src/client.ts.twig`

## Related Issue

Fixes CLI error: `appwrite init project` failing with `Cannot convert 168.79998779296875 to a BigInt` in appwrite-cli v13.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer, consistent handling of very large numeric values in JSON across Web, Node.js, React Native and CLI templates to preserve precision.

* **New Features**
  * Parsed responses and events now convert large numeric values into appropriate native types (BigInt or number) so integers and floats are represented correctly.
  * Parsing/serialization internals reorganized for more reliable JSON parsing with no public API changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->