### PR TITLE
Fix CLI deployment console URLs for self-hosted endpoints

### DIFF
--- a/templates/cli/lib/commands/push.ts
+++ b/templates/cli/lib/commands/push.ts
@@ -28,6 +28,8 @@ import {
   createSettingsObject,
   checkDeployConditions,
   arrayEqualsUnordered,
+  getFunctionDeploymentConsoleUrl,
+  getSiteDeploymentConsoleUrl,
 } from "../utils.js";
 import { Spinner, SPINNER_DOTS } from "../spinner.js";
 import { paginate } from "../paginate.js";
@@ -1056,19 +1058,13 @@ export class Push {
                 );
                 const endpoint =
                   localConfig.getEndpoint() || globalConfig.getEndpoint();
-                let region = "";
-                try {
-                  const hostname = new URL(endpoint).hostname;
-                  const firstSubdomain = hostname.split(".")[0];
-                  if (firstSubdomain.length === 3) {
-                    region = firstSubdomain;
-                  }
-                } catch {}
                 const projectId = localConfig.getProject().projectId;
-                const projectSlug = region
-                  ? `project-${region}-${projectId}`
-                  : `project-${projectId}`;
-                const consoleUrl = `${endpoint.replace(/\/v1\/?$/, "")}/console/${projectSlug}/functions/function-${func["$id"]}/deployment-${deploymentId}`;
+                const consoleUrl = getFunctionDeploymentConsoleUrl(
+                  endpoint,
+                  projectId,
+                  func["$id"],
+                  deploymentId,
+                );
 
                 updaterRow.stopSpinner();
                 updaterRow.update({
@@ -1470,19 +1466,13 @@ export class Push {
                 );
                 const endpoint =
                   localConfig.getEndpoint() || globalConfig.getEndpoint();
-                let region = "";
-                try {
-                  const hostname = new URL(endpoint).hostname;
-                  const firstSubdomain = hostname.split(".")[0];
-                  if (firstSubdomain.length === 3) {
-                    region = firstSubdomain;
-                  }
-                } catch {}
                 const projectId = localConfig.getProject().projectId;
-                const projectSlug = region
-                  ? `project-${region}-${projectId}`
-                  : `project-${projectId}`;
-                const consoleUrl = `${endpoint.replace(/\/v1\/?$/, "")}/console/${projectSlug}/sites/site-${site["$id"]}/deployments/deployment-${deploymentId}`;
+                const consoleUrl = getSiteDeploymentConsoleUrl(
+                  endpoint,
+                  projectId,
+                  site["$id"],
+                  deploymentId,
+                );
 
                 updaterRow.stopSpinner();
                 updaterRow.update({
@@ -2176,18 +2166,12 @@ const pushSite = async ({
     const { name, deployment, $id } = failed;
     const projectId = localConfig.getProject().projectId;
     const endpoint = localConfig.getEndpoint() || globalConfig.getEndpoint();
-    let region = "";
-    try {
-      const hostname = new URL(endpoint).hostname;
-      const firstSubdomain = hostname.split(".")[0];
-      if (firstSubdomain.length === 3) {
-        region = firstSubdomain;
-      }
-    } catch {}
-    const projectSlug = region
-      ? `project-${region}-${projectId}`
-      : `project-${projectId}`;
-    const failUrl = `${endpoint.replace(/\/v1\/?$/, "")}/console/${projectSlug}/sites/site-${$id}/deployments/deployment-${deployment}`;
+    const failUrl = getSiteDeploymentConsoleUrl(
+      endpoint,
+      projectId,
+      $id,
+      deployment,
+    );
 
     error(
       `Deployment of ${name} has failed. Check at ${failUrl} for more details\n`,
@@ -2327,18 +2311,12 @@ const pushFunction = async ({
     const { name, deployment, $id } = failed;
     const projectId = localConfig.getProject().projectId;
     const endpoint = localConfig.getEndpoint() || globalConfig.getEndpoint();
-    let region = "";
-    try {
-      const hostname = new URL(endpoint).hostname;
-      const firstSubdomain = hostname.split(".")[0];
-      if (firstSubdomain.length === 3) {
-        region = firstSubdomain;
-      }
-    } catch {}
-    const projectSlug = region
-      ? `project-${region}-${projectId}`
-      : `project-${projectId}`;
-    const failUrl = `${endpoint.replace(/\/v1\/?$/, "")}/console/${projectSlug}/functions/function-${$id}/deployment-${deployment}`;
+    const failUrl = getFunctionDeploymentConsoleUrl(
+      endpoint,
+      projectId,
+      $id,
+      deployment,
+    );
 
     error(
       `Deployment of ${name} has failed. Check at ${failUrl} for more details\n`,

--- a/templates/cli/lib/utils.ts
+++ b/templates/cli/lib/utils.ts
@@ -76,6 +76,53 @@ export const getErrorMessage = (error: unknown): string => {
   return String(error);
 };
 
+export const getConsoleBaseUrl = (endpoint: string): string => {
+  return endpoint.replace(/\/v1\/?$/, "");
+};
+
+export const getConsoleProjectSlug = (
+  endpoint: string,
+  projectId: string,
+): string => {
+  try {
+    const hostname = new URL(endpoint).hostname;
+    const isCloudHostname =
+      hostname === "cloud.appwrite.io" ||
+      hostname.endsWith(".cloud.appwrite.io");
+
+    if (!isCloudHostname) {
+      return `project-${projectId}`;
+    }
+
+    const firstSubdomain = hostname.split(".")[0];
+    return firstSubdomain.length === 3
+      ? `project-${firstSubdomain}-${projectId}`
+      : `project-${projectId}`;
+  } catch {
+    return `project-${projectId}`;
+  }
+};
+
+export const getFunctionDeploymentConsoleUrl = (
+  endpoint: string,
+  projectId: string,
+  functionId: string,
+  deploymentId: string,
+): string => {
+  const projectSlug = getConsoleProjectSlug(endpoint, projectId);
+  return `${getConsoleBaseUrl(endpoint)}/console/${projectSlug}/functions/function-${functionId}/deployment-${deploymentId}`;
+};
+
+export const getSiteDeploymentConsoleUrl = (
+  endpoint: string,
+  projectId: string,
+  siteId: string,
+  deploymentId: string,
+): string => {
+  const projectSlug = getConsoleProjectSlug(endpoint, projectId);
+  return `${getConsoleBaseUrl(endpoint)}/console/${projectSlug}/sites/site-${siteId}/deployments/deployment-${deploymentId}`;
+};
+
 type UpdateCheckCache = {
   checkedAt?: string;
   latestVersion?: string;


### PR DESCRIPTION
## What changed
This updates the CLI deployment console URL helpers to avoid inferring a region from any three-character subdomain. Region-prefixed project slugs are now only derived for Appwrite Cloud hostnames, and the deployment URL builders were centralized in `lib/utils.ts` so both push and failure paths reuse the same logic.

## Why
The previous heuristic treated endpoints like `https://api.example.com/v1` as if `api` were a cloud region, which produced broken console URLs such as `project-api-<id>` for self-hosted instances.

## Routing verification
I verified the current Appwrite Console router before changing paths:
- Functions use `/functions/function-{id}/deployment-{deploymentId}`
- Sites use `/sites/site-{id}/deployments/deployment-{deploymentId}`

Because of that, this PR does not change the function deployment path shape.

## Impact
Self-hosted users with three-character API subdomains now get valid console links for function and site deployments, including failure messages.

## Validation
- Regenerated the CLI SDK with `php example.php cli`
- Ran `composer lint-twig`
