### PR TITLE
fix(js): add fallback enum key when unicode values produce empty identifier

### DIFF
--- a/templates/web/src/enums/enum.ts.twig
+++ b/templates/web/src/enums/enum.ts.twig
@@ -2,6 +2,6 @@ export enum {{ enum.name | caseUcfirst }} {
 {% for value in enum.enum %}
 {% set key = enum.keys is empty ? value : enum.keys[loop.index0] %}
     {% set processed = key | replace({'-': ''}) | caseEnumKey %}
-    {{ processed is empty ? 'Value' ~ loop.index0 : processed }} = '{{ value }}',
+    {{ processed is empty ? '_Value' ~ loop.index0 : processed }} = '{{ value | e('js') }}',
 {% endfor %}
 }

--- a/templates/web/src/enums/enum.ts.twig
+++ b/templates/web/src/enums/enum.ts.twig
@@ -1,6 +1,7 @@
 export enum {{ enum.name | caseUcfirst }} {
 {% for value in enum.enum %}
 {% set key = enum.keys is empty ? value : enum.keys[loop.index0] %}
-    {{ key | replace({'-': ''}) | caseEnumKey }} = '{{ value }}',
+    {% set processed = key | replace({'-': ''}) | caseEnumKey %}
+    {{ processed is empty ? 'Value' ~ loop.index0 : processed }} = '{{ value }}',
 {% endfor %}
 }


### PR DESCRIPTION
… unicode values

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Fixes enum generation for the TypeScript SDK when enum values contain non-English (Unicode) characters.

Currently, when enum values contain characters outside `[a-zA-Z0-9]`, the `toCamelCase()` transformation strips all characters, resulting in an empty enum identifier and invalid TypeScript output.

Example of current broken output:

```ts
export enum ProvinceType {
     = "រាជធានី",
}
```

## Test Plan

1. Identified that enum values containing only Unicode characters (e.g. Khmer text) produce an empty identifier due to the `toCamelCase()` transformation removing non `[a-zA-Z0-9]` characters.
2. Updated `templates/web/src/enums/enum.ts.twig` to introduce a fallback when the processed enum key is empty.
3. Ran `composer lint-twig` to ensure there are no Twig syntax errors.
4. Verified that when enum values contain only Unicode characters, the generated enum key is replaced with a safe fallback (`Value0`, `Value1`, etc.).
5. Confirmed that existing behavior for standard ASCII enum values remains unchanged and still generates proper PascalCase enum keys.

## Related PRs and Issues

Closes #1256

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved enum member naming for empty or invalid keys by assigning deterministic fallback identifiers, preventing missing or invalid members and ensuring consistent, predictable enum declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->