### PR TITLE
cli: cleanup unused dependency and improve generate command

### DIFF
--- a/templates/cli/lib/commands/generate.ts
+++ b/templates/cli/lib/commands/generate.ts
@@ -129,12 +129,6 @@ const generateAction = async (
       const firstEntity = entities?.[0];
       const dbId = firstEntity?.databaseId ?? "databaseId";
       const tableName = firstEntity?.name ?? "tableName";
-      const formatAccessor = (value: string): string =>
-        /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(value)
-          ? `.${value}`
-          : `[${JSON.stringify(value)}]`;
-      const dbAccessor = formatAccessor(dbId);
-      const tableAccessor = formatAccessor(tableName);
 
       console.log("");
       log(`Import the generated SDK in your project:`);
@@ -165,7 +159,7 @@ export const generate = new Command("generate")
   )
   .option(
     "-o, --output <directory>",
-    "Output directory for generated files (default: generated)",
+    "Output directory for generated files",
     "generated",
   )
   .option(
@@ -176,5 +170,19 @@ export const generate = new Command("generate")
     "--server <mode>",
     "Override server-side generation (auto|true|false)",
     "auto",
+  )
+  .addHelpText(
+    "after",
+    `
+Example:
+  Import the generated SDK in your project:
+    import { databases } from "./generated/${SDK_TITLE_LOWER}/index.js";
+
+  Configure your SDK constants:
+    set values in ./generated/${SDK_TITLE_LOWER}/constants.ts
+
+  Usage:
+    const mydb = databases.use("databaseId");
+    await mydb.use("tableName").create({ ... });`,
   )
   .action(actionRunner(generateAction));

--- a/templates/cli/lib/parser.ts
+++ b/templates/cli/lib/parser.ts
@@ -244,6 +244,7 @@ export const commandDescriptions: Record<string, string> = {
   push: `The push command provides a convenient wrapper for pushing your functions, collections, buckets, teams, and messaging-topics.`,
   run: `The run command allows you to run the project locally to allow easy development and quick debugging.`,
   functions: `The functions command allows you to view, create, and manage your Cloud Functions.`,
+  generate: `The generate command allows you to generate a type-safe SDK from your ${SDK_TITLE} project configuration.`,
   health: `The health command allows you to both validate and monitor your ${SDK_TITLE} server's health.`,
   pull: `The pull command helps you pull your ${SDK_TITLE} project, functions, collections, buckets, teams, and messaging-topics`,
   locale: `The locale command allows you to customize your app based on your users' location.`,

--- a/templates/cli/package.json
+++ b/templates/cli/package.json
@@ -42,7 +42,6 @@
     "dotenv": "^16.4.5",
     "ejs": "^3.1.9",
     "handlebars": "^4.7.7",
-    "form-data": "^4.0.0",
     "ignore": "^7.0.5",
     "inquirer": "^8.2.4",
     "inquirer-search-list": "^1.2.6",

--- a/templates/cli/package.json.twig
+++ b/templates/cli/package.json.twig
@@ -42,7 +42,6 @@
     "dotenv": "^16.4.5",
     "ejs": "^3.1.9",
     "handlebars": "^4.7.7",
-    "form-data": "^4.0.0",
     "ignore": "^7.0.5",
     "inquirer": "^8.2.4",
     "inquirer-search-list": "^1.2.6",


### PR DESCRIPTION
## Summary
- Remove unused `form-data` dependency from CLI template (code uses `FormData` from `undici` instead)
- Add missing description for `generate` command in command descriptions
- Add usage example to `generate --help` showing how to use the generated SDK
- Fix duplicate default value display in `generate --help` output

## Test plan
- [ ] Verify `form-data` is not imported anywhere in CLI template code
- [ ] Run `appwrite generate --help` and confirm examples are displayed
- [ ] Verify CLI builds successfully without `form-data` dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added example usage and guidance text to the `generate` command, including SDK import and configuration instructions.

* **Documentation**
  * Updated `generate` command help text with clearer descriptions.
  * Simplified the output option description.

* **Chores**
  * Removed unused dependency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->