### PR TITLE
fix-37-add-custom-unmarshalJSON-method

### DIFF
--- a/templates/go/models/model.go.twig
+++ b/templates/go/models/model.go.twig
@@ -21,10 +21,14 @@ func (model {{ definition.name | caseUcfirst }}) New(data []byte) *{{ definition
     return &model
 }
 
-func (p *{{ definition.name | caseUcfirst }}) UnmarshalJSON(b []byte) error {
-    p.data = make([]byte, len(b))
-    copy(p.data, b)
-    return nil
+func (p *{{ definition.name | caseUcfirst }}) UnmarshalJSON(b []byte) error {  
+    p.data = make([]byte, len(b))  
+    copy(p.data, b)  
+
+    // Alias avoids infinite recursion (the alias has no methods).  
+    type Alias {{ definition.name | caseUcfirst }}  
+    aux := (*Alias)(p)  
+    return json.Unmarshal(b, aux)  
 }
 
 {%~ if definition.additionalProperties %}

--- a/templates/go/models/model.go.twig
+++ b/templates/go/models/model.go.twig
@@ -21,6 +21,12 @@ func (model {{ definition.name | caseUcfirst }}) New(data []byte) *{{ definition
     return &model
 }
 
+func (p *{{ definition.name | caseUcfirst }}) UnmarshalJSON(b []byte) error {
+    p.data = make([]byte, len(b))
+    copy(p.data, b)
+    return nil
+}
+
 {%~ if definition.additionalProperties %}
 // Use this method to get response in desired type
 {%~ endif %}

--- a/templates/go/models/model.go.twig
+++ b/templates/go/models/model.go.twig
@@ -21,22 +21,24 @@ func (model {{ definition.name | caseUcfirst }}) New(data []byte) *{{ definition
     return &model
 }
 
-func (p *{{ definition.name | caseUcfirst }}) UnmarshalJSON(b []byte) error {  
-    p.data = make([]byte, len(b))  
-    copy(p.data, b)  
+{%~ if definition.additionalProperties %}
+func (p *{{ definition.name | caseUcfirst }}) UnmarshalJSON(b []byte) error {
+    p.data = make([]byte, len(b))
+    copy(p.data, b)
 
-    // Alias avoids infinite recursion (the alias has no methods).  
-    type Alias {{ definition.name | caseUcfirst }}  
-    aux := (*Alias)(p)  
-    return json.Unmarshal(b, aux)  
+    // Alias avoids infinite recursion (the alias has no methods).
+    type Alias {{ definition.name | caseUcfirst }}
+    aux := (*Alias)(p)
+    return json.Unmarshal(b, aux)
 }
+{%~ endif %}
 
 {%~ if definition.additionalProperties %}
 // Use this method to get response in desired type
 {%~ endif %}
 func (model *{{ definition.name | caseUcfirst }}) Decode(value interface{}) error {
     if len(model.data) <= 0 {
-        return errors.New("method Decode() cannot be used on nested struct")
+        return errors.New("model must be initialized from raw JSON via New() or JSON unmarshalling")
     }
 
     err := json.Unmarshal(model.data, value)


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

I have added a custom unmarshalJSON method in the `model twig` file. Because earlier, the Go's default decoder used to skip the data field entirely and show nil. Hence, a custom unmarshalJSON method.


## Test Plan

1. Create a vendor directory using this command in the `CONTRIBUTING.md` insider sdk-generator directory
```bash
docker run --rm --interactive --tty --volume "$(pwd)":/app composer update --ignore-platform-reqs --optimize-autoloader --no-plugins --no-scripts --prefer-dist
```
2. Run this `docker run` command, which will create an `examples` dir including the `go` directory
```bash
docker run --rm -v $(pwd):/app -w /app php:8.0-cli-alpine sh -c "apk add --no-cache curl && php example.php go"
```
3. Inside `examples/go/models/` verify `preferences.go`. You will see the UnmarshalJSON method

## Related PRs and Issues
Issue it solves: [#37](https://github.com/appwrite/sdk-for-go/issues/37)
### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated Go models now support JSON unmarshalling and retain the original input for later decoding.

* **Bug Fixes**
  * Decode now returns a clearer error when attempted on an uninitialized model instance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->