### PR TITLE
Normalize CLI cloud console URLs

### DIFF
--- a/templates/cli/lib/utils.ts
+++ b/templates/cli/lib/utils.ts
@@ -104,7 +104,7 @@ export const getConsoleProjectSlug = (
   try {
     const hostname = new URL(endpoint).hostname;
 
-    if (!isCloudHostname) {
+    if (!isCloudHostname(hostname)) {
       return `project-${projectId}`;
     }
 

--- a/templates/cli/lib/utils.ts
+++ b/templates/cli/lib/utils.ts
@@ -76,8 +76,25 @@ export const getErrorMessage = (error: unknown): string => {
   return String(error);
 };
 
+const isCloudHostname = (hostname: string): boolean =>
+  hostname === "cloud.appwrite.io" || hostname.endsWith(".cloud.appwrite.io");
+
 export const getConsoleBaseUrl = (endpoint: string): string => {
-  return endpoint.replace(/\/v1\/?$/, "");
+  try {
+    const url = new URL(endpoint);
+
+    if (isCloudHostname(url.hostname)) {
+      url.hostname = "cloud.appwrite.io";
+    }
+
+    url.pathname = url.pathname.replace(/\/v1\/?$/, "");
+    url.search = "";
+    url.hash = "";
+
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return endpoint.replace(/\/v1\/?$/, "");
+  }
 };
 
 export const getConsoleProjectSlug = (
@@ -86,9 +103,6 @@ export const getConsoleProjectSlug = (
 ): string => {
   try {
     const hostname = new URL(endpoint).hostname;
-    const isCloudHostname =
-      hostname === "cloud.appwrite.io" ||
-      hostname.endsWith(".cloud.appwrite.io");
 
     if (!isCloudHostname) {
       return `project-${projectId}`;

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -203,6 +203,11 @@ abstract class Base extends TestCase
         '{"$id":"row1","custom":"value","nested":{"enabled":true}}',
     ];
 
+    protected const CLI_CONSOLE_URL_RESPONSES = [
+        'https://cloud.appwrite.io/console/project-sgp-chirag-project-prod/sites/site-chirag-profile-website/deployments/deployment-123',
+        'https://cloud.appwrite.io/console/project-sgp-chirag-project-prod/functions/function-sample-function/deployment-123',
+    ];
+
     protected const CHANNEL_HELPER_RESPONSES = [
         'databases.db1.collections.col1.documents',
         'databases.db1.collections.col1.documents.doc1',

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -206,6 +206,7 @@ abstract class Base extends TestCase
     protected const CLI_CONSOLE_URL_RESPONSES = [
         'https://cloud.appwrite.io/console/project-sgp-chirag-project-prod/sites/site-chirag-profile-website/deployments/deployment-123',
         'https://cloud.appwrite.io/console/project-sgp-chirag-project-prod/functions/function-sample-function/deployment-123',
+        'https://abc.example.com/console/project-self-hosted-project/sites/site-docs/deployments/deployment-456',
     ];
 
     protected const CHANNEL_HELPER_RESPONSES = [

--- a/tests/CLIBun10Test.php
+++ b/tests/CLIBun10Test.php
@@ -28,6 +28,7 @@ class CLIBun10Test extends Base
         ...Base::FOO_RESPONSES,
         ...Base::BAR_RESPONSES,
         ...Base::GENERAL_RESPONSES,
+        ...Base::CLI_CONSOLE_URL_RESPONSES,
         ...Base::UPLOAD_RESPONSES,
     ];
 

--- a/tests/CLIBun11Test.php
+++ b/tests/CLIBun11Test.php
@@ -28,6 +28,7 @@ class CLIBun11Test extends Base
         ...Base::FOO_RESPONSES,
         ...Base::BAR_RESPONSES,
         ...Base::GENERAL_RESPONSES,
+        ...Base::CLI_CONSOLE_URL_RESPONSES,
         ...Base::UPLOAD_RESPONSES,
     ];
 

--- a/tests/CLIBun13Test.php
+++ b/tests/CLIBun13Test.php
@@ -28,6 +28,7 @@ class CLIBun13Test extends Base
         ...Base::FOO_RESPONSES,
         ...Base::BAR_RESPONSES,
         ...Base::GENERAL_RESPONSES,
+        ...Base::CLI_CONSOLE_URL_RESPONSES,
         ...Base::UPLOAD_RESPONSES,
     ];
 

--- a/tests/languages/cli/test.js
+++ b/tests/languages/cli/test.js
@@ -1,5 +1,9 @@
 const { execSync } = require("child_process");
 const Client = require("./lib/client.ts").default;
+const {
+  getFunctionDeploymentConsoleUrl,
+  getSiteDeploymentConsoleUrl,
+} = require("./lib/utils.ts");
 
 const extractFirstValue = (output) => {
   const firstLine = output
@@ -94,6 +98,23 @@ console.log(extractFirstValue(output));
 // General
 output = execSync("bun ./dist/cli.cjs general redirect", { stdio: "pipe" }).toString();
 console.log(extractFirstValue(output));
+
+console.log(
+  getSiteDeploymentConsoleUrl(
+    "https://sgp.cloud.appwrite.io/v1",
+    "chirag-project-prod",
+    "chirag-profile-website",
+    "123",
+  ),
+);
+console.log(
+  getFunctionDeploymentConsoleUrl(
+    "https://sgp.cloud.appwrite.io/v1",
+    "chirag-project-prod",
+    "sample-function",
+    "123",
+  ),
+);
 
 output = execSync(
   "bun ./dist/cli.cjs general upload --x string  --y 123 --z string in array --file ../../resources/file.png",

--- a/tests/languages/cli/test.js
+++ b/tests/languages/cli/test.js
@@ -115,6 +115,14 @@ console.log(
     "123",
   ),
 );
+console.log(
+  getSiteDeploymentConsoleUrl(
+    "https://abc.example.com/v1",
+    "self-hosted-project",
+    "docs",
+    "456",
+  ),
+);
 
 output = execSync(
   "bun ./dist/cli.cjs general upload --x string  --y 123 --z string in array --file ../../resources/file.png",


### PR DESCRIPTION
## Summary
- normalize CLI deployment console links to `cloud.appwrite.io` when the configured API endpoint uses a regional Cloud hostname such as `sgp.cloud.appwrite.io`
- keep the existing cloud project slug behavior intact while fixing the incorrect console host in generated links
- add a CLI regression test that exercises both site and function deployment console URL helpers from a regional Cloud endpoint

## Why
The CLI was building deployment links directly from the API endpoint origin. For Appwrite Cloud projects configured with regional endpoints like `https://sgp.cloud.appwrite.io/v1`, that produced console links under the regional host instead of the canonical console host:

`https://sgp.cloud.appwrite.io/console/...`

The correct console URL should use:

`https://cloud.appwrite.io/console/...`

## Validation
- `php example.php cli console`
- `php -l tests/Base.php`
- `php -l tests/CLIBun10Test.php`
- `php -l tests/CLIBun11Test.php`
- `php -l tests/CLIBun13Test.php`
- `cd examples/cli && bun -e 'import { getSiteDeploymentConsoleUrl, getFunctionDeploymentConsoleUrl } from "./lib/utils.ts"; console.log(getSiteDeploymentConsoleUrl("https://sgp.cloud.appwrite.io/v1","chirag-project-prod","chirag-profile-website","123")); console.log(getFunctionDeploymentConsoleUrl("https://sgp.cloud.appwrite.io/v1","chirag-project-prod","sample-function","123"));'`

## Notes
- `composer test tests/CLIBun13Test.php` was started locally but did not complete cleanly in this environment; the direct helper/runtime assertion above did pass.