### PR TITLE
Fix CLI Homebrew checksum matcher in publish workflow template

### DIFF
--- a/templates/cli/.github/workflows/publish.yml
+++ b/templates/cli/.github/workflows/publish.yml
@@ -115,7 +115,7 @@ jobs:
           end
 
           checksums.each do |artifact, checksum|
-            pattern = /(\Q#{artifact}\E"\n\s+sha256 ")([0-9a-f]{64})(")/
+            pattern = /(#{Regexp.escape(artifact)}"\n\s+sha256 ")([0-9a-f]{64})(")/
             unless text.sub!(pattern) { "#{$1}#{checksum}#{$3}" }
               abort("Failed to update checksum for #{artifact}")
             end


### PR DESCRIPTION
## What does this PR do?

Sync the CLI publish workflow template with the fix already applied in `appwrite/sdk-for-cli`.

The generated workflow was using a Ruby regex literal with `\Q#{artifact}\E` when rewriting Homebrew SHA256 entries. That matcher failed in the release job, so the checksum update aborted even though the release assets and npm publish had already completed.

This switches the matcher to `Regexp.escape(artifact)`, which matches the generated formula content correctly.

## Test Plan

- Regenerated the CLI SDK with `php example.php cli`
- Verified the rendered workflow in `examples/cli/.github/workflows/publish.yml` uses `Regexp.escape(artifact)`
- Reproduced the checksum rewrite against `appwrite/sdk-for-cli` and confirmed the substitutions succeed with this pattern

## Related

- appwrite/sdk-for-cli#297
