### PR TITLE
[codex] Keep PHP request DTOs mutable

### DIFF
--- a/templates/php/src/Models/RequestModel.php.twig
+++ b/templates/php/src/Models/RequestModel.php.twig
@@ -21,7 +21,7 @@ use {{ spec.namespace | caseNamespace }}\Enums\{{ enumName | caseUcfirst | overr
 /**
  * {{ requestModel.description | unescape | raw }}
  */
-readonly class {{ requestModel.name | caseUcfirst | overrideIdentifier }}
+class {{ requestModel.name | caseUcfirst | overrideIdentifier }}
 {
     use ArraySerializable;
 

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -62,6 +62,11 @@ abstract class Base extends TestCase
         'POST:/v1/mock/tests/general/models/array:passed',
     ];
 
+    protected const DTO_MUTABILITY_RESPONSES = [
+        'request-model-mutable',
+        'response-model-readonly',
+    ];
+
     protected const UNION_RESPONSES = [
         'GET:/v1/mock/tests/union:passed',
         'test-data',

--- a/tests/PHP82Test.php
+++ b/tests/PHP82Test.php
@@ -23,6 +23,7 @@ class PHP82Test extends Base
         ...Base::UPLOAD_RESPONSES,
         ...Base::ENUM_RESPONSES,
         ...Base::MODEL_RESPONSES,
+        ...Base::DTO_MUTABILITY_RESPONSES,
         ...Base::EXCEPTION_RESPONSES,
         ...Base::OAUTH_RESPONSES,
         ...Base::QUERY_HELPER_RESPONSES,

--- a/tests/PHP83Test.php
+++ b/tests/PHP83Test.php
@@ -23,6 +23,7 @@ class PHP83Test extends Base
         ...Base::UPLOAD_RESPONSES,
         ...Base::ENUM_RESPONSES,
         ...Base::MODEL_RESPONSES,
+        ...Base::DTO_MUTABILITY_RESPONSES,
         ...Base::EXCEPTION_RESPONSES,
         ...Base::OAUTH_RESPONSES,
         ...Base::QUERY_HELPER_RESPONSES,

--- a/tests/languages/php/test.php
+++ b/tests/languages/php/test.php
@@ -147,6 +147,8 @@ $players = [
 ];
 $response = $general->createPlayers($players);
 echo $response->result . "\n";
+echo (new ReflectionProperty(Player::class, 'score'))->isReadOnly() ? "request-model-readonly\n" : "request-model-mutable\n";
+echo (new ReflectionProperty(\Appwrite\Models\Mock::class, 'result'))->isReadOnly() ? "response-model-readonly\n" : "response-model-mutable\n";
 
 try {
     $response = $general->error400();


### PR DESCRIPTION
## Summary
- generate PHP request models as mutable classes instead of `readonly class`
- keep PHP response models unchanged so response DTOs remain readonly
- add a PHP regression check that asserts request-model properties are mutable while response-model properties remain readonly

## Why
Response DTOs should stay immutable, but request DTOs may need to be built or adjusted before submission. The PHP request-model template was applying `readonly` to both model types.

## Validation
- `php example.php php`
- `composer lint-twig`
- reflection smoke check against the regenerated PHP test SDK confirming `Player::$score` is mutable and `Mock::$result` is readonly
