### PR TITLE
Simplify CLI init project prompts and output

### DIFF
--- a/templates/cli/lib/commands/init.ts
+++ b/templates/cli/lib/commands/init.ts
@@ -94,6 +94,11 @@ interface InitProjectNextStep {
   description: string;
 }
 
+interface InitProjectStepOptions {
+  start: "new" | "existing";
+  autoPulled: boolean;
+}
+
 const extractSelectionId = (value: string): string => {
   const match = value.match(/\(([^()]+)\)$/);
   return match ? match[1] : value;
@@ -135,6 +140,83 @@ const printInitProjectNextSteps = (steps: InitProjectNextStep[]): void => {
       `    ${chalk.cyan(step.command)}${spacing}${step.description}`,
     );
   }
+};
+
+const getLocalInitProjectResourceState = () => {
+  const functions = localConfig.getFunctions();
+  const sites = localConfig.getSites();
+  const collections = localConfig.getCollections();
+  const tables = localConfig.getTables();
+  const buckets = localConfig.getBuckets();
+  const teams = localConfig.getTeams();
+  const webhooks = localConfig.getWebhooks();
+  const topics = localConfig.getMessagingTopics();
+
+  return {
+    hasFunctions: functions.length > 0,
+    hasResources:
+      functions.length > 0 ||
+      sites.length > 0 ||
+      collections.length > 0 ||
+      tables.length > 0 ||
+      buckets.length > 0 ||
+      teams.length > 0 ||
+      webhooks.length > 0 ||
+      topics.length > 0,
+  };
+};
+
+const getInitProjectNextSteps = ({
+  start,
+  autoPulled,
+}: InitProjectStepOptions): InitProjectNextStep[] => {
+  const { hasFunctions, hasResources } = getLocalInitProjectResourceState();
+  const nextSteps: InitProjectNextStep[] = [];
+
+  if (start === "existing" && !autoPulled) {
+    nextSteps.push(
+      {
+        command: `${EXECUTABLE_NAME} pull`,
+        description: "Choose a resource to sync",
+      },
+      {
+        command: `${EXECUTABLE_NAME} init`,
+        description: "Create a new resource",
+      },
+    );
+
+    return nextSteps;
+  }
+
+  if (start === "new") {
+    nextSteps.push({
+      command: `${EXECUTABLE_NAME} init`,
+      description: "Create your first resource",
+    });
+
+    return nextSteps;
+  }
+
+  nextSteps.push({
+    command: `${EXECUTABLE_NAME} init`,
+    description: "Create another resource",
+  });
+
+  if (hasFunctions) {
+    nextSteps.push({
+      command: `${EXECUTABLE_NAME} run function`,
+      description: "Run a pulled function locally",
+    });
+  }
+
+  if (hasResources) {
+    nextSteps.push({
+      command: `${EXECUTABLE_NAME} push`,
+      description: "Deploy your local edits",
+    });
+  }
+
+  return nextSteps;
 };
 
 const installInitProjectSkills = async (): Promise<void> => {
@@ -344,25 +426,10 @@ const initProject = async ({
     await installInitProjectSkills();
   }
 
-  const nextSteps: InitProjectNextStep[] = [];
-
-  if (answers.start === "existing" && !autoPulled) {
-    nextSteps.push({
-      command: `${EXECUTABLE_NAME} pull all`,
-      description: "Sync existing resources",
-    });
-  }
-
-  nextSteps.push(
-    {
-      command: `${EXECUTABLE_NAME} init`,
-      description: "Create new resources",
-    },
-    {
-      command: `${EXECUTABLE_NAME} push`,
-      description: "Deploy local changes",
-    },
-  );
+  const nextSteps = getInitProjectNextSteps({
+    start: answers.start,
+    autoPulled,
+  });
 
   printInitProjectNextSteps(nextSteps);
 };

--- a/templates/cli/lib/commands/init.ts
+++ b/templates/cli/lib/commands/init.ts
@@ -3,6 +3,7 @@ import path from "path";
 import childProcess from "child_process";
 import { Command } from "commander";
 import inquirer from "inquirer";
+import chalk from "chalk";
 import { getProjectsService, getSitesService } from "../services.js";
 import { pullResources } from "./pull.js";
 import ID from "../id.js";
@@ -88,6 +89,48 @@ interface SiteTemplateDetails {
   variables?: SiteTemplateVariable[];
 }
 
+interface InitProjectNextStep {
+  command: string;
+  description: string;
+}
+
+const getExistingProjectSummary = async (
+  projectId: string,
+): Promise<ExistingProjectSummary> => {
+  const projectsService = await getProjectsService();
+  const project = await projectsService.get(projectId);
+
+  return {
+    $id: project.$id,
+    name: project.name,
+    region: project.region || "",
+  };
+};
+
+const printInitProjectSuccess = (message: string): void => {
+  console.log(`${chalk.green.bold("✓")} ${chalk.green(message)}`);
+};
+
+const printInitProjectNextSteps = (steps: InitProjectNextStep[]): void => {
+  if (steps.length === 0) {
+    return;
+  }
+
+  const longestCommand = steps.reduce(
+    (longest, step) => Math.max(longest, step.command.length),
+    0,
+  );
+
+  console.log("");
+  console.log("  Next steps:");
+
+  for (const step of steps) {
+    console.log(
+      `    ${chalk.cyan(step.command.padEnd(longestCommand + 4))}${step.description}`,
+    );
+  }
+};
+
 const initResources = async (): Promise<void> => {
   const actions: Record<string, InitResourceAction> = {
     function: initFunction,
@@ -160,10 +203,7 @@ const initProject = async ({
     };
 
     try {
-      const projectsService = await getProjectsService();
-      const existingProject: ExistingProjectSummary =
-        await projectsService.get(selectedProjectId);
-      answers.project = existingProject;
+      answers.project = await getExistingProjectSummary(selectedProjectId);
     } catch (e) {
       if (e instanceof AppwriteException && e.code === 404) {
         answers = {
@@ -176,6 +216,10 @@ const initProject = async ({
         throw e;
       }
     }
+  }
+
+  if (answers.start === "existing" && typeof answers.project === "string") {
+    answers.project = await getExistingProjectSummary(answers.project);
   }
 
   localConfig.clear(); // Clear the config to avoid any conflicts
@@ -238,43 +282,36 @@ const initProject = async ({
     }
   }
 
-  success(
-    `Project successfully ${answers.start === "existing" ? "linked" : "created"}. Details are now stored in appwrite.config.json file.`,
+  printInitProjectSuccess(
+    `Project ${answers.start === "existing" ? "linked" : "created"} → appwrite.config.json`,
   );
 
+  let autoPulled = false;
   if (answers.start === "existing") {
     const autopullAnswers: InitProjectAutopullAnswer = await inquirer.prompt(
       questionsInitProjectAutopull,
     );
     if (autopullAnswers.autopull) {
+      autoPulled = true;
       cliConfig.all = true;
       cliConfig.force = true;
       await pullResources({
         skipDeprecated: true,
       });
-    } else {
-      log(
-        `You can run '${EXECUTABLE_NAME} pull all' to synchronize all of your existing resources.`,
-      );
     }
   }
-
-  hint(
-    `Next you can use '${EXECUTABLE_NAME} init' to create resources in your project, or use '${EXECUTABLE_NAME} pull' and '${EXECUTABLE_NAME} push' to synchronize your project.`,
-  );
 
   if (!hasSkillsInstalled(localConfig.configDirectoryPath)) {
     try {
       const skillsCwd = localConfig.configDirectoryPath;
-      log("Setting up Appwrite agent skills ...");
       const { skills, tempDir } = fetchAvailableSkills();
       try {
         const detected = detectProjectSkills(skillsCwd, skills);
         if (detected.length > 0) {
           const names = detected.map((s) => s.dirName);
           placeSkills(skillsCwd, tempDir, names, [".agents", ".claude"], true);
-          success(
-            `Installed ${names.length} agent skill${names.length === 1 ? "" : "s"} based on your project: ${detected.map((s) => s.name).join(", ")}`,
+          printInitProjectSuccess(
+            `Installed ${names.length} agent skill${names.length === 1 ? "" : "s"}: ${detected.map((s) => s.name).join(", ")}`,
           );
         }
       } finally {
@@ -286,6 +323,28 @@ const initProject = async ({
       hint(`You can install them later with '${EXECUTABLE_NAME} init skill'.`);
     }
   }
+
+  const nextSteps: InitProjectNextStep[] = [];
+
+  if (answers.start === "existing" && !autoPulled) {
+    nextSteps.push({
+      command: `${EXECUTABLE_NAME} pull all`,
+      description: "Sync existing resources",
+    });
+  }
+
+  nextSteps.push(
+    {
+      command: `${EXECUTABLE_NAME} init`,
+      description: "Create new resources",
+    },
+    {
+      command: `${EXECUTABLE_NAME} push`,
+      description: "Deploy local changes",
+    },
+  );
+
+  printInitProjectNextSteps(nextSteps);
 };
 
 const initBucket = async (): Promise<void> => {

--- a/templates/cli/lib/commands/init.ts
+++ b/templates/cli/lib/commands/init.ts
@@ -125,8 +125,9 @@ const printInitProjectNextSteps = (steps: InitProjectNextStep[]): void => {
   console.log("  Next steps:");
 
   for (const step of steps) {
+    const spacing = " ".repeat(longestCommand - step.command.length + 4);
     console.log(
-      `    ${chalk.cyan(step.command.padEnd(longestCommand + 4))}${step.description}`,
+      `    ${chalk.cyan(step.command)}${spacing}${step.description}`,
     );
   }
 };

--- a/templates/cli/lib/commands/init.ts
+++ b/templates/cli/lib/commands/init.ts
@@ -94,11 +94,16 @@ interface InitProjectNextStep {
   description: string;
 }
 
+const extractSelectionId = (value: string): string => {
+  const match = value.match(/\(([^()]+)\)$/);
+  return match ? match[1] : value;
+};
+
 const getExistingProjectSummary = async (
   projectId: string,
 ): Promise<ExistingProjectSummary> => {
   const projectsService = await getProjectsService();
-  const project = await projectsService.get(projectId);
+  const project = await projectsService.get(extractSelectionId(projectId));
 
   return {
     $id: project.$id,
@@ -188,6 +193,9 @@ const initProject = async ({
       log("No changes made. Existing project configuration was kept.");
       return;
     }
+    if (typeof answers.organization === "string") {
+      answers.organization = extractSelectionId(answers.organization);
+    }
   } else {
     const selectedOrganization =
       organizationId ??
@@ -197,10 +205,12 @@ const initProject = async ({
     const selectedProjectId =
       projectId ?? (await inquirer.prompt([questionsInitProject[4]])).id;
 
+    const normalizedOrganization = extractSelectionId(selectedOrganization);
+
     answers = {
       start: "existing",
       project: selectedProjectId,
-      organization: selectedOrganization,
+      organization: normalizedOrganization,
     };
 
     try {
@@ -288,6 +298,7 @@ const initProject = async ({
     const autopullAnswers: InitProjectAutopullAnswer = await inquirer.prompt(
       questionsInitProjectAutopull,
     );
+    console.log("");
     printInitProjectSuccess("Project linked → appwrite.config.json");
     if (autopullAnswers.autopull) {
       autoPulled = true;
@@ -298,6 +309,7 @@ const initProject = async ({
       });
     }
   } else {
+    console.log("");
     printInitProjectSuccess("Project created → appwrite.config.json");
   }
 

--- a/templates/cli/lib/commands/init.ts
+++ b/templates/cli/lib/commands/init.ts
@@ -139,6 +139,7 @@ const printInitProjectNextSteps = (steps: InitProjectNextStep[]): void => {
 
 const installInitProjectSkills = async (): Promise<void> => {
   if (hasSkillsInstalled(localConfig.configDirectoryPath)) {
+    log("Agent skills already found. Skipping installation.");
     return;
   }
 

--- a/templates/cli/lib/commands/init.ts
+++ b/templates/cli/lib/commands/init.ts
@@ -301,6 +301,7 @@ const initProject = async ({
     console.log("");
     printInitProjectSuccess("Project linked → appwrite.config.json");
     if (autopullAnswers.autopull) {
+      console.log("");
       autoPulled = true;
       cliConfig.all = true;
       cliConfig.force = true;

--- a/templates/cli/lib/commands/init.ts
+++ b/templates/cli/lib/commands/init.ts
@@ -283,15 +283,12 @@ const initProject = async ({
     }
   }
 
-  printInitProjectSuccess(
-    `Project ${answers.start === "existing" ? "linked" : "created"} → appwrite.config.json`,
-  );
-
   let autoPulled = false;
   if (answers.start === "existing") {
     const autopullAnswers: InitProjectAutopullAnswer = await inquirer.prompt(
       questionsInitProjectAutopull,
     );
+    printInitProjectSuccess("Project linked → appwrite.config.json");
     if (autopullAnswers.autopull) {
       autoPulled = true;
       cliConfig.all = true;
@@ -300,6 +297,8 @@ const initProject = async ({
         skipDeprecated: true,
       });
     }
+  } else {
+    printInitProjectSuccess("Project created → appwrite.config.json");
   }
 
   if (!hasSkillsInstalled(localConfig.configDirectoryPath)) {

--- a/templates/cli/lib/commands/init.ts
+++ b/templates/cli/lib/commands/init.ts
@@ -263,7 +263,7 @@ const initProject = async ({
       answers.region,
     );
 
-    localConfig.setProject(response["$id"]);
+    localConfig.setProject(response["$id"], response.name ?? "");
     if (answers.region) {
       localConfig.setEndpoint(
         `https://${answers.region}.${url.host}${url.pathname}`,
@@ -284,7 +284,7 @@ const initProject = async ({
         break;
     }
 
-    localConfig.setProject(selectedProject.$id);
+    localConfig.setProject(selectedProject.$id, selectedProject.name ?? "");
 
     if (isCloud() && selectedProject.region) {
       localConfig.setEndpoint(

--- a/templates/cli/lib/commands/init.ts
+++ b/templates/cli/lib/commands/init.ts
@@ -137,6 +137,33 @@ const printInitProjectNextSteps = (steps: InitProjectNextStep[]): void => {
   }
 };
 
+const installInitProjectSkills = async (): Promise<void> => {
+  if (hasSkillsInstalled(localConfig.configDirectoryPath)) {
+    return;
+  }
+
+  try {
+    const skillsCwd = localConfig.configDirectoryPath;
+    const { skills, tempDir } = fetchAvailableSkills();
+    try {
+      const detected = detectProjectSkills(skillsCwd, skills);
+      if (detected.length > 0) {
+        const names = detected.map((s) => s.dirName);
+        placeSkills(skillsCwd, tempDir, names, [".agents", ".claude"], true);
+        printInitProjectSuccess(
+          `Installed ${names.length} agent skill${names.length === 1 ? "" : "s"}: ${detected.map((s) => s.name).join(", ")}`,
+        );
+      }
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    error(`Failed to install agent skills: ${msg}`);
+    hint(`You can install them later with '${EXECUTABLE_NAME} init skill'.`);
+  }
+};
+
 const initResources = async (): Promise<void> => {
   const actions: Record<string, InitResourceAction> = {
     function: initFunction,
@@ -300,6 +327,7 @@ const initProject = async ({
     );
     console.log("");
     printInitProjectSuccess("Project linked → appwrite.config.json");
+    await installInitProjectSkills();
     if (autopullAnswers.autopull) {
       console.log("");
       autoPulled = true;
@@ -312,29 +340,7 @@ const initProject = async ({
   } else {
     console.log("");
     printInitProjectSuccess("Project created → appwrite.config.json");
-  }
-
-  if (!hasSkillsInstalled(localConfig.configDirectoryPath)) {
-    try {
-      const skillsCwd = localConfig.configDirectoryPath;
-      const { skills, tempDir } = fetchAvailableSkills();
-      try {
-        const detected = detectProjectSkills(skillsCwd, skills);
-        if (detected.length > 0) {
-          const names = detected.map((s) => s.dirName);
-          placeSkills(skillsCwd, tempDir, names, [".agents", ".claude"], true);
-          printInitProjectSuccess(
-            `Installed ${names.length} agent skill${names.length === 1 ? "" : "s"}: ${detected.map((s) => s.name).join(", ")}`,
-          );
-        }
-      } finally {
-        fs.rmSync(tempDir, { recursive: true, force: true });
-      }
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      error(`Failed to install agent skills: ${msg}`);
-      hint(`You can install them later with '${EXECUTABLE_NAME} init skill'.`);
-    }
+    await installInitProjectSkills();
   }
 
   const nextSteps: InitProjectNextStep[] = [];

--- a/templates/cli/lib/constants.ts.twig
+++ b/templates/cli/lib/constants.ts.twig
@@ -39,6 +39,8 @@ export const CONFIG_RESOURCE_KEYS = [
   "buckets",
 {% elseif service.name == 'teams' %}
   "teams",
+{% elseif service.name == 'webhooks' %}
+  "webhooks",
 {% elseif service.name == 'messaging' %}
   "topics",
   "messages",

--- a/templates/cli/lib/questions.ts
+++ b/templates/cli/lib/questions.ts
@@ -65,6 +65,16 @@ const extractSelectionId = (value: string): string => {
   return match ? match[1] : value;
 };
 
+const getInitProjectOverrideMessage = (): string => {
+  const projectName = localConfig.getProject().projectName;
+
+  if (projectName) {
+    return `A project is already linked to this directory (${projectName}). Override?`;
+  }
+
+  return "A project is already linked to this directory. Override?";
+};
+
 const getIgnores = (runtime: string): string[] => {
   const language = runtime.split("-").slice(0, -1).join("-");
 
@@ -174,7 +184,7 @@ export const questionsInitProject: Question[] = [
   {
     type: "confirm",
     name: "override",
-    message: `An ${SDK_TITLE} project ( ${localConfig.getProject()["projectId"]} ) is already associated with the current directory. Would you like to override it?`,
+    message: getInitProjectOverrideMessage(),
     when() {
       return Object.keys(localConfig.getProject()).length !== 0;
     },

--- a/templates/cli/lib/questions.ts
+++ b/templates/cli/lib/questions.ts
@@ -57,6 +57,14 @@ const validateNonNegativeInteger = (value: string): boolean | string => {
   return true;
 };
 
+const buildSelectionLabel = (name: string, id: string): string =>
+  `${name} (${id})`;
+
+const extractSelectionId = (value: string): string => {
+  const match = value.match(/\(([^()]+)\)$/);
+  return match ? match[1] : value;
+};
+
 const getIgnores = (runtime: string): string[] => {
   const language = runtime.split("-").slice(0, -1).join("-");
 
@@ -214,9 +222,10 @@ export const questionsInitProject: Question[] = [
           );
 
       const choices = teams.map((team: any, _idx: number) => {
+        const label = buildSelectionLabel(team.name, team["$id"]);
         return {
-          name: `${team.name} (${team["$id"]})`,
-          value: team["$id"],
+          name: label,
+          value: label,
         };
       });
 
@@ -255,7 +264,7 @@ export const questionsInitProject: Question[] = [
         JSON.stringify({
           method: "equal",
           attribute: "teamId",
-          values: [answers.organization],
+          values: [extractSelectionId(answers.organization)],
         }),
         JSON.stringify({ method: "orderDesc", attribute: "$id" }),
       ];
@@ -270,11 +279,10 @@ export const questionsInitProject: Question[] = [
       );
 
       const choices = projects.map((project: any) => {
-        const label = `${project.name} (${project["$id"]})`;
+        const label = buildSelectionLabel(project.name, project["$id"]);
         return {
           name: label,
-          short: label,
-          value: project["$id"],
+          value: label,
         };
       });
 

--- a/templates/cli/lib/questions.ts
+++ b/templates/cli/lib/questions.ts
@@ -175,14 +175,14 @@ export const questionsInitProject: Question[] = [
     type: "list",
     name: "start",
     when: whenOverride,
-    message: "How would you like to start?",
+    message: "Select a setup method:",
     choices: [
       {
-        name: "Create new project",
+        name: "Create a new project",
         value: "new",
       },
       {
-        name: "Link directory to an existing project",
+        name: "Link this directory to an existing project",
         value: "existing",
       },
     ],
@@ -190,7 +190,7 @@ export const questionsInitProject: Question[] = [
   {
     type: "search-list",
     name: "organization",
-    message: "Choose your organization",
+    message: "Choose your organization:",
     choices: async () => {
       const client = await sdkForConsole(true);
       const { teams } = isCloud()
@@ -249,7 +249,7 @@ export const questionsInitProject: Question[] = [
   {
     type: "search-list",
     name: "project",
-    message: `Choose your ${SDK_TITLE} project.`,
+    message: "Choose your project:",
     choices: async (answers: Answers) => {
       const queries = [
         JSON.stringify({
@@ -274,10 +274,7 @@ export const questionsInitProject: Question[] = [
         return {
           name: label,
           short: label,
-          value: {
-            $id: project["$id"],
-            region: project.region || "",
-          },
+          value: project["$id"],
         };
       });
 
@@ -325,7 +322,7 @@ export const questionsInitProjectAutopull: Question[] = [
   {
     type: "confirm",
     name: "autopull",
-    message: `Would you like to pull all resources from the project you just linked?`,
+    message: "Pull all resources from this project?",
   },
 ];
 


### PR DESCRIPTION
## Summary
- simplify the `appwrite init project` prompts for the existing-project flow
- fix the project selector so it shows the selected project label instead of `[object Object]`
- replace the verbose post-init info/hint output with a compact success summary and next-steps block

## What Changed
- changed the setup prompt copy from `How would you like to start?` to `Select a setup method:`
- changed the existing-project option copy from `Link directory to an existing project` to `Link this directory to an existing project`
- changed the organization and project prompts to render clearer labels with colons
- changed the project selector to return a project ID string instead of an object, then re-fetch the project summary after selection so the CLI still has access to region metadata
- changed the autopull confirmation copy to `Pull all resources from this project?`
- replaced the long success/info/hint sequence with shorter success lines and a formatted `Next steps` section

## Before
Actual current output for the existing-project flow:

```console
$ appwrite init project
? How would you like to start? Link directory to an existing project
? Choose your organization 67610b8ee51f147ca943
? Choose your Appwrite project. [object Object]
✓ Success: Project successfully linked. Details are now stored in appwrite.config.json file.
? Would you like to pull all resources from the project you just linked? No
ℹ Info: You can run 'appwrite pull all' to synchronize all of your existing resources.
♥ Hint: Next you can use 'appwrite init' to create resources in your project, or use 'appwrite pull' and 'appwrite push' to synchronize your project.
ℹ Info: Setting up Appwrite agent skills ...
✓ Success: Installed 2 agent skills based on your project: appwrite-typescript, appwrite-cli
```

## After
Example output after this change. Organization and project names will vary based on the selected account data, but the prompt and summary structure will match this flow:

```console
$ appwrite init project
? Select a setup method: Link this directory to an existing project
? Choose your organization: My Organization (67610b8ee51f147ca943)
? Choose your project: My Cool App (abc123)
? Pull all resources from this project? No

✓ Project linked → appwrite.config.json
✓ Installed 2 agent skills: appwrite-typescript, appwrite-cli

  Next steps:
    appwrite pull all    Sync existing resources
    appwrite init        Create new resources
    appwrite push        Deploy local changes
```

## Testing
- `php example.php cli`
- `composer lint-twig`
- `bun install --frozen-lockfile` in `examples/cli`
- `bun run build` in `examples/cli`