### PR TITLE
feat: add string column types to agent skills

### DIFF
--- a/templates/agent-skills/dart.md.twig
+++ b/templates/agent-skills/dart.md.twig
@@ -82,6 +82,8 @@ await users.delete(userId: '[USER_ID]');
 ### Database Operations
 
 > **Note:** Use `TablesDB` (not the deprecated `Databases` class) for all new code. Only use `Databases` if the existing codebase already relies on it or the user explicitly requests it.
+>
+> **Tip:** Prefer named parameters (e.g., `databaseId: '...'`) for all SDK method calls. Only use positional arguments if the existing codebase already uses them or the user explicitly requests it.
 
 ```dart
 final tablesDB = TablesDB(client);

--- a/templates/agent-skills/dart.md.twig
+++ b/templates/agent-skills/dart.md.twig
@@ -126,6 +126,35 @@ await tablesDB.deleteRow(
 );
 ```
 
+#### String Column Types
+
+> **Note:** The legacy `string` type is deprecated. Use explicit column types for all new columns.
+
+| Type | Max characters | Indexing | Storage |
+|------|---------------|----------|---------|
+| `varchar` | 16,383 | Full index (if size ≤ 768) | Inline in row |
+| `text` | 16,383 | Prefix only | Off-page |
+| `mediumtext` | 4,194,303 | Prefix only | Off-page |
+| `longtext` | 1,073,741,823 | Prefix only | Off-page |
+
+- `varchar` is stored inline and counts towards the 64 KB row size limit. Prefer for short, indexed fields like names, slugs, or identifiers.
+- `text`, `mediumtext`, and `longtext` are stored off-page (only a 20-byte pointer lives in the row), so they don't consume the row size budget. `size` is not required for these types.
+
+```dart
+// Create table with explicit string column types
+await tablesDB.createTable(
+    databaseId: '[DATABASE_ID]',
+    tableId: ID.unique(),
+    name: 'articles',
+    columns: [
+        {'key': 'title',    'type': 'varchar',    'size': 255, 'required': true},   // inline, fully indexable
+        {'key': 'summary',  'type': 'text',                    'required': false},  // off-page, prefix index only
+        {'key': 'body',     'type': 'mediumtext',              'required': false},  // up to ~4 M chars
+        {'key': 'raw_data', 'type': 'longtext',                'required': false},  // up to ~1 B chars
+    ],
+);
+```
+
 ### Query Methods
 
 ```dart

--- a/templates/agent-skills/dotnet.md.twig
+++ b/templates/agent-skills/dotnet.md.twig
@@ -47,6 +47,8 @@ await users.Delete("[USER_ID]");
 ### Database Operations
 
 > **Note:** Use `TablesDB` (not the deprecated `Databases` class) for all new code. Only use `Databases` if the existing codebase already relies on it or the user explicitly requests it.
+>
+> **Tip:** Prefer named arguments (e.g., `databaseId: "..."`) for all SDK method calls. Only use positional arguments if the existing codebase already uses them or the user explicitly requests it.
 
 ```csharp
 var tablesDB = new TablesDB(client);

