### PR TITLE
fix: The CLI tool uses .gitignore to filter packaged files during deployment.

### DIFF
--- a/templates/cli/lib/commands/utils/deployment.ts
+++ b/templates/cli/lib/commands/utils/deployment.ts
@@ -3,6 +3,7 @@ import path from "path";
 import tar from "tar";
 import { Client, AppwriteException } from "@appwrite.io/console";
 import { error } from "../../parser.js";
+import ignore from "ignore";
 
 const POLL_DEBOUNCE = 2000; // Milliseconds
 
@@ -12,12 +13,24 @@ const POLL_DEBOUNCE = 2000; // Milliseconds
  */
 async function packageDirectory(dirPath: string): Promise<File> {
   const tempFile = `${dirPath.replace(/[^a-zA-Z0-9]/g, "_")}-${Date.now()}.tar.gz`;
+  
+  // Load .gitignore file if it exists
+  const ig = ignore();
+  const gitignorePath = path.join(dirPath, ".gitignore");
+
+  if (fs.existsSync(gitignorePath)) {
+    ig.add(fs.readFileSync(gitignorePath).toString());
+  }
 
   await tar.create(
     {
       gzip: true,
       file: tempFile,
       cwd: dirPath,
+      filter(xpath) {
+        const relativePath = path.join(dirPath, xpath);
+        return !ig.ignores(relativePath);
+      },      
     },
     ["."],
   );

--- a/templates/cli/lib/commands/utils/deployment.ts
+++ b/templates/cli/lib/commands/utils/deployment.ts
@@ -28,7 +28,14 @@ async function packageDirectory(dirPath: string): Promise<File> {
       file: tempFile,
       cwd: dirPath,
       filter(xpath) {
-        const relativePath = path.join(dirPath, xpath);
+        const relativePath = xpath
+          .replace(/^[.][\\/]/, "") // Remove leading ./ or .\
+          .replace(/\\/g, "/"); // Normalize to forward slashes
+
+        // Handle root directory "." specially
+        if (relativePath === "" || relativePath === ".") {
+          return true;
+        }
         return !ig.ignores(relativePath);
       },      
     },


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

fix: The CLI tool uses .gitignore to filter packaged files during deployment.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Deployment packages now automatically exclude files matching .gitignore patterns, simplifying the packaging process while maintaining existing deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->