### PR TITLE
Derive X-Appwrite-Response-Format header from spec version

### DIFF
--- a/example.php
+++ b/example.php
@@ -53,7 +53,6 @@ try {
             'gitRepoName' => 'reponame',
             'twitter' => 'appwrite',
             'discord' => ['564160730845151244', 'https://appwrite.io/discord'],
-            'defaultHeaders' => ['X-Appwrite-Response-Format' => '1.8.0'],
             'readme' => '**README**',
         ];
 
@@ -72,7 +71,6 @@ try {
             ->setGitRepoName($config['gitRepoName'])
             ->setTwitter($config['twitter'])
             ->setDiscord($config['discord'][0], $config['discord'][1])
-            ->setDefaultHeaders($config['defaultHeaders'])
             ->setReadme($config['readme']);
 
         if (isset($config['namespace'])) {

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -648,7 +648,10 @@ class SDK
                 'requestModels' => $this->spec->getRequestModels(),
                 'global' => [
                     'headers' => $this->spec->getGlobalHeaders(),
-                    'defaultHeaders' => $this->defaultHeaders,
+                    'defaultHeaders' => array_merge(
+                        $this->defaultHeaders,
+                        $this->spec->getVersion() !== '' ? ['X-Appwrite-Response-Format' => $this->spec->getVersion()] : [],
+                    ),
                 ],
             ],
             'language' => [


### PR DESCRIPTION
## Summary
- Automatically set `X-Appwrite-Response-Format` header from the spec's `info.version` field instead of hardcoding it in `example.php`
- Removes manual `defaultHeaders` configuration from `configureSDK()` — the header is now injected in `SDK.php` during generation

## Test plan
- [ ] Regenerate SDKs and verify `X-Appwrite-Response-Format` matches the full spec version (e.g. `1.8.2`)
- [ ] Verify no regressions in generated output for all languages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated response format header handling to dynamically use the specification version instead of a hardcoded value, ensuring compatibility with different API versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->