### PR TITLE
Fix CLI update behavior for standalone and Homebrew installs

### DIFF
--- a/templates/cli/cli.ts.twig
+++ b/templates/cli/cli.ts.twig
@@ -12,7 +12,7 @@ import inquirer from 'inquirer';
 import packageJson from './package.json' with { type: 'json' };
 import { commandDescriptions, cliConfig } from './lib/parser.js';
 import {
-    getLatestVersion,
+    getLatestVersionForCurrentInstallation,
     compareVersions,
     getCachedUpdateNotification,
     syncVersionCheckCache,
@@ -90,7 +90,9 @@ async function checkVersion(): Promise<void> {
     return;
 {% else %}
     try {
-        const latestVersion = await getLatestVersion({ timeoutMs: VERSION_CHECK_TIMEOUT_MS });
+        const latestVersion = await getLatestVersionForCurrentInstallation({
+            timeoutMs: VERSION_CHECK_TIMEOUT_MS,
+        });
         syncVersionCheckCache(version, latestVersion);
         const comparison = compareVersions(version, latestVersion);
 

--- a/templates/cli/lib/commands/update.ts
+++ b/templates/cli/lib/commands/update.ts
@@ -1,3 +1,6 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
 import { spawn } from "child_process";
 import { Command } from "commander";
 import chalk from "chalk";
@@ -9,6 +12,7 @@ import {
   getErrorMessage,
 } from "../utils.js";
 import {
+  EXECUTABLE_NAME,
   GITHUB_RELEASES_URL,
   NPM_PACKAGE_NAME,
   SDK_TITLE,
@@ -17,13 +21,47 @@ import packageJson from "../../package.json" with { type: "json" };
 const { version } = packageJson;
 
 type ExecCommandOptions = Exclude<Parameters<typeof spawn>[2], undefined>;
+type InstallationMethod = "npm" | "homebrew" | "standalone";
+
+const WINDOWS_EXECUTABLE_NAME = `${EXECUTABLE_NAME.toLowerCase()}.exe`;
+
+const getExecutablePaths = (): {
+  execPath: string;
+  realExecPath: string;
+  scriptPath: string;
+} => {
+  const execPath = process.execPath;
+  const scriptPath = process.argv[1] ?? "";
+
+  try {
+    return {
+      execPath,
+      realExecPath: fs.realpathSync.native(execPath),
+      scriptPath,
+    };
+  } catch (_error) {
+    return {
+      execPath,
+      realExecPath: execPath,
+      scriptPath,
+    };
+  }
+};
+
+const isExecutableName = (candidatePath: string): boolean => {
+  const basename = path.basename(candidatePath).toLowerCase();
+  return (
+    basename === EXECUTABLE_NAME.toLowerCase() ||
+    basename === WINDOWS_EXECUTABLE_NAME
+  );
+};
 
 /**
  * Check if the CLI was installed via npm
  */
 const isInstalledViaNpm = (): boolean => {
   try {
-    const scriptPath = process.argv[1];
+    const { scriptPath } = getExecutablePaths();
 
     if (
       scriptPath.includes("node_modules") &&
@@ -53,15 +91,127 @@ const isInstalledViaNpm = (): boolean => {
  */
 const isInstalledViaHomebrew = (): boolean => {
   try {
-    const scriptPath = process.argv[1];
-    return (
-      scriptPath.includes("/opt/homebrew/") ||
-      scriptPath.includes("/usr/local/Cellar/") ||
-      scriptPath.includes("/home/linuxbrew/.linuxbrew/") ||
-      scriptPath.includes("/linuxbrew/.linuxbrew/")
+    const { execPath, realExecPath, scriptPath } = getExecutablePaths();
+    const candidates = [scriptPath, execPath, realExecPath];
+
+    return candidates.some(
+      (candidate) =>
+        candidate.includes("/opt/homebrew/") ||
+        candidate.includes("/usr/local/Cellar/") ||
+        candidate.includes("/home/linuxbrew/.linuxbrew/") ||
+        candidate.includes("/linuxbrew/.linuxbrew/"),
     );
   } catch (_e) {
     return false;
+  }
+};
+
+/**
+ * Check if the CLI was installed via install script or native binary download
+ */
+const isInstalledViaStandaloneBinary = (): boolean => {
+  if (isInstalledViaNpm() || isInstalledViaHomebrew()) {
+    return false;
+  }
+
+  try {
+    const { execPath, realExecPath } = getExecutablePaths();
+    return [execPath, realExecPath].some(isExecutableName);
+  } catch (_e) {
+    return false;
+  }
+};
+
+const detectInstallationMethod = (): InstallationMethod | null => {
+  if (isInstalledViaNpm()) {
+    return "npm";
+  }
+
+  if (isInstalledViaHomebrew()) {
+    return "homebrew";
+  }
+
+  if (isInstalledViaStandaloneBinary()) {
+    return "standalone";
+  }
+
+  return null;
+};
+
+const getStandaloneBinaryArtifactName = (): string => {
+  const platform =
+    process.platform === "win32"
+      ? "win"
+      : process.platform === "darwin"
+        ? "darwin"
+        : process.platform === "linux"
+          ? "linux"
+          : null;
+
+  if (!platform) {
+    throw new Error(
+      `Standalone binary updates are not supported on ${process.platform}.`,
+    );
+  }
+
+  const arch = os.arch();
+  if (arch !== "x64" && arch !== "arm64") {
+    throw new Error(
+      `Standalone binary updates are not supported on ${arch} architecture.`,
+    );
+  }
+
+  const extension = platform === "win" ? ".exe" : "";
+  return `${NPM_PACKAGE_NAME}-${platform}-${arch}${extension}`;
+};
+
+const getStandaloneBinaryTargetPath = (): string => {
+  const { execPath } = getExecutablePaths();
+
+  try {
+    if (fs.lstatSync(execPath).isSymbolicLink()) {
+      return fs.realpathSync.native(execPath);
+    }
+  } catch (_error) {
+    // Fall back to the original exec path below.
+  }
+
+  return execPath;
+};
+
+const isDirectoryWritable = (directoryPath: string): boolean => {
+  try {
+    fs.accessSync(directoryPath, fs.constants.W_OK);
+    return true;
+  } catch (_error) {
+    return false;
+  }
+};
+
+const quoteShellArgument = (value: string): string => {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+};
+
+const downloadStandaloneBinary = async (
+  latestVersion: string,
+  destinationPath: string,
+): Promise<void> => {
+  const artifact = getStandaloneBinaryArtifactName();
+  const response = await fetch(
+    `${GITHUB_RELEASES_URL}/download/${latestVersion}/${artifact}`,
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download standalone binary (HTTP ${response.status}).`,
+    );
+  }
+
+  const body = Buffer.from(await response.arrayBuffer());
+  fs.writeFileSync(destinationPath, body);
+
+  if (process.platform !== "win32") {
+    fs.chmodSync(destinationPath, 0o755);
   }
 };
 
@@ -76,7 +226,7 @@ const execCommand = (
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       stdio: "inherit",
-      shell: true,
+      shell: process.platform === "win32",
       ...options,
     });
 
@@ -146,6 +296,59 @@ const updateViaHomebrew = async (): Promise<void> => {
 };
 
 /**
+ * Update a standalone/native binary install
+ */
+const updateViaStandaloneBinary = async (
+  latestVersion: string,
+): Promise<void> => {
+  if (process.platform === "win32") {
+    showManualInstructions(latestVersion);
+    return;
+  }
+
+  const targetPath = getStandaloneBinaryTargetPath();
+  const targetDir = path.dirname(targetPath);
+  const tempName = `${path.basename(targetPath)}.tmp-${process.pid}`;
+  const writableDirectory = isDirectoryWritable(targetDir);
+  const tempPath = writableDirectory
+    ? path.join(targetDir, tempName)
+    : path.join(os.tmpdir(), tempName);
+
+  try {
+    await downloadStandaloneBinary(latestVersion, tempPath);
+
+    if (writableDirectory) {
+      fs.renameSync(tempPath, targetPath);
+    } else {
+      const stagedTargetPath = path.join(targetDir, tempName);
+      const command = [
+        `install -m 755 ${quoteShellArgument(tempPath)} ${quoteShellArgument(stagedTargetPath)}`,
+        `mv -f ${quoteShellArgument(stagedTargetPath)} ${quoteShellArgument(targetPath)}`,
+      ].join(" && ");
+
+      await execCommand("sudo", ["sh", "-c", command]);
+    }
+
+    console.log("");
+    success("Updated to latest version via standalone binary!");
+    hint("Run 'appwrite --version' to verify the new version.");
+  } catch (e: unknown) {
+    const message = getErrorMessage(e);
+    console.log("");
+    error(`Failed to update standalone binary: ${message}`);
+    hint(`Download the latest release manually at: ${GITHUB_RELEASES_URL}`);
+  } finally {
+    try {
+      if (fs.existsSync(tempPath)) {
+        fs.unlinkSync(tempPath);
+      }
+    } catch (_error) {
+      // Ignore cleanup failures.
+    }
+  }
+};
+
+/**
  * Show manual update instructions
  */
 const showManualInstructions = (latestVersion: string): void => {
@@ -160,7 +363,25 @@ const showManualInstructions = (latestVersion: string): void => {
   console.log(`  brew upgrade appwrite`);
   console.log("");
 
-  log(`${chalk.bold("Option 3: Download Binary")}`);
+  if (process.platform !== "win32") {
+    try {
+      const artifact = getStandaloneBinaryArtifactName();
+      const targetPath = getStandaloneBinaryTargetPath();
+      const tempPath = path.join(os.tmpdir(), path.basename(targetPath));
+
+      log(`${chalk.bold("Option 3: Install Script / Standalone Binary")}`);
+      console.log(
+        `  curl -fsSL ${GITHUB_RELEASES_URL}/download/${latestVersion}/${artifact} -o ${tempPath}`,
+      );
+      console.log(`  chmod +x ${tempPath}`);
+      console.log(`  sudo mv -f ${tempPath} ${targetPath}`);
+      console.log("");
+    } catch (_error) {
+      // Fall back to the release page below when the current platform is unsupported.
+    }
+  }
+
+  log(`${chalk.bold("Option 4: Download Binary")}`);
   console.log(`  Visit: ${GITHUB_RELEASES_URL}/tag/${latestVersion}`);
 };
 
@@ -171,6 +392,14 @@ const chooseUpdateMethod = async (latestVersion: string): Promise<void> => {
   const choices = [
     { name: "NPM", value: "npm" },
     { name: "Homebrew", value: "homebrew" },
+    ...(process.platform === "win32"
+      ? []
+      : [
+          {
+            name: "Install script / standalone binary",
+            value: "standalone",
+          },
+        ]),
     { name: "Show manual instructions", value: "manual" },
   ];
 
@@ -190,6 +419,9 @@ const chooseUpdateMethod = async (latestVersion: string): Promise<void> => {
       break;
     case "homebrew":
       await updateViaHomebrew();
+      break;
+    case "standalone":
+      await updateViaStandaloneBinary(latestVersion);
       break;
     case "manual":
       showManualInstructions(latestVersion);
@@ -233,12 +465,21 @@ const updateCli = async ({ manual }: UpdateOptions = {}): Promise<void> => {
       return;
     }
 
-    if (isInstalledViaNpm()) {
-      await updateViaNpm();
-    } else if (isInstalledViaHomebrew()) {
-      await updateViaHomebrew();
-    } else {
-      await chooseUpdateMethod(latestVersion);
+    const installationMethod = detectInstallationMethod();
+
+    switch (installationMethod) {
+      case "npm":
+        await updateViaNpm();
+        break;
+      case "homebrew":
+        await updateViaHomebrew();
+        break;
+      case "standalone":
+        await updateViaStandaloneBinary(latestVersion);
+        break;
+      default:
+        await chooseUpdateMethod(latestVersion);
+        break;
     }
   } catch (e: unknown) {
     const message = getErrorMessage(e);

--- a/templates/cli/lib/commands/update.ts
+++ b/templates/cli/lib/commands/update.ts
@@ -7,7 +7,7 @@ import chalk from "chalk";
 import inquirer from "inquirer";
 import { success, log, warn, error, hint, actionRunner } from "../parser.js";
 import {
-  getLatestVersion,
+  getLatestVersionForInstallation,
   compareVersions,
   getErrorMessage,
 } from "../utils.js";
@@ -438,7 +438,10 @@ interface UpdateOptions {
  */
 const updateCli = async ({ manual }: UpdateOptions = {}): Promise<void> => {
   try {
-    const latestVersion = await getLatestVersion();
+    const installationMethod = detectInstallationMethod();
+    const latestVersion = await getLatestVersionForInstallation(
+      installationMethod,
+    );
 
     const comparison = compareVersions(version, latestVersion);
 
@@ -464,8 +467,6 @@ const updateCli = async ({ manual }: UpdateOptions = {}): Promise<void> => {
       showManualInstructions(latestVersion);
       return;
     }
-
-    const installationMethod = detectInstallationMethod();
 
     switch (installationMethod) {
       case "npm":

--- a/templates/cli/lib/commands/update.ts
+++ b/templates/cli/lib/commands/update.ts
@@ -56,6 +56,15 @@ const isExecutableName = (candidatePath: string): boolean => {
   );
 };
 
+const isHomebrewManagedPath = (candidatePath: string): boolean => {
+  return (
+    candidatePath.includes("/opt/homebrew/") ||
+    candidatePath.includes("/usr/local/Cellar/") ||
+    candidatePath.includes("/home/linuxbrew/.linuxbrew/") ||
+    candidatePath.includes("/linuxbrew/.linuxbrew/")
+  );
+};
+
 /**
  * Check if the CLI was installed via npm
  */
@@ -92,15 +101,9 @@ const isInstalledViaNpm = (): boolean => {
 const isInstalledViaHomebrew = (): boolean => {
   try {
     const { execPath, realExecPath, scriptPath } = getExecutablePaths();
-    const candidates = [scriptPath, execPath, realExecPath];
+    const runtimeCandidates = [execPath, realExecPath].filter(isExecutableName);
 
-    return candidates.some(
-      (candidate) =>
-        candidate.includes("/opt/homebrew/") ||
-        candidate.includes("/usr/local/Cellar/") ||
-        candidate.includes("/home/linuxbrew/.linuxbrew/") ||
-        candidate.includes("/linuxbrew/.linuxbrew/"),
-    );
+    return [scriptPath, ...runtimeCandidates].some(isHomebrewManagedPath);
   } catch (_e) {
     return false;
   }

--- a/templates/cli/lib/commands/update.ts
+++ b/templates/cli/lib/commands/update.ts
@@ -64,6 +64,15 @@ const getStandaloneBinaryTargetPath = (): string => {
   return execPath;
 };
 
+const isExpectedStandaloneBinaryPath = (candidatePath: string): boolean => {
+  const basename = path.basename(candidatePath).toLowerCase();
+  const expectedName = EXECUTABLE_NAME.toLowerCase();
+
+  return (
+    basename === expectedName || basename === `${expectedName}.exe`
+  );
+};
+
 const isDirectoryWritable = (directoryPath: string): boolean => {
   try {
     fs.accessSync(directoryPath, fs.constants.W_OK);
@@ -189,6 +198,13 @@ const updateViaStandaloneBinary = async (
   }
 
   const targetPath = getStandaloneBinaryTargetPath();
+  if (!isExpectedStandaloneBinaryPath(targetPath)) {
+    console.log("");
+    error("Could not determine the standalone binary path.");
+    hint(`Download the latest release manually at: ${GITHUB_RELEASES_URL}`);
+    return;
+  }
+
   const targetDir = path.dirname(targetPath);
   const tempName = `${path.basename(targetPath)}.tmp-${process.pid}`;
   const writableDirectory = isDirectoryWritable(targetDir);
@@ -249,6 +265,9 @@ const showManualInstructions = (latestVersion: string): void => {
     try {
       const artifact = getStandaloneBinaryArtifactName();
       const targetPath = getStandaloneBinaryTargetPath();
+      if (!isExpectedStandaloneBinaryPath(targetPath)) {
+        throw new Error("Could not determine the standalone binary path.");
+      }
       const tempPath = path.join(os.tmpdir(), path.basename(targetPath));
 
       log(`${chalk.bold("Option 3: Install Script / Standalone Binary")}`);
@@ -271,10 +290,14 @@ const showManualInstructions = (latestVersion: string): void => {
  * Show interactive menu for choosing update method
  */
 const chooseUpdateMethod = async (latestVersion: string): Promise<void> => {
+  const canOfferStandaloneUpdate =
+    process.platform !== "win32" &&
+    isExpectedStandaloneBinaryPath(getStandaloneBinaryTargetPath());
+
   const choices = [
     { name: "NPM", value: "npm" },
     { name: "Homebrew", value: "homebrew" },
-    ...(process.platform === "win32"
+    ...(!canOfferStandaloneUpdate
       ? []
       : [
           {

--- a/templates/cli/lib/commands/update.ts
+++ b/templates/cli/lib/commands/update.ts
@@ -7,6 +7,7 @@ import chalk from "chalk";
 import inquirer from "inquirer";
 import { success, log, warn, error, hint, actionRunner } from "../parser.js";
 import {
+  detectInstallationMethod,
   getLatestVersionForInstallation,
   compareVersions,
   getErrorMessage,
@@ -21,125 +22,6 @@ import packageJson from "../../package.json" with { type: "json" };
 const { version } = packageJson;
 
 type ExecCommandOptions = Exclude<Parameters<typeof spawn>[2], undefined>;
-type InstallationMethod = "npm" | "homebrew" | "standalone";
-
-const WINDOWS_EXECUTABLE_NAME = `${EXECUTABLE_NAME.toLowerCase()}.exe`;
-
-const getExecutablePaths = (): {
-  execPath: string;
-  realExecPath: string;
-  scriptPath: string;
-} => {
-  const execPath = process.execPath;
-  const scriptPath = process.argv[1] ?? "";
-
-  try {
-    return {
-      execPath,
-      realExecPath: fs.realpathSync.native(execPath),
-      scriptPath,
-    };
-  } catch (_error) {
-    return {
-      execPath,
-      realExecPath: execPath,
-      scriptPath,
-    };
-  }
-};
-
-const isExecutableName = (candidatePath: string): boolean => {
-  const basename = path.basename(candidatePath).toLowerCase();
-  return (
-    basename === EXECUTABLE_NAME.toLowerCase() ||
-    basename === WINDOWS_EXECUTABLE_NAME
-  );
-};
-
-const isHomebrewManagedPath = (candidatePath: string): boolean => {
-  return (
-    candidatePath.includes("/opt/homebrew/") ||
-    candidatePath.includes("/usr/local/Cellar/") ||
-    candidatePath.includes("/home/linuxbrew/.linuxbrew/") ||
-    candidatePath.includes("/linuxbrew/.linuxbrew/")
-  );
-};
-
-/**
- * Check if the CLI was installed via npm
- */
-const isInstalledViaNpm = (): boolean => {
-  try {
-    const { scriptPath } = getExecutablePaths();
-
-    if (
-      scriptPath.includes("node_modules") &&
-      scriptPath.includes(NPM_PACKAGE_NAME)
-    ) {
-      return true;
-    }
-
-    if (
-      scriptPath.includes("/usr/local/lib/node_modules/") ||
-      scriptPath.includes("/opt/homebrew/lib/node_modules/") ||
-      scriptPath.includes("/.npm-global/") ||
-      scriptPath.includes("/node_modules/.bin/") ||
-      scriptPath.includes("/.nvm/versions/node/")
-    ) {
-      return true;
-    }
-
-    return false;
-  } catch (_e) {
-    return false;
-  }
-};
-
-/**
- * Check if the CLI was installed via Homebrew
- */
-const isInstalledViaHomebrew = (): boolean => {
-  try {
-    const { execPath, realExecPath, scriptPath } = getExecutablePaths();
-    const runtimeCandidates = [execPath, realExecPath].filter(isExecutableName);
-
-    return [scriptPath, ...runtimeCandidates].some(isHomebrewManagedPath);
-  } catch (_e) {
-    return false;
-  }
-};
-
-/**
- * Check if the CLI was installed via install script or native binary download
- */
-const isInstalledViaStandaloneBinary = (): boolean => {
-  if (isInstalledViaNpm() || isInstalledViaHomebrew()) {
-    return false;
-  }
-
-  try {
-    const { execPath, realExecPath } = getExecutablePaths();
-    return [execPath, realExecPath].some(isExecutableName);
-  } catch (_e) {
-    return false;
-  }
-};
-
-const detectInstallationMethod = (): InstallationMethod | null => {
-  if (isInstalledViaNpm()) {
-    return "npm";
-  }
-
-  if (isInstalledViaHomebrew()) {
-    return "homebrew";
-  }
-
-  if (isInstalledViaStandaloneBinary()) {
-    return "standalone";
-  }
-
-  return null;
-};
 
 const getStandaloneBinaryArtifactName = (): string => {
   const platform =
@@ -169,7 +51,7 @@ const getStandaloneBinaryArtifactName = (): string => {
 };
 
 const getStandaloneBinaryTargetPath = (): string => {
-  const { execPath } = getExecutablePaths();
+  const execPath = process.execPath;
 
   try {
     if (fs.lstatSync(execPath).isSymbolicLink()) {

--- a/templates/cli/lib/commands/update.ts
+++ b/templates/cli/lib/commands/update.ts
@@ -196,13 +196,10 @@ const quoteShellArgument = (value: string): string => {
 };
 
 const downloadStandaloneBinary = async (
-  latestVersion: string,
   destinationPath: string,
 ): Promise<void> => {
   const artifact = getStandaloneBinaryArtifactName();
-  const response = await fetch(
-    `${GITHUB_RELEASES_URL}/download/${latestVersion}/${artifact}`,
-  );
+  const response = await fetch(`${GITHUB_RELEASES_URL}/latest/download/${artifact}`);
 
   if (!response.ok) {
     throw new Error(
@@ -318,7 +315,7 @@ const updateViaStandaloneBinary = async (
     : path.join(os.tmpdir(), tempName);
 
   try {
-    await downloadStandaloneBinary(latestVersion, tempPath);
+    await downloadStandaloneBinary(tempPath);
 
     if (writableDirectory) {
       fs.renameSync(tempPath, targetPath);
@@ -374,7 +371,7 @@ const showManualInstructions = (latestVersion: string): void => {
 
       log(`${chalk.bold("Option 3: Install Script / Standalone Binary")}`);
       console.log(
-        `  curl -fsSL ${GITHUB_RELEASES_URL}/download/${latestVersion}/${artifact} -o ${tempPath}`,
+        `  curl -fsSL ${GITHUB_RELEASES_URL}/latest/download/${artifact} -o ${tempPath}`,
       );
       console.log(`  chmod +x ${tempPath}`);
       console.log(`  sudo mv -f ${tempPath} ${targetPath}`);
@@ -385,7 +382,7 @@ const showManualInstructions = (latestVersion: string): void => {
   }
 
   log(`${chalk.bold("Option 4: Download Binary")}`);
-  console.log(`  Visit: ${GITHUB_RELEASES_URL}/tag/${latestVersion}`);
+  console.log(`  Visit: ${GITHUB_RELEASES_URL}/latest`);
 };
 
 /**

--- a/templates/cli/lib/utils.ts
+++ b/templates/cli/lib/utils.ts
@@ -135,6 +135,15 @@ const isExecutableName = (candidatePath: string): boolean => {
   );
 };
 
+const isHomebrewManagedPath = (candidatePath: string): boolean => {
+  return (
+    candidatePath.includes("/opt/homebrew/") ||
+    candidatePath.includes("/usr/local/Cellar/") ||
+    candidatePath.includes("/home/linuxbrew/.linuxbrew/") ||
+    candidatePath.includes("/linuxbrew/.linuxbrew/")
+  );
+};
+
 const isInstalledViaNpm = (): boolean => {
   try {
     const { scriptPath } = getExecutablePaths();
@@ -165,15 +174,9 @@ const isInstalledViaNpm = (): boolean => {
 const isInstalledViaHomebrew = (): boolean => {
   try {
     const { execPath, realExecPath, scriptPath } = getExecutablePaths();
-    const candidates = [scriptPath, execPath, realExecPath];
+    const runtimeCandidates = [execPath, realExecPath].filter(isExecutableName);
 
-    return candidates.some(
-      (candidate) =>
-        candidate.includes("/opt/homebrew/") ||
-        candidate.includes("/usr/local/Cellar/") ||
-        candidate.includes("/home/linuxbrew/.linuxbrew/") ||
-        candidate.includes("/linuxbrew/.linuxbrew/"),
-    );
+    return [scriptPath, ...runtimeCandidates].some(isHomebrewManagedPath);
   } catch (_error) {
     return false;
   }
@@ -218,7 +221,9 @@ const normalizeHomebrewVersion = (version: string): string => {
   return version.split("_")[0].trim();
 };
 
-const getHomebrewLatestVersion = async (): Promise<string> => {
+const getHomebrewLatestVersion = async (
+  options: { timeoutMs?: number } = {},
+): Promise<string> => {
   try {
     const output = childProcess.execFileSync(
       "brew",
@@ -226,6 +231,7 @@ const getHomebrewLatestVersion = async (): Promise<string> => {
       {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
+        timeout: options.timeoutMs,
         env: {
           ...process.env,
           HOMEBREW_NO_AUTO_UPDATE: "1",
@@ -487,7 +493,7 @@ export async function getLatestVersionForInstallation(
 ): Promise<string> {
   switch (getLatestVersionSource(method)) {
     case "homebrew":
-      return getHomebrewLatestVersion();
+      return getHomebrewLatestVersion(options);
     case "npm":
     default:
       return getLatestVersion(options);

--- a/templates/cli/lib/utils.ts
+++ b/templates/cli/lib/utils.ts
@@ -9,6 +9,7 @@ import { globalConfig } from "./config.js";
 import type { SettingsType } from "./commands/config.js";
 import {
   NPM_REGISTRY_URL,
+  NPM_PACKAGE_NAME,
   DEFAULT_ENDPOINT,
   EXECUTABLE_NAME,
   UPDATE_CHECK_INTERVAL_MS,
@@ -90,6 +91,163 @@ export const getErrorMessage = (error: unknown): string => {
   return String(error);
 };
 
+export type InstallationMethod = "npm" | "homebrew" | "standalone";
+type LatestVersionSource = "npm" | "homebrew";
+type HomebrewInfoResponse = {
+  formulae?: Array<{
+    versions?: {
+      stable?: string;
+    };
+  }>;
+};
+
+const WINDOWS_EXECUTABLE_NAME = `${EXECUTABLE_NAME.toLowerCase()}.exe`;
+const HOMEBREW_FORMULA_NAME = EXECUTABLE_NAME.toLowerCase();
+
+const getExecutablePaths = (): {
+  execPath: string;
+  realExecPath: string;
+  scriptPath: string;
+} => {
+  const execPath = process.execPath;
+  const scriptPath = process.argv[1] ?? "";
+
+  try {
+    return {
+      execPath,
+      realExecPath: fs.realpathSync.native(execPath),
+      scriptPath,
+    };
+  } catch (_error) {
+    return {
+      execPath,
+      realExecPath: execPath,
+      scriptPath,
+    };
+  }
+};
+
+const isExecutableName = (candidatePath: string): boolean => {
+  const basename = path.basename(candidatePath).toLowerCase();
+  return (
+    basename === EXECUTABLE_NAME.toLowerCase() ||
+    basename === WINDOWS_EXECUTABLE_NAME
+  );
+};
+
+const isInstalledViaNpm = (): boolean => {
+  try {
+    const { scriptPath } = getExecutablePaths();
+
+    if (
+      scriptPath.includes("node_modules") &&
+      scriptPath.includes(NPM_PACKAGE_NAME)
+    ) {
+      return true;
+    }
+
+    if (
+      scriptPath.includes("/usr/local/lib/node_modules/") ||
+      scriptPath.includes("/opt/homebrew/lib/node_modules/") ||
+      scriptPath.includes("/.npm-global/") ||
+      scriptPath.includes("/node_modules/.bin/") ||
+      scriptPath.includes("/.nvm/versions/node/")
+    ) {
+      return true;
+    }
+
+    return false;
+  } catch (_error) {
+    return false;
+  }
+};
+
+const isInstalledViaHomebrew = (): boolean => {
+  try {
+    const { execPath, realExecPath, scriptPath } = getExecutablePaths();
+    const candidates = [scriptPath, execPath, realExecPath];
+
+    return candidates.some(
+      (candidate) =>
+        candidate.includes("/opt/homebrew/") ||
+        candidate.includes("/usr/local/Cellar/") ||
+        candidate.includes("/home/linuxbrew/.linuxbrew/") ||
+        candidate.includes("/linuxbrew/.linuxbrew/"),
+    );
+  } catch (_error) {
+    return false;
+  }
+};
+
+const isInstalledViaStandaloneBinary = (): boolean => {
+  if (isInstalledViaNpm() || isInstalledViaHomebrew()) {
+    return false;
+  }
+
+  try {
+    const { execPath, realExecPath } = getExecutablePaths();
+    return [execPath, realExecPath].some(isExecutableName);
+  } catch (_error) {
+    return false;
+  }
+};
+
+export const detectInstallationMethod = (): InstallationMethod | null => {
+  if (isInstalledViaNpm()) {
+    return "npm";
+  }
+
+  if (isInstalledViaHomebrew()) {
+    return "homebrew";
+  }
+
+  if (isInstalledViaStandaloneBinary()) {
+    return "standalone";
+  }
+
+  return null;
+};
+
+const getLatestVersionSource = (
+  method: InstallationMethod | null = detectInstallationMethod(),
+): LatestVersionSource => {
+  return method === "homebrew" ? "homebrew" : "npm";
+};
+
+const normalizeHomebrewVersion = (version: string): string => {
+  return version.split("_")[0].trim();
+};
+
+const getHomebrewLatestVersion = async (): Promise<string> => {
+  try {
+    const output = childProcess.execFileSync(
+      "brew",
+      ["info", "--json=v2", HOMEBREW_FORMULA_NAME],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...process.env,
+          HOMEBREW_NO_AUTO_UPDATE: "1",
+        },
+      },
+    );
+
+    const parsed = JSON.parse(output) as HomebrewInfoResponse;
+    const stableVersion = parsed.formulae?.[0]?.versions?.stable;
+
+    if (typeof stableVersion !== "string" || stableVersion.trim() === "") {
+      throw new Error("Homebrew did not return a stable formula version.");
+    }
+
+    return normalizeHomebrewVersion(stableVersion);
+  } catch (error) {
+    throw new Error(
+      `Failed to fetch latest Homebrew version: ${getErrorMessage(error)}`,
+    );
+  }
+};
+
 const isCloudHostname = (hostname: string): boolean =>
   hostname === "cloud.appwrite.io" || hostname.endsWith(".cloud.appwrite.io");
 
@@ -157,6 +315,7 @@ type UpdateCheckCache = {
   notifiedAt?: string;
   checkedOn?: string;
   notifiedOn?: string;
+  source?: LatestVersionSource;
 };
 
 const UPDATE_CHECK_FILE_NAME = "update-check.json";
@@ -234,6 +393,10 @@ const readUpdateCheckCache = (): UpdateCheckCache | null => {
         typeof parsed.notifiedAt === "string"
           ? parsed.notifiedAt
           : normalizeLegacyDate(parsed.notifiedOn),
+      source:
+        parsed.source === "npm" || parsed.source === "homebrew"
+          ? parsed.source
+          : undefined,
     };
   } catch (_error) {
     return null;
@@ -261,18 +424,36 @@ const tryWriteUpdateCheckCache = (cache: UpdateCheckCache): void => {
   }
 };
 
+const getCacheForVersionSource = (
+  cache: UpdateCheckCache | null,
+  source: LatestVersionSource,
+): UpdateCheckCache | null => {
+  if (!cache) {
+    return null;
+  }
+
+  if (typeof cache.source === "string") {
+    return cache.source === source ? cache : null;
+  }
+
+  // Legacy caches without a source were populated from npm.
+  return source === "npm" ? cache : null;
+};
+
 export const syncVersionCheckCache = (
   currentVersion: string,
   latestVersion: string,
 ): void => {
   const now = getCurrentTimestamp();
-  const existingCache = readUpdateCheckCache();
+  const source = getLatestVersionSource();
+  const existingCache = getCacheForVersionSource(readUpdateCheckCache(), source);
   const updateAvailable = compareVersions(currentVersion, latestVersion) > 0;
 
   tryWriteUpdateCheckCache({
     checkedAt: now,
     latestVersion,
     notifiedAt: updateAvailable ? now : existingCache?.notifiedAt,
+    source,
   });
 };
 
@@ -300,6 +481,25 @@ export async function getLatestVersion(
   }
 }
 
+export async function getLatestVersionForInstallation(
+  method: InstallationMethod | null,
+  options: { timeoutMs?: number } = {},
+): Promise<string> {
+  switch (getLatestVersionSource(method)) {
+    case "homebrew":
+      return getHomebrewLatestVersion();
+    case "npm":
+    default:
+      return getLatestVersion(options);
+  }
+}
+
+export async function getLatestVersionForCurrentInstallation(
+  options: { timeoutMs?: number } = {},
+): Promise<string> {
+  return getLatestVersionForInstallation(detectInstallationMethod(), options);
+}
+
 /**
  * Compare versions using semantic versioning
  */
@@ -322,7 +522,9 @@ export async function getCachedUpdateNotification(
   currentVersion: string,
 ): Promise<string | null> {
   const now = getCurrentTimestamp();
-  const cache = readUpdateCheckCache();
+  const installationMethod = detectInstallationMethod();
+  const source = getLatestVersionSource(installationMethod);
+  const cache = getCacheForVersionSource(readUpdateCheckCache(), source);
 
   if (isWithinUpdateInterval(cache?.checkedAt)) {
     if (!cache) {
@@ -346,9 +548,12 @@ export async function getCachedUpdateNotification(
   }
 
   try {
-    const latestVersion = await getLatestVersion({
-      timeoutMs: DEFAULT_UPDATE_CHECK_TIMEOUT_MS,
-    });
+    const latestVersion = await getLatestVersionForInstallation(
+      installationMethod,
+      {
+        timeoutMs: DEFAULT_UPDATE_CHECK_TIMEOUT_MS,
+      },
+    );
     const updateAvailable = compareVersions(currentVersion, latestVersion) > 0;
     const alreadyNotifiedRecently = isWithinUpdateInterval(cache?.notifiedAt);
 
@@ -357,6 +562,7 @@ export async function getCachedUpdateNotification(
       latestVersion,
       notifiedAt:
         updateAvailable && !alreadyNotifiedRecently ? now : cache?.notifiedAt,
+      source,
     });
 
     return updateAvailable && !alreadyNotifiedRecently ? latestVersion : null;


### PR DESCRIPTION
## Related
- N/A

## Summary
- detect the CLI installation method consistently through shared utilities and reuse that logic in `appwrite update`, cached update notices, and `--version` checks
- add a standalone/native binary self-update flow, but only when the running executable is actually the Appwrite CLI binary
- use Homebrew as the version source for Homebrew-installed CLI updates instead of npm, including timeout-aware background checks
- avoid GitHub tag-format assumptions by downloading standalone assets from `/releases/latest/download/...`

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ ] Workflow or CI update

## Testing
- `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php cli`
- `docker run --rm -v $(pwd):/app -w /app/examples/cli oven/bun:1.3 bun run build:types`
- `docker run --rm -v $(pwd):/app -w /app/examples/cli oven/bun:1.3 bun run build:cli`

## Risk
- Windows standalone installs still fall back to manual instructions
- Homebrew-aware update checks depend on local `brew info --json=v2` output and availability
