### PR TITLE
Add realtime deployment log streaming to CLI pushes

### DIFF
--- a/docs/cli-realtime-deployment-logs-demo.svg
+++ b/docs/cli-realtime-deployment-logs-demo.svg
@@ -1,0 +1,43 @@
+<svg width="1152" height="768" viewBox="0 0 1152 768" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1152" height="768" rx="16" fill="#111418"/>
+  <rect x="24" y="24" width="1104" height="720" rx="12" fill="#151A1F" stroke="#232B34"/>
+  <circle cx="56" cy="56" r="8" fill="#FF5F56"/>
+  <circle cx="80" cy="56" r="8" fill="#FFBD2E"/>
+  <circle cx="104" cy="56" r="8" fill="#27C93F"/>
+  <text x="140" y="62" fill="#8FA3B8" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="18">appwrite-cli push site</text>
+
+  <g font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="17">
+    <text x="42" y="112" fill="#A7F3D0">? Which sites would you like to push? Testing deployment logs (testing-deployment-logs)</text>
+    <text x="42" y="140" fill="#7DD3FC">ℹ Info: Validating sites ...</text>
+    <text x="42" y="168" fill="#7DD3FC">ℹ Info: Checking for changes ...</text>
+    <text x="42" y="212" fill="#A7F3D0">? Do you want to create a deployment for your sites? Yes</text>
+    <text x="42" y="240" fill="#A7F3D0">? Do you want to activate the deployment after it is ready? Yes</text>
+    <text x="42" y="268" fill="#7DD3FC">ℹ Info: Pushing sites ...</text>
+
+    <text x="42" y="320" fill="#D1D5DB" font-weight="700">Build logs</text>
+
+    <text x="42" y="360" fill="#9CA3AF">[13:54:09] [open-runtimes] Environment preparation started.</text>
+    <text x="42" y="386" fill="#9CA3AF">[13:54:09] [open-runtimes] Environment preparation finished.</text>
+    <text x="42" y="412" fill="#9CA3AF">[13:54:09] [open-runtimes] Build command execution started.</text>
+
+    <text x="42" y="454" fill="#E5E7EB">added 28 packages, and audited 29 packages in 3s</text>
+    <text x="42" y="496" fill="#E5E7EB">7 packages are looking for funding</text>
+    <text x="42" y="522" fill="#E5E7EB">  run `npm fund` for details</text>
+    <text x="42" y="564" fill="#E5E7EB">2 high severity vulnerabilities</text>
+    <text x="42" y="606" fill="#E5E7EB">To address all issues, run:</text>
+    <text x="42" y="632" fill="#E5E7EB">  npm audit fix</text>
+    <text x="42" y="674" fill="#E5E7EB">&gt; starter-for-js@0.0.0 build</text>
+    <text x="42" y="700" fill="#E5E7EB">&gt; vite build</text>
+
+    <text x="588" y="360" fill="#4ADE80">vite v6.2.0 building for production...</text>
+    <text x="588" y="386" fill="#4ADE80">transforming...</text>
+    <text x="588" y="412" fill="#D1D5DB">✓ 7 modules transformed.</text>
+    <text x="588" y="438" fill="#D1D5DB">rendering chunks...</text>
+    <text x="588" y="464" fill="#D1D5DB">computing gzip size...</text>
+    <text x="588" y="504" fill="#9CA3AF">dist/assets/index-D4bHiO3k.css   39.49 kB │ gzip: 8.99 kB</text>
+    <text x="588" y="530" fill="#9CA3AF">dist/assets/index-BCiwvRPY.js    15.77 kB │ gzip: 6.48 kB</text>
+    <text x="588" y="572" fill="#4ADE80">✓ built in 572ms</text>
+
+    <text x="42" y="730" fill="#22C55E">✓ Realtime build logs streamed in the CLI during deployment</text>
+  </g>
+</svg>

--- a/templates/cli/lib/commands/push.ts
+++ b/templates/cli/lib/commands/push.ts
@@ -906,7 +906,9 @@ export class Push {
     } = options;
 
     Spinner.start(false);
-    const deploymentLogsController = createDeploymentLogsController(logs);
+    const deploymentLogsController = createDeploymentLogsController(
+      logs && !asyncDeploy,
+    );
     let successfullyPushed = 0;
     let successfullyDeployed = 0;
     const failedDeployments: FailedDeployment[] = [];
@@ -1190,6 +1192,16 @@ export class Push {
                   onDeploymentUpdate: (deployment) => {
                     deploymentLogPrinter.ingest(deployment);
                   },
+                  onClose: () => {
+                    currentDeploymentEnd =
+                      "Log stream disconnected; polling status...";
+                    updaterRow.update({
+                      end: withDeploymentLogsHint(
+                        currentDeploymentEnd,
+                        deploymentLogsController,
+                      ),
+                    });
+                  },
                 })
               : null;
             let currentDeploymentEnd = deploymentWatcher
@@ -1406,7 +1418,9 @@ export class Push {
     } = options;
 
     Spinner.start(false);
-    const deploymentLogsController = createDeploymentLogsController(logs);
+    const deploymentLogsController = createDeploymentLogsController(
+      logs && !asyncDeploy,
+    );
     let successfullyPushed = 0;
     let successfullyDeployed = 0;
     const failedDeployments: FailedDeployment[] = [];
@@ -1687,6 +1701,16 @@ export class Push {
                   event: `sites.${site["$id"]}.deployments.${deploymentId}.update`,
                   onDeploymentUpdate: (deployment) => {
                     deploymentLogPrinter.ingest(deployment);
+                  },
+                  onClose: () => {
+                    currentDeploymentEnd =
+                      "Log stream disconnected; polling status...";
+                    updaterRow.update({
+                      end: withDeploymentLogsHint(
+                        currentDeploymentEnd,
+                        deploymentLogsController,
+                      ),
+                    });
                   },
                 })
               : null;

--- a/templates/cli/lib/commands/push.ts
+++ b/templates/cli/lib/commands/push.ts
@@ -183,10 +183,31 @@ function createDeploymentLogsController(
     };
   }
 
+  let isClosed = false;
+
+  const cleanup = (): void => {
+    if (isClosed) {
+      return;
+    }
+
+    isClosed = true;
+    stdin.off("keypress", onKeypress);
+    if (shouldRestoreRawMode) {
+      stdin.setRawMode(false);
+    }
+    stdin.pause();
+  };
+
   const onKeypress = (
     input: string,
     key: { ctrl?: boolean; meta?: boolean; name?: string },
   ): void => {
+    if (key.ctrl && key.name === "c") {
+      cleanup();
+      process.kill(process.pid, "SIGINT");
+      return;
+    }
+
     const pressedKey = (key.name ?? input ?? "").toLowerCase();
     if (pressedKey !== "l" || key.ctrl || key.meta) {
       return;
@@ -233,13 +254,7 @@ function createDeploymentLogsController(
         printer.flush();
       }
     },
-    close: (): void => {
-      stdin.off("keypress", onKeypress);
-      if (shouldRestoreRawMode) {
-        stdin.setRawMode(false);
-      }
-      stdin.pause();
-    },
+    close: cleanup,
   };
 }
 

--- a/templates/cli/lib/commands/push.ts
+++ b/templates/cli/lib/commands/push.ts
@@ -1333,14 +1333,18 @@ export class Push {
               }
           } catch (e: any) {
             errors.push(e);
+            deploymentLogPrinter.complete();
+            if (deploymentLogPrinter.hasPrintedLogs()) {
+              Spinner.log("");
+            }
             updaterRow.fail({
               errorMessage:
                 e.message ?? "Unknown error occurred. Please try again",
-              });
-            } finally {
-              unsubscribeToggle();
-              await deploymentWatcher?.close();
-            }
+            });
+          } finally {
+            unsubscribeToggle();
+            await deploymentWatcher?.close();
+          }
           }
 
           updaterRow.stopSpinner();
@@ -1827,14 +1831,18 @@ export class Push {
               }
           } catch (e: any) {
             errors.push(e);
+            deploymentLogPrinter.complete();
+            if (deploymentLogPrinter.hasPrintedLogs()) {
+              Spinner.log("");
+            }
             updaterRow.fail({
               errorMessage:
                 e.message ?? "Unknown error occurred. Please try again",
-              });
-            } finally {
-              unsubscribeToggle();
-              await deploymentWatcher?.close();
-            }
+            });
+          } finally {
+            unsubscribeToggle();
+            await deploymentWatcher?.close();
+          }
           }
 
           updaterRow.stopSpinner();

