### PR TITLE
Ship native CLI binaries via Homebrew and automate formula publishing

### DIFF
--- a/example.php
+++ b/example.php
@@ -29,11 +29,6 @@ use Appwrite\SDK\Language\Rust;
 
 try {
 
-    function envOrDefault(string $key, string $default): string {
-        $value = getenv($key);
-        return ($value !== false && $value !== '') ? $value : $default;
-    }
-
     function getSSLPage($url) {
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_HEADER, false);
@@ -180,10 +175,20 @@ try {
   /  _  \ |_) | |_) \ V  V /| |  | | ||  __/ / /___/ /___/\/ /_
   \_/ \_/ .__/| .__/ \_/\_/ |_|  |_|\__\___| \____/\____/\____/
         |_|   |_|                                                ");
-        $language->setHomebrewSha256('homebrewMacArm64Sha256', envOrDefault('APPWRITE_CLI_HOMEBREW_MAC_ARM64_SHA256', str_repeat('0', 64)));
-        $language->setHomebrewSha256('homebrewMacX64Sha256', envOrDefault('APPWRITE_CLI_HOMEBREW_MAC_X64_SHA256', str_repeat('0', 64)));
-        $language->setHomebrewSha256('homebrewLinuxArm64Sha256', envOrDefault('APPWRITE_CLI_HOMEBREW_LINUX_ARM64_SHA256', str_repeat('0', 64)));
-        $language->setHomebrewSha256('homebrewLinuxX64Sha256', envOrDefault('APPWRITE_CLI_HOMEBREW_LINUX_X64_SHA256', str_repeat('0', 64)));
+        // Generated formulas start with placeholder checksums. The generated CLI
+        // publish workflow rewrites them after the native release binaries exist.
+        foreach ([
+            'APPWRITE_CLI_HOMEBREW_MAC_ARM64_SHA256' => 'homebrewMacArm64Sha256',
+            'APPWRITE_CLI_HOMEBREW_MAC_X64_SHA256' => 'homebrewMacX64Sha256',
+            'APPWRITE_CLI_HOMEBREW_LINUX_ARM64_SHA256' => 'homebrewLinuxArm64Sha256',
+            'APPWRITE_CLI_HOMEBREW_LINUX_X64_SHA256' => 'homebrewLinuxX64Sha256',
+        ] as $envKey => $paramKey) {
+            $sha256 = getenv($envKey);
+
+            if ($sha256 !== false && $sha256 !== '') {
+                $language->setHomebrewSha256($paramKey, $sha256);
+            }
+        }
 
         $sdk  = new SDK($language, new Swagger2($spec));
         $sdk->setTest(false);

--- a/example.php
+++ b/example.php
@@ -29,6 +29,11 @@ use Appwrite\SDK\Language\Rust;
 
 try {
 
+    function envOrDefault(string $key, string $default): string {
+        $value = getenv($key);
+        return ($value !== false && $value !== '') ? $value : $default;
+    }
+
     function getSSLPage($url) {
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_HEADER, false);
@@ -175,6 +180,10 @@ try {
   /  _  \ |_) | |_) \ V  V /| |  | | ||  __/ / /___/ /___/\/ /_
   \_/ \_/ .__/| .__/ \_/\_/ |_|  |_|\__\___| \____/\____/\____/
         |_|   |_|                                                ");
+        $language->setHomebrewSha256('homebrewMacArm64Sha256', envOrDefault('APPWRITE_CLI_HOMEBREW_MAC_ARM64_SHA256', str_repeat('0', 64)));
+        $language->setHomebrewSha256('homebrewMacX64Sha256', envOrDefault('APPWRITE_CLI_HOMEBREW_MAC_X64_SHA256', str_repeat('0', 64)));
+        $language->setHomebrewSha256('homebrewLinuxArm64Sha256', envOrDefault('APPWRITE_CLI_HOMEBREW_LINUX_ARM64_SHA256', str_repeat('0', 64)));
+        $language->setHomebrewSha256('homebrewLinuxX64Sha256', envOrDefault('APPWRITE_CLI_HOMEBREW_LINUX_X64_SHA256', str_repeat('0', 64)));
 
         $sdk  = new SDK($language, new Swagger2($spec));
         $sdk->setTest(false);

