### PR TITLE
[codex] Fix CLI pull empty directories when code is skipped

### DIFF
--- a/templates/cli/lib/commands/pull.ts
+++ b/templates/cli/lib/commands/pull.ts
@@ -305,11 +305,11 @@ export class Pull {
 
       result.push(functionConfig);
 
-      if (!fs.existsSync(absoluteFuncPath)) {
-        fs.mkdirSync(absoluteFuncPath, { recursive: true });
-      }
-
       if (options.code !== false) {
+        if (!fs.existsSync(absoluteFuncPath)) {
+          fs.mkdirSync(absoluteFuncPath, { recursive: true });
+        }
+
         await downloadDeploymentCode({
           resourceId: func["$id"],
           resourcePath: absoluteFuncPath,
@@ -407,11 +407,11 @@ export class Pull {
 
       result.push(siteConfig);
 
-      if (!fs.existsSync(absoluteSitePath)) {
-        fs.mkdirSync(absoluteSitePath, { recursive: true });
-      }
-
       if (options.code !== false) {
+        if (!fs.existsSync(absoluteSitePath)) {
+          fs.mkdirSync(absoluteSitePath, { recursive: true });
+        }
+
         await downloadDeploymentCode({
           resourceId: site["$id"],
           resourcePath: absoluteSitePath,


### PR DESCRIPTION
## Summary
Fix the CLI SDK pull flow so declining source download for functions or sites does not create empty local directories.

## Root Cause
`pull functions` and `pull sites` created the resource directory before checking whether source code download was enabled. When the user answered no or used `--no-code`, the directory creation still happened and left behind an empty folder.

## What Changed
Move directory creation for pulled functions and sites inside the `options.code !== false` branch so directories are only created when deployment code will actually be downloaded.

## Impact
Users can pull function or site configuration without getting empty `functions/<name>` or `sites/<name>` directories when they skip source code.

## Validation
- Regenerated the CLI SDK with `php example.php cli`
- Ran `composer lint-twig`
- Built the regenerated CLI package with `npm ci && npm run build` in `examples/cli`
