### PR TITLE
Guard populateGenerics against undefined model definitions

### DIFF
--- a/src/SDK/Language/Web.php
+++ b/src/SDK/Language/Web.php
@@ -307,6 +307,10 @@ class Web extends JS
 
     protected function populateGenerics(string $model, array $spec, array &$generics, bool $skipFirst = false)
     {
+        if (!array_key_exists($model, $spec['definitions'])) {
+            return;
+        }
+
         if (!$skipFirst && $spec['definitions'][$model]['additionalProperties']) {
             $generics[] = $this->toPascalCase($model);
         }


### PR DESCRIPTION
## Summary
- Add early return in `Web::populateGenerics()` when the model doesn't exist in `$spec['definitions']`
- Fixes PHP warnings (`Undefined array key "any"`) being emitted into generated TypeScript/JS output when a sub-schema references a model like `any` that has no definition
- The caller `getGenerics()` already has this guard, but the recursive call from within `populateGenerics` bypasses it

## Test plan
- [ ] Existing SDK generation tests pass
- [ ] Generate Web SDK from a spec containing `any` model references — no PHP warnings in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)