--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -155,6 +155,9 @@ class CLI extends Node
     }
 
     /**
+     * Override a generated Homebrew formula checksum placeholder when a release
+     * build already knows the target binary SHA256.
+     *
      * @param string $key
      * @param string $sha256
      * @return $this

--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -70,6 +70,10 @@ class CLI extends Node
         'executableName' => 'executable',
         'logo' => '',
         'logoUnescaped' => '',
+        'homebrewMacArm64Sha256' => '0000000000000000000000000000000000000000000000000000000000000000',
+        'homebrewMacX64Sha256' => '0000000000000000000000000000000000000000000000000000000000000000',
+        'homebrewLinuxArm64Sha256' => '0000000000000000000000000000000000000000000000000000000000000000',
+        'homebrewLinuxX64Sha256' => '0000000000000000000000000000000000000000000000000000000000000000',
     ];
 
     /**
@@ -146,6 +150,18 @@ class CLI extends Node
     public function setLogoUnescaped(string $logo): self
     {
         $this->setParam('logoUnescaped', $logo);
+
+        return $this;
+    }
+
+    /**
+     * @param string $key
+     * @param string $sha256
+     * @return $this
+     */
+    public function setHomebrewSha256(string $key, string $sha256): self
+    {
+        $this->setParam($key, $sha256);
 
         return $this;
     }

--- a/templates/agent-skills/cli.md.twig
+++ b/templates/agent-skills/cli.md.twig
@@ -11,7 +11,7 @@
 # npm
 npm install -g appwrite-cli
 
-# macOS (Homebrew)
+# macOS (Homebrew native binary)
 brew install appwrite
 
 # macOS / Linux (script)

--- a/templates/cli/.github/workflows/publish.yml
+++ b/templates/cli/.github/workflows/publish.yml
@@ -97,42 +97,32 @@ jobs:
           export LINUX_ARM64_SHA256="$(sha256sum "build/${EXECUTABLE_NAME}-cli-linux-arm64" | awk '{print $1}')"
           export LINUX_X64_SHA256="$(sha256sum "build/${EXECUTABLE_NAME}-cli-linux-x64" | awk '{print $1}')"
 
-          python3 <<'PY'
-          import os
-          import re
-          from pathlib import Path
-
-          formula_path = Path(os.environ["FORMULA_PATH"])
-          executable = os.environ["EXECUTABLE_NAME"]
-          release_tag = os.environ["RELEASE_TAG"]
+          ruby <<'RUBY'
+          formula_path = ENV.fetch("FORMULA_PATH")
+          executable = ENV.fetch("EXECUTABLE_NAME")
+          release_tag = ENV.fetch("RELEASE_TAG")
           checksums = {
-              f"{executable}-cli-darwin-arm64": os.environ["MAC_ARM64_SHA256"],
-              f"{executable}-cli-darwin-x64": os.environ["MAC_X64_SHA256"],
-              f"{executable}-cli-linux-arm64": os.environ["LINUX_ARM64_SHA256"],
-              f"{executable}-cli-linux-x64": os.environ["LINUX_X64_SHA256"],
+            "#{executable}-cli-darwin-arm64" => ENV.fetch("MAC_ARM64_SHA256"),
+            "#{executable}-cli-darwin-x64" => ENV.fetch("MAC_X64_SHA256"),
+            "#{executable}-cli-linux-arm64" => ENV.fetch("LINUX_ARM64_SHA256"),
+            "#{executable}-cli-linux-x64" => ENV.fetch("LINUX_X64_SHA256"),
           }
 
-          text = formula_path.read_text()
-          text, count = re.subn(
-              r'^(  version ")([^"]+)(")$',
-              rf'\g<1>{release_tag}\g<3>',
-              text,
-              count=1,
-              flags=re.MULTILINE,
-          )
-          if count != 1:
-              raise SystemExit("Failed to update formula version")
+          text = File.read(formula_path)
 
