### PR TITLE
Fix malformed team membership REST example

### DIFF
--- a/src/SDK/Language/REST.php
+++ b/src/SDK/Language/REST.php
@@ -2,6 +2,8 @@
 
 namespace Appwrite\SDK\Language;
 
+use Twig\TwigFunction;
+
 class REST extends HTTP
 {
     /**
@@ -147,5 +149,35 @@ class REST extends HTTP
             'template'      => '/rest/docs/example.md.twig',
           ],
         ];
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('restExampleBodyParameters', function (array $service, array $method): array {
+                return $this->getExampleBodyParameters($service, $method);
+            }),
+        ];
+    }
+
+    /**
+     * Keep the team membership REST example focused on the copy-pasteable
+     * invite-by-email flow. The docs pipeline derives cURL snippets from this
+     * output and trims placeholder-only alternatives later on.
+     */
+    public function getExampleBodyParameters(array $service, array $method): array
+    {
+        $parameters = $method['parameters']['body'] ?? [];
+
+        if (($service['name'] ?? null) !== 'teams' || ($method['name'] ?? null) !== 'createMembership') {
+            return $parameters;
+        }
+
+        $preferred = ['email', 'roles', 'url'];
+        $filtered = \array_values(\array_filter($parameters, function (array $parameter) use ($preferred): bool {
+            return \in_array($parameter['name'] ?? null, $preferred, true);
+        }));
+
+        return empty($filtered) ? $parameters : $filtered;
     }
 }

--- a/templates/rest/docs/example.md.twig
+++ b/templates/rest/docs/example.md.twig
@@ -15,10 +15,11 @@ Host: {{ spec.host }}
 {% endfor %}
 {% for key, header in method.headers %}
 {% if header == 'application/json' %}
+{% set bodyParameters = restExampleBodyParameters(service, method) %}
 
-{% if method.parameters.body %}
+{% if bodyParameters %}
 {
-{% for parameter in method.parameters.body %}
+{% for parameter in bodyParameters %}
   "{{ parameter.name }}": {{ parameter | paramExample }}{% if not loop.last %},{% endif ~%}
 {% endfor %}
 }

--- a/tests/RESTExamplesTest.php
+++ b/tests/RESTExamplesTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests;
+
+use Appwrite\SDK\Language\REST;
+use PHPUnit\Framework\TestCase;
+
+class RESTExamplesTest extends TestCase
+{
+    public function testCreateMembershipExampleUsesStableBodyParameters(): void
+    {
+        $language = new REST();
+        $service = ['name' => 'teams'];
+        $method = [
+            'name' => 'createMembership',
+            'parameters' => [
+                'body' => [
+                    ['name' => 'email'],
+                    ['name' => 'userId'],
+                    ['name' => 'phone'],
+                    ['name' => 'roles'],
+                    ['name' => 'url'],
+                    ['name' => 'name'],
+                ],
+            ],
+        ];
+
+        $parameters = $language->getExampleBodyParameters($service, $method);
+
+        $this->assertSame(['email', 'roles', 'url'], \array_column($parameters, 'name'));
+    }
+
+    public function testOtherMethodsKeepTheirOriginalBodyParameters(): void
+    {
+        $language = new REST();
+        $service = ['name' => 'teams'];
+        $method = [
+            'name' => 'updateMembership',
+            'parameters' => [
+                'body' => [
+                    ['name' => 'roles'],
+                    ['name' => 'name'],
+                ],
+            ],
+        ];
+
+        $parameters = $language->getExampleBodyParameters($service, $method);
+
+        $this->assertSame(['roles', 'name'], \array_column($parameters, 'name'));
+    }
+}


### PR DESCRIPTION
## Summary
- fix the REST example generation for `teams.createMembership` so it emits the copy-pasteable invite-by-email payload from CLO-4199
- route the REST example template through a small body-parameter selector instead of changing broader request example behavior
- add a focused regression test for the membership example and a control test for non-membership methods

## Why
The docs pipeline derives the public cURL snippet from the generated REST example.

Before this change, the generated REST payload for `POST /teams/{teamId}/memberships` included additional optional fields after `url`:
- `userId`
- `phone`
- `name`

The downstream docs rendering trims those extra fields for the membership invite example, which can leave the visible cURL body ending in a trailing comma after `url`.

This change keeps the generator output aligned with the intended invite-by-email flow from the issue so the derived cURL stays valid JSON.

Linear issue: https://linear.app/appwrite/issue/CLO-4199/fix-malformed-memberships-curl-example-generated-by-sdk-generator

## Before
### Generated REST example
```http
POST /v1/teams/{teamId}/memberships HTTP/1.1
Host: cloud.appwrite.io
Content-Type: application/json
X-Appwrite-Response-Format: 1.9.1
X-Appwrite-Project: <YOUR_PROJECT_ID>
X-Appwrite-Key: <YOUR_API_KEY>
X-Appwrite-JWT: <YOUR_JWT>

{
  "email": "email@example.com",
  "userId": "<USER_ID>",
  "phone": "+12065550100",
  "roles": [],
  "url": "https://example.com",
  "name": "<NAME>"
}
```

### Visible cURL symptom in docs
```bash
curl -X POST https://appwrite.XXXX/v1/teams/XXXXX/memberships \
     -H "Content-Type: application/json" \
     -H "X-Appwrite-Response-Format: 1.9.0" \
     -H "X-Appwrite-Project: XXXXX" \
     -H "X-Appwrite-JWT: XXXXXXX" \
     -d '{
           "email": "igor@XXX",
           "roles": ["member"],
           "url": "https://example.com",
         }' -s | jq
```

## After
### Generated REST example
```http
POST /v1/teams/{teamId}/memberships HTTP/1.1
Host: cloud.appwrite.io
Content-Type: application/json
X-Appwrite-Response-Format: 1.9.1
X-Appwrite-Project: <YOUR_PROJECT_ID>
X-Appwrite-Key: <YOUR_API_KEY>
X-Appwrite-JWT: <YOUR_JWT>

{
  "email": "email@example.com",
  "roles": [],
  "url": "https://example.com"
}
```

### Expected cURL body after docs conversion
```bash
curl -X POST https://appwrite.XXXX/v1/teams/XXXXX/memberships \
     -H "Content-Type: application/json" \
     -H "X-Appwrite-Response-Format: 1.9.0" \
     -H "X-Appwrite-Project: XXXXX" \
     -H "X-Appwrite-JWT: XXXXXXX" \
     -d '{
           "email": "igor@XXX",
           "roles": ["member"],
           "url": "https://example.com"
         }' -s | jq
```

## Diff in generated example
```diff
 {
   "email": "email@example.com",
-  "userId": "<USER_ID>",
-  "phone": "+12065550100",
   "roles": [],
-  "url": "https://example.com",
-  "name": "<NAME>"
+  "url": "https://example.com"
 }
```

## Testing
- `php example.php rest`
- `vendor/bin/phpunit tests/RESTExamplesTest.php`
- `composer lint-twig`
