### PR TITLE
feat(cli): support text/varchar/mediumtext/longtext attributes

### DIFF
--- a/templates/cli/lib/commands/config-validations.ts
+++ b/templates/cli/lib/commands/config-validations.ts
@@ -18,7 +18,7 @@ export const validateRequiredDefault = (data: {
 };
 
 /**
- * Validates that string type attributes must have a size defined,
+ * Validates that string/varchar type attributes must have a size defined,
  * unless they have a format (email, url, ip, enum) which defines the size
  */
 export const validateStringSize = (data: {
@@ -26,8 +26,8 @@ export const validateStringSize = (data: {
   size?: number | null;
   format?: string | null;
 }) => {
-  // Skip validation if not a string type
-  if (data.type !== "string") {
+  // Skip validation if not a string-like type that requires size
+  if (data.type !== "string" && data.type !== "varchar") {
     return true;
   }
 

--- a/templates/cli/lib/commands/config.ts
+++ b/templates/cli/lib/commands/config.ts
@@ -194,6 +194,10 @@ const AttributeSchema = z
     key: z.string(),
     type: z.enum([
       "string",
+      "text",
+      "varchar",
+      "mediumtext",
+      "longtext",
       "integer",
       "double",
       "boolean",
@@ -233,7 +237,7 @@ const AttributeSchema = z
     path: ["default"],
   })
   .refine(validateStringSize, {
-    message: "When 'type' is 'string', 'size' must be defined",
+    message: "When 'type' is 'string' or 'varchar', 'size' must be defined",
     path: ["size"],
   });
 
@@ -270,6 +274,10 @@ const ColumnSchema = z
     key: z.string(),
     type: z.enum([
       "string",
+      "text",
+      "varchar",
+      "mediumtext",
+      "longtext",
       "integer",
       "double",
       "boolean",
@@ -310,7 +318,7 @@ const ColumnSchema = z
     path: ["default"],
   })
   .refine(validateStringSize, {
-    message: "When 'type' is 'string', 'size' must be defined",
+    message: "When 'type' is 'string' or 'varchar', 'size' must be defined",
     path: ["size"],
   });
 

--- a/templates/cli/lib/commands/push.ts
+++ b/templates/cli/lib/commands/push.ts
@@ -2324,7 +2324,7 @@ const pushCollection = async (): Promise<void> => {
   const { successfullyPushed, errors } = result;
 
   if (successfullyPushed === 0) {
-    error("No collections were pushed.");
+    warn("No collections were pushed.");
   } else {
     success(`Successfully pushed ${successfullyPushed} collections.`);
   }

--- a/templates/cli/lib/commands/utils/attributes.ts
+++ b/templates/cli/lib/commands/utils/attributes.ts
@@ -250,6 +250,43 @@ export class Attributes {
               encrypt: attribute.encrypt,
             });
         }
+      case "varchar":
+        return databasesService.createVarcharAttribute({
+          databaseId,
+          collectionId,
+          key: attribute.key,
+          size: attribute.size,
+          required: attribute.required,
+          xdefault: attribute.default,
+          array: attribute.array,
+        });
+      case "text":
+        return databasesService.createTextAttribute({
+          databaseId,
+          collectionId,
+          key: attribute.key,
+          required: attribute.required,
+          xdefault: attribute.default,
+          array: attribute.array,
+        });
+      case "mediumtext":
+        return databasesService.createMediumtextAttribute({
+          databaseId,
+          collectionId,
+          key: attribute.key,
+          required: attribute.required,
+          xdefault: attribute.default,
+          array: attribute.array,
+        });
+      case "longtext":
+        return databasesService.createLongtextAttribute({
+          databaseId,
+          collectionId,
+          key: attribute.key,
+          required: attribute.required,
+          xdefault: attribute.default,
+          array: attribute.array,
+        });
       case "integer":
         return databasesService.createIntegerAttribute({
           databaseId,
@@ -382,6 +419,39 @@ export class Attributes {
               xdefault: attribute.default,
             });
         }
+      case "varchar":
+        return databasesService.updateVarcharAttribute({
+          databaseId,
+          collectionId,
+          key: attribute.key,
+          required: attribute.required,
+          xdefault: attribute.default,
+          size: attribute.size,
+        });
+      case "text":
+        return databasesService.updateTextAttribute({
+          databaseId,
+          collectionId,
+          key: attribute.key,
+          required: attribute.required,
+          xdefault: attribute.default,
+        });
+      case "mediumtext":
+        return databasesService.updateMediumtextAttribute({
+          databaseId,
+          collectionId,
+          key: attribute.key,
+          required: attribute.required,
+          xdefault: attribute.default,
+        });
+      case "longtext":
+        return databasesService.updateLongtextAttribute({
+          databaseId,
+          collectionId,
+          key: attribute.key,
+          required: attribute.required,
+          xdefault: attribute.default,
+        });
       case "integer":
         return databasesService.updateIntegerAttribute({
           databaseId,


### PR DESCRIPTION
## What
- add create/update support for text, varchar, mediumtext, and longtext in CLI attribute sync
- extend config schema enums for attributes/columns to allow the new types
- enforce size validation for varchar in addition to string

## Validation
- npm run build:types (templates/cli)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for varchar, text, mediumtext, and longtext field types; config schemas updated to recognize them.

* **Improvements**
  * Login/logout flows improved with more robust MFA and session handling for a smoother sign-in experience.
  * User feedback when no resources are pushed now reported as a warning instead of an error.

* **Bug Fixes**
  * Size validation now enforces a defined size for varchar alongside string.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->