### PR TITLE
Fix CLI deployment inactivity timeout and help usage name

### DIFF
--- a/templates/cli/cli.ts.twig
+++ b/templates/cli/cli.ts.twig
@@ -122,6 +122,7 @@ if (process.argv.includes('-v') || process.argv.includes('--version')) {
         await maybeShowUpdateNotice();
 
         program
+            .name('{{ language.params.executableName|caseLower }}')
             .description(commandDescriptions['main'])
             .configureHelp({
                 helpWidth: process.stdout.columns || 80,

--- a/templates/cli/lib/commands/push.ts
+++ b/templates/cli/lib/commands/push.ts
@@ -174,20 +174,15 @@ function getDeploymentProgressSignature(
 }
 
 function createDeploymentTimeoutTracker(
-  deployment?: Record<string, unknown>,
+  deployment: Record<string, unknown>,
 ): {
-  touch: (deployment?: Record<string, unknown>) => void;
+  touch: (deployment: Record<string, unknown>) => void;
   hasTimedOut: () => boolean;
 } {
   let lastActivityAt = Date.now();
   let lastSignature: string | null = null;
 
-  const touch = (nextDeployment?: Record<string, unknown>): void => {
-    if (!nextDeployment) {
-      lastActivityAt = Date.now();
-      return;
-    }
-
+  const touch = (nextDeployment: Record<string, unknown>): void => {
     const nextSignature = getDeploymentProgressSignature(nextDeployment);
     if (nextSignature === lastSignature) {
       return;

--- a/templates/cli/lib/commands/push.ts
+++ b/templates/cli/lib/commands/push.ts
@@ -147,6 +147,64 @@ function getDeploymentTimeoutErrorMessage(): string {
   return `Deployment got stuck for more than ${DEPLOYMENT_TIMEOUT_MINUTES} minutes`;
 }
 
+function getDeploymentProgressSignature(
+  deployment: Record<string, unknown>,
+): string {
+  const status =
+    typeof deployment["status"] === "string" ? deployment["status"] : "";
+  const buildLogs =
+    typeof deployment["buildLogs"] === "string"
+      ? deployment["buildLogs"]
+      : "";
+  const updatedAt =
+    typeof deployment["$updatedAt"] === "string"
+      ? deployment["$updatedAt"]
+      : "";
+  const { screenshotLight, screenshotDark } =
+    getSiteDeploymentScreenshots(deployment);
+
+  return JSON.stringify({
+    status,
+    updatedAt,
+    buildLogsLength: buildLogs.length,
+    buildLogsTail: buildLogs.slice(-200),
+    screenshotLight: screenshotLight ?? "",
+    screenshotDark: screenshotDark ?? "",
+  });
+}
+
+function createDeploymentTimeoutTracker(
+  deployment?: Record<string, unknown>,
+): {
+  touch: (deployment?: Record<string, unknown>) => void;
+  hasTimedOut: () => boolean;
+} {
+  let lastActivityAt = Date.now();
+  let lastSignature: string | null = null;
+
+  const touch = (nextDeployment?: Record<string, unknown>): void => {
+    if (!nextDeployment) {
+      lastActivityAt = Date.now();
+      return;
+    }
+
+    const nextSignature = getDeploymentProgressSignature(nextDeployment);
+    if (nextSignature === lastSignature) {
+      return;
+    }
+
+    lastSignature = nextSignature;
+    lastActivityAt = Date.now();
+  };
+
+  touch(deployment);
+
+  return {
+    touch,
+    hasTimedOut: () => Date.now() - lastActivityAt > DEPLOYMENT_TIMEOUT_MS,
+  };
+}
+
 async function getTerminalImage() {
   terminalImageModulePromise ??= import("terminal-image").then(
     (module) => module.default,
@@ -1555,6 +1613,8 @@ export class Push {
               deploymentId,
             );
             let waitingSince: number | null = null;
+            const deploymentTimeoutTracker =
+              createDeploymentTimeoutTracker(response);
             const deploymentLogPrinter = createDeploymentLogPrinter({
               label: `function:${func.name}`,
               showPrefix: functions.length > 1,
@@ -1567,6 +1627,7 @@ export class Push {
                     localConfig.getEndpoint() || globalConfig.getEndpoint(),
                   event: `functions.${func["$id"]}.deployments.${deploymentId}.update`,
                   onDeploymentUpdate: (deployment) => {
+                    deploymentTimeoutTracker.touch(deployment);
                     deploymentLogPrinter.ingest(deployment);
                   },
                   onClose: () => {
@@ -1602,10 +1663,8 @@ export class Push {
                 ),
               });
 
-              let timeoutDeadline = Date.now() + DEPLOYMENT_TIMEOUT_MS;
-
               while (true) {
-                if (Date.now() > timeoutDeadline) {
+                if (deploymentTimeoutTracker.hasTimedOut()) {
                   deploymentLogPrinter.complete();
                   failedDeployments.push({
                     name: func["name"],
@@ -1630,6 +1689,7 @@ export class Push {
                   functionId: func["$id"],
                   deploymentId: deploymentId,
                 });
+                deploymentTimeoutTracker.touch(response);
                 deploymentLogPrinter.ingest(response);
 
                 const status = response["status"];
@@ -2064,6 +2124,8 @@ export class Push {
             let waitingSince: number | null = null;
             let readyWithoutScreenshotsSince: number | null = null;
             let activationApplied = false;
+            const deploymentTimeoutTracker =
+              createDeploymentTimeoutTracker(response);
             const deploymentLogPrinter = createDeploymentLogPrinter({
               label: `site:${site.name}`,
               showPrefix: sites.length > 1,
@@ -2076,6 +2138,7 @@ export class Push {
                     localConfig.getEndpoint() || globalConfig.getEndpoint(),
                   event: `sites.${site["$id"]}.deployments.${deploymentId}.update`,
                   onDeploymentUpdate: (deployment) => {
+                    deploymentTimeoutTracker.touch(deployment);
                     deploymentLogPrinter.ingest(deployment);
                   },
                   onClose: () => {
@@ -2111,10 +2174,8 @@ export class Push {
                 ),
               });
 
-              let timeoutDeadline = Date.now() + DEPLOYMENT_TIMEOUT_MS;
-
               while (true) {
-                if (Date.now() > timeoutDeadline) {
+                if (deploymentTimeoutTracker.hasTimedOut()) {
                   deploymentLogPrinter.complete();
                   failedDeployments.push({
                     name: site["name"],
@@ -2139,6 +2200,7 @@ export class Push {
                   siteId: site["$id"],
                   deploymentId: deploymentId,
                 });
+                deploymentTimeoutTracker.touch(response);
                 deploymentLogPrinter.ingest(response);
 
                 const status = response["status"];
@@ -2176,11 +2238,6 @@ export class Push {
 
                   if (!screenshotsReady) {
                     readyWithoutScreenshotsSince ??= Date.now();
-                    timeoutDeadline = Math.max(
-                      timeoutDeadline,
-                      readyWithoutScreenshotsSince +
-                        SITE_SCREENSHOT_FINALIZATION_TIMEOUT_MS,
-                    );
 
                     if (
                       Date.now() - readyWithoutScreenshotsSince <


### PR DESCRIPTION
## Summary
- reset CLI deployment timeout checks based on deployment inactivity instead of total elapsed time, so active builds with realtime logs do not fail after 10 minutes
- preserve the existing site screenshot finalization flow while removing the old fixed deadline extension logic
- force Commander help usage to show `appwrite` for nested commands instead of the compiled binary basename

## Testing
- `docker run --rm -v "$PWD":/app -w /app php:8.3-cli php example.php cli`
- `cd examples/cli && bun run build:cli`
- `cd examples/cli && node dist/cli.cjs sites get-deployment --help`
- `composer lint-twig`
