### PR TITLE
Add Rust docs example generation

### DIFF
--- a/src/SDK/Language/Rust.php
+++ b/src/SDK/Language/Rust.php
@@ -691,6 +691,24 @@ class Rust extends Language
         return $baseType;
     }
 
+    /**
+     * Snake-case using the same algorithm as the caseSnake Twig filter (SDK.php),
+     * so PHP-generated variable references match template-generated declarations.
+     */
+    protected function toCaseSnake(string $value): string
+    {
+        preg_match_all('!([A-Za-z][A-Z0-9]*(?=$|[A-Z][a-z0-9])|[A-Za-z][a-z0-9]+)!', $value, $matches);
+        $ret = $matches[0];
+
+        foreach ($ret as &$match) {
+            $match = $match == strtoupper($match)
+                ? strtolower($match)
+                : lcfirst($match);
+        }
+
+        return implode('_', $ret);
+    }
+
     protected function formatArrayItemExample(mixed $value, array $items = []): string
     {
         $itemType = $items["type"] ?? null;
@@ -715,7 +733,7 @@ class Rust extends Language
         $enumValues = $param["enumValues"] ?? [];
 
         if (empty($enumValues)) {
-            return "";
+            return $this->getParamExample($param);
         }
 
         $enumKeys = $param["enumKeys"] ?? [];
@@ -774,7 +792,7 @@ class Rust extends Language
     protected function getDocsArgumentExample(array $param, string $crateName): string
     {
         if (($param["type"] ?? "") === self::TYPE_FILE) {
-            $value = $this->toSnakeCase($param["name"] ?? "file");
+            $value = $this->toCaseSnake($param["name"] ?? "file");
 
             if (isset($this->getIdentifierOverrides()[$value])) {
                 $value = $this->getIdentifierOverrides()[$value];

--- a/src/SDK/Language/Rust.php
+++ b/src/SDK/Language/Rust.php
@@ -578,9 +578,6 @@ class Rust extends Language
             new TwigFilter("caseEnumKey", function (string $value) {
                 return $this->toPascalCase($value);
             }),
-            new TwigFilter("enumExample", function (array $param, string $prefix = "") {
-                return $this->getEnumExample($param, $prefix);
-            }, ["is_safe" => ["html"]]),
             new TwigFilter("docsArgumentExample", function (array $param, string $crateName) {
                 return $this->getDocsArgumentExample($param, $crateName);
             }, ["is_safe" => ["html"]]),

--- a/src/SDK/Language/Rust.php
+++ b/src/SDK/Language/Rust.php
@@ -153,6 +153,11 @@ class Rust extends Language
                 "template" => "rust/README.md.twig",
             ],
             [
+                "scope" => "method",
+                "destination" => "docs/examples/{{service.name | caseLower}}/{{method.name | caseKebab}}.md",
+                "template" => "rust/docs/example.md.twig",
+            ],
+            [
                 "scope" => "default",
                 "destination" => "CHANGELOG.md",
                 "template" => "rust/CHANGELOG.md.twig",
@@ -465,6 +470,32 @@ class Rust extends Language
                     $output .= "serde_json::json!({})";
                     break;
                 case self::TYPE_ARRAY:
+                    if (\is_string($example) && $this->isPermissionString($example)) {
+                        return $this->getPermissionExample($example);
+                    }
+
+                    $items = $param["items"] ?? $param["array"] ?? [];
+
+                    if (\is_string($example) && $example !== "") {
+                        $decoded = json_decode($example, true);
+
+                        if (\is_array($decoded)) {
+                            $formatted = array_map(
+                                fn ($value) => $this->formatArrayItemExample($value, $items),
+                                $decoded,
+                            );
+
+                            return "vec![" . implode(", ", $formatted) . "]";
+                        }
+                    } elseif (\is_array($example)) {
+                        $formatted = array_map(
+                            fn ($value) => $this->formatArrayItemExample($value, $items),
+                            $example,
+                        );
+
+                        return "vec![" . implode(", ", $formatted) . "]";
+                    }
+
                     if (preg_match('/^\[(.*)]$/s', $example, $match)) {
                         $example = $match[1];
                     }
@@ -477,6 +508,37 @@ class Rust extends Language
         }
 
         return $output;
+    }
+
+    public function getPermissionExample(string $example): string
+    {
+        $permissions = [];
+
+        foreach ($this->extractPermissionParts($example) as $permission) {
+            $action = $this->transformPermissionAction($permission["action"]);
+            $roleName = $this->transformPermissionRole($permission["role"]);
+            $roleId = $permission["id"] ?? null;
+            $innerRole = $permission["innerRole"] ?? null;
+
+            if ($roleId === null && str_contains($roleName, "/")) {
+                [$roleName, $innerRole] = explode("/", $roleName, 2);
+            }
+
+            $roleExpr = match ($roleName) {
+                "any" => "Role::any()",
+                "guests" => "Role::guests()",
+                "users" => "Role::users(" . ($innerRole !== null ? 'Some("' . addslashes($innerRole) . '")' : "None") . ")",
+                "user" => 'Role::user("' . addslashes((string)$roleId) . '", ' . ($innerRole !== null ? 'Some("' . addslashes($innerRole) . '")' : "None") . ")",
+                "team" => 'Role::team("' . addslashes((string)$roleId) . '", ' . ($innerRole !== null ? 'Some("' . addslashes($innerRole) . '")' : "None") . ")",
+                "member" => 'Role::member("' . addslashes((string)$roleId) . '")',
+                "label" => 'Role::label("' . addslashes((string)$roleId) . '")',
+                default => 'Role::from("' . addslashes($roleName) . '")',
+            };
+
+            $permissions[] = "Permission::{$action}({$roleExpr}).to_string()";
+        }
+
+        return $this->getArrayOf(implode(", ", $permissions));
     }
 
     /**
@@ -516,6 +578,12 @@ class Rust extends Language
             new TwigFilter("caseEnumKey", function (string $value) {
                 return $this->toPascalCase($value);
             }),
+            new TwigFilter("enumExample", function (array $param, string $prefix = "") {
+                return $this->getEnumExample($param, $prefix);
+            }, ["is_safe" => ["html"]]),
+            new TwigFilter("docsArgumentExample", function (array $param, string $crateName) {
+                return $this->getDocsArgumentExample($param, $crateName);
+            }, ["is_safe" => ["html"]]),
             new TwigFilter("inputType", function (
                 array $property,
                 array $spec = [],
@@ -621,6 +689,107 @@ class Rust extends Language
 
         // Default: return base type as-is
         return $baseType;
+    }
+
+    protected function formatArrayItemExample(mixed $value, array $items = []): string
+    {
+        $itemType = $items["type"] ?? null;
+
+        return match ($itemType) {
+            self::TYPE_INTEGER, self::TYPE_NUMBER => (string)$value,
+            self::TYPE_BOOLEAN => $value ? "true" : "false",
+            self::TYPE_OBJECT => "serde_json::json!(" . json_encode($value, JSON_UNESCAPED_SLASHES) . ")",
+            self::TYPE_STRING => '"' . addslashes((string)$value) . '"' . ".into()",
+            default => match (true) {
+                \is_string($value) => '"' . addslashes($value) . '"' . ".into()",
+                \is_bool($value) => $value ? "true" : "false",
+                \is_int($value), \is_float($value) => (string)$value,
+                \is_array($value) => "serde_json::json!(" . json_encode($value, JSON_UNESCAPED_SLASHES) . ")",
+                default => "serde_json::Value::Null",
+            },
+        };
+    }
+
+    protected function getEnumExample(array $param, string $prefix = ""): string
+    {
+        $enumValues = $param["enumValues"] ?? [];
+
+        if (empty($enumValues)) {
+            return "";
+        }
+
+        $enumKeys = $param["enumKeys"] ?? [];
+        $enumName = $this->toPascalCase($param["enumName"] ?? $param["name"] ?? "");
+        $example = $param["example"] ?? null;
+        $isArray = ($param["type"] ?? "") === self::TYPE_ARRAY;
+
+        $resolveKey = function ($value) use ($enumValues, $enumKeys) {
+            $index = array_search($value, $enumValues, true);
+
+            if ($index !== false && isset($enumKeys[$index]) && $enumKeys[$index] !== "") {
+                return $this->toPascalCase($enumKeys[$index]);
+            }
+
+            if ($index !== false && isset($enumValues[$index])) {
+                return $this->toPascalCase($enumValues[$index]);
+            }
+
+            $fallback = $enumKeys[0] ?? $enumValues[0] ?? $value;
+
+            return $this->toPascalCase((string)$fallback);
+        };
+
+        $enumPath = $prefix . $enumName . "::";
+
+        if ($isArray) {
+            $values = [];
+
+            if (\is_string($example) && $example !== "") {
+                $decoded = json_decode($example, true);
+
+                if (\is_array($decoded)) {
+                    $values = $decoded;
+                }
+            } elseif (\is_array($example)) {
+                $values = $example;
+            }
+
+            if (empty($values)) {
+                $values = [$enumValues[0]];
+            }
+
+            $items = array_map(
+                fn ($value) => $enumPath . $resolveKey($value),
+                $values,
+            );
+
+            return "vec![" . implode(", ", $items) . "]";
+        }
+
+        $value = ($example !== null && $example !== "") ? $example : $enumValues[0];
+
+        return $enumPath . $resolveKey($value);
+    }
+
+    protected function getDocsArgumentExample(array $param, string $crateName): string
+    {
+        if (($param["type"] ?? "") === self::TYPE_FILE) {
+            $value = $this->toSnakeCase($param["name"] ?? "file");
+
+            if (isset($this->getIdentifierOverrides()[$value])) {
+                $value = $this->getIdentifierOverrides()[$value];
+            }
+
+            return ($param["required"] ?? false) ? $value : "Some({$value})";
+        }
+
+        if (!empty($param["enumValues"]) || !empty($param["enumName"])) {
+            $value = $this->getEnumExample($param, $crateName . "::enums::");
+        } else {
+            $value = $this->getParamExample($param);
+        }
+
+        return ($param["required"] ?? false) ? $value : "Some({$value})";
     }
 
     /**

--- a/templates/rust/docs/example.md.twig
+++ b/templates/rust/docs/example.md.twig
@@ -1,0 +1,56 @@
+```rust
+{% set crateName = sdk.cratePackage | default('appwrite') | rustCrateName %}
+{% set hasFileParam = method.parameters.all | filter((param) => param.type == 'file') | length > 0 %}
+use {{ crateName }}::Client;
+use {{ crateName }}::services::{{ service.name | caseUcfirst }};
+{% if hasFileParam %}
+use {{ crateName }}::InputFile;
+{% endif %}
+{% if method.parameters.all | hasPermissionParam %}
+use {{ crateName }}::permission::Permission;
+use {{ crateName }}::role::Role;
+{% endif %}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new();
+    client.set_endpoint("{{ spec.endpointDocs | raw }}"); // Your API Endpoint
+{% for node in method.auth %}
+{% for key, header in node|keys %}
+    client.set_{{ header | caseSnake }}("{{ node[header]['x-appwrite']['demo'] | raw }}"); // {{ node[header].description }}
+{% endfor %}
+{% endfor %}
+
+    let {{ service.name | caseSnake }} = {{ service.name | caseUcfirst }}::new(&client);
+{% for parameter in method.parameters.all %}
+{% if parameter.type == 'file' %}
+
+    let {{ parameter.name | caseSnake | overrideIdentifier }} = InputFile::from_path("path/to/file.png", None).await?;
+{% endif %}
+{% endfor %}
+{% set resultType = method | returnType(spec, 'crate') | rustType %}
+
+{% if method.parameters.all | length == 0 %}
+    {% if resultType != 'crate::error::Result<()>' %}let result = {% endif %}{{ service.name | caseSnake }}.{{ method.name | caseSnake | overrideIdentifier }}().await?;
+{% else %}
+{% set arguments = [] %}
+{% for parameter in method.parameters.all %}
+{% set argument = parameter | docsArgumentExample(crateName) %}
+{% if not loop.last %}
+{% set argument = argument ~ ',' %}
+{% endif %}
+{% if not parameter.required %}
+{% set argument = argument ~ ' // optional' %}
+{% endif %}
+{% set arguments = arguments | merge([argument]) %}
+{% endfor %}
+    {% if resultType != 'crate::error::Result<()>' %}let result = {% endif %}{{ service.name | caseSnake }}.{{ method.name | caseSnake | overrideIdentifier }}(
+        {{ arguments | join("\n        ") | raw }}
+    ).await?;
+{% endif %}
+
+    {% if resultType != 'crate::error::Result<()>' %}let _ = result;
+
+    {% endif %}Ok(())
+}
+```


### PR DESCRIPTION
## Summary
- add method-scoped Rust docs example generation to the SDK generator
- add a Rust docs example template for `docs/examples/<service>/<method>.md`
- regenerate Rust example fixtures under `examples/rust/docs/examples`

## Generated examples
`examples/rust/docs/examples/account/create.md`
```rust
use appwrite::Client;
use appwrite::services::Account;

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let client = Client::new();
    client.set_endpoint("https://<REGION>.cloud.appwrite.io/v1"); // Your API Endpoint
    client.set_project("<YOUR_PROJECT_ID>"); // Your project ID

    let account = Account::new(&client);

    let result = account.create(
        "<USER_ID>",
        "email@example.com",
        "",
        Some("<NAME>") // optional
    ).await?;

    let _ = result;

    Ok(())
}
```

`examples/rust/docs/examples/storage/create-file.md`
```rust
use appwrite::Client;
use appwrite::services::Storage;
use appwrite::InputFile;
use appwrite::permission::Permission;
use appwrite::role::Role;

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let client = Client::new();
    client.set_endpoint("https://<REGION>.cloud.appwrite.io/v1"); // Your API Endpoint
    client.set_project("<YOUR_PROJECT_ID>"); // Your project ID

    let storage = Storage::new(&client);

    let file = InputFile::from_path("path/to/file.png", None).await?;

    let result = storage.create_file(
        "<BUCKET_ID>",
        "<FILE_ID>",
        file,
        Some(vec![Permission::read(Role::any()).to_string()]) // optional
    ).await?;

    let _ = result;

    Ok(())
}
```

`examples/rust/docs/examples/tablesdb/create-row.md`
```rust
use appwrite::Client;
use appwrite::services::TablesDB;
use appwrite::permission::Permission;
use appwrite::role::Role;

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let client = Client::new();
    client.set_endpoint("https://<REGION>.cloud.appwrite.io/v1"); // Your API Endpoint
    client.set_project("<YOUR_PROJECT_ID>"); // Your project ID

    let tables_db = TablesDB::new(&client);

    let result = tables_db.create_row(
        "<DATABASE_ID>",
        "<TABLE_ID>",
        "<ROW_ID>",
        serde_json::json!({}),
        Some(vec![Permission::read(Role::any()).to_string()]), // optional
        Some("<TRANSACTION_ID>") // optional
    ).await?;

    let _ = result;

    Ok(())
}
```

## Related
- CLO-4230
- https://linear.app/appwrite/issue/CLO-4230/sdk-generator-add-docs-example-generation-support-for-rust-sdk

## Testing
- `docker run --rm -v "$PWD":/app -w /app php:8.3-cli php example.php rust`
- `composer lint-twig`

## Notes
- full `vendor/bin/phpunit` was not completed because it runs the cross-SDK Docker-backed integration matrix, which is out of scope for this Rust docs-generation change
