### PR TITLE
Add subscription handling to Realtime services across multiple platforms

### DIFF
--- a/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
+++ b/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
@@ -109,11 +109,7 @@ class Realtime(client: Client) : Service(client), CoroutineScope {
         synchronized(subscriptionLock) {
             pendingSubscribeSlots.clear()
             activeSubscriptions.forEach { (slot, subscription) ->
-                val queries = if (subscription.queries.isEmpty()) {
-                    setOf("""{"method":"select","values":["*"]}""")
-                } else {
-                    subscription.queries
-                }
+                val queries = subscription.queries
                 val row = mutableMapOf<String, Any>(
                     "channels" to subscription.channels.toList(),
                     "queries" to queries.toList()

--- a/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
+++ b/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
@@ -8,6 +8,7 @@ import {{ sdk.namespace | caseDot }}.exceptions.{{ spec.title | caseUcfirst }}Ex
 import {{ sdk.namespace | caseDot }}.extensions.forEachAsync
 import {{ sdk.namespace | caseDot }}.extensions.fromJson
 import {{ sdk.namespace | caseDot }}.extensions.jsonCast
+import {{ sdk.namespace | caseDot }}.extensions.toJson
 import {{ sdk.namespace | caseDot }}.models.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.Dispatchers.IO

--- a/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
+++ b/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
@@ -114,7 +114,7 @@ class Realtime(client: Client) : Service(client), CoroutineScope {
                     "channels" to subscription.channels.toList(),
                     "queries" to queries.toList()
                 )
-                val knownSubscriptionId = slotToSubscriptionId[slot] ?: slotToSubscriptionId[slot - 1]
+                val knownSubscriptionId = slotToSubscriptionId[slot]
                 if (!knownSubscriptionId.isNullOrEmpty()) {
                     row["subscriptionId"] = knownSubscriptionId
                 }

--- a/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
+++ b/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
@@ -35,6 +35,7 @@ class Realtime(client: Client) : Service(client), CoroutineScope {
         private const val TYPE_ERROR = "error"
         private const val TYPE_EVENT = "event"
         private const val TYPE_PONG = "pong"
+        private const val TYPE_RESPONSE = "response"
         private const val HEARTBEAT_INTERVAL = 20_000L // 20 seconds
 
         private var socket: RealWebSocket? = null
@@ -44,6 +45,7 @@ class Realtime(client: Client) : Service(client), CoroutineScope {
         private val slotToSubscriptionId = ConcurrentHashMap<Int, String>()
         // Inverse map: subscriptionId -> slot index (for O(1) lookup)
         private val subscriptionIdToSlot = ConcurrentHashMap<String, Int>()
+        private val pendingSubscribeSlots = mutableListOf<Int>()
 
         private var reconnectAttempts = 0
         private val subscriptionsCounter = AtomicInteger(0)
@@ -61,51 +63,14 @@ class Realtime(client: Client) : Service(client), CoroutineScope {
         val request: Request
         val newSocket: RealWebSocket?
         synchronized(subscriptionLock) {
-            // Rebuild activeChannels from all slots
-            val allChannels = mutableSetOf<String>()
-            activeSubscriptions.values.forEach { subscription ->
-                allChannels.addAll(subscription.channels)
-            }
-
-            if (allChannels.isEmpty()) {
+            if (activeSubscriptions.isEmpty()) {
                 reconnect = false
                 closeSocket()
                 return
             }
 
             val encodedProject = java.net.URLEncoder.encode(client.config["project"].toString(), "UTF-8")
-            var queryParams = "project=$encodedProject"
-
-            allChannels.forEach { channel ->
-                val encodedChannel = java.net.URLEncoder.encode(channel, "UTF-8")
-                queryParams += "&channels[]=$encodedChannel"
-            }
-
-            // Build query string from slots → channels → queries
-            // Format: channel[slot][]=query (each query sent as separate parameter)
-            // For each slot, repeat its queries under each channel it subscribes to
-            // Example: slot 1 → channels [tests, prod], queries [q1, q2]
-            //   Produces: tests[1][]=q1&tests[1][]=q2&prod[1][]=q1&prod[1][]=q2
-            val selectAllQuery = Query.select(listOf("*")).toString()
-            activeSubscriptions.forEach { (slot, subscription) ->
-                // Get queries array - each query is a separate string
-                val queries = if (subscription.queries.isEmpty()) {
-                    listOf(selectAllQuery)
-                } else {
-                    subscription.queries.toList()
-                }
-
-                // Repeat this slot's queries under each channel it subscribes to
-                // Each query is sent as a separate parameter: channel[slot][]=q1&channel[slot][]=q2
-                subscription.channels.forEach { channel ->
-                    val encodedChannel = java.net.URLEncoder.encode(channel, "UTF-8")
-                    queries.forEach { query ->
-                        val encodedQuery = java.net.URLEncoder.encode(query, "UTF-8")
-                        queryParams += "&$encodedChannel[$slot][]=$encodedQuery"
-                    }
-                }
-            }
-
+            val queryParams = "project=$encodedProject"
             val url = "${client.endpointRealtime}/realtime?$queryParams"
             request = Request.Builder().url(url).build()
 
@@ -135,6 +100,38 @@ class Realtime(client: Client) : Service(client), CoroutineScope {
     private fun closeSocket() {
         stopHeartbeat()
         socket?.close(RealtimeCode.POLICY_VIOLATION.value, null)
+    }
+
+    private fun sendSubscribeMessage() {
+        val ws = socket ?: return
+        val rows = mutableListOf<Map<String, Any>>()
+
+        synchronized(subscriptionLock) {
+            pendingSubscribeSlots.clear()
+            activeSubscriptions.forEach { (slot, subscription) ->
+                val queries = if (subscription.queries.isEmpty()) {
+                    setOf("""{"method":"select","values":["*"]}""")
+                } else {
+                    subscription.queries
+                }
+                val row = mutableMapOf<String, Any>(
+                    "channels" to subscription.channels.toList(),
+                    "queries" to queries.toList()
+                )
+                val knownSubscriptionId = slotToSubscriptionId[slot] ?: slotToSubscriptionId[slot - 1]
+                if (!knownSubscriptionId.isNullOrEmpty()) {
+                    row["subscriptionId"] = knownSubscriptionId
+                }
+                rows.add(row)
+                pendingSubscribeSlots.add(slot)
+            }
+        }
+
+        if (rows.isEmpty()) {
+            return
+        }
+
+        ws.send(mapOf("type" to "subscribe", "data" to rows).toJson())
     }
 
     private fun startHeartbeat() {
@@ -223,8 +220,14 @@ class Realtime(client: Client) : Service(client), CoroutineScope {
                 callback as (RealtimeResponseEvent<*>) -> Unit
             )
         }
-        // Sequential: rebuild socket immediately for A -> A+B -> A+B+C.
-        createSocket()
+        // Reuse active socket when possible; otherwise create it.
+        synchronized(subscriptionLock) {
+            if (socket != null) {
+                sendSubscribeMessage()
+            } else {
+                createSocket()
+            }
+        }
 
         return RealtimeSubscription {
             // Unsubscribe must update all three maps atomically so that
@@ -235,8 +238,16 @@ class Realtime(client: Client) : Service(client), CoroutineScope {
                 slotToSubscriptionId.remove(slot)
                 subscriptionId?.let { subscriptionIdToSlot.remove(it) }
             }
-            // Sequential: rebuild socket immediately after unsubscribe.
-            this@Realtime.createSocket()
+            synchronized(subscriptionLock) {
+                if (activeSubscriptions.isEmpty()) {
+                    reconnect = false
+                    closeSocket()
+                } else if (socket != null) {
+                    sendSubscribeMessage()
+                } else {
+                    this@Realtime.createSocket()
+                }
+            }
         }
     }
 
@@ -268,6 +279,7 @@ class Realtime(client: Client) : Service(client), CoroutineScope {
                 when (message.type) {
                     TYPE_ERROR -> handleResponseError(message)
                     TYPE_CONNECTED -> handleResponseConnected(message)
+                    TYPE_RESPONSE -> handleResponseAction(message)
                     TYPE_EVENT -> handleResponseEvent(message)
                     TYPE_PONG -> {}
                 }
@@ -276,26 +288,45 @@ class Realtime(client: Client) : Service(client), CoroutineScope {
         
         private fun handleResponseConnected(message: RealtimeResponse) {
             val messageData = message.data?.jsonCast<Map<String, Any>>() ?: return
-            val subscriptions = messageData["subscriptions"] as? Map<*, *> ?: return
+            val subscriptions = messageData["subscriptions"] as? Map<*, *>
 
-            // Store subscription ID mappings from backend
-            // Format: { "0": "sub_a1f9", "1": "sub_b83c", ... }
-            synchronized(subscriptionLock) {
-                val newSlotToSub = mutableMapOf<Int, String>()
-                val newSubToSlot = mutableMapOf<String, Int>()
-
-                subscriptions.forEach { (slotStr, subscriptionId) ->
-                    val slot = (slotStr as? String)?.toIntOrNull()
-                    if (slot != null && subscriptionId is String) {
-                        newSlotToSub[slot] = subscriptionId
-                        newSubToSlot[subscriptionId] = slot
+            if (subscriptions != null) {
+                // Store subscription ID mappings from backend.
+                // Try direct slot first, then slot+1 for zero-based server maps.
+                synchronized(subscriptionLock) {
+                    subscriptions.forEach { (slotStr, subscriptionId) ->
+                        val slot = (slotStr as? String)?.toIntOrNull()
+                        if (slot != null && subscriptionId is String) {
+                            val targetSlot = when {
+                                activeSubscriptions.containsKey(slot) -> slot
+                                activeSubscriptions.containsKey(slot + 1) -> slot + 1
+                                else -> slot
+                            }
+                            slotToSubscriptionId[targetSlot] = subscriptionId
+                            subscriptionIdToSlot[subscriptionId] = targetSlot
+                        }
                     }
                 }
+            }
 
-                slotToSubscriptionId.clear()
-                slotToSubscriptionId.putAll(newSlotToSub)
-                subscriptionIdToSlot.clear()
-                subscriptionIdToSlot.putAll(newSubToSlot)
+            sendSubscribeMessage()
+        }
+
+        private fun handleResponseAction(message: RealtimeResponse) {
+            val actionData = message.data?.jsonCast<Map<String, Any>>() ?: return
+            if (actionData["to"] != "subscribe") {
+                return
+            }
+            val subscriptions = actionData["subscriptions"] as? List<*> ?: return
+
+            synchronized(subscriptionLock) {
+                subscriptions.forEachIndexed { index, item ->
+                    val slot = pendingSubscribeSlots.getOrNull(index) ?: return@forEachIndexed
+                    val row = item as? Map<*, *> ?: return@forEachIndexed
+                    val subscriptionId = row["subscriptionId"] as? String ?: return@forEachIndexed
+                    slotToSubscriptionId[slot] = subscriptionId
+                    subscriptionIdToSlot[subscriptionId] = slot
+                }
             }
         }
 

--- a/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
+++ b/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
@@ -322,7 +322,10 @@ class Realtime(client: Client) : Service(client), CoroutineScope {
             val subscriptions = actionData["subscriptions"] as? List<*> ?: return
 
             synchronized(subscriptionLock) {
-                val pendingSlots = pendingSubscribeSlotsQueue.removeFirstOrNull() ?: return
+                if (pendingSubscribeSlotsQueue.isEmpty()) {
+                    return
+                }
+                val pendingSlots = pendingSubscribeSlotsQueue.removeFirst()
                 subscriptions.forEachIndexed { index, item ->
                     val slot = pendingSlots.getOrNull(index) ?: return@forEachIndexed
                     val row = item as? Map<*, *> ?: return@forEachIndexed

--- a/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
+++ b/templates/android/library/src/main/java/io/package/services/Realtime.kt.twig
@@ -46,7 +46,8 @@ class Realtime(client: Client) : Service(client), CoroutineScope {
         private val slotToSubscriptionId = ConcurrentHashMap<Int, String>()
         // Inverse map: subscriptionId -> slot index (for O(1) lookup)
         private val subscriptionIdToSlot = ConcurrentHashMap<String, Int>()
-        private val pendingSubscribeSlots = mutableListOf<Int>()
+        // Queue of slot snapshots per in-flight subscribe message (FIFO with server responses).
+        private val pendingSubscribeSlotsQueue = ArrayDeque<List<Int>>()
 
         private var reconnectAttempts = 0
         private val subscriptionsCounter = AtomicInteger(0)
@@ -106,9 +107,9 @@ class Realtime(client: Client) : Service(client), CoroutineScope {
     private fun sendSubscribeMessage() {
         val ws = socket ?: return
         val rows = mutableListOf<Map<String, Any>>()
+        val slotsForMessage = mutableListOf<Int>()
 
         synchronized(subscriptionLock) {
-            pendingSubscribeSlots.clear()
             activeSubscriptions.forEach { (slot, subscription) ->
                 val queries = subscription.queries
                 val row = mutableMapOf<String, Any>(
@@ -120,12 +121,16 @@ class Realtime(client: Client) : Service(client), CoroutineScope {
                     row["subscriptionId"] = knownSubscriptionId
                 }
                 rows.add(row)
-                pendingSubscribeSlots.add(slot)
+                slotsForMessage.add(slot)
             }
         }
 
         if (rows.isEmpty()) {
             return
+        }
+
+        synchronized(subscriptionLock) {
+            pendingSubscribeSlotsQueue.addLast(slotsForMessage.toList())
         }
 
         ws.send(mapOf("type" to "subscribe", "data" to rows).toJson())
@@ -317,8 +322,9 @@ class Realtime(client: Client) : Service(client), CoroutineScope {
             val subscriptions = actionData["subscriptions"] as? List<*> ?: return
 
             synchronized(subscriptionLock) {
+                val pendingSlots = pendingSubscribeSlotsQueue.removeFirstOrNull() ?: return
                 subscriptions.forEachIndexed { index, item ->
-                    val slot = pendingSubscribeSlots.getOrNull(index) ?: return@forEachIndexed
+                    val slot = pendingSlots.getOrNull(index) ?: return@forEachIndexed
                     val row = item as? Map<*, *> ?: return@forEachIndexed
                     val subscriptionId = row["subscriptionId"] as? String ?: return@forEachIndexed
                     slotToSubscriptionId[slot] = subscriptionId

--- a/templates/apple/Sources/Services/Realtime.swift.twig
+++ b/templates/apple/Sources/Services/Realtime.swift.twig
@@ -108,7 +108,7 @@ open class Realtime : Service {
                 "channels": Array(subscription.channels),
                 "queries": queries
             ]
-            if let knownSubscriptionId = slotToSubscriptionId[slot] ?? slotToSubscriptionId[slot - 1] {
+            if let knownSubscriptionId = slotToSubscriptionId[slot] {
                 row["subscriptionId"] = knownSubscriptionId
             }
             rows.append(row)

--- a/templates/apple/Sources/Services/Realtime.swift.twig
+++ b/templates/apple/Sources/Services/Realtime.swift.twig
@@ -103,8 +103,7 @@ open class Realtime : Service {
         pendingSubscribeSlots.removeAll()
 
         for (slot, subscription) in activeSubscriptions {
-            let storedQueries = activeSubscriptionQueries[slot] ?? []
-            let queries = storedQueries.isEmpty ? [#"{"method":"select","values":["*"]}"#] : storedQueries
+            let queries = activeSubscriptionQueries[slot] ?? []
             var row: [String: Any] = [
                 "channels": Array(subscription.channels),
                 "queries": queries

--- a/templates/apple/Sources/Services/Realtime.swift.twig
+++ b/templates/apple/Sources/Services/Realtime.swift.twig
@@ -8,6 +8,7 @@ open class Realtime : Service {
     private let TYPE_ERROR = "error"
     private let TYPE_EVENT = "event"
     private let TYPE_PONG = "pong"
+    private let TYPE_RESPONSE = "response"
     private let DEBOUNCE_NANOS = 1_000_000
     private let HEARTBEAT_INTERVAL: UInt64 = 20_000_000_000 // 20 seconds in nanoseconds
 
@@ -19,6 +20,7 @@ open class Realtime : Service {
     private var slotToSubscriptionId = [Int: String]()
     // Inverse map: subscriptionId -> slot index (for O(1) lookup)
     private var subscriptionIdToSlot = [String: Int]()
+    private var pendingSubscribeSlots = [Int]()
     private var heartbeatTask: Task<Void, Swift.Error>? = nil
 
     let connectSync = DispatchQueue(label: "ConnectSync")
@@ -68,46 +70,13 @@ open class Realtime : Service {
     }
 
     private func createSocket() async throws {
-        // Rebuild activeChannels from all slots
-        var allChannels = Set<String>()
-        for subscription in activeSubscriptions.values {
-            allChannels.formUnion(subscription.channels)
-        }
-
-        guard allChannels.count > 0 else {
+        guard activeSubscriptions.count > 0 else {
             reconnect = false
             try await closeSocket()
             return
         }
 
-        var queryParams = "project=\(client.config["project"]!)"
-
-        for channel in allChannels {
-            let encodedChannel = channel.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? channel
-            queryParams += "&channels[]=\(encodedChannel)"
-        }
-
-        // Build query string from slots → channels → queries
-        // Format: channel[slot][]=query (each query sent as separate parameter)
-        // For each slot, repeat its queries under each channel it subscribes to
-        // Example: slot 1 → channels [tests, prod], queries [q1, q2]
-        //   Produces: tests[1][]=q1&tests[1][]=q2&prod[1][]=q1&prod[1][]=q2
-        let selectAllQuery = Query.select(["*"])
-        for (slot, subscription) in activeSubscriptions {
-            // Get queries array - each query is a separate string
-            let queries = activeSubscriptionQueries[slot] ?? []
-            let queryArray = queries.isEmpty ? [selectAllQuery] : queries
-            
-            // Repeat this slot's queries under each channel it subscribes to
-            // Each query is sent as a separate parameter: channel[slot][]=q1&channel[slot][]=q2
-            for channel in subscription.channels {
-                let encodedChannel = channel.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? channel
-                for query in queryArray {
-                    let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
-                    queryParams += "&\(encodedChannel)[\(slot)][]=\(encodedQuery)"
-                }
-            }
-        }
+        let queryParams = "project=\(client.config["project"]!)"
 
         let url = "\(client.endPointRealtime!)/realtime?\(queryParams)"
 
@@ -123,6 +92,42 @@ open class Realtime : Service {
         )
 
         try await socketClient?.connect()
+    }
+
+    private func sendSubscribeMessage() {
+        guard let ws = socketClient, ws.isConnected else {
+            return
+        }
+
+        var rows = [[String: Any]]()
+        pendingSubscribeSlots.removeAll()
+
+        for (slot, subscription) in activeSubscriptions {
+            let storedQueries = activeSubscriptionQueries[slot] ?? []
+            let queries = storedQueries.isEmpty ? [#"{"method":"select","values":["*"]}"#] : storedQueries
+            var row: [String: Any] = [
+                "channels": Array(subscription.channels),
+                "queries": queries
+            ]
+            if let knownSubscriptionId = slotToSubscriptionId[slot] ?? slotToSubscriptionId[slot - 1] {
+                row["subscriptionId"] = knownSubscriptionId
+            }
+            rows.append(row)
+            pendingSubscribeSlots.append(slot)
+        }
+
+        if rows.isEmpty {
+            return
+        }
+
+        let payload: [String: Any] = [
+            "type": "subscribe",
+            "data": rows
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: payload),
+           let text = String(data: data, encoding: .utf8) {
+            ws.send(text: text)
+        }
     }
 
     private func closeSocket() async throws {
@@ -243,7 +248,11 @@ open class Realtime : Service {
         try await Task.sleep(nanoseconds: UInt64(DEBOUNCE_NANOS))
 
         if self.subCallDepth == 1 {
-            try await self.createSocket()
+            if let ws = self.socketClient, ws.isConnected {
+                self.sendSubscribeMessage()
+            } else {
+                try await self.createSocket()
+            }
         }
 
         connectSync.sync {
@@ -258,7 +267,16 @@ open class Realtime : Service {
             if let sid = subscriptionId {
                 self.subscriptionIdToSlot[sid] = nil
             }
-            try await self.createSocket()
+            if self.activeSubscriptions.isEmpty {
+                self.reconnect = false
+                try await self.closeSocket()
+                return
+            }
+            if let ws = self.socketClient, ws.isConnected {
+                self.sendSubscribeMessage()
+            } else {
+                try await self.createSocket()
+            }
         }
     }
 
@@ -275,20 +293,47 @@ extension Realtime: WebSocketClientDelegate {
     }
     
     private func handleResponseConnected(from json: [String: Any]) {
-        guard let data = json["data"] as? [String: Any],
-              let subscriptions = data["subscriptions"] as? [String: String] else {
+        guard let data = json["data"] as? [String: Any] else {
             return
         }
         
-        // Store subscription ID mappings from backend
-        // Format: { "0": "sub_a1f9", "1": "sub_b83c", ... }
-        slotToSubscriptionId.removeAll()
-        subscriptionIdToSlot.removeAll()
-        for (slotStr, subscriptionId) in subscriptions {
-            if let slot = Int(slotStr) {
-                slotToSubscriptionId[slot] = subscriptionId
-                subscriptionIdToSlot[subscriptionId] = slot
+        if let subscriptions = data["subscriptions"] as? [String: String] {
+            // Store subscription ID mappings from backend.
+            // Try direct slot first, then slot+1 for zero-based server maps.
+            for (slotStr, subscriptionId) in subscriptions {
+                if let slot = Int(slotStr) {
+                    let targetSlot: Int
+                    if activeSubscriptions[slot] != nil {
+                        targetSlot = slot
+                    } else if activeSubscriptions[slot + 1] != nil {
+                        targetSlot = slot + 1
+                    } else {
+                        targetSlot = slot
+                    }
+                    slotToSubscriptionId[targetSlot] = subscriptionId
+                    subscriptionIdToSlot[subscriptionId] = targetSlot
+                }
             }
+        }
+
+        sendSubscribeMessage()
+    }
+
+    private func handleResponseAction(from json: [String: Any]) {
+        guard let data = json["data"] as? [String: Any],
+              data["to"] as? String == "subscribe",
+              let subscriptions = data["subscriptions"] as? [[String: Any]] else {
+            return
+        }
+
+        for (index, item) in subscriptions.enumerated() {
+            guard index < pendingSubscribeSlots.count,
+                  let subscriptionId = item["subscriptionId"] as? String else {
+                continue
+            }
+            let slot = pendingSubscribeSlots[index]
+            slotToSubscriptionId[slot] = subscriptionId
+            subscriptionIdToSlot[subscriptionId] = slot
         }
     }
 
@@ -308,6 +353,8 @@ extension Realtime: WebSocketClientDelegate {
             }
         case "connected":
             handleResponseConnected(from: json)
+        case TYPE_RESPONSE:
+            handleResponseAction(from: json)
         case TYPE_EVENT:
             handleResponseEvent(from: json)
         case TYPE_PONG:

--- a/templates/flutter/lib/src/realtime_mixin.dart.twig
+++ b/templates/flutter/lib/src/realtime_mixin.dart.twig
@@ -245,7 +245,7 @@ mixin RealtimeMixin {
   }
 
   void _sendSubscribeMessage() {
-    if (_websok == null) {
+    if (_websok == null || _websok?.closeCode != null) {
       return;
     }
 
@@ -260,7 +260,7 @@ mixin RealtimeMixin {
         'channels': subscription.channels,
         'queries': queries,
       };
-      final knownSubscriptionId = _slotToSubscriptionId[slot] ?? _slotToSubscriptionId[slot - 1];
+      final knownSubscriptionId = _slotToSubscriptionId[slot];
       if (knownSubscriptionId != null && knownSubscriptionId.isNotEmpty) {
         row['subscriptionId'] = knownSubscriptionId;
       }

--- a/templates/flutter/lib/src/realtime_mixin.dart.twig
+++ b/templates/flutter/lib/src/realtime_mixin.dart.twig
@@ -158,7 +158,6 @@ mixin RealtimeMixin {
             }
             break;
           case 'pong':
-            debugPrint('Received heartbeat response from realtime server');
             break;
           case 'event':
             final messageData = data.data as Map<String, dynamic>;

--- a/templates/flutter/lib/src/realtime_mixin.dart.twig
+++ b/templates/flutter/lib/src/realtime_mixin.dart.twig
@@ -255,9 +255,7 @@ mixin RealtimeMixin {
     for (var entry in _subscriptions.entries) {
       final slot = entry.key;
       final subscription = entry.value;
-      final queries = subscription.queries.isNotEmpty
-          ? subscription.queries
-          : ['{"method":"select","values":["*"]}'];
+      final queries = subscription.queries;
       final row = <String, dynamic>{
         'channels': subscription.channels,
         'queries': queries,

--- a/templates/flutter/lib/src/realtime_mixin.dart.twig
+++ b/templates/flutter/lib/src/realtime_mixin.dart.twig
@@ -22,6 +22,7 @@ mixin RealtimeMixin {
   final Map<int, String> _slotToSubscriptionId = {};
   // Inverse map: subscriptionId -> slot index (for O(1) lookup)
   final Map<String, int> _subscriptionIdToSlot = {};
+  final List<int> _pendingSubscribeSlots = [];
   int _subscriptionsCounter = 0;
   WebSocketChannel? _websok;
   String? _lastUrl;
@@ -80,6 +81,7 @@ mixin RealtimeMixin {
         _lastUrl = uri.toString();
       } else {
         if (_lastUrl == uri.toString() && _websok?.closeCode == null) {
+          _sendSubscribeMessage();
           _creatingSocket = false;
           return;
         }
@@ -99,16 +101,23 @@ mixin RealtimeMixin {
             final message = RealtimeResponseConnected.fromMap(data.data);
             
             // Store subscription ID mappings from backend
-            // Format: { "0": "sub_a1f9", "1": "sub_b83c", ... }
-            _slotToSubscriptionId.clear();
-            _subscriptionIdToSlot.clear();
+            // Format: { "0": "sub_a1f9", "1": "sub_b83c", ... }.
+            // Try direct slot first, then slot+1 for zero-based server maps.
             if (data.data['subscriptions'] != null) {
               final subscriptions = data.data['subscriptions'] as Map<String, dynamic>;
               subscriptions.forEach((slotStr, subscriptionId) {
                 final slot = int.tryParse(slotStr);
                 if (slot != null) {
-                  _slotToSubscriptionId[slot] = subscriptionId.toString();
-                  _subscriptionIdToSlot[subscriptionId.toString()] = slot;
+                  final directSlotExists = _subscriptions.containsKey(slot);
+                  final shiftedSlot = slot + 1;
+                  final shiftedSlotExists = _subscriptions.containsKey(shiftedSlot);
+                  final targetSlot = directSlotExists
+                      ? slot
+                      : shiftedSlotExists
+                          ? shiftedSlot
+                          : slot;
+                  _slotToSubscriptionId[targetSlot] = subscriptionId.toString();
+                  _subscriptionIdToSlot[subscriptionId.toString()] = targetSlot;
                 }
               });
             }
@@ -125,7 +134,28 @@ mixin RealtimeMixin {
                 }));
               }
             }
+            _sendSubscribeMessage();
             _startHeartbeat(); // Start heartbeat after successful connection
+            break;
+          case 'response':
+            final actionData = data.data as Map<String, dynamic>;
+            if (actionData['to'] != 'subscribe') {
+              break;
+            }
+            final subscriptions = actionData['subscriptions'] as List<dynamic>?;
+            if (subscriptions == null) {
+              break;
+            }
+            for (var index = 0; index < subscriptions.length; index++) {
+              final slot = index < _pendingSubscribeSlots.length ? _pendingSubscribeSlots[index] : null;
+              final item = subscriptions[index] as Map<String, dynamic>?;
+              final subscriptionId = item?['subscriptionId']?.toString();
+              if (slot == null || subscriptionId == null || subscriptionId.isEmpty) {
+                continue;
+              }
+              _slotToSubscriptionId[slot] = subscriptionId;
+              _subscriptionIdToSlot[subscriptionId] = slot;
+            }
             break;
           case 'pong':
             debugPrint('Received heartbeat response from realtime server');
@@ -206,49 +236,48 @@ mixin RealtimeMixin {
     }
     var uri = Uri.parse(client.endPointRealtime!);
     
-    // Collect all unique channels from all slots
-    final allChannels = <String>{};
-    for (var subscription in _subscriptions.values) {
-      allChannels.addAll(subscription.channels);
-    }
-    
-    // Build query string from slots → channels → queries
-    // Format: channel[slot][]=query (each query sent as separate parameter)
-    // For each slot, repeat its queries under each channel it subscribes to
-    // Example: slot 1 → channels [tests, prod], queries [q1, q2]
-    //   Produces: tests[1][]=q1&tests[1][]=q2&prod[1][]=q1&prod[1][]=q2
     var queryParams = "project=${Uri.encodeComponent(client.config['project']!)}";
-    
-    for (var channel in allChannels) {
-      final encodedChannel = Uri.encodeComponent(channel);
-      queryParams += "&channels[]=$encodedChannel";
-    }
-
-    // Hardcode the select query string since Query is not accessible in this mixin
-    // This is equivalent to Query.select(["*"]) which returns: {"method":"select","values":["*"]}
-    final selectAllQuery = '{"method":"select","values":["*"]}';
-    for (var entry in _subscriptions.entries) {
-      final slot = entry.key;
-      final subscription = entry.value;
-      
-      // Get queries array - each query is a separate string
-      final queries = subscription.queries.isEmpty ? [selectAllQuery] : subscription.queries;
-      
-      // Repeat this slot's queries under each channel it subscribes to
-      // Each query is sent as a separate parameter: channel[slot][]=q1&channel[slot][]=q2
-      for (var channel in subscription.channels) {
-        final encodedChannel = Uri.encodeComponent(channel);
-        for (var query in queries) {
-          final encodedQuery = Uri.encodeComponent(query);
-          queryParams += "&$encodedChannel[$slot][]=$encodedQuery";
-        }
-      }
-    }
 
     final portPart = (uri.hasPort && uri.port != 80 && uri.port != 443)
         ? ':${uri.port}'
         : '';
     return Uri.parse("${uri.scheme}://${uri.host}$portPart${uri.path}/realtime?$queryParams");
+  }
+
+  void _sendSubscribeMessage() {
+    if (_websok == null) {
+      return;
+    }
+
+    final rows = <Map<String, dynamic>>[];
+    _pendingSubscribeSlots.clear();
+
+    for (var entry in _subscriptions.entries) {
+      final slot = entry.key;
+      final subscription = entry.value;
+      final queries = subscription.queries.isNotEmpty
+          ? subscription.queries
+          : ['{"method":"select","values":["*"]}'];
+      final row = <String, dynamic>{
+        'channels': subscription.channels,
+        'queries': queries,
+      };
+      final knownSubscriptionId = _slotToSubscriptionId[slot] ?? _slotToSubscriptionId[slot - 1];
+      if (knownSubscriptionId != null && knownSubscriptionId.isNotEmpty) {
+        row['subscriptionId'] = knownSubscriptionId;
+      }
+      rows.add(row);
+      _pendingSubscribeSlots.add(slot);
+    }
+
+    if (rows.isEmpty) {
+      return;
+    }
+
+    _websok!.sink.add(jsonEncode({
+      'type': 'subscribe',
+      'data': rows,
+    }));
   }
 
   /// Convert channel value to string
@@ -282,14 +311,12 @@ mixin RealtimeMixin {
           }
           controller.close();
 
-          // Rebuild channels from remaining slots
-          final remainingChannels = <String>{};
-          for (var sub in _subscriptions.values) {
-            remainingChannels.addAll(sub.channels);
-          }
-
-          if (remainingChannels.isNotEmpty) {
-            await Future.delayed(Duration.zero, () => _createSocket());
+          if (_subscriptions.isNotEmpty) {
+            if (_websok != null && _websok?.closeCode == null) {
+              _sendSubscribeMessage();
+            } else {
+              await Future.delayed(Duration.zero, () => _createSocket());
+            }
           } else {
             await _closeConnection();
           }

--- a/templates/flutter/lib/src/realtime_mixin.dart.twig
+++ b/templates/flutter/lib/src/realtime_mixin.dart.twig
@@ -103,10 +103,10 @@ mixin RealtimeMixin {
             // Store subscription ID mappings from backend
             // Format: { "0": "sub_a1f9", "1": "sub_b83c", ... }.
             // Try direct slot first, then slot+1 for zero-based server maps.
-            if (data.data['subscriptions'] != null) {
-              final subscriptions = data.data['subscriptions'] as Map<String, dynamic>;
-              subscriptions.forEach((slotStr, subscriptionId) {
-                final slot = int.tryParse(slotStr);
+            final rawSubscriptions = data.data['subscriptions'];
+            if (rawSubscriptions is Map) {
+              rawSubscriptions.forEach((slotStr, subscriptionId) {
+                final slot = int.tryParse(slotStr.toString());
                 if (slot != null) {
                   final directSlotExists = _subscriptions.containsKey(slot);
                   final shiftedSlot = slot + 1;

--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -57,8 +57,24 @@ type RealtimeResponse = {
 }
 
 type RealtimeRequest = {
-    type: 'authentication';
-    data: RealtimeRequestAuthenticate;
+    type: 'authentication' | 'subscribe';
+    data: RealtimeRequestAuthenticate | RealtimeRequestSubscribe[];
+}
+
+type RealtimeRequestSubscribe = {
+    subscriptionId?: string;
+    channels: string[];
+    queries: string[];
+}
+
+type RealtimeResponseAction = {
+    to?: string;
+    success?: boolean;
+    subscriptions?: Array<{
+        subscriptionId?: string;
+        channels?: string[];
+        queries?: string[];
+    }>;
 }
 
 export type RealtimeResponseEvent<T extends unknown> = {
@@ -66,6 +82,7 @@ export type RealtimeResponseEvent<T extends unknown> = {
     channels: string[];
     timestamp: number;
     payload: T;
+    subscriptions?: string[];
 }
 
 type RealtimeResponseError = {
@@ -76,6 +93,7 @@ type RealtimeResponseError = {
 type RealtimeResponseConnected = {
     channels: string[];
     user?: object;
+    subscriptions?: Record<string, string>;
 }
 
 type RealtimeResponseAuthenticated = {
@@ -103,13 +121,14 @@ type Realtime = {
 
     url?: string;
     lastMessage?: RealtimeResponse;
-    channels: Set<string>;
-    queries: Set<string>;
     subscriptions: Map<number, {
         channels: string[];
         queries: string[];
         callback: (payload: RealtimeResponseEvent<any>) => void
     }>;
+    slotToSubscriptionId: Map<number, string>;
+    subscriptionIdToSlot: Map<string, number>;
+    pendingSubscribeSlots: number[];
     subscriptionsCounter: number;
     reconnect: boolean;
     reconnectAttempts: number;
@@ -117,7 +136,7 @@ type Realtime = {
     connect: () => void;
     createSocket: () => void;
     createHeartbeat: () => void;
-    cleanUp: (channels: string[], queries: string[]) => void;
+    sendSubscribeMessage: () => void;
     onMessage: (event: MessageEvent) => void;
 }
 
@@ -257,9 +276,10 @@ class Client {
         timeout: undefined,
         heartbeat: undefined,
         url: '',
-        channels: new Set(),
-        queries: new Set(),
         subscriptions: new Map(),
+        slotToSubscriptionId: new Map(),
+        subscriptionIdToSlot: new Map(),
+        pendingSubscribeSlots: [],
         subscriptionsCounter: 0,
         reconnect: true,
         reconnectAttempts: 0,
@@ -294,7 +314,7 @@ class Client {
             }, 20_000);
         },
         createSocket: () => {
-            if (this.realtime.channels.size < 1) {
+            if (this.realtime.subscriptions.size < 1) {
                 this.realtime.reconnect = false;
                 this.realtime.socket?.close();
                 return;
@@ -302,12 +322,6 @@ class Client {
 
             const channels = new URLSearchParams();
             channels.set('project', this.config.project);
-            this.realtime.channels.forEach(channel => {
-                channels.append('channels[]', channel);
-            });
-            this.realtime.queries.forEach(query => {
-                channels.append('queries[]', query);
-            });
 
             const url = this.config.endpointRealtime + '/realtime?' + channels.toString();
 
@@ -356,23 +370,124 @@ class Client {
                         this.realtime.createSocket();
                     }, timeout);
                 })
+            } else if (this.realtime.socket?.readyState === WebSocket.OPEN) {
+                // URL is unchanged; re-send subscribe message to apply updated queries.
+                this.realtime.sendSubscribeMessage();
             }
+        },
+        sendSubscribeMessage: () => {
+            if (!this.realtime.socket || this.realtime.socket.readyState !== WebSocket.OPEN) {
+                return;
+            }
+
+            const rows: RealtimeRequestSubscribe[] = [];
+            this.realtime.pendingSubscribeSlots = [];
+
+            this.realtime.subscriptions.forEach((sub, slot) => {
+                const queries = sub.queries && sub.queries.length > 0
+                    ? sub.queries
+                    : [Query.select(['*']).toString()];
+
+                const row: RealtimeRequestSubscribe = {
+                    channels: sub.channels,
+                    queries
+                };
+                const knownSubscriptionId = this.realtime.slotToSubscriptionId.get(slot) ?? this.realtime.slotToSubscriptionId.get(slot - 1);
+                if (knownSubscriptionId) {
+                    row.subscriptionId = knownSubscriptionId;
+                }
+
+                rows.push(row);
+                this.realtime.pendingSubscribeSlots.push(slot);
+            });
+
+            if (rows.length < 1) {
+                return;
+            }
+
+            this.realtime.socket.send(JSONbig.stringify(<RealtimeRequest>{
+                type: 'subscribe',
+                data: rows
+            }));
         },
         onMessage: (event) => {
             try {
                 const message: RealtimeResponse = JSONbig.parse(event.data);
                 this.realtime.lastMessage = message;
                 switch (message.type) {
-                    case 'event':
-                        let data = <RealtimeResponseEvent<unknown>>message.data;
-                        if (data?.channels) {
-                            const isSubscribed = data.channels.some(channel => this.realtime.channels.has(channel));
-                            if (!isSubscribed) return;
-                            this.realtime.subscriptions.forEach(subscription => {
-                                if (data.channels.some(channel => subscription.channels.includes(channel))) {
-                                    setTimeout(() => subscription.callback(data));
+                    case 'connected': {
+                        const messageData = <RealtimeResponseConnected>message.data;
+                        if (messageData?.subscriptions) {
+                            for (const [slotStr, subscriptionId] of Object.entries(messageData.subscriptions)) {
+                                const slot = Number(slotStr);
+                                if (isNaN(slot) || typeof subscriptionId !== 'string') {
+                                    continue;
                                 }
-                            })
+
+                                const directSlotExists = this.realtime.subscriptions.has(slot);
+                                const shiftedSlot = slot + 1;
+                                const shiftedSlotExists = this.realtime.subscriptions.has(shiftedSlot);
+                                const targetSlot = directSlotExists ? slot : shiftedSlotExists ? shiftedSlot : slot;
+                                this.realtime.slotToSubscriptionId.set(targetSlot, subscriptionId);
+                                this.realtime.subscriptionIdToSlot.set(subscriptionId, targetSlot);
+                            }
+                        }
+
+                        let session = this.config.session;
+                        if (!session) {
+                            const cookie = JSONbig.parse(window.localStorage.getItem('cookieFallback') ?? '{}');
+                            session = cookie?.[`a_session_${this.config.project}`];
+                        }
+                        if (session && !messageData?.user) {
+                            this.realtime.socket?.send(JSONbig.stringify(<RealtimeRequest>{
+                                type: 'authentication',
+                                data: {
+                                    session
+                                }
+                            }));
+                        }
+
+                        this.realtime.sendSubscribeMessage();
+                        break;
+                    }
+                    case 'response': {
+                        const action = message.data as RealtimeResponseAction;
+                        if (action?.to !== 'subscribe' || !Array.isArray(action.subscriptions)) {
+                            break;
+                        }
+
+                        action.subscriptions.forEach((subscription, index) => {
+                            const subscriptionId = subscription?.subscriptionId;
+                            const slot = this.realtime.pendingSubscribeSlots[index];
+                            if (!subscriptionId || slot === undefined) {
+                                return;
+                            }
+
+                            this.realtime.slotToSubscriptionId.set(slot, subscriptionId);
+                            this.realtime.subscriptionIdToSlot.set(subscriptionId, slot);
+                        });
+                        break;
+                    }
+                    case 'event':
+                        const data = <RealtimeResponseEvent<unknown>>message.data;
+                        if (data?.channels) {
+                            if (data.subscriptions && data.subscriptions.length > 0) {
+                                data.subscriptions.forEach((subscriptionId) => {
+                                    const slot = this.realtime.subscriptionIdToSlot.get(subscriptionId);
+                                    if (slot !== undefined) {
+                                        const subscription = this.realtime.subscriptions.get(slot);
+                                        if (subscription) {
+                                            setTimeout(() => subscription.callback(data));
+                                        }
+                                    }
+                                });
+                            } else {
+                                this.realtime.subscriptions.forEach(subscription => {
+                                    if (data.channels.some(channel => subscription.channels.includes(channel))) {
+                                        setTimeout(() => subscription.callback(data));
+                                    }
+                                });
+                            }
                         }
                         break;
                     case 'pong':
@@ -385,31 +500,6 @@ class Client {
             } catch (e) {
                 console.error(e);
             }
-        },
-        cleanUp: (channels, queries) => {
-            this.realtime.channels.forEach(channel => {
-                if (channels.includes(channel)) {
-                    let found = Array.from(this.realtime.subscriptions).some(([_key, subscription] )=> {
-                        return subscription.channels.includes(channel);
-                    })
-
-                    if (!found) {
-                        this.realtime.channels.delete(channel);
-                    }
-                }
-            })
-
-            this.realtime.queries.forEach(query => {
-                if (queries.includes(query)) {
-                    let found = Array.from(this.realtime.subscriptions).some(([_key, subscription]) => {
-                        return subscription.queries?.includes(query);
-                    })
-
-                    if (!found) {
-                        this.realtime.queries.delete(query);
-                    }
-                }
-            })
         }
     }
 
@@ -444,10 +534,8 @@ class Client {
         queries: (string | Query)[] = []
     ): () => void {
         let channelArray = typeof channels === 'string' ? [channels] : channels;
-        channelArray.forEach(channel => this.realtime.channels.add(channel));
 
         const queryStrings = (queries ?? []).map(q => typeof q === 'string' ? q : q.toString());
-        queryStrings.forEach(query => this.realtime.queries.add(query));
 
         const counter = this.realtime.subscriptionsCounter++;
         this.realtime.subscriptions.set(counter, {
@@ -459,8 +547,12 @@ class Client {
         this.realtime.connect();
 
         return () => {
+            const subscriptionId = this.realtime.slotToSubscriptionId.get(counter);
             this.realtime.subscriptions.delete(counter);
-            this.realtime.cleanUp(channelArray, queryStrings);
+            this.realtime.slotToSubscriptionId.delete(counter);
+            if (subscriptionId) {
+                this.realtime.subscriptionIdToSlot.delete(subscriptionId);
+            }
             this.realtime.connect();
         }
     }

--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -384,9 +384,7 @@ class Client {
             this.realtime.pendingSubscribeSlots = [];
 
             this.realtime.subscriptions.forEach((sub, slot) => {
-                const queries = sub.queries && sub.queries.length > 0
-                    ? sub.queries
-                    : [Query.select(['*']).toString()];
+                const queries = sub.queries ?? [];
 
                 const row: RealtimeRequestSubscribe = {
                     channels: sub.channels,

--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -390,7 +390,7 @@ class Client {
                     channels: sub.channels,
                     queries
                 };
-                const knownSubscriptionId = this.realtime.slotToSubscriptionId.get(slot) ?? this.realtime.slotToSubscriptionId.get(slot - 1);
+                const knownSubscriptionId = this.realtime.slotToSubscriptionId.get(slot);
                 if (knownSubscriptionId) {
                     row.subscriptionId = knownSubscriptionId;
                 }

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -609,9 +609,7 @@ class Client {
             this.realtime.pendingSubscribeSlots = [];
 
             this.realtime.subscriptions.forEach((sub, slot) => {
-                const queries = sub.queries && sub.queries.length > 0
-                    ? sub.queries
-                    : [Query.select(['*']).toString()];
+                const queries = sub.queries ?? [];
 
                 const row: RealtimeRequestSubscribe = {
                     channels: sub.channels,

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -616,7 +616,7 @@ class Client {
                     queries
                 };
 
-                const knownSubscriptionId = this.realtime.slotToSubscriptionId.get(slot) ?? this.realtime.slotToSubscriptionId.get(slot - 1);
+                const knownSubscriptionId = this.realtime.slotToSubscriptionId.get(slot);
                 if (knownSubscriptionId) {
                     row.subscriptionId = knownSubscriptionId;
                 }
@@ -811,6 +811,16 @@ class Client {
             if (subscriptionId) {
                 this.realtime.subscriptionIdToSlot.delete(subscriptionId);
             }
+            // Remove channels that are no longer referenced by any active subscription.
+            const stillUsed = new Set<string>();
+            this.realtime.subscriptions.forEach(sub => {
+                sub.channels.forEach(channel => stillUsed.add(channel));
+            });
+            this.realtime.channels.forEach(channel => {
+                if (!stillUsed.has(channel)) {
+                    this.realtime.channels.delete(channel);
+                }
+            });
             this.realtime.connect();
         }
     }

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -76,14 +76,30 @@ type RealtimeResponse = {
  */
 type RealtimeRequest = {
     /**
-     * Type of the request: 'authentication'.
+     * Type of the request: 'authentication' or 'subscribe'.
      */
-    type: 'authentication';
+    type: 'authentication' | 'subscribe';
 
     /**
      * Data required for authentication.
      */
-    data: RealtimeRequestAuthenticate;
+    data: RealtimeRequestAuthenticate | RealtimeRequestSubscribe[];
+}
+
+type RealtimeRequestSubscribe = {
+    subscriptionId?: string;
+    channels: string[];
+    queries: string[];
+}
+
+type RealtimeResponseAction = {
+    to?: string;
+    success?: boolean;
+    subscriptions?: Array<{
+        subscriptionId?: string;
+        channels?: string[];
+        queries?: string[];
+    }>;
 }
 
 /**
@@ -218,11 +234,6 @@ type Realtime = {
     channels: Set<string>;
 
     /**
-     * Set of query strings the client is subscribed to.
-     */
-    queries: Set<string>;
-
-    /**
      * Map of subscriptions containing channel names and corresponding callback functions.
      */
     subscriptions: Map<number, {
@@ -240,6 +251,8 @@ type Realtime = {
      * Map subscription ID -> slot index (for O(1) event dispatch).
      */
     subscriptionIdToSlot: Map<string, number>;
+
+    pendingSubscribeSlots: number[];
 
     /**
      * Counter for managing subscriptions.
@@ -276,12 +289,7 @@ type Realtime = {
      */
     createHeartbeat: () => void;
 
-    /**
-     * Function to clean up resources associated with specified channels.
-     *
-     * @param {string[]} channels - List of channel names to clean up.
-     */
-    cleanUp: (channels: string[], queries: string[]) => void;
+    sendSubscribeMessage: () => void;
 
     /**
      * Function to handle incoming messages from the WebSocket connection.
@@ -497,10 +505,10 @@ class Client {
         heartbeat: undefined,
         url: '',
         channels: new Set(),
-        queries: new Set(),
         subscriptions: new Map(),
         slotToSubscriptionId: new Map(),
         subscriptionIdToSlot: new Map(),
+        pendingSubscribeSlots: [],
         subscriptionsCounter: 0,
         reconnect: true,
         reconnectAttempts: 0,
@@ -542,22 +550,8 @@ class Client {
             }
 
             const encodedProject = encodeURIComponent((this.config.project as string) ?? '');
-            let queryParams = 'project=' + encodedProject;
-
-            this.realtime.channels.forEach(channel => {
-                queryParams += '&channels[]=' + encodeURIComponent(channel);
-            });
-
-            // Per-subscription queries: channel[slot][]=query so server can route events by subscription
-            const selectAllQuery = Query.select(['*']).toString();
-            this.realtime.subscriptions.forEach((sub, slot) => {
-                const queries = sub.queries.length > 0 ? sub.queries : [selectAllQuery];
-                sub.channels.forEach(channel => {
-                    queries.forEach(query => {
-                        queryParams += '&' + encodeURIComponent(channel) + '[' + slot + '][]=' + encodeURIComponent(query);
-                    });
-                });
-            });
+            // URL carries only the project; channels/queries are sent via subscribe message.
+            const queryParams = 'project=' + encodedProject;
 
             const url = this.config.endpointRealtime + '/realtime?' + queryParams;
 
@@ -601,7 +595,46 @@ class Client {
                         this.realtime.createSocket();
                     }, timeout);
                 })
+            } else if (this.realtime.socket?.readyState === WebSocket.OPEN) {
+                // URL is unchanged; re-send subscribe message to apply updated queries.
+                this.realtime.sendSubscribeMessage();
             }
+        },
+        sendSubscribeMessage: () => {
+            if (!this.realtime.socket || this.realtime.socket.readyState !== WebSocket.OPEN) {
+                return;
+            }
+
+            const rows: RealtimeRequestSubscribe[] = [];
+            this.realtime.pendingSubscribeSlots = [];
+
+            this.realtime.subscriptions.forEach((sub, slot) => {
+                const queries = sub.queries && sub.queries.length > 0
+                    ? sub.queries
+                    : [Query.select(['*']).toString()];
+
+                const row: RealtimeRequestSubscribe = {
+                    channels: sub.channels,
+                    queries
+                };
+
+                const knownSubscriptionId = this.realtime.slotToSubscriptionId.get(slot) ?? this.realtime.slotToSubscriptionId.get(slot - 1);
+                if (knownSubscriptionId) {
+                    row.subscriptionId = knownSubscriptionId;
+                }
+
+                rows.push(row);
+                this.realtime.pendingSubscribeSlots.push(slot);
+            });
+
+            if (rows.length < 1) {
+                return;
+            }
+
+            this.realtime.socket.send(JSONbig.stringify(<RealtimeRequest>{
+                type: 'subscribe',
+                data: rows
+            }));
         },
         onMessage: (event) => {
             try {
@@ -611,17 +644,29 @@ class Client {
                     case 'connected': {
                         const messageData = <RealtimeResponseConnected>message.data;
                         if (messageData?.subscriptions) {
-                            this.realtime.slotToSubscriptionId.clear();
-                            this.realtime.subscriptionIdToSlot.clear();
                             for (const [slotStr, subscriptionId] of Object.entries(messageData.subscriptions)) {
                                 const slot = Number(slotStr);
-                                if (!isNaN(slot) && typeof subscriptionId === 'string') {
-                                    this.realtime.slotToSubscriptionId.set(slot, subscriptionId);
-                                    this.realtime.subscriptionIdToSlot.set(subscriptionId, slot);
+                                if (isNaN(slot) || typeof subscriptionId !== 'string') {
+                                    continue;
                                 }
+
+                                const directSlotExists = this.realtime.subscriptions.has(slot);
+                                const shiftedSlot = slot + 1;
+                                const shiftedSlotExists = this.realtime.subscriptions.has(shiftedSlot);
+                                const targetSlot = directSlotExists ? slot : shiftedSlotExists ? shiftedSlot : slot;
+
+                                this.realtime.slotToSubscriptionId.set(targetSlot, subscriptionId);
+                                this.realtime.subscriptionIdToSlot.set(subscriptionId, targetSlot);
                             }
                         }
 
+                        this.realtime.subscriptions.forEach((_sub, slot) => {
+                            const existing = this.realtime.slotToSubscriptionId.get(slot);
+                            if (existing) {
+                                this.realtime.subscriptionIdToSlot.set(existing, slot);
+                            }
+                        });
+                        
                         let session = this.config.session;
                         if (!session) {
                             const cookie = JSONbig.parse(window.localStorage.getItem('cookieFallback') ?? '{}');
@@ -635,6 +680,26 @@ class Client {
                                 }
                             }));
                         }
+
+                        this.realtime.sendSubscribeMessage();
+                        break;
+                    }
+                    case 'response': {
+                        const action = message.data as RealtimeResponseAction;
+                        if (action?.to !== 'subscribe' || !Array.isArray(action.subscriptions)) {
+                            break;
+                        }
+
+                        action.subscriptions.forEach((subscription, index) => {
+                            const subscriptionId = subscription?.subscriptionId;
+                            const slot = this.realtime.pendingSubscribeSlots[index];
+                            if (!subscriptionId || slot === undefined) {
+                                return;
+                            }
+
+                            this.realtime.slotToSubscriptionId.set(slot, subscriptionId);
+                            this.realtime.subscriptionIdToSlot.set(subscriptionId, slot);
+                        });
                         break;
                     }
                     case 'event': {
@@ -673,31 +738,6 @@ class Client {
             } catch (e) {
                 console.error(e);
             }
-        },
-        cleanUp: (channels, queries) => {
-            this.realtime.channels.forEach(channel => {
-                if (channels.includes(channel)) {
-                    let found = Array.from(this.realtime.subscriptions).some(([_key, subscription] )=> {
-                        return subscription.channels.includes(channel);
-                    })
-
-                    if (!found) {
-                        this.realtime.channels.delete(channel);
-                    }
-                }
-            })
-
-            this.realtime.queries.forEach(query => {
-                if (queries.includes(query)) {
-                    let found = Array.from(this.realtime.subscriptions).some(([_key, subscription]) => {
-                        return subscription.queries?.includes(query);
-                    });
-
-                    if (!found) {
-                        this.realtime.queries.delete(query);
-                    }
-                }
-            })
         }
     }
 
@@ -757,8 +797,6 @@ class Client {
         channelStrings.forEach(channel => this.realtime.channels.add(channel));
 
         const queryStrings = (queries ?? []).map(q => typeof q === 'string' ? q : q.toString());
-        queryStrings.forEach(query => this.realtime.queries.add(query));
-
         const counter = this.realtime.subscriptionsCounter++;
         this.realtime.subscriptions.set(counter, {
             channels: channelStrings,
@@ -769,8 +807,12 @@ class Client {
         this.realtime.connect();
 
         return () => {
+            const subscriptionId = this.realtime.slotToSubscriptionId.get(counter);
             this.realtime.subscriptions.delete(counter);
-            this.realtime.cleanUp(channelStrings, queryStrings);
+            this.realtime.slotToSubscriptionId.delete(counter);
+            if (subscriptionId) {
+                this.realtime.subscriptionIdToSlot.delete(subscriptionId);
+            }
             this.realtime.connect();
         }
     }

--- a/templates/web/src/services/realtime.ts.twig
+++ b/templates/web/src/services/realtime.ts.twig
@@ -32,10 +32,24 @@ export type RealtimeResponseConnected = {
 }
 
 export type RealtimeRequest = {
-    type: 'authentication';
-    data: {
-        session: string;
-    };
+    type: 'authentication' | 'subscribe';
+    data: any;
+}
+
+type RealtimeRequestSubscribeRow = {
+    subscriptionId?: string;
+    channels: string[];
+    queries: string[];
+}
+
+type RealtimeResponseAction = {
+    to?: string;
+    success?: boolean;
+    subscriptions?: Array<{
+        subscriptionId?: string;
+        channels?: string[];
+        queries?: string[];
+    }>;
 }
 
 export enum RealtimeCode {
@@ -49,6 +63,7 @@ export class Realtime {
     private readonly TYPE_EVENT = 'event';
     private readonly TYPE_PONG = 'pong';
     private readonly TYPE_CONNECTED = 'connected';
+    private readonly TYPE_RESPONSE = 'response';
     private readonly DEBOUNCE_MS = 1;
     private readonly HEARTBEAT_INTERVAL = 20000; // 20 seconds in milliseconds
 
@@ -63,6 +78,7 @@ export class Realtime {
     private heartbeatTimer?: number;
 
     private subCallDepth = 0;
+    private pendingSubscribeSlots: number[] = [];
     private reconnectAttempts = 0;
     private subscriptionsCounter = 0;
     private connectionId = 0;
@@ -134,39 +150,8 @@ export class Realtime {
             throw new {{spec.title | caseUcfirst}}Exception('Missing project ID');
         }
 
-        // Collect all unique channels from all slots
-        const allChannels = new Set<string>();
-        for (const subscription of this.activeSubscriptions.values()) {
-            for (const channel of subscription.channels) {
-                allChannels.add(channel);
-            }
-        }
-
-        let queryParams = `project=${projectId}`;
-        for (const channel of allChannels) {
-            queryParams += `&channels[]=${encodeURIComponent(channel)}`;
-        }
-
-        // Build query string from slots → channels → queries
-        // Format: channel[slot][]=query
-        // For each slot, repeat its queries under each channel it subscribes to
-        // Example: slot 1 → channels [tests, prod], queries [q1, q2]
-        //   Produces: tests[1][]=q1&tests[1][]=q2&prod[1][]=q1&prod[1][]=q2
-        const selectAllQuery = Query.select(['*']).toString();
-        for (const [slot, subscription] of this.activeSubscriptions) {
-            // queries is string[] - iterate over each query string
-            const queries = subscription.queries.length === 0 
-                ? [selectAllQuery] 
-                : subscription.queries;
-            
-            // Repeat this slot's queries under each channel it subscribes to
-            // Each query is sent as a separate parameter: channel[slot][]=q1&channel[slot][]=q2
-            for (const channel of subscription.channels) {
-                for (const query of queries) {
-                    queryParams += `&${encodeURIComponent(channel)}[${slot}][]=${encodeURIComponent(query)}`;
-                }
-            }
-        }
+        // URL carries only the project; channels/queries are sent via the subscribe message.
+        const queryParams = `project=${projectId}`;
 
         const endpoint =
             this.client.config.endpointRealtime !== ''
@@ -293,6 +278,44 @@ export class Realtime {
         return new Promise(resolve => setTimeout(resolve, ms));
     }
 
+    private getKnownSubscriptionId(slot: number): string | undefined {
+        return this.slotToSubscriptionId.get(slot) ?? this.slotToSubscriptionId.get(slot - 1);
+    }
+
+    private sendSubscribeMessage(): void {
+        if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+            return;
+        }
+
+        const rows: RealtimeRequestSubscribeRow[] = [];
+        this.pendingSubscribeSlots = [];
+
+        for (const [slot, subscription] of this.activeSubscriptions) {
+            const queries = subscription.queries ?? [];
+
+            const row: RealtimeRequestSubscribeRow = {
+                channels: Array.from(subscription.channels),
+                queries
+            };
+            const knownSubscriptionId = this.getKnownSubscriptionId(slot);
+            if (knownSubscriptionId) {
+                row.subscriptionId = knownSubscriptionId;
+            }
+
+            rows.push(row);
+            this.pendingSubscribeSlots.push(slot);
+        }
+
+        if (rows.length < 1) {
+            return;
+        }
+
+        this.socket.send(JSON.stringify(<RealtimeRequest>{
+            type: 'subscribe',
+            data: rows
+        }));
+    }
+
     /**
      * Convert a channel value to a string
      *
@@ -408,7 +431,11 @@ export class Realtime {
         await this.sleep(this.DEBOUNCE_MS);
 
         if (this.subCallDepth === 1) {
-            await this.createSocket();
+            if (!this.socket || this.socket.readyState > WebSocket.OPEN) {
+                await this.createSocket();
+            } else if (this.socket.readyState === WebSocket.OPEN) {
+                this.sendSubscribeMessage();
+            }
         }
 
         this.subCallDepth--;
@@ -421,7 +448,17 @@ export class Realtime {
                 if (subscriptionId) {
                     this.subscriptionIdToSlot.delete(subscriptionId);
                 }
-                await this.createSocket();
+                if (this.activeSubscriptions.size === 0) {
+                    this.reconnect = false;
+                    await this.closeSocket();
+                    return;
+                }
+
+                if (!this.socket || this.socket.readyState > WebSocket.OPEN) {
+                    await this.createSocket();
+                } else if (this.socket.readyState === WebSocket.OPEN) {
+                    this.sendSubscribeMessage();
+                }
             }
         };
     }
@@ -447,6 +484,9 @@ export class Realtime {
             case this.TYPE_PONG:
                 // Handle pong response if needed
                 break;
+            case this.TYPE_RESPONSE:
+                this.handleResponseAction(message);
+                break;
         }
     }
 
@@ -457,16 +497,23 @@ export class Realtime {
 
         const messageData = message.data as RealtimeResponseConnected;
 
-        // Store subscription ID mappings from backend
-        // Format: { "0": "sub_a1f9", "1": "sub_b83c", ... }
+        // Store subscription ID mappings from backend.
+        // Use direct slot first; if URL mapping is zero-based, try slot+1.
         if (messageData.subscriptions) {
-            this.slotToSubscriptionId.clear();
-            this.subscriptionIdToSlot.clear();
             for (const [slotStr, subscriptionId] of Object.entries(messageData.subscriptions)) {
                 const slot = Number(slotStr);
-                if (!isNaN(slot)) {
-                    this.slotToSubscriptionId.set(slot, subscriptionId);
-                    this.subscriptionIdToSlot.set(subscriptionId, slot);
+                if (isNaN(slot)) {
+                    continue;
+                }
+
+                const directSlotExists = this.activeSubscriptions.has(slot);
+                const shiftedSlot = slot + 1;
+                const shiftedSlotExists = this.activeSubscriptions.has(shiftedSlot);
+                const targetSlot = directSlotExists ? slot : shiftedSlotExists ? shiftedSlot : slot;
+
+                if (typeof subscriptionId === 'string') {
+                    this.slotToSubscriptionId.set(targetSlot, subscriptionId);
+                    this.subscriptionIdToSlot.set(subscriptionId, targetSlot);
                 }
             }
         }
@@ -489,6 +536,8 @@ export class Realtime {
                 }
             }));
         }
+
+        this.sendSubscribeMessage();
     }
 
     private handleResponseError(message: RealtimeResponse): void {
@@ -532,6 +581,25 @@ export class Realtime {
                     subscription.callback(response);
                 }
             }
+        }
+    }
+
+    private handleResponseAction(message: RealtimeResponse): void {
+        const data = message.data as RealtimeResponseAction | undefined;
+        if (!data || data.to !== 'subscribe' || !Array.isArray(data.subscriptions)) {
+            return;
+        }
+
+        for (let i = 0; i < data.subscriptions.length; i++) {
+            const subscription = data.subscriptions[i];
+            const subscriptionId = subscription?.subscriptionId;
+            const slot = this.pendingSubscribeSlots[i];
+            if (slot === undefined || !subscriptionId) {
+                continue;
+            }
+
+            this.slotToSubscriptionId.set(slot, subscriptionId);
+            this.subscriptionIdToSlot.set(subscriptionId, slot);
         }
     }
 }

--- a/templates/web/src/services/realtime.ts.twig
+++ b/templates/web/src/services/realtime.ts.twig
@@ -279,7 +279,7 @@ export class Realtime {
     }
 
     private getKnownSubscriptionId(slot: number): string | undefined {
-        return this.slotToSubscriptionId.get(slot) ?? this.slotToSubscriptionId.get(slot - 1);
+        return this.slotToSubscriptionId.get(slot);
     }
 
     private sendSubscribeMessage(): void {

--- a/tests/languages/android/Tests.kt
+++ b/tests/languages/android/Tests.kt
@@ -80,7 +80,7 @@ class ServiceTest {
 
         // reset configs
         client.setProject("console")
-            .setEndpointRealtime("wss://cloud.appwrite.io/v1")
+            .setEndpointRealtime("wss://fra.stage.cloud.appwrite.io/v1")
 
         val foo = Foo(client)
         val bar = Bar(client)

--- a/tests/languages/apple/Tests.swift
+++ b/tests/languages/apple/Tests.swift
@@ -34,7 +34,7 @@ class Tests: XCTestCase {
 
         // reset configs
         client.setProject("console")
-        client.setEndpointRealtime("wss://cloud.appwrite.io/v1")
+        client.setEndpointRealtime("wss://fra.stage.cloud.appwrite.io/v1")
         client.setSelfSigned(false)
 
         let foo = Foo(client)

--- a/tests/languages/flutter/tests.dart
+++ b/tests/languages/flutter/tests.dart
@@ -33,7 +33,7 @@ void main() async {
 
   client.setSelfSigned();
   client.setProject('console');
-  client.setEndPointRealtime("wss://cloud.appwrite.io/v1");
+  client.setEndPointRealtime("wss://fra.stage.cloud.appwrite.io/v1");
 
   Realtime realtime = Realtime(client);
   // Subscribe without queries

--- a/tests/languages/web/index.html
+++ b/tests/languages/web/index.html
@@ -39,7 +39,7 @@
 
             // Realtime setup
             client.setProject('console');
-            client.setEndpointRealtime('wss://cloud.appwrite.io/v1');
+            client.setEndpointRealtime('wss://fra.stage.cloud.appwrite.io/v1');
 
             const realtime = new Realtime(client);
             const realtimeWithFailure = new Realtime(client);


### PR DESCRIPTION
- [x] Investigate CI failures for Android and Flutter builds
- [ ] Fix Android: Add missing `import toJson` to `Realtime.kt.twig` template
- [ ] Revert staging URL in test files (flutter/tests.dart, android/Tests.kt, apple/Tests.swift, web/index.html)
- [ ] Regenerate Android examples after template fix
- [ ] Validate fixes with parallel validation