-          for artifact, checksum in checksums.items():
-              pattern = re.compile(
-                  rf'({re.escape(artifact)}"\n\s+sha256 ")([0-9a-f]{{64}})(")'
-              )
-              text, count = pattern.subn(rf'\g<1>{checksum}\g<3>', text, count=1)
-              if count != 1:
-                  raise SystemExit(f"Failed to update checksum for {artifact}")
+          unless text.sub!(/^(\s*version ")([^"]+)(")$/) { "#{$1}#{release_tag}#{$3}" }
+            abort("Failed to update formula version")
+          end
 
-          formula_path.write_text(text)
-          PY
+          checksums.each do |artifact, checksum|
+            pattern = /(\Q#{artifact}\E"\n\s+sha256 ")([0-9a-f]{64})(")/
+            unless text.sub!(pattern) { "#{$1}#{checksum}#{$3}" }
+              abort("Failed to update checksum for #{artifact}")
+            end
+          end
+
+          File.write(formula_path, text)
+          RUBY
 
           ruby -c "$FORMULA_PATH"
 

--- a/templates/cli/.github/workflows/publish.yml
+++ b/templates/cli/.github/workflows/publish.yml
@@ -6,13 +6,15 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_TOKEN }}
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -66,3 +68,81 @@ jobs:
           GHR_PATH: build/
           GHR_REPLACE: false
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Update Homebrew formula checksums
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          TARGET_COMMITISH: ${{ github.event.release.target_commitish }}
+        run: |
+          set -euo pipefail
+
+          TARGET_BRANCH="$TARGET_COMMITISH"
+          if ! git ls-remote --exit-code --heads origin "$TARGET_BRANCH" >/dev/null 2>&1; then
+            TARGET_BRANCH="master"
+          fi
+
+          git fetch origin "$TARGET_BRANCH"
+          git switch -C "$TARGET_BRANCH" "origin/$TARGET_BRANCH"
+
+          FORMULA_PATH="$(find Formula -maxdepth 1 -name '*.rb' | head -n 1)"
+          if [ -z "$FORMULA_PATH" ]; then
+            echo "Formula file not found"
+            exit 1
+          fi
+
+          EXECUTABLE_NAME="$(basename "$FORMULA_PATH" .rb)"
+          export FORMULA_PATH RELEASE_TAG EXECUTABLE_NAME
+          export MAC_ARM64_SHA256="$(sha256sum "build/${EXECUTABLE_NAME}-cli-darwin-arm64" | awk '{print $1}')"
+          export MAC_X64_SHA256="$(sha256sum "build/${EXECUTABLE_NAME}-cli-darwin-x64" | awk '{print $1}')"
+          export LINUX_ARM64_SHA256="$(sha256sum "build/${EXECUTABLE_NAME}-cli-linux-arm64" | awk '{print $1}')"
+          export LINUX_X64_SHA256="$(sha256sum "build/${EXECUTABLE_NAME}-cli-linux-x64" | awk '{print $1}')"
+
+          python3 <<'PY'
+          import os
+          import re
+          from pathlib import Path
+
+          formula_path = Path(os.environ["FORMULA_PATH"])
+          executable = os.environ["EXECUTABLE_NAME"]
+          release_tag = os.environ["RELEASE_TAG"]
+          checksums = {
+              f"{executable}-cli-darwin-arm64": os.environ["MAC_ARM64_SHA256"],
+              f"{executable}-cli-darwin-x64": os.environ["MAC_X64_SHA256"],
+              f"{executable}-cli-linux-arm64": os.environ["LINUX_ARM64_SHA256"],
+              f"{executable}-cli-linux-x64": os.environ["LINUX_X64_SHA256"],
+          }
+
+          text = formula_path.read_text()
+          text, count = re.subn(
+              r'^(  version ")([^"]+)(")$',
+              rf'\g<1>{release_tag}\g<3>',
+              text,
+              count=1,
+              flags=re.MULTILINE,
+          )
+          if count != 1:
+              raise SystemExit("Failed to update formula version")
+
+          for artifact, checksum in checksums.items():
+              pattern = re.compile(
+                  rf'({re.escape(artifact)}"\n\s+sha256 ")([0-9a-f]{{64}})(")'
+              )
+              text, count = pattern.subn(rf'\g<1>{checksum}\g<3>', text, count=1)
+              if count != 1:
+                  raise SystemExit(f"Failed to update checksum for {artifact}")
+
+          formula_path.write_text(text)
+          PY
+
+          ruby -c "$FORMULA_PATH"
+
+          if git diff --quiet -- "$FORMULA_PATH"; then
+            echo "Homebrew formula already up to date"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$FORMULA_PATH"
+          git commit -m "chore: update Homebrew formula for ${RELEASE_TAG}"
+          git push origin "$TARGET_BRANCH"

