### PR TITLE
fixed timestamp type in ts client

### DIFF
--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -89,7 +89,7 @@ type RealtimeResponseEvent<T extends unknown> = {
     /**
      * Timestamp indicating the time of the event.
      */
-    timestamp: number;
+    timestamp: string;
 
     /**
      * Payload containing event-specific data.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

RealtimeResponseEvent type and client type for timestamp is different in ts

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Updated the timestamp format for real-time response events from numeric to string representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->