--- a/templates/agent-skills/dotnet.md.twig
+++ b/templates/agent-skills/dotnet.md.twig
@@ -73,6 +73,31 @@ await tablesDB.UpdateRow("[DATABASE_ID]", "[TABLE_ID]", "[ROW_ID]",
 await tablesDB.DeleteRow("[DATABASE_ID]", "[TABLE_ID]", "[ROW_ID]");
 ```
 
+#### String Column Types
+
+> **Note:** The legacy `string` type is deprecated. Use explicit column types for all new columns.
+
+| Type | Max characters | Indexing | Storage |
+|------|---------------|----------|---------|
+| `varchar` | 16,383 | Full index (if size ≤ 768) | Inline in row |
+| `text` | 16,383 | Prefix only | Off-page |
+| `mediumtext` | 4,194,303 | Prefix only | Off-page |
+| `longtext` | 1,073,741,823 | Prefix only | Off-page |
+
+- `varchar` is stored inline and counts towards the 64 KB row size limit. Prefer for short, indexed fields like names, slugs, or identifiers.
+- `text`, `mediumtext`, and `longtext` are stored off-page (only a 20-byte pointer lives in the row), so they don't consume the row size budget. `size` is not required for these types.
+
+```csharp
+// Create table with explicit string column types
+await tablesDB.CreateTable("[DATABASE_ID]", ID.Unique(), "articles",
+    new List<object> {
+        new { key = "title",    type = "varchar",    size = 255, required = true  },  // inline, fully indexable
+        new { key = "summary",  type = "text",                   required = false },  // off-page, prefix index only
+        new { key = "body",     type = "mediumtext",             required = false },  // up to ~4 M chars
+        new { key = "raw_data", type = "longtext",               required = false },  // up to ~1 B chars
+    });
+```
+
 ### Query Methods
 
 ```csharp

--- a/templates/agent-skills/go.md.twig
+++ b/templates/agent-skills/go.md.twig
@@ -59,6 +59,8 @@ _, err = service.Delete("[USER_ID]")
 ### Database Operations
 
 > **Note:** Use `TablesDB` (not the deprecated `Databases` class) for all new code. Only use `Databases` if the existing codebase already relies on it or the user explicitly requests it.
+>
+> **Tip:** Prefer explicit functional option parameters (e.g., `tablesdb.WithUpdateRowData(...)`) over bare positional arguments where available. Only use positional-only style if the existing codebase already uses it or the user explicitly requests it.
 
 ```go
 service := tablesdb.New(clt)

--- a/templates/agent-skills/go.md.twig
+++ b/templates/agent-skills/go.md.twig
@@ -92,6 +92,35 @@ _, err = service.UpdateRow(
 _, err = service.DeleteRow("[DATABASE_ID]", "[TABLE_ID]", "[ROW_ID]")
 ```
 
+#### String Column Types
+
+> **Note:** The legacy `string` type is deprecated. Use explicit column types for all new columns.
+
+| Type | Max characters | Indexing | Storage |
+|------|---------------|----------|---------|
+| `varchar` | 16,383 | Full index (if size ≤ 768) | Inline in row |
+| `text` | 16,383 | Prefix only | Off-page |
+| `mediumtext` | 4,194,303 | Prefix only | Off-page |
+| `longtext` | 1,073,741,823 | Prefix only | Off-page |
+
+- `varchar` is stored inline and counts towards the 64 KB row size limit. Prefer for short, indexed fields like names, slugs, or identifiers.
+- `text`, `mediumtext`, and `longtext` are stored off-page (only a 20-byte pointer lives in the row), so they don't consume the row size budget. `size` is not required for these types.
+
+```go
+// Create table with explicit string column types
+_, err = service.CreateTable(
+    "[DATABASE_ID]",
+    id.Unique(),
+    "articles",
+    tablesdb.WithCreateTableColumns([]map[string]interface{}{
+        {"key": "title",    "type": "varchar",    "size": 255, "required": true},
+        {"key": "summary",  "type": "text",                    "required": false},
+        {"key": "body",     "type": "mediumtext",              "required": false},
+        {"key": "raw_data", "type": "longtext",                "required": false},
+    }),
+)
+```
+
 ### Query Methods
 
 ```go

--- a/templates/agent-skills/kotlin.md.twig
+++ b/templates/agent-skills/kotlin.md.twig
@@ -109,6 +109,8 @@ users.delete(userId = "[USER_ID]")
 ### Database Operations
 
 > **Note:** Use `TablesDB` (not the deprecated `Databases` class) for all new code. Only use `Databases` if the existing codebase already relies on it or the user explicitly requests it.
+>
+> **Tip:** Prefer named arguments (e.g., `databaseId = "..."`) for all SDK method calls. Only use positional arguments if the existing codebase already uses them or the user explicitly requests it.
 
 ```kotlin
 val tablesDB = TablesDB(client)

--- a/templates/agent-skills/kotlin.md.twig
+++ b/templates/agent-skills/kotlin.md.twig
@@ -150,6 +150,35 @@ tablesDB.deleteRow(
 )
 ```
 
+#### String Column Types
+
+> **Note:** The legacy `string` type is deprecated. Use explicit column types for all new columns.
+
+| Type | Max characters | Indexing | Storage |
+|------|---------------|----------|---------|
+| `varchar` | 16,383 | Full index (if size ≤ 768) | Inline in row |
+| `text` | 16,383 | Prefix only | Off-page |
+| `mediumtext` | 4,194,303 | Prefix only | Off-page |
+| `longtext` | 1,073,741,823 | Prefix only | Off-page |
+
+- `varchar` is stored inline and counts towards the 64 KB row size limit. Prefer for short, indexed fields like names, slugs, or identifiers.
+- `text`, `mediumtext`, and `longtext` are stored off-page (only a 20-byte pointer lives in the row), so they don't consume the row size budget. `size` is not required for these types.
+
+```kotlin
+// Create table with explicit string column types
+tablesDB.createTable(
+    databaseId = "[DATABASE_ID]",
+    tableId = ID.unique(),
+    name = "articles",
+    columns = listOf(
+        mapOf("key" to "title",    "type" to "varchar",    "size" to 255, "required" to true),
+        mapOf("key" to "summary",  "type" to "text",                      "required" to false),
+        mapOf("key" to "body",     "type" to "mediumtext",                "required" to false),
+        mapOf("key" to "raw_data", "type" to "longtext",                  "required" to false),
+    )
+)
+```
+
 ### Query Methods
 
 ```kotlin

--- a/templates/agent-skills/php.md.twig
+++ b/templates/agent-skills/php.md.twig
@@ -52,6 +52,8 @@ $users->delete('[USER_ID]');
 ### Database Operations
 
 > **Note:** Use `TablesDB` (not the deprecated `Databases` class) for all new code. Only use `Databases` if the existing codebase already relies on it or the user explicitly requests it.
+>
+> **Tip:** Prefer named arguments (PHP 8+, e.g., `databaseId: '...'`) for all SDK method calls. Only use positional arguments if the existing codebase already uses them or the user explicitly requests it.
 
 ```php
 $tablesDB = new TablesDB($client);

--- a/templates/agent-skills/php.md.twig
+++ b/templates/agent-skills/php.md.twig
@@ -82,6 +82,30 @@ $tablesDB->updateRow('[DATABASE_ID]', '[TABLE_ID]', '[ROW_ID]', [
 $tablesDB->deleteRow('[DATABASE_ID]', '[TABLE_ID]', '[ROW_ID]');
 ```
 
+#### String Column Types
+
+> **Note:** The legacy `string` type is deprecated. Use explicit column types for all new columns.
+
+| Type | Max characters | Indexing | Storage |
+|------|---------------|----------|---------|
+| `varchar` | 16,383 | Full index (if size ≤ 768) | Inline in row |
+| `text` | 16,383 | Prefix only | Off-page |
+| `mediumtext` | 4,194,303 | Prefix only | Off-page |
+| `longtext` | 1,073,741,823 | Prefix only | Off-page |
+
+- `varchar` is stored inline and counts towards the 64 KB row size limit. Prefer for short, indexed fields like names, slugs, or identifiers.
+- `text`, `mediumtext`, and `longtext` are stored off-page (only a 20-byte pointer lives in the row), so they don't consume the row size budget. `size` is not required for these types.
+
+```php
+// Create table with explicit string column types
+$tablesDB->createTable('[DATABASE_ID]', ID::unique(), 'articles', [
+    ['key' => 'title',    'type' => 'varchar',    'size' => 255, 'required' => true],
+    ['key' => 'summary',  'type' => 'text',                      'required' => false],
+    ['key' => 'body',     'type' => 'mediumtext',                'required' => false],
+    ['key' => 'raw_data', 'type' => 'longtext',                  'required' => false],
+]);
+```
+
 ### Query Methods
 
 ```php

--- a/templates/agent-skills/python.md.twig
+++ b/templates/agent-skills/python.md.twig
@@ -84,6 +84,35 @@ tables_db.update_row('[DATABASE_ID]', '[TABLE_ID]', '[ROW_ID]', {
 tables_db.delete_row('[DATABASE_ID]', '[TABLE_ID]', '[ROW_ID]')
 ```
 
+#### String Column Types
+
+> **Note:** The legacy `string` type is deprecated. Use explicit column types for all new columns.
+
+| Type | Max characters | Indexing | Storage |
+|------|---------------|----------|---------|
+| `varchar` | 16,383 | Full index (if size ≤ 768) | Inline in row |
+| `text` | 16,383 | Prefix only | Off-page |
+| `mediumtext` | 4,194,303 | Prefix only | Off-page |
+| `longtext` | 1,073,741,823 | Prefix only | Off-page |
+
+- `varchar` is stored inline and counts towards the 64 KB row size limit. Prefer for short, indexed fields like names, slugs, or identifiers.
+- `text`, `mediumtext`, and `longtext` are stored off-page (only a 20-byte pointer lives in the row), so they don't consume the row size budget. `size` is not required for these types.
+
+```python
+# Create table with explicit string column types
+tables_db.create_table(
+    database_id='[DATABASE_ID]',
+    table_id=ID.unique(),
+    name='articles',
+    columns=[
+        {'key': 'title',    'type': 'varchar',    'size': 255, 'required': True},   # inline, fully indexable
+        {'key': 'summary',  'type': 'text',                    'required': False},  # off-page, prefix index only
+        {'key': 'body',     'type': 'mediumtext',              'required': False},  # up to ~4 M chars
+        {'key': 'raw_data', 'type': 'longtext',                'required': False},  # up to ~1 B chars
+    ]
+)
+```
+
 ### Query Methods
 
 ```python

--- a/templates/agent-skills/python.md.twig
+++ b/templates/agent-skills/python.md.twig
@@ -54,6 +54,8 @@ users.delete('[USER_ID]')
 ### Database Operations
 
 > **Note:** Use `TablesDB` (not the deprecated `Databases` class) for all new code. Only use `Databases` if the existing codebase already relies on it or the user explicitly requests it.
+>
+> **Tip:** Prefer keyword arguments (e.g., `database_id='...'`) over positional arguments for all SDK method calls. Only use positional style if the existing codebase already uses it or the user explicitly requests it.
 
 ```python
 tables_db = TablesDB(client)

--- a/templates/agent-skills/ruby.md.twig
+++ b/templates/agent-skills/ruby.md.twig
@@ -84,6 +84,35 @@ tables_db.update_row(
 tables_db.delete_row(database_id: '[DATABASE_ID]', table_id: '[TABLE_ID]', row_id: '[ROW_ID]')
 ```
 
+#### String Column Types
+
+> **Note:** The legacy `string` type is deprecated. Use explicit column types for all new columns.
+
+| Type | Max characters | Indexing | Storage |
+|------|---------------|----------|---------|
+| `varchar` | 16,383 | Full index (if size ≤ 768) | Inline in row |
+| `text` | 16,383 | Prefix only | Off-page |
+| `mediumtext` | 4,194,303 | Prefix only | Off-page |
+| `longtext` | 1,073,741,823 | Prefix only | Off-page |
+
+- `varchar` is stored inline and counts towards the 64 KB row size limit. Prefer for short, indexed fields like names, slugs, or identifiers.
+- `text`, `mediumtext`, and `longtext` are stored off-page (only a 20-byte pointer lives in the row), so they don't consume the row size budget. `size` is not required for these types.
+
+```ruby
+# Create table with explicit string column types
+tables_db.create_table(
+    database_id: '[DATABASE_ID]',
+    table_id: ID.unique,
+    name: 'articles',
+    columns: [
+        { key: 'title',    type: 'varchar',    size: 255, required: true  },  # inline, fully indexable
+        { key: 'summary',  type: 'text',                  required: false },  # off-page, prefix index only
+        { key: 'body',     type: 'mediumtext',            required: false },  # up to ~4 M chars
+        { key: 'raw_data', type: 'longtext',              required: false },  # up to ~1 B chars
+    ]
+)
+```
+
 ### Query Methods
 
 ```ruby

--- a/templates/agent-skills/ruby.md.twig
+++ b/templates/agent-skills/ruby.md.twig
@@ -47,6 +47,8 @@ users.delete(user_id: '[USER_ID]')
 ### Database Operations
 
 > **Note:** Use `TablesDB` (not the deprecated `Databases` class) for all new code. Only use `Databases` if the existing codebase already relies on it or the user explicitly requests it.
+>
+> **Tip:** Prefer keyword arguments (e.g., `database_id: '...'`) for all SDK method calls. Only use positional arguments if the existing codebase already uses them or the user explicitly requests it.
 
 ```ruby
 tables_db = TablesDB.new(client)

--- a/templates/agent-skills/swift.md.twig
+++ b/templates/agent-skills/swift.md.twig
@@ -79,6 +79,8 @@ try await users.delete(userId: "[USER_ID]")
 ### Database Operations
 
 > **Note:** Use `TablesDB` (not the deprecated `Databases` class) for all new code. Only use `Databases` if the existing codebase already relies on it or the user explicitly requests it.
+>
+> **Tip:** Prefer named parameters (e.g., `databaseId: "..."`) for all SDK method calls. Only use positional arguments if the existing codebase already uses them or the user explicitly requests it.
 
 ```swift
 let tablesDB = TablesDB(client)

--- a/templates/agent-skills/swift.md.twig
+++ b/templates/agent-skills/swift.md.twig
@@ -108,6 +108,35 @@ try await tablesDB.updateRow(databaseId: "[DATABASE_ID]", tableId: "[TABLE_ID]",
 try await tablesDB.deleteRow(databaseId: "[DATABASE_ID]", tableId: "[TABLE_ID]", rowId: "[ROW_ID]")
 ```
 
+#### String Column Types
+
+> **Note:** The legacy `string` type is deprecated. Use explicit column types for all new columns.
+
+| Type | Max characters | Indexing | Storage |
+|------|---------------|----------|---------|
+| `varchar` | 16,383 | Full index (if size ≤ 768) | Inline in row |
+| `text` | 16,383 | Prefix only | Off-page |
+| `mediumtext` | 4,194,303 | Prefix only | Off-page |
+| `longtext` | 1,073,741,823 | Prefix only | Off-page |
+
+- `varchar` is stored inline and counts towards the 64 KB row size limit. Prefer for short, indexed fields like names, slugs, or identifiers.
+- `text`, `mediumtext`, and `longtext` are stored off-page (only a 20-byte pointer lives in the row), so they don't consume the row size budget. `size` is not required for these types.
+
+```swift
+// Create table with explicit string column types
+try await tablesDB.createTable(
+    databaseId: "[DATABASE_ID]",
+    tableId: ID.unique(),
+    name: "articles",
+    columns: [
+        ["key": "title",    "type": "varchar",    "size": 255, "required": true],
+        ["key": "summary",  "type": "text",                    "required": false],
+        ["key": "body",     "type": "mediumtext",              "required": false],
+        ["key": "raw_data", "type": "longtext",                "required": false],
+    ]
+)
+```
+
 ### Query Methods
 
 ```swift

--- a/templates/agent-skills/typescript.md.twig
+++ b/templates/agent-skills/typescript.md.twig
@@ -158,6 +158,35 @@ await tablesDB.deleteRow({
 });
 ```
 
+#### String Column Types
+
+> **Note:** The legacy `string` type is deprecated. Use explicit column types for all new columns.
+
+| Type | Max characters | Indexing | Storage |
+|------|---------------|----------|---------|
+| `varchar` | 16,383 | Full index (if size ≤ 768) | Inline in row |
+| `text` | 16,383 | Prefix only | Off-page |
+| `mediumtext` | 4,194,303 | Prefix only | Off-page |
+| `longtext` | 1,073,741,823 | Prefix only | Off-page |
+
+- `varchar` is stored inline and counts towards the 64 KB row size limit. Prefer for short, indexed fields like names, slugs, or identifiers.
+- `text`, `mediumtext`, and `longtext` are stored off-page (only a 20-byte pointer lives in the row), so they don't consume the row size budget. `size` is not required for these types.
+
+```typescript
+// Create table with explicit string column types
+await tablesDB.createTable({
+    databaseId: '[DATABASE_ID]',
+    tableId: ID.unique(),
+    name: 'articles',
+    columns: [
+        { key: 'title',    type: 'varchar',    size: 255, required: true  },  // inline, fully indexable
+        { key: 'summary',  type: 'text',                  required: false },  // off-page, prefix index only
+        { key: 'body',     type: 'mediumtext',            required: false },  // up to ~4 M chars
+        { key: 'raw_data', type: 'longtext',              required: false },  // up to ~1 B chars
+    ]
+});
+```
+
 #### TypeScript Generics
 
 ```typescript

--- a/templates/agent-skills/typescript.md.twig
+++ b/templates/agent-skills/typescript.md.twig
@@ -106,6 +106,8 @@ await users.delete({ userId: '[USER_ID]' });
 ### Database Operations
 
 > **Note:** Use `TablesDB` (not the deprecated `Databases` class) for all new code. Only use `Databases` if the existing codebase already relies on it or the user explicitly requests it.
+>
+> **Tip:** Prefer the object-params calling style (e.g., `{ databaseId: '...' }`) for all SDK method calls. Only use positional arguments if the existing codebase already uses them or the user explicitly requests it.
 
 ```typescript
 const tablesDB = new TablesDB(client);


### PR DESCRIPTION
## Summary

- Documents the new `varchar`, `text`, `mediumtext`, and `longtext` column types across all 9 language agent skill files (TypeScript, Python, Dart, Go, PHP, Ruby, .NET, Kotlin, Swift)
- Adds a `#### String Column Types` subsection to each file with a type comparison table (max chars, indexing, storage), trade-off notes, and a language-idiomatic `createTable` example
- Marks the legacy `string` type as deprecated

## Test plan

- [ ] Review the rendered skill markdown for each language to confirm the table and code example display correctly
- [ ] Verify the `createTable` code examples follow each language's idiomatic style
- [ ] Confirm the deprecation notice for `string` is clear and consistent across all files