### PR TITLE
Fix nullable PHP model hydration for empty strings

### DIFF
--- a/templates/php/src/Models/ArraySerializable.php.twig
+++ b/templates/php/src/Models/ArraySerializable.php.twig
@@ -165,14 +165,14 @@ trait ArraySerializable
         $type = $parameter->getType();
 
         if ($type instanceof \ReflectionNamedType && !$type->isBuiltin()) {
-            if ($type->allowsNull() && $value === '') {
-                return null;
-            }
-
             $typeName = $type->getName();
 
             if (!method_exists($typeName, 'from')) {
                 return $value;
+            }
+
+            if ($type->allowsNull() && $value === '') {
+                return null;
             }
 
             return is_array($value) ? $typeName::from($value) : $typeName::from((string) $value);

--- a/templates/php/src/Models/ArraySerializable.php.twig
+++ b/templates/php/src/Models/ArraySerializable.php.twig
@@ -165,6 +165,10 @@ trait ArraySerializable
         $type = $parameter->getType();
 
         if ($type instanceof \ReflectionNamedType && !$type->isBuiltin()) {
+            if ($type->allowsNull() && $value === '') {
+                return null;
+            }
+
             $typeName = $type->getName();
 
             if (!method_exists($typeName, 'from')) {


### PR DESCRIPTION
## Summary
- normalize empty-string values to `null` during PHP model hydration when the generated property type is nullable
- keep the change scoped to nullable non-builtin `from()`-hydrated values so optional enum/model fields no longer throw on wire-level `""` sentinels

## Context
The PHP generator now emits nullable model properties for some response fields, but the shared `ArraySerializable` hydrator still passed `""` into `Type::from(...)`. That causes hydration failures for nullable enum-like fields where the API uses an empty string as an unset sentinel.

## Testing
- `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php php`
- `composer lint-twig`
- `vendor/bin/phpunit tests/PHP83Test.php`