--- a/templates/cli/lib/commands/push.ts
+++ b/templates/cli/lib/commands/push.ts
@@ -200,8 +200,12 @@ function createDeploymentLogsController(
 
   const onKeypress = (
     input: string,
-    key: { ctrl?: boolean; meta?: boolean; name?: string },
+    key: { ctrl?: boolean; meta?: boolean; name?: string } | undefined,
   ): void => {
+    if (!key) {
+      return;
+    }
+
     if (key.ctrl && key.name === "c") {
       cleanup();
       process.kill(process.pid, "SIGINT");

--- a/templates/cli/lib/commands/push.ts
+++ b/templates/cli/lib/commands/push.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import readline from "node:readline";
 import { parse as parseDotenv } from "dotenv";
 import chalk from "chalk";
 import inquirer from "inquirer";
@@ -34,7 +35,11 @@ import {
 } from "../utils.js";
 import { Spinner, SPINNER_DOTS } from "../spinner.js";
 import { paginate } from "../paginate.js";
-import { pushDeployment } from "./utils/deployment.js";
+import {
+  createDeploymentLogPrinter,
+  pushDeployment,
+  watchDeploymentUpdates,
+} from "./utils/deployment.js";
 import {
   questionsPushBuckets,
   questionsPushTeams,
@@ -95,6 +100,148 @@ import { checkAndApplyTablesDBChanges } from "./utils/database-sync.js";
 const POLL_DEBOUNCE = 2000; // Milliseconds
 const POLL_DEFAULT_VALUE = 30;
 const DEPLOYMENT_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+const DEPLOYMENT_TIMEOUT_MINUTES = Math.round(
+  DEPLOYMENT_TIMEOUT_MS / (60 * 1000),
+);
+const WAITING_JOKE_THRESHOLD_MS = 30 * 1000; // 30 seconds
+const WAITING_JOKE_URL = "https://xkcd.com/303/";
+
+function getDeploymentProgressText(
+  status: string,
+  waitingSince: number | null,
+): string {
+  if (
+    status === "waiting" &&
+    waitingSince !== null &&
+    Date.now() - waitingSince >= WAITING_JOKE_THRESHOLD_MS
+  ) {
+    return `Still waiting... ${WAITING_JOKE_URL}`;
+  }
+
+  return `Status: ${status}`;
+}
+
+function getDeploymentTimeoutErrorMessage(): string {
+  return `Deployment got stuck for more than ${DEPLOYMENT_TIMEOUT_MINUTES} minutes`;
+}
+
+interface FailedDeployment {
+  name: string;
+  $id: string;
+  deployment: string;
+  reason?: "failed" | "timeout";
+  consoleUrl?: string;
+}
+
+type DeploymentLogPrinterHandle = ReturnType<typeof createDeploymentLogPrinter>;
+
+interface DeploymentLogsController {
+  isVisible: () => boolean;
+  getToggleHint: () => string;
+  onToggle: (listener: () => void) => () => void;
+  registerPrinter: (printer: DeploymentLogPrinterHandle) => void;
+  close: () => void;
+}
+
+function withDeploymentLogsHint(
+  message: string,
+  deploymentLogsController: DeploymentLogsController,
+): string {
+  const hint = deploymentLogsController.getToggleHint();
+  return hint.length > 0 ? `${message} • ${hint}` : message;
+}
+
+function createDeploymentLogsController(
+  enabled: boolean,
+): DeploymentLogsController {
+  const printers = new Set<DeploymentLogPrinterHandle>();
+  const listeners = new Set<() => void>();
+  let isVisible = enabled;
+
+  if (!enabled || !process.stdin.isTTY) {
+    return {
+      isVisible: () => isVisible,
+      getToggleHint: () => "",
+      onToggle: () => () => {},
+      registerPrinter: () => {},
+      close: () => {},
+    };
+  }
+
+  const stdin = process.stdin as NodeJS.ReadStream & {
+    isRaw?: boolean;
+    setRawMode?: (mode: boolean) => void;
+  };
+
+  if (typeof stdin.setRawMode !== "function") {
+    return {
+      isVisible: () => isVisible,
+      getToggleHint: () => "",
+      onToggle: () => () => {},
+      registerPrinter: () => {},
+      close: () => {},
+    };
+  }
+
+  const onKeypress = (
+    input: string,
+    key: { ctrl?: boolean; meta?: boolean; name?: string },
+  ): void => {
+    const pressedKey = (key.name ?? input ?? "").toLowerCase();
+    if (pressedKey !== "l" || key.ctrl || key.meta) {
+      return;
+    }
+
+    isVisible = !isVisible;
+
+    for (const listener of listeners) {
+      listener();
+    }
+
+    if (isVisible) {
+      for (const printer of printers) {
+        printer.flush();
+      }
+    }
+  };
+
+  readline.emitKeypressEvents(stdin);
+  stdin.resume();
+
+  const shouldRestoreRawMode = stdin.isRaw !== true;
+  if (shouldRestoreRawMode) {
+    stdin.setRawMode(true);
+  }
+
+  stdin.on("keypress", onKeypress);
+
+  return {
+    isVisible: () => isVisible,
+    getToggleHint: (): string =>
+      isVisible
+        ? "Press l to pause log stream"
+        : "Press l to resume log stream",
+    onToggle: (listener: () => void): (() => void) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    registerPrinter: (printer: DeploymentLogPrinterHandle): void => {
+      printers.add(printer);
+      if (isVisible) {
+        printer.flush();
+      }
+    },
+    close: (): void => {
+      stdin.off("keypress", onKeypress);
+      if (shouldRestoreRawMode) {
+        stdin.setRawMode(false);
+      }
+      stdin.pause();
+    },
+  };
+}
 
 export interface PushOptions {
   all?: boolean;
@@ -114,12 +261,14 @@ export interface PushOptions {
     code?: boolean;
     activate?: boolean;
     withVariables?: boolean;
+    logs?: boolean;
   };
   siteOptions?: {
     async?: boolean;
     code?: boolean;
     activate?: boolean;
     withVariables?: boolean;
+    logs?: boolean;
   };
   tableOptions?: {
     attempts?: number;
@@ -132,6 +281,7 @@ interface PushSiteOptions {
   code?: boolean;
   activate?: boolean;
   withVariables?: boolean;
+  logs?: boolean;
 }
 
 interface PushFunctionOptions {
@@ -140,6 +290,7 @@ interface PushFunctionOptions {
   code?: boolean;
   activate?: boolean;
   withVariables?: boolean;
+  logs?: boolean;
 }
 
 interface PushTableOptions {
@@ -719,11 +870,12 @@ export class Push {
       code?: boolean;
       activate?: boolean;
       withVariables?: boolean;
+      logs?: boolean;
     } = {},
   ): Promise<{
     successfullyPushed: number;
     successfullyDeployed: number;
-    failedDeployments: any[];
+    failedDeployments: FailedDeployment[];
     errors: any[];
   }> {
     const {
@@ -731,88 +883,56 @@ export class Push {
       code,
       activate = true,
       withVariables,
+      logs = true,
     } = options;
 
     Spinner.start(false);
+    const deploymentLogsController = createDeploymentLogsController(logs);
     let successfullyPushed = 0;
     let successfullyDeployed = 0;
-    const failedDeployments: any[] = [];
+    const failedDeployments: FailedDeployment[] = [];
     const errors: any[] = [];
     const deploymentLogs: {
       url: string;
       consoleUrl: string;
-      elapsed: string;
     }[] = [];
 
-    await Promise.all(
-      functions.map(async (func: any) => {
-        let response: any = {};
+    try {
+      await Promise.all(
+        functions.map(async (func: any) => {
+          let response: any = {};
 
-        const ignore = func.ignore ? "appwrite.config.json" : ".gitignore";
-        let functionExists = false;
-        let deploymentCreated = false;
+          const ignore = func.ignore ? "appwrite.config.json" : ".gitignore";
+          let functionExists = false;
+          let deploymentCreated = false;
 
-        const updaterRow = new Spinner({
-          status: "",
-          resource: func.name,
-          id: func["$id"],
-          end: `Ignoring using: ${ignore}`,
-        });
-
-        updaterRow.update({ status: "Getting" }).startSpinner(SPINNER_DOTS);
-        const functionsService = await getFunctionsService(this.projectClient);
-        try {
-          response = await functionsService.get({ functionId: func["$id"] });
-          functionExists = true;
-          if (response.runtime !== func.runtime) {
-            updaterRow.fail({
-              errorMessage: `Runtime mismatch! (local=${func.runtime},remote=${response.runtime}) Please delete remote function or update your appwrite.config.json`,
-            });
-            return;
-          }
-
-          updaterRow
-            .update({ status: "Updating" })
-            .replaceSpinner(SPINNER_DOTS);
-
-          response = await functionsService.update({
-            functionId: func["$id"],
-            name: func.name,
-            runtime: func.runtime,
-            execute: func.execute,
-            events: func.events,
-            schedule: func.schedule,
-            timeout: func.timeout,
-            enabled: func.enabled,
-            logging: func.logging,
-            entrypoint: func.entrypoint,
-            commands: func.commands,
-            scopes: func.scopes,
-            buildSpecification: func.buildSpecification,
-            runtimeSpecification: func.runtimeSpecification,
-            deploymentRetention: func.deploymentRetention,
+          const updaterRow = new Spinner({
+            status: "",
+            resource: func.name,
+            id: func["$id"],
+            end: `Ignoring using: ${ignore}`,
           });
-        } catch (e: any) {
-          if (Number(e.code) === 404) {
-            functionExists = false;
-          } else {
-            errors.push(e);
-            updaterRow.fail({
-              errorMessage:
-                e.message ?? "General error occurs please try again",
-            });
-            return;
-          }
-        }
 
-        if (!functionExists) {
-          updaterRow
-            .update({ status: "Creating" })
-            .replaceSpinner(SPINNER_DOTS);
-
+          updaterRow.update({ status: "Getting" }).startSpinner(SPINNER_DOTS);
+          const functionsService = await getFunctionsService(
+            this.projectClient,
+          );
           try {
-            response = await functionsService.create({
-              functionId: func.$id,
+            response = await functionsService.get({ functionId: func["$id"] });
+            functionExists = true;
+            if (response.runtime !== func.runtime) {
+              updaterRow.fail({
+                errorMessage: `Runtime mismatch! (local=${func.runtime},remote=${response.runtime}) Please delete remote function or update your appwrite.config.json`,
+              });
+              return;
+            }
+
+            updaterRow
+              .update({ status: "Updating" })
+              .replaceSpinner(SPINNER_DOTS);
+
+            response = await functionsService.update({
+              functionId: func["$id"],
               name: func.name,
               runtime: func.runtime,
               execute: func.execute,
@@ -828,296 +948,405 @@ export class Push {
               runtimeSpecification: func.runtimeSpecification,
               deploymentRetention: func.deploymentRetention,
             });
-
-            let domain = "";
-            try {
-              const consoleService = await getConsoleService(
-                this.consoleClient,
-              );
-              const variables = await consoleService.variables();
-              domain = ID.unique() + "." + variables["_APP_DOMAIN_FUNCTIONS"];
-            } catch (err) {
-              this.error("Error fetching console variables.");
-              throw err;
-            }
-
-            try {
-              const proxyService = await getProxyService(this.projectClient);
-              await proxyService.createFunctionRule(domain, func.$id);
-            } catch (err) {
-              this.error("Error creating function rule.");
-              throw err;
-            }
-
-            updaterRow.update({ status: "Created" });
           } catch (e: any) {
-            errors.push(e);
+            if (Number(e.code) === 404) {
+              functionExists = false;
+            } else {
+              errors.push(e);
+              updaterRow.fail({
+                errorMessage:
+                  e.message ?? "General error occurs please try again",
+              });
+              return;
+            }
+          }
+
+          if (!functionExists) {
+            updaterRow
+              .update({ status: "Creating" })
+              .replaceSpinner(SPINNER_DOTS);
+
+            try {
+              response = await functionsService.create({
+                functionId: func.$id,
+                name: func.name,
+                runtime: func.runtime,
+                execute: func.execute,
+                events: func.events,
+                schedule: func.schedule,
+                timeout: func.timeout,
+                enabled: func.enabled,
+                logging: func.logging,
+                entrypoint: func.entrypoint,
+                commands: func.commands,
+                scopes: func.scopes,
+                buildSpecification: func.buildSpecification,
+                runtimeSpecification: func.runtimeSpecification,
+                deploymentRetention: func.deploymentRetention,
+              });
+
+              let domain = "";
+              try {
+                const consoleService = await getConsoleService(
+                  this.consoleClient,
+                );
+                const variables = await consoleService.variables();
+                domain = ID.unique() + "." + variables["_APP_DOMAIN_FUNCTIONS"];
+              } catch (err) {
+                this.error("Error fetching console variables.");
+                throw err;
+              }
+
+              try {
+                const proxyService = await getProxyService(this.projectClient);
+                await proxyService.createFunctionRule(domain, func.$id);
+              } catch (err) {
+                this.error("Error creating function rule.");
+                throw err;
+              }
+
+              updaterRow.update({ status: "Created" });
+            } catch (e: any) {
+              errors.push(e);
+              updaterRow.fail({
+                errorMessage:
+                  e.message ?? "General error occurs please try again",
+              });
+              return;
+            }
+          }
+
+          if (withVariables) {
+            updaterRow
+              .update({ status: "Updating variables" })
+              .replaceSpinner(SPINNER_DOTS);
+
+            const functionsServiceForVars = await getFunctionsService(
+              this.projectClient,
+            );
+            const { variables } = await functionsServiceForVars.listVariables({
+              functionId: func["$id"],
+            });
+
+            await Promise.all(
+              variables.map(async (variable: any) => {
+                const functionsServiceDel = await getFunctionsService(
+                  this.projectClient,
+                );
+                await functionsServiceDel.deleteVariable({
+                  functionId: func["$id"],
+                  variableId: variable["$id"],
+                });
+              }),
+            );
+
+            const envFileLocation = `${func["path"]}/.env`;
+            let envVariables: Array<{ key: string; value: string }> = [];
+            try {
+              if (fs.existsSync(envFileLocation)) {
+                const envObject = parseDotenv(
+                  fs.readFileSync(envFileLocation, "utf8"),
+                );
+                envVariables = Object.entries(envObject || {}).map(
+                  ([key, value]) => ({ key, value }),
+                );
+              }
+            } catch (_error) {
+              envVariables = [];
+            }
+            await Promise.all(
+              envVariables.map(async (variable) => {
+                const functionsServiceCreate = await getFunctionsService(
+                  this.projectClient,
+                );
+                await functionsServiceCreate.createVariable({
+                  functionId: func["$id"],
+                  key: variable.key,
+                  value: variable.value,
+                  secret: false,
+                });
+              }),
+            );
+          }
+
+          if (code === false) {
+            successfullyPushed++;
+            successfullyDeployed++;
+            updaterRow.update({ status: "Pushed" });
+            updaterRow.stopSpinner();
+            return;
+          }
+
+          if (!func.path) {
+            errors.push(
+              new Error(`Function '${func.name}' has no path configured`),
+            );
             updaterRow.fail({
-              errorMessage:
-                e.message ?? "General error occurs please try again",
+              errorMessage: `No path configured for function`,
             });
             return;
           }
-        }
 
-        if (withVariables) {
-          updaterRow
-            .update({ status: "Updating variables" })
-            .replaceSpinner(SPINNER_DOTS);
-
-          const functionsServiceForVars = await getFunctionsService(
-            this.projectClient,
-          );
-          const { variables } = await functionsServiceForVars.listVariables({
-            functionId: func["$id"],
-          });
-
-          await Promise.all(
-            variables.map(async (variable: any) => {
-              const functionsServiceDel = await getFunctionsService(
-                this.projectClient,
-              );
-              await functionsServiceDel.deleteVariable({
-                functionId: func["$id"],
-                variableId: variable["$id"],
-              });
-            }),
-          );
-
-          const envFileLocation = `${func["path"]}/.env`;
-          let envVariables: Array<{ key: string; value: string }> = [];
-          try {
-            if (fs.existsSync(envFileLocation)) {
-              const envObject = parseDotenv(
-                fs.readFileSync(envFileLocation, "utf8"),
-              );
-              envVariables = Object.entries(envObject || {}).map(
-                ([key, value]) => ({ key, value }),
-              );
-            }
-          } catch (_error) {
-            envVariables = [];
+          if (
+            !fs.existsSync(func.path) ||
+            fs.readdirSync(func.path).length === 0
+          ) {
+            errors.push(
+              new Error(`Deployment not found or empty at path: ${func.path}`),
+            );
+            updaterRow.fail({
+              errorMessage: `path not found or empty: ${path.relative(process.cwd(), path.resolve(func.path))}`,
+            });
+            return;
           }
-          await Promise.all(
-            envVariables.map(async (variable) => {
-              const functionsServiceCreate = await getFunctionsService(
-                this.projectClient,
-              );
-              await functionsServiceCreate.createVariable({
-                functionId: func["$id"],
-                key: variable.key,
-                value: variable.value,
-                secret: false,
-              });
-            }),
-          );
-        }
 
-        if (code === false) {
-          successfullyPushed++;
-          successfullyDeployed++;
-          updaterRow.update({ status: "Pushed" });
-          updaterRow.stopSpinner();
-          return;
-        }
-
-        if (!func.path) {
-          errors.push(
-            new Error(`Function '${func.name}' has no path configured`),
-          );
-          updaterRow.fail({
-            errorMessage: `No path configured for function`,
-          });
-          return;
-        }
-
-        if (
-          !fs.existsSync(func.path) ||
-          fs.readdirSync(func.path).length === 0
-        ) {
-          errors.push(
-            new Error(`Deployment not found or empty at path: ${func.path}`),
-          );
-          updaterRow.fail({
-            errorMessage: `path not found or empty: ${path.relative(process.cwd(), path.resolve(func.path))}`,
-          });
-          return;
-        }
-
-        const deployStartTime = Date.now();
-        try {
-          updaterRow.update({ status: "Pushing" }).replaceSpinner(SPINNER_DOTS);
-          const functionsServiceDeploy = await getFunctionsService(
-            this.projectClient,
-          );
-
-          const result = await pushDeployment({
-            resourcePath: func.path,
-            extraIgnoreRules: normalizeIgnoreRules(func.ignore),
-            createDeployment: async (codeFile) => {
-              return await functionsServiceDeploy.createDeployment({
-                functionId: func["$id"],
-                entrypoint: func.entrypoint,
-                commands: func.commands,
-                code: codeFile,
-                activate,
-              });
-            },
-            pollForStatus: false,
-          });
-
-          response = result.deployment;
-          updaterRow.update({ status: "Pushed" });
-
-          deploymentCreated = true;
-          successfullyPushed++;
-        } catch (e: any) {
-          errors.push(e);
-
-          switch (e.code) {
-            case "ENOENT":
-              updaterRow.fail({
-                errorMessage: `Deployment not found at path: ${path.resolve(func.path)}`,
-              });
-              break;
-            default:
-              updaterRow.fail({
-                errorMessage:
-                  e.message ?? "An unknown error occurred. Please try again.",
-              });
-          }
-        }
-
-        if (deploymentCreated && !asyncDeploy) {
           try {
-            const deploymentId = response["$id"];
-            updaterRow.update({
-              status: "Deploying",
-              end: "Checking deployment status...",
+            updaterRow
+              .update({ status: "Pushing" })
+              .replaceSpinner(SPINNER_DOTS);
+            const functionsServiceDeploy = await getFunctionsService(
+              this.projectClient,
+            );
+
+            const result = await pushDeployment({
+              resourcePath: func.path,
+              extraIgnoreRules: normalizeIgnoreRules(func.ignore),
+              createDeployment: async (codeFile) => {
+                return await functionsServiceDeploy.createDeployment({
+                  functionId: func["$id"],
+                  entrypoint: func.entrypoint,
+                  commands: func.commands,
+                  code: codeFile,
+                  activate,
+                });
+              },
+              pollForStatus: false,
             });
 
-            const timeoutDeadline = Date.now() + DEPLOYMENT_TIMEOUT_MS;
+            response = result.deployment;
+            updaterRow.update({ status: "Pushed" });
 
-            while (true) {
-              if (Date.now() > timeoutDeadline) {
-                failedDeployments.push({
-                  name: func["name"],
-                  $id: func["$id"],
-                  deployment: deploymentId,
-                });
-                updaterRow.fail({
-                  errorMessage: "Deployment timed out after 10 minutes",
-                });
-                break;
-              }
-
-              const functionsServicePoll = await getFunctionsService(
-                this.projectClient,
-              );
-              response = await functionsServicePoll.getDeployment({
-                functionId: func["$id"],
-                deploymentId: deploymentId,
-              });
-
-              const status = response["status"];
-              if (status === "ready") {
-                if (activate) {
-                  updaterRow.update({
-                    status: "Activating",
-                    end: "Setting active deployment...",
-                  });
-
-                  const functionsServiceActivate = await getFunctionsService(
-                    this.projectClient,
-                  );
-                  await functionsServiceActivate.updateFunctionDeployment({
-                    functionId: func["$id"],
-                    deploymentId,
-                  });
-                }
-
-                successfullyDeployed++;
-
-                let url = "";
-                const proxyServiceUrl = await getProxyService(
-                  this.projectClient,
-                );
-                const res = await proxyServiceUrl.listRules({
-                  queries: [
-                    Query.limit(1),
-                    Query.equal("deploymentResourceType", "function"),
-                    Query.equal("deploymentResourceId", func["$id"]),
-                    Query.equal("trigger", "manual"),
-                  ],
-                });
-
-                if (Number(res.total) === 1) {
-                  url = `https://${res.rules[0].domain}`;
-                }
-
-                const elapsed = ((Date.now() - deployStartTime) / 1000).toFixed(
-                  1,
-                );
-                const endpoint =
-                  localConfig.getEndpoint() || globalConfig.getEndpoint();
-                const projectId = localConfig.getProject().projectId;
-                const consoleUrl = getFunctionDeploymentConsoleUrl(
-                  endpoint,
-                  projectId,
-                  func["$id"],
-                  deploymentId,
-                );
-
-                updaterRow.stopSpinner();
-                updaterRow.update({
-                  status: activate ? "Deployed" : "Built",
-                  end: "",
-                });
-
-                deploymentLogs.push({ url, consoleUrl, elapsed });
-
-                break;
-              } else if (status === "failed") {
-                failedDeployments.push({
-                  name: func["name"],
-                  $id: func["$id"],
-                  deployment: response["$id"],
-                });
-                updaterRow.fail({ errorMessage: `Failed to deploy` });
-
-                break;
-              } else {
-                updaterRow.update({
-                  status: "Deploying",
-                  end: `Current status: ${status}`,
-                });
-              }
-
-              await new Promise((resolve) =>
-                setTimeout(resolve, POLL_DEBOUNCE),
-              );
-            }
+            deploymentCreated = true;
+            successfullyPushed++;
           } catch (e: any) {
             errors.push(e);
-            updaterRow.fail({
-              errorMessage:
-                e.message ?? "Unknown error occurred. Please try again",
-            });
+
+            switch (e.code) {
+              case "ENOENT":
+                updaterRow.fail({
+                  errorMessage: `Deployment not found at path: ${path.resolve(func.path)}`,
+                });
+                break;
+              default:
+                updaterRow.fail({
+                  errorMessage:
+                    e.message ?? "An unknown error occurred. Please try again.",
+                });
+            }
           }
+
+          if (deploymentCreated && !asyncDeploy) {
+            const deploymentId = response["$id"];
+            const endpoint =
+              localConfig.getEndpoint() || globalConfig.getEndpoint();
+            const projectId = localConfig.getProject().projectId;
+            const consoleUrl = getFunctionDeploymentConsoleUrl(
+              endpoint,
+              projectId,
+              func["$id"],
+              deploymentId,
+            );
+            let waitingSince: number | null = null;
+            const deploymentLogPrinter = createDeploymentLogPrinter({
+              label: `function:${func.name}`,
+              showPrefix: functions.length > 1,
+              isVisible: deploymentLogsController.isVisible,
+            });
+            deploymentLogsController.registerPrinter(deploymentLogPrinter);
+            const deploymentWatcher = logs
+              ? await watchDeploymentUpdates({
+                  endpoint:
+                    localConfig.getEndpoint() || globalConfig.getEndpoint(),
+                  event: `functions.${func["$id"]}.deployments.${deploymentId}.update`,
+                  onDeploymentUpdate: (deployment) => {
+                    deploymentLogPrinter.ingest(deployment);
+                  },
+                })
+              : null;
+            let currentDeploymentEnd = deploymentWatcher
+              ? "Streaming build logs..."
+              : "Checking deployment status...";
+            const unsubscribeToggle = deploymentLogsController.onToggle(() => {
+              updaterRow.update({
+                end: withDeploymentLogsHint(
+                  currentDeploymentEnd,
+                  deploymentLogsController,
+                ),
+              });
+            });
+
+            try {
+              updaterRow.update({
+                status: "Deploying",
+                end: withDeploymentLogsHint(
+                  currentDeploymentEnd,
+                  deploymentLogsController,
+                ),
+              });
+
+              const timeoutDeadline = Date.now() + DEPLOYMENT_TIMEOUT_MS;
+
+              while (true) {
+                if (Date.now() > timeoutDeadline) {
+                  unsubscribeToggle();
+                  failedDeployments.push({
+                    name: func["name"],
+                    $id: func["$id"],
+                    deployment: deploymentId,
+                    reason: "timeout",
+                    consoleUrl,
+                  });
+                  if (deploymentLogPrinter.hasPrintedLogs()) {
+                    Spinner.log("");
+                  }
+                  updaterRow.fail({
+                    errorMessage: getDeploymentTimeoutErrorMessage(),
+                  });
+                  break;
+                }
+
+                const functionsServicePoll = await getFunctionsService(
+                  this.projectClient,
+                );
+                response = await functionsServicePoll.getDeployment({
+                  functionId: func["$id"],
+                  deploymentId: deploymentId,
+                });
+                deploymentLogPrinter.ingest(response);
+
+                const status = response["status"];
+                if (status === "waiting") {
+                  waitingSince ??= Date.now();
+                } else {
+                  waitingSince = null;
+                }
+
+                if (status === "ready") {
+                  if (activate) {
+                    unsubscribeToggle();
+                    updaterRow.update({
+                      status: "Activating",
+                      end: "Setting active deployment...",
+                    });
+
+                    const functionsServiceActivate = await getFunctionsService(
+                      this.projectClient,
+                    );
+                    await functionsServiceActivate.updateFunctionDeployment({
+                      functionId: func["$id"],
+                      deploymentId,
+                    });
+                  }
+
+                  successfullyDeployed++;
+
+                  let url = "";
+                  const proxyServiceUrl = await getProxyService(
+                    this.projectClient,
+                  );
+                  const res = await proxyServiceUrl.listRules({
+                    queries: [
+                      Query.limit(1),
+                      Query.equal("deploymentResourceType", "function"),
+                      Query.equal("deploymentResourceId", func["$id"]),
+                      Query.equal("trigger", "manual"),
+                    ],
+                  });
+
+                  if (Number(res.total) === 1) {
+                    url = `https://${res.rules[0].domain}`;
+                  }
+
+                  if (deploymentLogPrinter.hasPrintedLogs()) {
+                    Spinner.log("");
+                  }
+                  unsubscribeToggle();
+                  updaterRow.stopSpinner();
+                  updaterRow.update({
+                    status: activate ? "Deployed" : "Built",
+                    end: "",
+                  });
+
+                  deploymentLogs.push({ url, consoleUrl });
+
+                  break;
+                } else if (status === "failed") {
+                  unsubscribeToggle();
+                  failedDeployments.push({
+                    name: func["name"],
+                    $id: func["$id"],
+                    deployment: response["$id"],
+                    reason: "failed",
+                    consoleUrl,
+                  });
+                  if (deploymentLogPrinter.hasPrintedLogs()) {
+                    Spinner.log("");
+                  }
+                  updaterRow.fail({ errorMessage: `Failed to deploy` });
+
+                  break;
+                } else {
+                  currentDeploymentEnd = getDeploymentProgressText(
+                    status,
+                    waitingSince,
+                  );
+                  updaterRow.update({
+                    status: "Deploying",
+                    end: withDeploymentLogsHint(
+                      currentDeploymentEnd,
+                      deploymentLogsController,
+                    ),
+                  });
+                }
+
+                await new Promise((resolve) =>
+                  setTimeout(resolve, POLL_DEBOUNCE),
+                );
+              }
+            } catch (e: any) {
+              errors.push(e);
+              unsubscribeToggle();
+              updaterRow.fail({
+                errorMessage:
+                  e.message ?? "Unknown error occurred. Please try again",
+              });
+            } finally {
+              unsubscribeToggle();
+              await deploymentWatcher?.close();
+            }
+          }
+
+          updaterRow.stopSpinner();
+        }),
+      );
+    } finally {
+      deploymentLogsController.close();
+      Spinner.stop();
+    }
+
+    if (deploymentLogs.length > 0) {
+      process.stdout.write("\n");
+      deploymentLogs.forEach((dl, index) => {
+        if (index > 0) {
+          process.stdout.write("\n");
         }
 
-        updaterRow.stopSpinner();
-      }),
-    );
-
-    Spinner.stop();
-
-    for (const dl of deploymentLogs) {
-      if (dl.url) {
-        this.log(`  ${chalk.cyan("→")} ${dl.url}`);
-      }
-      this.log(`  ${chalk.cyan("→")} ${dl.consoleUrl}`);
-      this.success(`Successfully deployed in ${chalk.bold(dl.elapsed + "s")}`);
+        if (dl.url) {
+          this.log(`Preview link: ${chalk.cyan(dl.url)}`);
+        }
+        this.log(`Deployment page: ${chalk.cyan(dl.consoleUrl)}`);
+      });
+      process.stdout.write("\n");
     }
 
     return {
@@ -1135,11 +1364,12 @@ export class Push {
       code?: boolean;
       activate?: boolean;
       withVariables?: boolean;
+      logs?: boolean;
     } = {},
   ): Promise<{
     successfullyPushed: number;
     successfullyDeployed: number;
-    failedDeployments: any[];
+    failedDeployments: FailedDeployment[];
     errors: any[];
   }> {
     const {
@@ -1147,88 +1377,54 @@ export class Push {
       code,
       activate = true,
       withVariables,
+      logs = true,
     } = options;
 
     Spinner.start(false);
+    const deploymentLogsController = createDeploymentLogsController(logs);
     let successfullyPushed = 0;
     let successfullyDeployed = 0;
-    const failedDeployments: any[] = [];
+    const failedDeployments: FailedDeployment[] = [];
     const errors: any[] = [];
     const deploymentLogs: {
       url: string;
       consoleUrl: string;
-      elapsed: string;
     }[] = [];
 
-    await Promise.all(
-      sites.map(async (site: any) => {
-        let response: any = {};
+    try {
+      await Promise.all(
+        sites.map(async (site: any) => {
+          let response: any = {};
 
-        let siteExists = false;
-        let deploymentCreated = false;
+          let siteExists = false;
+          let deploymentCreated = false;
 
-        const updaterRow = new Spinner({
-          status: "",
-          resource: site.name,
-          id: site["$id"],
-          end: "Ignoring using: .gitignore",
-        });
-
-        updaterRow.update({ status: "Getting" }).startSpinner(SPINNER_DOTS);
-
-        const sitesService = await getSitesService(this.projectClient);
-        try {
-          response = await sitesService.get({ siteId: site["$id"] });
-          siteExists = true;
-          if (response.framework !== site.framework) {
-            updaterRow.fail({
-              errorMessage: `Framework mismatch! (local=${site.framework},remote=${response.framework}) Please delete remote site or update your appwrite.config.json`,
-            });
-            return;
-          }
-
-          updaterRow
-            .update({ status: "Updating" })
-            .replaceSpinner(SPINNER_DOTS);
-
-          response = await sitesService.update({
-            siteId: site["$id"],
-            name: site.name,
-            framework: site.framework,
-            enabled: site.enabled,
-            logging: site.logging,
-            timeout: site.timeout,
-            installCommand: site.installCommand,
-            buildCommand: site.buildCommand,
-            outputDirectory: site.outputDirectory,
-            buildRuntime: site.buildRuntime,
-            adapter: site.adapter,
-            startCommand: site.startCommand,
-            buildSpecification: site.buildSpecification,
-            runtimeSpecification: site.runtimeSpecification,
-            deploymentRetention: site.deploymentRetention,
+          const updaterRow = new Spinner({
+            status: "",
+            resource: site.name,
+            id: site["$id"],
+            end: "Ignoring using: .gitignore",
           });
-        } catch (e: any) {
-          if (Number(e.code) === 404) {
-            siteExists = false;
-          } else {
-            errors.push(e);
-            updaterRow.fail({
-              errorMessage:
-                e.message ?? "General error occurs please try again",
-            });
-            return;
-          }
-        }
 
-        if (!siteExists) {
-          updaterRow
-            .update({ status: "Creating" })
-            .replaceSpinner(SPINNER_DOTS);
+          updaterRow.update({ status: "Getting" }).startSpinner(SPINNER_DOTS);
 
+          const sitesService = await getSitesService(this.projectClient);
           try {
-            response = await sitesService.create({
-              siteId: site.$id,
+            response = await sitesService.get({ siteId: site["$id"] });
+            siteExists = true;
+            if (response.framework !== site.framework) {
+              updaterRow.fail({
+                errorMessage: `Framework mismatch! (local=${site.framework},remote=${response.framework}) Please delete remote site or update your appwrite.config.json`,
+              });
+              return;
+            }
+
+            updaterRow
+              .update({ status: "Updating" })
+              .replaceSpinner(SPINNER_DOTS);
+
+            response = await sitesService.update({
+              siteId: site["$id"],
               name: site.name,
               framework: site.framework,
               enabled: site.enabled,
@@ -1244,288 +1440,405 @@ export class Push {
               runtimeSpecification: site.runtimeSpecification,
               deploymentRetention: site.deploymentRetention,
             });
-
-            let domain = "";
-            try {
-              const consoleService = await getConsoleService(
-                this.consoleClient,
-              );
-              const variables = await consoleService.variables();
-              const domains = variables["_APP_DOMAIN_SITES"].split(",");
-              domain = ID.unique() + "." + domains[0].trim();
-            } catch (err) {
-              this.error("Error fetching console variables.");
-              throw err;
-            }
-
-            try {
-              const proxyService = await getProxyService(this.projectClient);
-              await proxyService.createSiteRule(domain, site.$id);
-            } catch (err) {
-              this.error("Error creating site rule.");
-              throw err;
-            }
-
-            updaterRow.update({ status: "Created" });
           } catch (e: any) {
-            errors.push(e);
-            updaterRow.fail({
-              errorMessage:
-                e.message ?? "General error occurs please try again",
-            });
-            return;
-          }
-        }
-
-        if (withVariables) {
-          updaterRow
-            .update({ status: "Creating variables" })
-            .replaceSpinner(SPINNER_DOTS);
-
-          const sitesServiceForVars = await getSitesService(this.projectClient);
-          const { variables } = await sitesServiceForVars.listVariables({
-            siteId: site["$id"],
-          });
-
-          await Promise.all(
-            variables.map(async (variable: any) => {
-              const sitesServiceDel = await getSitesService(this.projectClient);
-              await sitesServiceDel.deleteVariable({
-                siteId: site["$id"],
-                variableId: variable["$id"],
+            if (Number(e.code) === 404) {
+              siteExists = false;
+            } else {
+              errors.push(e);
+              updaterRow.fail({
+                errorMessage:
+                  e.message ?? "General error occurs please try again",
               });
-            }),
-          );
-
-          const envFileLocation = `${site["path"]}/.env`;
-          let envVariables: Array<{ key: string; value: string }> = [];
-          try {
-            if (fs.existsSync(envFileLocation)) {
-              const envObject = parseDotenv(
-                fs.readFileSync(envFileLocation, "utf8"),
-              );
-              envVariables = Object.entries(envObject || {}).map(
-                ([key, value]) => ({ key, value }),
-              );
+              return;
             }
-          } catch (_error) {
-            envVariables = [];
           }
-          await Promise.all(
-            envVariables.map(async (variable) => {
-              const sitesServiceCreate = await getSitesService(
-                this.projectClient,
-              );
-              await sitesServiceCreate.createVariable({
-                siteId: site["$id"],
-                key: variable.key,
-                value: variable.value,
-                secret: false,
-              });
-            }),
-          );
-        }
 
-        if (code === false) {
-          successfullyPushed++;
-          successfullyDeployed++;
-          updaterRow.update({ status: "Pushed" });
-          updaterRow.stopSpinner();
-          return;
-        }
+          if (!siteExists) {
+            updaterRow
+              .update({ status: "Creating" })
+              .replaceSpinner(SPINNER_DOTS);
 
-        if (!site.path) {
-          errors.push(new Error(`Site '${site.name}' has no path configured`));
-          updaterRow.fail({
-            errorMessage: `No path configured for site`,
-          });
-          return;
-        }
-
-        if (
-          !fs.existsSync(site.path) ||
-          fs.readdirSync(site.path).length === 0
-        ) {
-          errors.push(
-            new Error(`Deployment not found or empty at path: ${site.path}`),
-          );
-          updaterRow.fail({
-            errorMessage: `path not found or empty: ${path.relative(process.cwd(), path.resolve(site.path))}`,
-          });
-          return;
-        }
-
-        const deployStartTime = Date.now();
-        try {
-          updaterRow.update({ status: "Pushing" }).replaceSpinner(SPINNER_DOTS);
-          const sitesServiceDeploy = await getSitesService(this.projectClient);
-
-          const result = await pushDeployment({
-            resourcePath: site.path,
-            createDeployment: async (codeFile) => {
-              return await sitesServiceDeploy.createDeployment({
-                siteId: site["$id"],
+            try {
+              response = await sitesService.create({
+                siteId: site.$id,
+                name: site.name,
+                framework: site.framework,
+                enabled: site.enabled,
+                logging: site.logging,
+                timeout: site.timeout,
                 installCommand: site.installCommand,
                 buildCommand: site.buildCommand,
                 outputDirectory: site.outputDirectory,
-                code: codeFile,
-                activate,
+                buildRuntime: site.buildRuntime,
+                adapter: site.adapter,
+                startCommand: site.startCommand,
+                buildSpecification: site.buildSpecification,
+                runtimeSpecification: site.runtimeSpecification,
+                deploymentRetention: site.deploymentRetention,
               });
-            },
-            pollForStatus: false,
-          });
 
-          response = result.deployment;
-          updaterRow.update({ status: "Pushed" });
-          deploymentCreated = true;
-          successfullyPushed++;
-        } catch (e: any) {
-          errors.push(e);
+              let domain = "";
+              try {
+                const consoleService = await getConsoleService(
+                  this.consoleClient,
+                );
+                const variables = await consoleService.variables();
+                const domains = variables["_APP_DOMAIN_SITES"].split(",");
+                domain = ID.unique() + "." + domains[0].trim();
+              } catch (err) {
+                this.error("Error fetching console variables.");
+                throw err;
+              }
 
-          switch (e.code) {
-            case "ENOENT":
-              updaterRow.fail({
-                errorMessage: `Deployment not found at path: ${path.resolve(site.path)}`,
-              });
-              break;
-            default:
+              try {
+                const proxyService = await getProxyService(this.projectClient);
+                await proxyService.createSiteRule(domain, site.$id);
+              } catch (err) {
+                this.error("Error creating site rule.");
+                throw err;
+              }
+
+              updaterRow.update({ status: "Created" });
+            } catch (e: any) {
+              errors.push(e);
               updaterRow.fail({
                 errorMessage:
-                  e.message ?? "An unknown error occurred. Please try again.",
+                  e.message ?? "General error occurs please try again",
               });
+              return;
+            }
           }
-        }
 
-        if (deploymentCreated && !asyncDeploy) {
-          try {
-            const deploymentId = response["$id"];
-            updaterRow.update({
-              status: "Deploying",
-              end: "Checking deployment status...",
+          if (withVariables) {
+            updaterRow
+              .update({ status: "Creating variables" })
+              .replaceSpinner(SPINNER_DOTS);
+
+            const sitesServiceForVars = await getSitesService(
+              this.projectClient,
+            );
+            const { variables } = await sitesServiceForVars.listVariables({
+              siteId: site["$id"],
             });
 
-            const timeoutDeadline = Date.now() + DEPLOYMENT_TIMEOUT_MS;
-
-            while (true) {
-              if (Date.now() > timeoutDeadline) {
-                failedDeployments.push({
-                  name: site["name"],
-                  $id: site["$id"],
-                  deployment: deploymentId,
-                });
-                updaterRow.fail({
-                  errorMessage: "Deployment timed out after 10 minutes",
-                });
-                break;
-              }
-
-              const sitesServicePoll = await getSitesService(
-                this.projectClient,
-              );
-              response = await sitesServicePoll.getDeployment({
-                siteId: site["$id"],
-                deploymentId: deploymentId,
-              });
-
-              const status = response["status"];
-              if (status === "ready") {
-                if (activate) {
-                  updaterRow.update({
-                    status: "Activating",
-                    end: "Setting active deployment...",
-                  });
-
-                  const sitesServiceActivate = await getSitesService(
-                    this.projectClient,
-                  );
-                  await sitesServiceActivate.updateSiteDeployment({
-                    siteId: site["$id"],
-                    deploymentId,
-                  });
-                }
-
-                successfullyDeployed++;
-
-                let url = "";
-                const proxyServiceUrl = await getProxyService(
+            await Promise.all(
+              variables.map(async (variable: any) => {
+                const sitesServiceDel = await getSitesService(
                   this.projectClient,
                 );
-                const res = await proxyServiceUrl.listRules({
-                  queries: [
-                    Query.limit(1),
-                    Query.equal("deploymentResourceType", "site"),
-                    Query.equal("deploymentResourceId", site["$id"]),
-                    Query.equal("trigger", "manual"),
-                  ],
+                await sitesServiceDel.deleteVariable({
+                  siteId: site["$id"],
+                  variableId: variable["$id"],
                 });
+              }),
+            );
 
-                if (Number(res.total) === 1) {
-                  url = `https://${res.rules[0].domain}`;
-                }
-
-                const elapsed = ((Date.now() - deployStartTime) / 1000).toFixed(
-                  1,
+            const envFileLocation = `${site["path"]}/.env`;
+            let envVariables: Array<{ key: string; value: string }> = [];
+            try {
+              if (fs.existsSync(envFileLocation)) {
+                const envObject = parseDotenv(
+                  fs.readFileSync(envFileLocation, "utf8"),
                 );
-                const endpoint =
-                  localConfig.getEndpoint() || globalConfig.getEndpoint();
-                const projectId = localConfig.getProject().projectId;
-                const consoleUrl = getSiteDeploymentConsoleUrl(
-                  endpoint,
-                  projectId,
-                  site["$id"],
-                  deploymentId,
+                envVariables = Object.entries(envObject || {}).map(
+                  ([key, value]) => ({ key, value }),
                 );
-
-                updaterRow.stopSpinner();
-                updaterRow.update({
-                  status: activate ? "Deployed" : "Built",
-                  end: "",
-                });
-
-                deploymentLogs.push({ url, consoleUrl, elapsed });
-
-                break;
-              } else if (status === "failed") {
-                failedDeployments.push({
-                  name: site["name"],
-                  $id: site["$id"],
-                  deployment: response["$id"],
-                });
-                updaterRow.fail({ errorMessage: `Failed to deploy` });
-
-                break;
-              } else {
-                updaterRow.update({
-                  status: "Deploying",
-                  end: `Current status: ${status}`,
-                });
               }
-
-              await new Promise((resolve) =>
-                setTimeout(resolve, POLL_DEBOUNCE),
-              );
+            } catch (_error) {
+              envVariables = [];
             }
+            await Promise.all(
+              envVariables.map(async (variable) => {
+                const sitesServiceCreate = await getSitesService(
+                  this.projectClient,
+                );
+                await sitesServiceCreate.createVariable({
+                  siteId: site["$id"],
+                  key: variable.key,
+                  value: variable.value,
+                  secret: false,
+                });
+              }),
+            );
+          }
+
+          if (code === false) {
+            successfullyPushed++;
+            successfullyDeployed++;
+            updaterRow.update({ status: "Pushed" });
+            updaterRow.stopSpinner();
+            return;
+          }
+
+          if (!site.path) {
+            errors.push(
+              new Error(`Site '${site.name}' has no path configured`),
+            );
+            updaterRow.fail({
+              errorMessage: `No path configured for site`,
+            });
+            return;
+          }
+
+          if (
+            !fs.existsSync(site.path) ||
+            fs.readdirSync(site.path).length === 0
+          ) {
+            errors.push(
+              new Error(`Deployment not found or empty at path: ${site.path}`),
+            );
+            updaterRow.fail({
+              errorMessage: `path not found or empty: ${path.relative(process.cwd(), path.resolve(site.path))}`,
+            });
+            return;
+          }
+
+          try {
+            updaterRow
+              .update({ status: "Pushing" })
+              .replaceSpinner(SPINNER_DOTS);
+            const sitesServiceDeploy = await getSitesService(
+              this.projectClient,
+            );
+
+            const result = await pushDeployment({
+              resourcePath: site.path,
+              createDeployment: async (codeFile) => {
+                return await sitesServiceDeploy.createDeployment({
+                  siteId: site["$id"],
+                  installCommand: site.installCommand,
+                  buildCommand: site.buildCommand,
+                  outputDirectory: site.outputDirectory,
+                  code: codeFile,
+                  activate,
+                });
+              },
+              pollForStatus: false,
+            });
+
+            response = result.deployment;
+            updaterRow.update({ status: "Pushed" });
+            deploymentCreated = true;
+            successfullyPushed++;
           } catch (e: any) {
             errors.push(e);
-            updaterRow.fail({
-              errorMessage:
-                e.message ?? "Unknown error occurred. Please try again",
-            });
+
+            switch (e.code) {
+              case "ENOENT":
+                updaterRow.fail({
+                  errorMessage: `Deployment not found at path: ${path.resolve(site.path)}`,
+                });
+                break;
+              default:
+                updaterRow.fail({
+                  errorMessage:
+                    e.message ?? "An unknown error occurred. Please try again.",
+                });
+            }
           }
+
+          if (deploymentCreated && !asyncDeploy) {
+            const deploymentId = response["$id"];
+            const endpoint =
+              localConfig.getEndpoint() || globalConfig.getEndpoint();
+            const projectId = localConfig.getProject().projectId;
+            const consoleUrl = getSiteDeploymentConsoleUrl(
+              endpoint,
+              projectId,
+              site["$id"],
+              deploymentId,
+            );
+            let waitingSince: number | null = null;
+            const deploymentLogPrinter = createDeploymentLogPrinter({
+              label: `site:${site.name}`,
+              showPrefix: sites.length > 1,
+              isVisible: deploymentLogsController.isVisible,
+            });
+            deploymentLogsController.registerPrinter(deploymentLogPrinter);
+            const deploymentWatcher = logs
+              ? await watchDeploymentUpdates({
+                  endpoint:
+                    localConfig.getEndpoint() || globalConfig.getEndpoint(),
+                  event: `sites.${site["$id"]}.deployments.${deploymentId}.update`,
+                  onDeploymentUpdate: (deployment) => {
+                    deploymentLogPrinter.ingest(deployment);
+                  },
+                })
+              : null;
+            let currentDeploymentEnd = deploymentWatcher
+              ? "Streaming build logs..."
+              : "Checking deployment status...";
+            const unsubscribeToggle = deploymentLogsController.onToggle(() => {
+              updaterRow.update({
+                end: withDeploymentLogsHint(
+                  currentDeploymentEnd,
+                  deploymentLogsController,
+                ),
+              });
+            });
+
+            try {
+              updaterRow.update({
+                status: "Deploying",
+                end: withDeploymentLogsHint(
+                  currentDeploymentEnd,
+                  deploymentLogsController,
+                ),
+              });
+
+              const timeoutDeadline = Date.now() + DEPLOYMENT_TIMEOUT_MS;
+
+              while (true) {
+                if (Date.now() > timeoutDeadline) {
+                  unsubscribeToggle();
+                  failedDeployments.push({
+                    name: site["name"],
+                    $id: site["$id"],
+                    deployment: deploymentId,
+                    reason: "timeout",
+                    consoleUrl,
+                  });
+                  if (deploymentLogPrinter.hasPrintedLogs()) {
+                    Spinner.log("");
+                  }
+                  updaterRow.fail({
+                    errorMessage: getDeploymentTimeoutErrorMessage(),
+                  });
+                  break;
+                }
+
+                const sitesServicePoll = await getSitesService(
+                  this.projectClient,
+                );
+                response = await sitesServicePoll.getDeployment({
+                  siteId: site["$id"],
+                  deploymentId: deploymentId,
+                });
+                deploymentLogPrinter.ingest(response);
+
+                const status = response["status"];
+                if (status === "waiting") {
+                  waitingSince ??= Date.now();
+                } else {
+                  waitingSince = null;
+                }
+
+                if (status === "ready") {
+                  if (activate) {
+                    unsubscribeToggle();
+                    updaterRow.update({
+                      status: "Activating",
+                      end: "Setting active deployment...",
+                    });
+
+                    const sitesServiceActivate = await getSitesService(
+                      this.projectClient,
+                    );
+                    await sitesServiceActivate.updateSiteDeployment({
+                      siteId: site["$id"],
+                      deploymentId,
+                    });
+                  }
+
+                  successfullyDeployed++;
+
+                  let url = "";
+                  const proxyServiceUrl = await getProxyService(
+                    this.projectClient,
+                  );
+                  const res = await proxyServiceUrl.listRules({
+                    queries: [
+                      Query.limit(1),
+                      Query.equal("deploymentResourceType", "site"),
+                      Query.equal("deploymentResourceId", site["$id"]),
+                      Query.equal("trigger", "manual"),
+                    ],
+                  });
+
+                  if (Number(res.total) === 1) {
+                    url = `https://${res.rules[0].domain}`;
+                  }
+
+                  if (deploymentLogPrinter.hasPrintedLogs()) {
+                    Spinner.log("");
+                  }
+                  unsubscribeToggle();
+                  updaterRow.stopSpinner();
+                  updaterRow.update({
+                    status: activate ? "Deployed" : "Built",
+                    end: "",
+                  });
+
+                  deploymentLogs.push({ url, consoleUrl });
+
+                  break;
+                } else if (status === "failed") {
+                  unsubscribeToggle();
+                  failedDeployments.push({
+                    name: site["name"],
+                    $id: site["$id"],
+                    deployment: response["$id"],
+                    reason: "failed",
+                    consoleUrl,
+                  });
+                  if (deploymentLogPrinter.hasPrintedLogs()) {
+                    Spinner.log("");
+                  }
+                  updaterRow.fail({ errorMessage: `Failed to deploy` });
+
+                  break;
+                } else {
+                  currentDeploymentEnd = getDeploymentProgressText(
+                    status,
+                    waitingSince,
+                  );
+                  updaterRow.update({
+                    status: "Deploying",
+                    end: withDeploymentLogsHint(
+                      currentDeploymentEnd,
+                      deploymentLogsController,
+                    ),
+                  });
+                }
+
+                await new Promise((resolve) =>
+                  setTimeout(resolve, POLL_DEBOUNCE),
+                );
+              }
+            } catch (e: any) {
+              errors.push(e);
+              unsubscribeToggle();
+              updaterRow.fail({
+                errorMessage:
+                  e.message ?? "Unknown error occurred. Please try again",
+              });
+            } finally {
+              unsubscribeToggle();
+              await deploymentWatcher?.close();
+            }
+          }
+
+          updaterRow.stopSpinner();
+        }),
+      );
+    } finally {
+      deploymentLogsController.close();
+      Spinner.stop();
+    }
+
+    if (deploymentLogs.length > 0) {
+      process.stdout.write("\n");
+      deploymentLogs.forEach((dl, index) => {
+        if (index > 0) {
+          process.stdout.write("\n");
         }
 
-        updaterRow.stopSpinner();
-      }),
-    );
-
-    Spinner.stop();
-
-    for (const dl of deploymentLogs) {
-      if (dl.url) {
-        this.log(`  ${chalk.cyan("→")} ${dl.url}`);
-      }
-      this.log(`  ${chalk.cyan("→")} ${dl.consoleUrl}`);
-      this.success(`Successfully deployed in ${chalk.bold(dl.elapsed + "s")}`);
+        if (dl.url) {
+          this.log(`Preview link: ${chalk.cyan(dl.url)}`);
+        }
+        this.log(`Deployment page: ${chalk.cyan(dl.consoleUrl)}`);
+      });
+      process.stdout.write("\n");
     }
 
     return {
@@ -1884,9 +2197,9 @@ async function createPushInstance(
 
 const pushResources = async ({
   skipDeprecated = false,
-}: {
-  skipDeprecated?: boolean;
-} = {}): Promise<void> => {
+  functionOptions,
+  siteOptions,
+}: PushOptions = {}): Promise<void> => {
   if (cliConfig.all) {
     checkDeployConditions(localConfig);
 
@@ -1961,11 +2274,13 @@ const pushResources = async ({
         code: allowFunctionsCodePush === true,
         activate: activateFunctionsDeployment ?? true,
         withVariables: false,
+        logs: functionOptions?.logs,
       },
       siteOptions: {
         code: allowSitesCodePush === true,
         activate: activateSitesDeployment ?? true,
         withVariables: false,
+        logs: siteOptions?.logs,
       },
     });
   } else {
@@ -2063,6 +2378,7 @@ const pushSite = async ({
   code,
   activate,
   withVariables,
+  logs,
 }: PushSiteOptions = {}): Promise<void> => {
   process.chdir(localConfig.configDirectoryPath);
 
@@ -2149,12 +2465,14 @@ const pushSite = async ({
 
   log("Pushing sites ...");
 
+  const pushStartTime = Date.now();
   const pushInstance = await createPushInstance();
   const result = await pushInstance.pushSites(sites, {
     async: asyncDeploy,
     code: shouldPushCode,
     activate: shouldActivate ?? true,
     withVariables,
+    logs,
   });
 
   const {
@@ -2163,20 +2481,28 @@ const pushSite = async ({
     failedDeployments,
     errors,
   } = result;
+  const totalElapsed = ((Date.now() - pushStartTime) / 1000).toFixed(1);
 
   failedDeployments.forEach((failed) => {
-    const { name, deployment, $id } = failed;
-    const projectId = localConfig.getProject().projectId;
-    const endpoint = localConfig.getEndpoint() || globalConfig.getEndpoint();
-    const failUrl = getSiteDeploymentConsoleUrl(
-      endpoint,
-      projectId,
-      $id,
-      deployment,
-    );
+    const { name } = failed;
+    const failUrl =
+      failed.consoleUrl ??
+      getSiteDeploymentConsoleUrl(
+        localConfig.getEndpoint() || globalConfig.getEndpoint(),
+        localConfig.getProject().projectId,
+        failed.$id,
+        failed.deployment,
+      );
+
+    if (failed.reason === "timeout") {
+      error(
+        `Deployment of ${name} got stuck for more than ${DEPLOYMENT_TIMEOUT_MINUTES} minutes. Check deployment here: ${failUrl}\n`,
+      );
+      return;
+    }
 
     error(
-      `Deployment of ${name} has failed. Check at ${failUrl} for more details\n`,
+      `Deployment of ${name} has failed. Check deployment here: ${failUrl}\n`,
     );
   });
 
@@ -2185,10 +2511,12 @@ const pushSite = async ({
       error("No sites were pushed.");
     } else if (successfullyDeployed !== successfullyPushed) {
       warn(
-        `Successfully pushed ${successfullyDeployed} of ${successfullyPushed} sites`,
+        `Successfully deployed ${successfullyDeployed} of ${successfullyPushed} sites in ${chalk.bold(totalElapsed + "s")}.`,
       );
     } else {
-      success(`Successfully pushed ${successfullyPushed} sites.`);
+      success(
+        `Successfully deployed ${successfullyPushed} ${successfullyPushed === 1 ? "site" : "sites"} in ${chalk.bold(totalElapsed + "s")}.`,
+      );
     }
   } else {
     success(`Successfully pushed ${successfullyPushed} sites.`);
@@ -2207,6 +2535,7 @@ const pushFunction = async ({
   code,
   activate,
   withVariables,
+  logs,
 }: PushFunctionOptions = {}): Promise<void> => {
   process.chdir(localConfig.configDirectoryPath);
 
@@ -2294,12 +2623,14 @@ const pushFunction = async ({
 
   log("Pushing functions ...");
 
+  const pushStartTime = Date.now();
   const pushInstance = await createPushInstance();
   const result = await pushInstance.pushFunctions(functions, {
     async: asyncDeploy,
     code: shouldPushCode,
     activate: shouldActivate ?? true,
     withVariables,
+    logs,
   });
 
   const {
@@ -2308,20 +2639,28 @@ const pushFunction = async ({
     failedDeployments,
     errors,
   } = result;
+  const totalElapsed = ((Date.now() - pushStartTime) / 1000).toFixed(1);
 
   failedDeployments.forEach((failed) => {
-    const { name, deployment, $id } = failed;
-    const projectId = localConfig.getProject().projectId;
-    const endpoint = localConfig.getEndpoint() || globalConfig.getEndpoint();
-    const failUrl = getFunctionDeploymentConsoleUrl(
-      endpoint,
-      projectId,
-      $id,
-      deployment,
-    );
+    const { name } = failed;
+    const failUrl =
+      failed.consoleUrl ??
+      getFunctionDeploymentConsoleUrl(
+        localConfig.getEndpoint() || globalConfig.getEndpoint(),
+        localConfig.getProject().projectId,
+        failed.$id,
+        failed.deployment,
+      );
+
+    if (failed.reason === "timeout") {
+      error(
+        `Deployment of ${name} got stuck for more than ${DEPLOYMENT_TIMEOUT_MINUTES} minutes. Check deployment here: ${failUrl}\n`,
+      );
+      return;
+    }
 
     error(
-      `Deployment of ${name} has failed. Check at ${failUrl} for more details\n`,
+      `Deployment of ${name} has failed. Check deployment here: ${failUrl}\n`,
     );
   });
 
@@ -2330,10 +2669,12 @@ const pushFunction = async ({
       error("No functions were pushed.");
     } else if (successfullyDeployed !== successfullyPushed) {
       warn(
-        `Successfully pushed ${successfullyDeployed} of ${successfullyPushed} functions`,
+        `Successfully deployed ${successfullyDeployed} of ${successfullyPushed} functions in ${chalk.bold(totalElapsed + "s")}.`,
       );
     } else {
-      success(`Successfully pushed ${successfullyPushed} functions.`);
+      success(
+        `Successfully deployed ${successfullyPushed} ${successfullyPushed === 1 ? "function" : "functions"} in ${chalk.bold(totalElapsed + "s")}.`,
+      );
     }
   } else {
     success(`Successfully pushed ${successfullyPushed} functions.`);
@@ -2791,10 +3132,15 @@ export const push = new Command("push")
 push
   .command("all")
   .description("Push all resource.")
+  .option("--no-logs", "Don't stream deployment build logs")
   .action(
-    actionRunner(() => {
+    actionRunner((options: { logs?: boolean }) => {
       cliConfig.all = true;
-      return pushResources({ skipDeprecated: true });
+      return pushResources({
+        skipDeprecated: true,
+        functionOptions: { logs: options.logs },
+        siteOptions: { logs: options.logs },
+      });
     }),
   );
 
@@ -2810,6 +3156,7 @@ push
   .option(`-f, --function-id <function-id>`, `ID of function to run`)
   .option(`-A, --async`, `Don't wait for functions deployments status`)
   .option("--no-code", "Don't push the function's code")
+  .option("--no-logs", "Don't stream deployment build logs")
   .option(
     "--activate [value]",
     "Activate the function's deployment after it is ready.",
@@ -2826,6 +3173,7 @@ push
   .option(`-f, --site-id <site-id>`, `ID of site to run`)
   .option(`-A, --async`, `Don't wait for sites deployments status`)
   .option("--no-code", "Don't push the site's code")
+  .option("--no-logs", "Don't stream deployment build logs")
   .option(
     "--activate [value]",
     "Activate the site's deployment after it is ready.",

--- a/templates/cli/lib/commands/push.ts
+++ b/templates/cli/lib/commands/push.ts
@@ -1213,7 +1213,7 @@ export class Push {
 
               while (true) {
                 if (Date.now() > timeoutDeadline) {
-                  unsubscribeToggle();
+                  deploymentLogPrinter.complete();
                   failedDeployments.push({
                     name: func["name"],
                     $id: func["$id"],
@@ -1248,10 +1248,13 @@ export class Push {
 
                 if (status === "ready") {
                   if (activate) {
-                    unsubscribeToggle();
+                    currentDeploymentEnd = "Setting active deployment...";
                     updaterRow.update({
                       status: "Activating",
-                      end: "Setting active deployment...",
+                      end: withDeploymentLogsHint(
+                        currentDeploymentEnd,
+                        deploymentLogsController,
+                      ),
                     });
 
                     const functionsServiceActivate = await getFunctionsService(
@@ -1282,10 +1285,10 @@ export class Push {
                     url = `https://${res.rules[0].domain}`;
                   }
 
+                  deploymentLogPrinter.complete();
                   if (deploymentLogPrinter.hasPrintedLogs()) {
                     Spinner.log("");
                   }
-                  unsubscribeToggle();
                   updaterRow.stopSpinner();
                   updaterRow.update({
                     status: activate ? "Deployed" : "Built",
@@ -1296,7 +1299,7 @@ export class Push {
 
                   break;
                 } else if (status === "failed") {
-                  unsubscribeToggle();
+                  deploymentLogPrinter.complete();
                   failedDeployments.push({
                     name: func["name"],
                     $id: func["$id"],
@@ -1328,12 +1331,11 @@ export class Push {
                   setTimeout(resolve, POLL_DEBOUNCE),
                 );
               }
-            } catch (e: any) {
-              errors.push(e);
-              unsubscribeToggle();
-              updaterRow.fail({
-                errorMessage:
-                  e.message ?? "Unknown error occurred. Please try again",
+          } catch (e: any) {
+            errors.push(e);
+            updaterRow.fail({
+              errorMessage:
+                e.message ?? "Unknown error occurred. Please try again",
               });
             } finally {
               unsubscribeToggle();
@@ -1705,7 +1707,7 @@ export class Push {
 
               while (true) {
                 if (Date.now() > timeoutDeadline) {
-                  unsubscribeToggle();
+                  deploymentLogPrinter.complete();
                   failedDeployments.push({
                     name: site["name"],
                     $id: site["$id"],
@@ -1740,10 +1742,13 @@ export class Push {
 
                 if (status === "ready") {
                   if (activate) {
-                    unsubscribeToggle();
+                    currentDeploymentEnd = "Setting active deployment...";
                     updaterRow.update({
                       status: "Activating",
-                      end: "Setting active deployment...",
+                      end: withDeploymentLogsHint(
+                        currentDeploymentEnd,
+                        deploymentLogsController,
+                      ),
                     });
 
                     const sitesServiceActivate = await getSitesService(
@@ -1774,10 +1779,10 @@ export class Push {
                     url = `https://${res.rules[0].domain}`;
                   }
 
+                  deploymentLogPrinter.complete();
                   if (deploymentLogPrinter.hasPrintedLogs()) {
                     Spinner.log("");
                   }
-                  unsubscribeToggle();
                   updaterRow.stopSpinner();
                   updaterRow.update({
                     status: activate ? "Deployed" : "Built",
@@ -1788,7 +1793,7 @@ export class Push {
 
                   break;
                 } else if (status === "failed") {
-                  unsubscribeToggle();
+                  deploymentLogPrinter.complete();
                   failedDeployments.push({
                     name: site["name"],
                     $id: site["$id"],
@@ -1820,12 +1825,11 @@ export class Push {
                   setTimeout(resolve, POLL_DEBOUNCE),
                 );
               }
-            } catch (e: any) {
-              errors.push(e);
-              unsubscribeToggle();
-              updaterRow.fail({
-                errorMessage:
-                  e.message ?? "Unknown error occurred. Please try again",
+          } catch (e: any) {
+            errors.push(e);
+            updaterRow.fail({
+              errorMessage:
+                e.message ?? "Unknown error occurred. Please try again",
               });
             } finally {
               unsubscribeToggle();

--- a/templates/cli/lib/commands/utils/deployment.ts
+++ b/templates/cli/lib/commands/utils/deployment.ts
@@ -55,6 +55,7 @@ interface WatchDeploymentUpdatesParams {
 interface DeploymentLogPrinter {
   ingest: (deployment: DeploymentDetails) => void;
   flush: () => void;
+  complete: () => void;
   getLastLogs: () => string;
   hasPrintedLogs: () => boolean;
 }
@@ -130,15 +131,17 @@ function writeLogChunk(
   label: string | undefined,
   chunk: string,
   showPrefix: boolean,
+  includePartial: boolean = false,
 ): string {
   if (chunk.length === 0) {
     return "";
   }
 
   const prefix = showPrefix && label ? `${chalk.cyan(`[${label}]`)} ` : "";
-  const printableChunk = chunk.endsWith("\n")
-    ? chunk
-    : chunk.slice(0, chunk.lastIndexOf("\n") + 1);
+  const printableChunk =
+    includePartial || chunk.endsWith("\n")
+      ? chunk
+      : chunk.slice(0, chunk.lastIndexOf("\n") + 1);
 
   if (printableChunk.length === 0) {
     return "";
@@ -169,7 +172,7 @@ export function createDeploymentLogPrinter(
     isVisible = () => true,
   } = options;
 
-  const flush = (): void => {
+  const flush = (includePartial: boolean = false): void => {
     if (!isVisible() || lastLogs.length === 0 || lastLogs === lastPrintedLogs) {
       return;
     }
@@ -186,6 +189,7 @@ export function createDeploymentLogPrinter(
         label,
         lastLogs.slice(lastPrintedLogs.length),
         showPrefix,
+        includePartial,
       );
       if (printedChunk.length === 0) {
         return;
@@ -200,7 +204,12 @@ export function createDeploymentLogPrinter(
       return;
     }
 
-    const printedChunk = writeLogChunk(label, lastLogs, showPrefix);
+    const printedChunk = writeLogChunk(
+      label,
+      lastLogs,
+      showPrefix,
+      includePartial,
+    );
     if (printedChunk.length === 0) {
       return;
     }
@@ -225,6 +234,10 @@ export function createDeploymentLogPrinter(
 
     flush(): void {
       flush();
+    },
+
+    complete(): void {
+      flush(true);
     },
 
     getLastLogs(): string {

--- a/templates/cli/lib/commands/utils/deployment.ts
+++ b/templates/cli/lib/commands/utils/deployment.ts
@@ -50,6 +50,7 @@ interface WatchDeploymentUpdatesParams {
   endpoint: string;
   event: string;
   onDeploymentUpdate: (deployment: DeploymentDetails) => void;
+  onClose?: () => void;
 }
 
 interface DeploymentLogPrinter {
@@ -298,12 +299,24 @@ export async function watchDeploymentUpdates(
   }
 
   let closed = false;
+  let closingExplicitly = false;
+  let hasNotifiedClose = false;
+
+  const notifyClose = (): void => {
+    if (hasNotifiedClose) {
+      return;
+    }
+
+    hasNotifiedClose = true;
+    params.onClose?.();
+  };
 
   const close = async (): Promise<void> => {
     if (closed) {
       return;
     }
 
+    closingExplicitly = true;
     closed = true;
 
     await new Promise<void>((resolve) => {
@@ -369,11 +382,15 @@ export async function watchDeploymentUpdates(
   });
 
   socket.addEventListener("error", () => {
+    notifyClose();
     void close();
   });
 
   socket.addEventListener("close", () => {
     closed = true;
+    if (!closingExplicitly) {
+      notifyClose();
+    }
   });
 
   return { close };

--- a/templates/cli/lib/commands/utils/deployment.ts
+++ b/templates/cli/lib/commands/utils/deployment.ts
@@ -130,28 +130,29 @@ function writeLogChunk(
   label: string | undefined,
   chunk: string,
   showPrefix: boolean,
-): void {
+): string {
   if (chunk.length === 0) {
-    return;
+    return "";
   }
 
   const prefix = showPrefix && label ? `${chalk.cyan(`[${label}]`)} ` : "";
-  const normalizedChunk = chunk.replace(/\r\n/g, "\n");
-  const endsWithNewLine = normalizedChunk.endsWith("\n");
-  const lines = normalizedChunk.split("\n");
+  const printableChunk = chunk.endsWith("\n")
+    ? chunk
+    : chunk.slice(0, chunk.lastIndexOf("\n") + 1);
 
-  if (!endsWithNewLine) {
-    const lastLine = lines.pop();
-    if (lastLine !== undefined) {
-      lines.push(lastLine);
-    }
-  } else {
-    lines.pop();
+  if (printableChunk.length === 0) {
+    return "";
   }
+
+  const normalizedChunk = printableChunk.replace(/\r\n/g, "\n");
+  const lines = normalizedChunk.split("\n");
+  lines.pop();
 
   for (const line of lines) {
     Spinner.log(`${prefix}${line}`);
   }
+
+  return printableChunk;
 }
 
 export function createDeploymentLogPrinter(
@@ -181,8 +182,15 @@ export function createDeploymentLogPrinter(
     }
 
     if (lastPrintedLogs.length > 0 && lastLogs.startsWith(lastPrintedLogs)) {
-      writeLogChunk(label, lastLogs.slice(lastPrintedLogs.length), showPrefix);
-      lastPrintedLogs = lastLogs;
+      const printedChunk = writeLogChunk(
+        label,
+        lastLogs.slice(lastPrintedLogs.length),
+        showPrefix,
+      );
+      if (printedChunk.length === 0) {
+        return;
+      }
+      lastPrintedLogs += printedChunk;
       hasPrintedLogs = true;
       return;
     }
@@ -192,8 +200,11 @@ export function createDeploymentLogPrinter(
       return;
     }
 
-    writeLogChunk(label, lastLogs, showPrefix);
-    lastPrintedLogs = lastLogs;
+    const printedChunk = writeLogChunk(label, lastLogs, showPrefix);
+    if (printedChunk.length === 0) {
+      return;
+    }
+    lastPrintedLogs = printedChunk;
     hasPrintedLogs = true;
   };
 
@@ -270,7 +281,6 @@ export async function watchDeploymentUpdates(
 
   const close = async (): Promise<void> => {
     if (closed) {
-      await closeDispatcher(dispatcher);
       return;
     }
 

--- a/templates/cli/lib/commands/utils/deployment.ts
+++ b/templates/cli/lib/commands/utils/deployment.ts
@@ -154,7 +154,9 @@ function writeLogChunk(
 
   const normalizedChunk = printableChunk.replace(/\r\n/g, "\n");
   const lines = normalizedChunk.split("\n");
-  lines.pop();
+  if (normalizedChunk.endsWith("\n")) {
+    lines.pop();
+  }
 
   for (const line of lines) {
     Spinner.log(`${prefix}${line}`);

--- a/templates/cli/lib/commands/utils/deployment.ts
+++ b/templates/cli/lib/commands/utils/deployment.ts
@@ -3,8 +3,12 @@ import os from "os";
 import path from "path";
 import { create, extract } from "tar";
 import ignoreModule from "ignore";
+import chalk from "chalk";
+import { Agent, WebSocket } from "undici";
 import { Client, AppwriteException } from "@appwrite.io/console";
 import { error } from "../../parser.js";
+import { globalConfig } from "../../config.js";
+import { Spinner } from "../../spinner.js";
 
 const ignore: typeof ignoreModule =
   (ignoreModule as unknown as { default?: typeof ignoreModule }).default ??
@@ -27,6 +31,322 @@ interface DeploymentDetails {
   $id: string;
   status: string;
   [key: string]: unknown;
+}
+
+interface RealtimeEnvelope {
+  type?: string;
+  data?: {
+    events?: string[];
+    payload?: DeploymentDetails;
+    user?: unknown;
+  };
+}
+
+interface DeploymentUpdateSubscription {
+  close: () => Promise<void>;
+}
+
+interface WatchDeploymentUpdatesParams {
+  endpoint: string;
+  event: string;
+  onDeploymentUpdate: (deployment: DeploymentDetails) => void;
+}
+
+interface DeploymentLogPrinter {
+  ingest: (deployment: DeploymentDetails) => void;
+  flush: () => void;
+  getLastLogs: () => string;
+  hasPrintedLogs: () => boolean;
+}
+
+interface DeploymentLogPrinterOptions {
+  heading?: string;
+  label?: string;
+  showPrefix?: boolean;
+  isVisible?: () => boolean;
+}
+
+interface ClosableDispatcher {
+  close?: () => Promise<void>;
+  destroy?: () => Promise<void> | void;
+}
+
+function getCookieHeader(cookie: string): string | null {
+  const [pair = ""] = cookie.split(";", 1);
+  const sanitized = pair.trim();
+
+  return sanitized.length > 0 ? sanitized : null;
+}
+
+function getSessionSecret(cookieHeader: string | null): string | null {
+  if (!cookieHeader) {
+    return null;
+  }
+
+  const [, value = ""] = cookieHeader.split("=", 2);
+  if (value.length === 0) {
+    return null;
+  }
+
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function getRealtimeUrl(endpoint: string): string {
+  const realtimeEndpoint = endpoint
+    .replace("https://", "wss://")
+    .replace("http://", "ws://");
+  const url = new URL(`${realtimeEndpoint}/realtime`);
+  url.searchParams.set("project", "console");
+  url.searchParams.append("channels[]", "console");
+
+  return url.toString();
+}
+
+function getMessageData(rawData: unknown): string | null {
+  if (typeof rawData === "string") {
+    return rawData;
+  }
+
+  if (rawData instanceof ArrayBuffer) {
+    return Buffer.from(rawData).toString("utf8");
+  }
+
+  if (ArrayBuffer.isView(rawData)) {
+    return Buffer.from(
+      rawData.buffer,
+      rawData.byteOffset,
+      rawData.byteLength,
+    ).toString("utf8");
+  }
+
+  return null;
+}
+
+function writeLogChunk(
+  label: string | undefined,
+  chunk: string,
+  showPrefix: boolean,
+): void {
+  if (chunk.length === 0) {
+    return;
+  }
+
+  const prefix = showPrefix && label ? `${chalk.cyan(`[${label}]`)} ` : "";
+  const normalizedChunk = chunk.replace(/\r\n/g, "\n");
+  const endsWithNewLine = normalizedChunk.endsWith("\n");
+  const lines = normalizedChunk.split("\n");
+
+  if (!endsWithNewLine) {
+    const lastLine = lines.pop();
+    if (lastLine !== undefined) {
+      lines.push(lastLine);
+    }
+  } else {
+    lines.pop();
+  }
+
+  for (const line of lines) {
+    Spinner.log(`${prefix}${line}`);
+  }
+}
+
+export function createDeploymentLogPrinter(
+  options: DeploymentLogPrinterOptions = {},
+): DeploymentLogPrinter {
+  let lastLogs = "";
+  let lastPrintedLogs = "";
+  let hasPrintedHeader = false;
+  let hasPrintedLogs = false;
+  const {
+    heading = "Build logs",
+    label,
+    showPrefix = false,
+    isVisible = () => true,
+  } = options;
+
+  const flush = (): void => {
+    if (!isVisible() || lastLogs.length === 0 || lastLogs === lastPrintedLogs) {
+      return;
+    }
+
+    if (!hasPrintedHeader) {
+      Spinner.log("");
+      Spinner.log(chalk.cyan.bold(heading));
+      Spinner.log("");
+      hasPrintedHeader = true;
+    }
+
+    if (lastPrintedLogs.length > 0 && lastLogs.startsWith(lastPrintedLogs)) {
+      writeLogChunk(label, lastLogs.slice(lastPrintedLogs.length), showPrefix);
+      lastPrintedLogs = lastLogs;
+      hasPrintedLogs = true;
+      return;
+    }
+
+    if (lastPrintedLogs.startsWith(lastLogs)) {
+      lastPrintedLogs = lastLogs;
+      return;
+    }
+
+    writeLogChunk(label, lastLogs, showPrefix);
+    lastPrintedLogs = lastLogs;
+    hasPrintedLogs = true;
+  };
+
+  return {
+    ingest(deployment: DeploymentDetails): void {
+      const currentLogs =
+        typeof deployment["buildLogs"] === "string"
+          ? deployment["buildLogs"]
+          : "";
+
+      if (currentLogs.length === 0 || currentLogs === lastLogs) {
+        return;
+      }
+
+      lastLogs = currentLogs;
+      flush();
+    },
+
+    flush(): void {
+      flush();
+    },
+
+    getLastLogs(): string {
+      return lastLogs;
+    },
+
+    hasPrintedLogs(): boolean {
+      return hasPrintedLogs;
+    },
+  };
+}
+
+async function closeDispatcher(dispatcher: ClosableDispatcher): Promise<void> {
+  if (typeof dispatcher.close === "function") {
+    await dispatcher.close();
+    return;
+  }
+
+  if (typeof dispatcher.destroy === "function") {
+    await dispatcher.destroy();
+  }
+}
+
+export async function watchDeploymentUpdates(
+  params: WatchDeploymentUpdatesParams,
+): Promise<DeploymentUpdateSubscription | null> {
+  const cookieHeader = getCookieHeader(globalConfig.getCookie());
+  if (!cookieHeader) {
+    return null;
+  }
+
+  const sessionSecret = getSessionSecret(cookieHeader);
+  const selfSigned = globalConfig.getSelfSigned();
+  const dispatcher = new Agent({
+    connect: {
+      rejectUnauthorized: !selfSigned,
+    },
+  });
+
+  let socket: WebSocket;
+  try {
+    socket = new WebSocket(getRealtimeUrl(params.endpoint), {
+      headers: {
+        cookie: cookieHeader,
+      },
+      dispatcher,
+    });
+  } catch {
+    await closeDispatcher(dispatcher);
+    return null;
+  }
+
+  let closed = false;
+
+  const close = async (): Promise<void> => {
+    if (closed) {
+      await closeDispatcher(dispatcher);
+      return;
+    }
+
+    closed = true;
+
+    await new Promise<void>((resolve) => {
+      if (socket.readyState >= WebSocket.CLOSING) {
+        resolve();
+        return;
+      }
+
+      const cleanup = (): void => {
+        socket.removeEventListener("close", cleanup);
+        resolve();
+      };
+
+      socket.addEventListener("close", cleanup, { once: true });
+      socket.close(1000, "done");
+    });
+
+    await closeDispatcher(dispatcher);
+  };
+
+  socket.addEventListener("message", (event: unknown) => {
+    const data = getMessageData((event as { data?: unknown }).data);
+    if (!data) {
+      return;
+    }
+
+    let message: RealtimeEnvelope;
+    try {
+      message = JSON.parse(data) as RealtimeEnvelope;
+    } catch {
+      return;
+    }
+
+    if (
+      message.type === "connected" &&
+      sessionSecret &&
+      !message.data?.user &&
+      socket.readyState === WebSocket.OPEN
+    ) {
+      socket.send(
+        JSON.stringify({
+          type: "authentication",
+          data: {
+            session: sessionSecret,
+          },
+        }),
+      );
+      return;
+    }
+
+    if (message.type !== "event") {
+      return;
+    }
+
+    if (
+      !message.data?.events?.includes(params.event) ||
+      !message.data.payload
+    ) {
+      return;
+    }
+
+    params.onDeploymentUpdate(message.data.payload);
+  });
+
+  socket.addEventListener("error", () => {
+    void close();
+  });
+
+  socket.addEventListener("close", () => {
+    closed = true;
+  });
+
+  return { close };
 }
 
 /**

--- a/templates/cli/lib/commands/utils/deployment.ts
+++ b/templates/cli/lib/commands/utils/deployment.ts
@@ -84,7 +84,12 @@ function getSessionSecret(cookieHeader: string | null): string | null {
     return null;
   }
 
-  const [, value = ""] = cookieHeader.split("=", 2);
+  const separatorIndex = cookieHeader.indexOf("=");
+  if (separatorIndex === -1) {
+    return null;
+  }
+
+  const value = cookieHeader.slice(separatorIndex + 1);
   if (value.length === 0) {
     return null;
   }

--- a/templates/cli/lib/spinner.ts
+++ b/templates/cli/lib/spinner.ts
@@ -1,5 +1,6 @@
 import progress from "cli-progress";
 import chalk from "chalk";
+import stringWidth from "string-width";
 
 const SPINNER_ARC = "arc";
 const SPINNER_DOTS = "dots";
@@ -33,6 +34,8 @@ class Spinner {
   static updatesBar: progress.MultiBar;
   private bar: progress.SingleBar;
   private spinnerInterval?: NodeJS.Timeout;
+  private static readonly DEFAULT_MIDDLE_WIDTH = 40;
+  private static readonly MIN_MIDDLE_WIDTH = 1;
 
   static start(
     clearOnComplete: boolean = true,
@@ -52,13 +55,26 @@ class Spinner {
     Spinner.updatesBar.stop();
   }
 
+  static log(message: string): void {
+    if (!message.endsWith("\n")) {
+      message += "\n";
+    }
+
+    if (Spinner.updatesBar) {
+      Spinner.updatesBar.log(message);
+      return;
+    }
+
+    process.stdout.write(message);
+  }
+
   static formatter(
     _options: unknown,
     _params: unknown,
     payload: SpinnerPayload,
   ): string {
     const status = payload.status.padEnd(12);
-    const middle = `${payload.resource} (${payload.id})`.padEnd(40);
+    const middle = `${payload.resource} (${payload.id})`;
 
     let prefix = chalk.cyan(payload.prefix ?? "⧗");
     let start = chalk.cyan(status);
@@ -82,6 +98,42 @@ class Spinner {
     return Spinner.line(prefix, start, middle, end);
   }
 
+  private static fitMiddle(
+    prefix: string,
+    start: string,
+    middle: string,
+    end: string,
+    separator: string,
+  ): string {
+    const terminalWidth = process.stdout.columns ?? 120;
+    const startWidth = stringWidth(`${prefix} ${start} ${separator} `);
+    const endWidth = end ? stringWidth(` ${separator} ${end}`) : 0;
+    const availableWidth = Math.max(
+      Spinner.MIN_MIDDLE_WIDTH,
+      terminalWidth - startWidth - endWidth,
+    );
+    const targetWidth = Math.min(Spinner.DEFAULT_MIDDLE_WIDTH, availableWidth);
+
+    if (stringWidth(middle) <= targetWidth) {
+      return middle.padEnd(targetWidth);
+    }
+
+    if (targetWidth <= 1) {
+      return "…";
+    }
+
+    let truncated = "";
+    for (const char of middle) {
+      const next = `${truncated}${char}`;
+      if (stringWidth(`${next}…`) > targetWidth) {
+        break;
+      }
+      truncated = next;
+    }
+
+    return `${truncated}…`;
+  }
+
   static line(
     prefix: string,
     start: string,
@@ -89,7 +141,15 @@ class Spinner {
     end: string,
     separator: string = "•",
   ): string {
-    return `${prefix} ${start} ${separator} ${middle} ${!end ? "" : separator} ${end}`;
+    const fittedMiddle = Spinner.fitMiddle(
+      prefix,
+      start,
+      middle,
+      end,
+      separator,
+    );
+
+    return `${prefix} ${start} ${separator} ${fittedMiddle} ${!end ? "" : separator} ${end}`;
   }
 
   constructor(


### PR DESCRIPTION
## Summary
- stream function and site deployment build logs in real time during `push`
- add interactive and opt-out controls for log streaming in the CLI
- improve deploy status, timeout, and post-deploy output formatting

## Screenshot
![CLI realtime deployment logs](https://raw.githubusercontent.com/appwrite/sdk-generator/feat/cli-realtime-deployment-logs/docs/cli-realtime-deployment-logs-demo.svg)

## What Changed
- added a console realtime watcher in `templates/cli/lib/commands/utils/deployment.ts` that authenticates with the stored console session and listens for deployment update events
- added an incremental deployment log printer that tails `buildLogs`, supports pause/resume behavior, and keeps polling as the source-of-truth fallback
- integrated realtime deployment updates into both function and site push flows in `templates/cli/lib/commands/push.ts`
- added `--no-logs` to `push all`, `push function`, and `push site`
- added interactive `l` toggling in TTY mode to pause/resume log streaming while a deployment is running
- improved waiting-state messaging, including a delayed wait-room link and a deployment-specific timeout message with a console URL
- fixed spinner/log interleaving by routing streamed logs through the spinner output path
- tightened spinner truncation so the status/hint text survives narrow terminals more reliably
- cleaned up post-deploy output with labeled links and explicit spacing around the deployment link block

## Testing
- `docker run --rm -v "$PWD":/app -w /app php:8.3-cli php example.php cli`
- `npm run build` (from `examples/cli`)
- `npm run mac-arm64` (from `examples/cli`)
- `node dist/cli.cjs push site --help` (from `examples/cli`)
- `node dist/cli.cjs push function --help` (from `examples/cli`)
- `node dist/cli.cjs push all --help` (from `examples/cli`)
- `./build/appwrite-cli-darwin-arm64 push site --help` (from `examples/cli`)
- `./build/appwrite-cli-darwin-arm64 push function --help` (from `examples/cli`)
- `./build/appwrite-cli-darwin-arm64 push all --help` (from `examples/cli`)

## Notes
- `examples/cli` was regenerated and verified locally during development, but the generated output files are not tracked in this repository
- no linked issue for this change
