### PR TITLE
fix(cli): filter index fields and fix string size validation when pulling tables

### DIFF
--- a/templates/cli/lib/commands/config-validations.ts
+++ b/templates/cli/lib/commands/config-validations.ts
@@ -18,18 +18,29 @@ export const validateRequiredDefault = (data: {
 };
 
 /**
- * Validates that string type attributes must have a size defined
+ * Validates that string type attributes must have a size defined,
+ * unless they have a format (email, url, ip, enum) which defines the size
  */
 export const validateStringSize = (data: {
   type: string;
   size?: number | null;
+  format?: string | null;
 }) => {
-  if (
-    data.type === "string" &&
-    (data.size === undefined || data.size === null)
-  ) {
+  // Skip validation if not a string type
+  if (data.type !== "string") {
+    return true;
+  }
+
+  // String columns with format don't need explicit size
+  if (data.format && data.format !== "") {
+    return true;
+  }
+
+  // Regular string columns need size
+  if (data.size === undefined || data.size === null) {
     return false;
   }
+
   return true;
 };
 

--- a/templates/cli/lib/commands/pull.ts
+++ b/templates/cli/lib/commands/pull.ts
@@ -41,6 +41,7 @@ import {
   DatabaseSchema,
   TableSchema,
   ColumnSchema,
+  IndexTableSchema,
   BucketSchema,
   TopicSchema,
 } from "./config.js";
@@ -551,9 +552,15 @@ export class Pull {
           filterBySchema(col, ColumnSchema),
         );
 
+        // Filter indexes to only include schema-defined fields
+        const filteredIndexes = table.indexes?.map((idx: any) =>
+          filterBySchema(idx, IndexTableSchema),
+        );
+
         allTables.push({
           ...filterBySchema(table, TableSchema),
           columns: filteredColumns || [],
+          indexes: filteredIndexes || [],
         });
       }
     }


### PR DESCRIPTION
## Summary
- Filter out `$id`, `$createdAt`, `$updatedAt`, `error`, and `lengths` fields from indexes when pulling tables using `filterBySchema`
- Update `validateStringSize` to skip the size requirement for string columns that have a format (email, url, ip, enum) since formats define their own size

## Test plan
- [ ] Run `appwrite pull tables` and verify indexes no longer contain extra fields
- [ ] Verify config validation passes for string columns with formats (email, url, ip, enum) that don't have explicit size

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional format field support for string attributes, enabling strings with defined formats (email, url, ip, enum) to bypass size validation requirements.
  * Table data structures now include index information.

* **Bug Fixes**
  * String size validation is now conditional—only required when no format is specified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->