### PR TITLE
Add type generation support for text/varchar/mediumtext/longtext attributes

### DIFF
--- a/templates/cli/lib/shared/typescript-type-utils.ts
+++ b/templates/cli/lib/shared/typescript-type-utils.ts
@@ -37,6 +37,10 @@ export function getTypeScriptType(
 
   switch (attribute.type) {
     case "string":
+    case "text":
+    case "varchar":
+    case "mediumtext":
+    case "longtext":
     case "datetime":
       type = "string";
       if (attribute.format === "enum") {

--- a/templates/cli/lib/type-generation/attribute.ts
+++ b/templates/cli/lib/type-generation/attribute.ts
@@ -1,5 +1,9 @@
 export const AttributeType = {
   STRING: "string",
+  TEXT: "text",
+  VARCHAR: "varchar",
+  MEDIUMTEXT: "mediumtext",
+  LONGTEXT: "longtext",
   INTEGER: "integer",
   FLOAT: "double",
   BOOLEAN: "boolean",

--- a/templates/cli/lib/type-generation/languages/csharp.ts
+++ b/templates/cli/lib/type-generation/languages/csharp.ts
@@ -10,6 +10,10 @@ export class CSharp extends LanguageMeta {
     let type = "";
     switch (attribute.type) {
       case AttributeType.STRING:
+      case AttributeType.TEXT:
+      case AttributeType.VARCHAR:
+      case AttributeType.MEDIUMTEXT:
+      case AttributeType.LONGTEXT:
       case AttributeType.DATETIME:
         type = "string";
         if (attribute.format === AttributeType.ENUM) {
@@ -126,7 +130,7 @@ public class <%= toPascalCase(collection.name) %>
                 }
             // ARRAY TYPES
             } else if (attribute.array) {
-                if (attribute.type === 'string' || attribute.type === 'datetime' || attribute.type === 'email') {
+                if (['string', 'text', 'varchar', 'mediumtext', 'longtext', 'datetime', 'email'].includes(attribute.type)) {
                     -%>((IEnumerable<object>)map["<%- attribute.key %>"]).Select(x => x?.ToString())<%- attribute.required ? '.Where(x => x != null)' : '' %>.ToList()!<%
                 } else if (attribute.type === 'integer') {
                     -%>((IEnumerable<object>)map["<%- attribute.key %>"]).Select(x => <%- !attribute.required ? 'x == null ? (long?)null : ' : '' %>Convert.ToInt64(x)).ToList()<%
@@ -142,7 +146,7 @@ public class <%= toPascalCase(collection.name) %>
                 -%><%- !attribute.required ? 'map["' + attribute.key + '"] == null ? null : ' : '' %>Convert.ToDouble(map["<%- attribute.key %>"])<%
             } else if (attribute.type === 'boolean') {
                 -%>(<%- getType(attribute, collections, collection.name) %>)map["<%- attribute.key %>"]<%
-            } else if (attribute.type === 'string' || attribute.type === 'datetime' || attribute.type === 'email') {
+            } else if (['string', 'text', 'varchar', 'mediumtext', 'longtext', 'datetime', 'email'].includes(attribute.type)) {
                 -%>map["<%- attribute.key %>"]<%- !attribute.required ? '?' : '' %>.ToString()<%- attribute.required ? '!' : ''%><%
             } else {
                 -%>default<%

--- a/templates/cli/lib/type-generation/languages/dart.ts
+++ b/templates/cli/lib/type-generation/languages/dart.ts
@@ -72,6 +72,10 @@ export class Dart extends LanguageMeta {
     let type = "";
     switch (attribute.type) {
       case AttributeType.STRING:
+      case AttributeType.TEXT:
+      case AttributeType.VARCHAR:
+      case AttributeType.MEDIUMTEXT:
+      case AttributeType.LONGTEXT:
       case AttributeType.DATETIME:
         type = "String";
         if (attribute.format === AttributeType.ENUM) {
@@ -193,7 +197,7 @@ class <%= toPascalCase(collection.name) %> {
   factory <%= toPascalCase(collection.name) %>.fromMap(Map<String, dynamic> map) {
     return <%= toPascalCase(collection.name) %>(<% if (__attrs.length > 0) { %>
 <% for (const [index, attribute] of Object.entries(__attrs)) { -%>
-      <%= strict ? toCamelCase(attribute.key) : attribute.key %>: <% if (attribute.type === '${AttributeType.STRING}' || attribute.type === '${AttributeType.EMAIL}' || attribute.type === '${AttributeType.DATETIME}') { -%>
+      <%= strict ? toCamelCase(attribute.key) : attribute.key %>: <% if (['${AttributeType.STRING}', '${AttributeType.TEXT}', '${AttributeType.VARCHAR}', '${AttributeType.MEDIUMTEXT}', '${AttributeType.LONGTEXT}', '${AttributeType.EMAIL}', '${AttributeType.DATETIME}'].includes(attribute.type)) { -%>
 <% if (attribute.format === '${AttributeType.ENUM}') { -%>
 <% if (attribute.array) { -%>
 (map['<%= attribute.key %>'] as List<dynamic>?)?.map((e) => <%- toPascalCase(collection.name) %><%- toPascalCase(attribute.key) %>.values.firstWhere((element) => element.value == e)).toList()<% } else { -%>

--- a/templates/cli/lib/type-generation/languages/java.ts
+++ b/templates/cli/lib/type-generation/languages/java.ts
@@ -10,6 +10,10 @@ export class Java extends LanguageMeta {
     let type = "";
     switch (attribute.type) {
       case AttributeType.STRING:
+      case AttributeType.TEXT:
+      case AttributeType.VARCHAR:
+      case AttributeType.MEDIUMTEXT:
+      case AttributeType.LONGTEXT:
       case AttributeType.DATETIME:
         type = "String";
         if (attribute.format === AttributeType.ENUM) {

--- a/templates/cli/lib/type-generation/languages/javascript.ts
+++ b/templates/cli/lib/type-generation/languages/javascript.ts
@@ -8,6 +8,10 @@ export class JavaScript extends LanguageMeta {
     let type = "";
     switch (attribute.type) {
       case AttributeType.STRING:
+      case AttributeType.TEXT:
+      case AttributeType.VARCHAR:
+      case AttributeType.MEDIUMTEXT:
+      case AttributeType.LONGTEXT:
       case AttributeType.DATETIME:
         type = "string";
         if (attribute.format === AttributeType.ENUM) {

--- a/templates/cli/lib/type-generation/languages/kotlin.ts
+++ b/templates/cli/lib/type-generation/languages/kotlin.ts
@@ -10,6 +10,10 @@ export class Kotlin extends LanguageMeta {
     let type = "";
     switch (attribute.type) {
       case AttributeType.STRING:
+      case AttributeType.TEXT:
+      case AttributeType.VARCHAR:
+      case AttributeType.MEDIUMTEXT:
+      case AttributeType.LONGTEXT:
       case AttributeType.DATETIME:
         type = "String";
         if (attribute.format === AttributeType.ENUM) {

--- a/templates/cli/lib/type-generation/languages/php.ts
+++ b/templates/cli/lib/type-generation/languages/php.ts
@@ -13,6 +13,10 @@ export class PHP extends LanguageMeta {
     let type = "";
     switch (attribute.type) {
       case AttributeType.STRING:
+      case AttributeType.TEXT:
+      case AttributeType.VARCHAR:
+      case AttributeType.MEDIUMTEXT:
+      case AttributeType.LONGTEXT:
       case AttributeType.DATETIME:
         type = "string";
         if (attribute.format === AttributeType.ENUM) {

--- a/templates/cli/lib/type-generation/languages/swift.ts
+++ b/templates/cli/lib/type-generation/languages/swift.ts
@@ -10,6 +10,10 @@ export class Swift extends LanguageMeta {
     let type = "";
     switch (attribute.type) {
       case AttributeType.STRING:
+      case AttributeType.TEXT:
+      case AttributeType.VARCHAR:
+      case AttributeType.MEDIUMTEXT:
+      case AttributeType.LONGTEXT:
       case AttributeType.DATETIME:
         type = "String";
         if (attribute.format === AttributeType.ENUM) {
@@ -129,7 +133,7 @@ public class <%- toPascalCase(collection.name) %>: Codable {
 <% for (const [index, attribute] of Object.entries(collection.attributes)) { -%>
 <% if (attribute.type === 'relationship') { -%>
             "<%- attribute.key %>": <%- strict ? toCamelCase(attribute.key) : attribute.key %> as Any<% if (index < collection.attributes.length - 1) { %>,<% } %>
-<% } else if (attribute.array && attribute.type !== 'string' && attribute.type !== 'integer' && attribute.type !== 'float' && attribute.type !== 'boolean') { -%>
+<% } else if (attribute.array && !['string', 'text', 'varchar', 'mediumtext', 'longtext', 'integer', 'float', 'boolean'].includes(attribute.type)) { -%>
             "<%- attribute.key %>": <%- strict ? toCamelCase(attribute.key) : attribute.key %>?.map { $0.toMap() } as Any<% if (index < collection.attributes.length - 1) { %>,<% } %>
 <% } else { -%>
             "<%- attribute.key %>": <%- strict ? toCamelCase(attribute.key) : attribute.key %> as Any<% if (index < collection.attributes.length - 1) { %>,<% } %>
@@ -145,7 +149,7 @@ public class <%- toPascalCase(collection.name) %>: Codable {
 <% const relationshipType = getType(attribute, collections, collection.name).replace('?', ''); -%>
             <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> <%- relationshipType %><% if (index < collection.attributes.length - 1) { %>,<% } %>
 <% } else if (attribute.array) { -%>
-<% if (attribute.type === 'string') { -%>
+<% if (['string', 'text', 'varchar', 'mediumtext', 'longtext'].includes(attribute.type)) { -%>
             <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [String]<% if (index < collection.attributes.length - 1) { %>,<% } %>
 <% } else if (attribute.type === 'integer') { -%>
             <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [Int]<% if (index < collection.attributes.length - 1) { %>,<% } %>
@@ -157,9 +161,9 @@ public class <%- toPascalCase(collection.name) %>: Codable {
             <%- strict ? toCamelCase(attribute.key) : attribute.key %>: (map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> [[String: Any]])<% if (!attribute.required) { %>?<% } %>.map { <%- toPascalCase(attribute.type) %>.from(map: $0) }<% if (index < collection.attributes.length - 1) { %>,<% } %>
 <% } -%>
 <% } else { -%>
-<% if ((attribute.type === 'string' || attribute.type === 'email' || attribute.type === 'datetime') && attribute.format !== 'enum') { -%>
+<% if (['string', 'text', 'varchar', 'mediumtext', 'longtext', 'email', 'datetime'].includes(attribute.type) && attribute.format !== 'enum') { -%>
             <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> String<% if (index < collection.attributes.length - 1) { %>,<% } %>
-<% } else if (attribute.type === 'string' && attribute.format === 'enum') { -%>
+<% } else if (['string', 'text', 'varchar', 'mediumtext', 'longtext'].includes(attribute.type) && attribute.format === 'enum') { -%>
             <%- strict ? toCamelCase(attribute.key) : attribute.key %>: <%- toPascalCase(collection.name) %><%- toPascalCase(attribute.key) %>(rawValue: map["<%- attribute.key %>"] as! String)!<% if (index < collection.attributes.length - 1) { %>,<% } %>
 <% } else if (attribute.type === 'integer') { -%>
             <%- strict ? toCamelCase(attribute.key) : attribute.key %>: map["<%- attribute.key %>"] as<% if (!attribute.required) { %>?<% } else { %>!<% } %> Int<% if (index < collection.attributes.length - 1) { %>,<% } %>


### PR DESCRIPTION
## What
- add new attribute constants for `text`, `varchar`, `mediumtext`, `longtext`
- map these new attribute types to string across type-generation languages
- update TS shared type utils to treat these attribute types as `string`
- update Dart/C#/Swift template parsing branches for the new string-like types

## Why
Generated SDK typing failed with: `Unknown attribute type: text`.

## Validation
- npm run build:types (templates/cli)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for TEXT, VARCHAR, MEDIUMTEXT, and LONGTEXT column types mapped to string across all code generators, improving consistency for arrays, map/object conversion, and serialization.
  * Normalized numeric mapping by replacing float-case handling with double, aligning numeric type generation across targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->