--- a/templates/cli/Formula/formula.rb.twig
+++ b/templates/cli/Formula/formula.rb.twig
@@ -9,7 +9,10 @@ class {{ spec.title| caseUcfirst }} < Formula
   end
 
   def self.binary_os
-    OS.mac? ? "darwin" : "linux"
+    return "darwin" if OS.mac?
+    return "linux" if OS.linux?
+
+    raise "Homebrew formula is only supported on macOS and Linux"
   end
 
   def self.binary_name
@@ -17,7 +20,10 @@ class {{ spec.title| caseUcfirst }} < Formula
   end
 
   def self.build_target
-    "#{OS.mac? ? "mac" : "linux"}-#{binary_arch}"
+    return "mac-#{binary_arch}" if OS.mac?
+    return "linux-#{binary_arch}" if OS.linux?
+
+    raise "Homebrew formula is only supported on macOS and Linux"
   end
 
   # Release automation injects per-target SHA256 values when publishing binaries.

--- a/templates/cli/Formula/formula.rb.twig
+++ b/templates/cli/Formula/formula.rb.twig
@@ -20,8 +20,26 @@ class {{ spec.title| caseUcfirst }} < Formula
     "#{OS.mac? ? "mac" : "linux"}-#{binary_arch}"
   end
 
-  url "https://github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/releases/download/#{version}/#{binary_name}"
-  sha256 :no_check
+  # Release automation injects per-target SHA256 values when publishing binaries.
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/releases/download/#{version}/{{ language.params.executableName }}-cli-darwin-arm64"
+      sha256 "{{ language.params.homebrewMacArm64Sha256 }}"
+    else
+      url "https://github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/releases/download/#{version}/{{ language.params.executableName }}-cli-darwin-x64"
+      sha256 "{{ language.params.homebrewMacX64Sha256 }}"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/releases/download/#{version}/{{ language.params.executableName }}-cli-linux-arm64"
+      sha256 "{{ language.params.homebrewLinuxArm64Sha256 }}"
+    else
+      url "https://github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/releases/download/#{version}/{{ language.params.executableName }}-cli-linux-x64"
+      sha256 "{{ language.params.homebrewLinuxX64Sha256 }}"
+    end
+  end
 
   head "https://github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}.git", branch: "master" do
     depends_on "bun" => :build

--- a/templates/cli/Formula/formula.rb.twig
+++ b/templates/cli/Formula/formula.rb.twig
@@ -1,19 +1,44 @@
-require "language/node"
-
 class {{ spec.title| caseUcfirst }} < Formula
-  desc "CLI is a Node based command-line tool for {{ spec.title| caseUcfirst }} API"
+  desc "Command-line tool for interacting with the {{ spec.title| caseUcfirst }} API"
   homepage "{{ sdk.url }}"
   license "{{ sdk.license }}"
-  head "https://github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}.git", branch: "master"
+  version "{{ sdk.version }}"
 
-  depends_on "node"
+  def self.binary_arch
+    Hardware::CPU.arm? ? "arm64" : "x64"
+  end
+
+  def self.binary_os
+    OS.mac? ? "darwin" : "linux"
+  end
+
+  def self.binary_name
+    "{{ language.params.executableName }}-cli-#{binary_os}-#{binary_arch}"
+  end
+
+  def self.build_target
+    "#{OS.mac? ? "mac" : "linux"}-#{binary_arch}"
+  end
+
+  url "https://github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/releases/download/#{version}/#{binary_name}"
+  sha256 :no_check
+
+  head "https://github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}.git", branch: "master" do
+    depends_on "bun" => :build
+  end
 
   def install
-    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    if build.head?
+      system "bun", "install", "--frozen-lockfile"
+      system "bun", "run", self.class.build_target
+      bin.install "build/#{self.class.binary_name}" => "{{ language.params.executableName|caseLower }}"
+      return
+    end
+
+    bin.install self.class.binary_name => "{{ language.params.executableName|caseLower }}"
   end
 
   test do
-    system "true"
+    assert_match "Usage:", shell_output("#{bin}/{{ language.params.executableName|caseLower }} --help")
   end
 end

--- a/templates/cli/README.md.twig
+++ b/templates/cli/README.md.twig
@@ -22,7 +22,7 @@
 
 ## Installation
 
-The {{ spec.title }} CLI is a Node based command line tool to help you interact with the {{ spec.title }} API. The CLI is distributed both as an [`npm package`](https://www.npmjs.com/package/{{ spec.title|caseLower }}-cli) as well as [pre built binaries](https://github.com/{{ sdk.gitUserName|url_encode }}/{{ sdk.gitRepoName|url_encode }}/releases/latest) for specific operating systems and architectures.
+The {{ spec.title }} CLI is a command line tool to help you interact with the {{ spec.title }} API. The CLI is distributed both as an [`npm package`](https://www.npmjs.com/package/{{ spec.title|caseLower }}-cli) as well as [native binaries](https://github.com/{{ sdk.gitUserName|url_encode }}/{{ sdk.gitRepoName|url_encode }}/releases/latest) for specific operating systems and architectures.
 
 ### Install using NPM
 ---
@@ -54,6 +54,8 @@ $ wget -q {{ sdk.url }}/cli/install.sh  -O - | /bin/bash
 ```bash
 $ brew install {{ language.params.executableName }} 
 ```
+
+Homebrew installs the native binary for your platform.
 
 ### Windows
 Via Powershell

--- a/templates/cli/lib/commands/update.ts
+++ b/templates/cli/lib/commands/update.ts
@@ -56,7 +56,10 @@ const isInstalledViaHomebrew = (): boolean => {
     const scriptPath = process.argv[1];
     return (
       scriptPath.includes("/opt/homebrew/") ||
-      scriptPath.includes("/usr/local/Cellar/")
+      scriptPath.includes("/usr/local/Cellar/") ||
+      scriptPath.includes("/usr/local/bin/") ||
+      scriptPath.includes("/home/linuxbrew/.linuxbrew/") ||
+      scriptPath.includes("/linuxbrew/.linuxbrew/")
     );
   } catch (_e) {
     return false;

--- a/templates/cli/lib/commands/update.ts
+++ b/templates/cli/lib/commands/update.ts
@@ -57,7 +57,6 @@ const isInstalledViaHomebrew = (): boolean => {
     return (
       scriptPath.includes("/opt/homebrew/") ||
       scriptPath.includes("/usr/local/Cellar/") ||
-      scriptPath.includes("/usr/local/bin/") ||
       scriptPath.includes("/home/linuxbrew/.linuxbrew/") ||
       scriptPath.includes("/linuxbrew/.linuxbrew/")
     );


### PR DESCRIPTION
## Summary
- install platform-specific native CLI binaries via the generated Homebrew formula instead of `npm install`
- keep `--HEAD` installs building from source and tighten Homebrew install detection in `appwrite update`
- replace `sha256 :no_check` with per-platform checksum fields and automate formula version/checksum updates during CLI release publishing

## Why
The CLI already ships native binaries, but Homebrew was still installing the Node/shebang entrypoint. Moving Homebrew to native binaries is the right packaging model, but it also requires the formula to contain real per-asset SHA256 values. This PR updates the generated formula and teaches the publish workflow to write the final release tag and checksums back into the formula after the binaries are uploaded.

## Impact
- `brew install appwrite` installs the native binary for the current macOS or Linux target
- `brew install --HEAD appwrite` still builds a native binary from source with Bun
- published formulas contain real platform-specific SHA256 values instead of skipping integrity checks
- `appwrite update` only treats actual Homebrew-managed paths as Homebrew installs

## Validation
- `php example.php cli console`
- `composer lint-twig`
- `php -l example.php`
- `php -l src/SDK/Language/CLI.php`
- `ruby -c examples/cli/Formula/appwrite.rb`
- `ruby -e 'require "yaml"; YAML.load_file("examples/cli/.github/workflows/publish.yml"); puts "yaml ok"'`
- `cd examples/cli && npm ci && npm run build`
- `cd examples/cli && node dist/cli.cjs --help`
- `cd examples/cli && node dist/cli.cjs update --manual`
- `cd examples/cli && bun run mac-arm64`