### PR TITLE
Improve CLI runtime list rendering

### DIFF
--- a/templates/cli/lib/response-config.ts
+++ b/templates/cli/lib/response-config.ts
@@ -214,6 +214,20 @@ const InvoiceSummarySchema = createSummarySchema(
   "Expected an invoice summary row",
 );
 
+const RuntimeSummarySchema = createSummarySchema(
+  {
+    $id: z.string().nullable().optional(),
+    key: z.string().nullable().optional(),
+    name: z.string().nullable().optional(),
+    version: z.union([z.string(), z.number()]).nullable().optional(),
+    base: z.string().nullable().optional(),
+    image: z.string().nullable().optional(),
+    logo: z.string().nullable().optional(),
+  },
+  ["$id", "name", "version", "base", "image"],
+  "Expected a runtime summary row",
+);
+
 const paymentMethodLabel = (row: JsonObject): string => {
   const brand = valueFrom<string>(row, "brand") ?? "";
   const last4 = valueFrom<string>(row, "last4") ?? "";
@@ -264,10 +278,41 @@ const paymentMethodStatus = (row: JsonObject): string => {
   return "status: pending";
 };
 
+const runtimeLabel = (row: JsonObject): string => {
+  const name = compactText(valueFrom(row, "name"), "");
+  const key = compactText(valueFrom(row, "key"), "");
+  const version = valueFrom<string | number>(row, "version");
+  const runtimeName = name || (key ? toTitleCase(key) : "Runtime");
+
+  if (version == null || String(version).trim() === "") {
+    return runtimeName;
+  }
+
+  return `${runtimeName} ${version}`;
+};
+
 const structuredCollectionRenderers: Record<
   string,
   StructuredCollectionRenderer
 > = {
+  runtimes: createColumnRenderer(RuntimeSummarySchema, [
+    {
+      header: "runtime",
+      value: (row, context) => indexedLabel(runtimeLabel(row), context),
+    },
+    {
+      header: "id",
+      value: (row) => compactText(valueFrom(row, "$id")),
+    },
+    {
+      header: "base",
+      value: (row) => compactText(valueFrom(row, "base")),
+    },
+    {
+      header: "image",
+      value: (row) => compactText(valueFrom(row, "image")),
+    },
+  ]),
   identities: createColumnRenderer(IdentitySummarySchema, [
     {
       header: "identity",

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -223,6 +223,10 @@ abstract class Base extends TestCase
         'CLI_LOCAL_SOURCE_PREFLIGHT:passed',
     ];
 
+    protected const CLI_RUNTIME_RENDERING_RESPONSES = [
+        'CLI_RUNTIME_RENDERING:passed',
+    ];
+
     protected const CHANNEL_HELPER_RESPONSES = [
         'databases.db1.collections.col1.documents',
         'databases.db1.collections.col1.documents.doc1',

--- a/tests/CLIBun10Test.php
+++ b/tests/CLIBun10Test.php
@@ -32,6 +32,7 @@ class CLIBun10Test extends Base
         ...Base::UPLOAD_RESPONSES,
         ...Base::CLI_HEADERS_RESPONSES,
         ...Base::CLI_LOCAL_FUNCTION_EMULATION_RESPONSES,
+        ...Base::CLI_RUNTIME_RENDERING_RESPONSES,
         ...Base::CLI_TYPEGEN_RESPONSES,
     ];
 

--- a/tests/CLIBun11Test.php
+++ b/tests/CLIBun11Test.php
@@ -32,6 +32,7 @@ class CLIBun11Test extends Base
         ...Base::UPLOAD_RESPONSES,
         ...Base::CLI_HEADERS_RESPONSES,
         ...Base::CLI_LOCAL_FUNCTION_EMULATION_RESPONSES,
+        ...Base::CLI_RUNTIME_RENDERING_RESPONSES,
         ...Base::CLI_TYPEGEN_RESPONSES,
     ];
 

--- a/tests/CLIBun13Test.php
+++ b/tests/CLIBun13Test.php
@@ -32,6 +32,7 @@ class CLIBun13Test extends Base
         ...Base::UPLOAD_RESPONSES,
         ...Base::CLI_HEADERS_RESPONSES,
         ...Base::CLI_LOCAL_FUNCTION_EMULATION_RESPONSES,
+        ...Base::CLI_RUNTIME_RENDERING_RESPONSES,
         ...Base::CLI_TYPEGEN_RESPONSES,
     ];
 

--- a/tests/languages/cli/test.js
+++ b/tests/languages/cli/test.js
@@ -2,6 +2,7 @@ const { execSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const Client = require("./lib/client.ts").default;
+const { parse } = require("./lib/parser.ts");
 const {
   openRuntimesVersion,
   systemTools,
@@ -30,6 +31,37 @@ const extractFirstValue = (output) => {
   }
 
   return firstLine.trim();
+};
+
+const stripAnsi = (value) => value.replace(/\u001b\[[0-9;]*m/g, "");
+
+const captureStdout = (callback) => {
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  const originalConsoleLog = console.log.bind(console);
+  let output = "";
+
+  console.log = (...args) => {
+    output += `${args.join(" ")}\n`;
+  };
+
+  process.stdout.write = (chunk, encoding, cb) => {
+    output += Buffer.isBuffer(chunk) ? chunk.toString() : String(chunk);
+
+    if (typeof cb === "function") {
+      cb();
+    }
+
+    return true;
+  };
+
+  try {
+    callback();
+  } finally {
+    console.log = originalConsoleLog;
+    process.stdout.write = originalWrite;
+  }
+
+  return stripAnsi(output).replace(/\r/g, "");
 };
 
 execSync(
@@ -199,6 +231,88 @@ try {
   fs.rmSync(validSourceDir, { recursive: true, force: true });
 }
 console.log("CLI_LOCAL_SOURCE_PREFLIGHT:passed");
+
+const runtimeRenderingOutput = captureStdout(() =>
+  parse({
+    total: 4,
+    runtimes: [
+      {
+        $id: "node-16.0",
+        key: "node",
+        name: "Node.js",
+        version: "16.0",
+        base: "node:16.20.2-alpine3.18",
+        image: "openruntimes/node:v5-16.0",
+        logo: "node.png",
+      },
+      {
+        $id: "node-18.0",
+        key: "node",
+        name: "Node.js",
+        version: "18.0",
+        base: "node:18.20.4-alpine3.20",
+        image: "openruntimes/node:v5-18.0",
+        logo: "node.png",
+      },
+      {
+        $id: "python-3.12",
+        key: "python",
+        name: "Python",
+        version: "3.12",
+        base: "python:3.12.6-alpine3.20",
+        image: "openruntimes/python:v5-3.12",
+        logo: "python.png",
+      },
+      {
+        $id: "flutter-3.41",
+        key: "flutter",
+        name: "Flutter",
+        version: "3.41",
+        base: "ghcr.io/cirruslabs/flutter:3.41.0",
+        image: "openruntimes/flutter:v5-3.41",
+        logo: "flutter.png",
+      },
+    ],
+  }),
+)
+  .split("\n")
+  .map((line) => line.replace(/\s+$/g, ""))
+  .join("\n");
+
+for (const expectedToken of [
+  "total  4",
+  "runtimes (4)",
+  "runtime",
+  "id",
+  "base",
+  "image",
+  "[1] Node.js 16.0",
+  "node-16.0",
+  "openruntimes/node:v5-16.0",
+  "ghcr.io/cirruslabs/flutter:3.41.0",
+]) {
+  if (!runtimeRenderingOutput.includes(expectedToken)) {
+    throw new Error(
+      `Expected runtime rendering to include ${JSON.stringify(expectedToken)}.\n${runtimeRenderingOutput}`,
+    );
+  }
+}
+
+for (const forbiddenToken of [
+  "$id      ",
+  "key      ",
+  "name     ",
+  "version  ",
+  "logo     ",
+]) {
+  if (runtimeRenderingOutput.includes(forbiddenToken)) {
+    throw new Error(
+      `Expected runtime rendering to omit ${JSON.stringify(forbiddenToken)}.\n${runtimeRenderingOutput}`,
+    );
+  }
+}
+
+console.log("CLI_RUNTIME_RENDERING:passed");
 
 // Type generation regression: generated concrete row query helpers must compile on TS 5.9+
 fs.rmSync(path.join(process.cwd(), "generated"), {

--- a/tests/languages/cli/test.js
+++ b/tests/languages/cli/test.js
@@ -35,7 +35,10 @@ const extractFirstValue = (output) => {
 
 const stripAnsi = (value) => value.replace(/\u001b\[[0-9;]*m/g, "");
 
-const captureStdout = (callback) => {
+// Sync-only capture helper. The callback must complete all writes before it
+// returns, and async callbacks are rejected explicitly to avoid misleading
+// "missing token" assertions when output arrives later.
+const captureStdoutSync = (callback) => {
   const originalWrite = process.stdout.write.bind(process.stdout);
   const originalConsoleLog = console.log.bind(console);
   let output = "";
@@ -55,7 +58,11 @@ const captureStdout = (callback) => {
   };
 
   try {
-    callback();
+    const result = callback();
+
+    if (result && typeof result.then === "function") {
+      throw new Error("captureStdoutSync only supports synchronous callbacks.");
+    }
   } finally {
     console.log = originalConsoleLog;
     process.stdout.write = originalWrite;
@@ -232,7 +239,7 @@ try {
 }
 console.log("CLI_LOCAL_SOURCE_PREFLIGHT:passed");
 
-const runtimeRenderingOutput = captureStdout(() =>
+const runtimeRenderingOutput = captureStdoutSync(() =>
   parse({
     total: 4,
     runtimes: [


### PR DESCRIPTION
## What does this PR do?

Improves the CLI rendering for `appwrite functions list-runtimes` by adding a dedicated structured renderer for the `runtimes` collection.

Instead of falling back to the verbose per-item key/value block, the command now renders a compact aligned table with the fields that are most useful when choosing a runtime:

- `runtime`
- `id`
- `base`
- `image`

It also adds a CLI regression test that asserts this renderer is used and that the old verbose layout is no longer emitted for runtime lists.

## Test Plan

- `vendor/bin/phpunit tests/CLIBun13Test.php`
- `vendor/bin/phpunit tests/CLIBun10Test.php tests/CLIBun11Test.php`
- `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php cli`

## Before

```text
appwrite functions list-runtimes
total  4

runtimes (4)
  [1]
    $id      node-16.0
    key      node
    name     Node.js
    version  16.0
    base     node:16.20.2-alpine3.18
    image    openruntimes/node:v5-16.0
    logo     node.png
  [2]
    $id      node-18.0
    key      node
    name     Node.js
    version  18.0
    base     node:18.20.4-alpine3.20
    image    openruntimes/node:v5-18.0
    logo     node.png
  [3]
    $id      python-3.12
    key      python
    name     Python
    version  3.12
    base     python:3.12.6-alpine3.20
    image    openruntimes/python:v5-3.12
    logo     python.png
  [4]
    $id      flutter-3.41
    key      flutter
    name     Flutter
    version  3.41
    base     ghcr.io/cirruslabs/flutter:3.41.0
    image    openruntimes/flutter:v5-3.41
    logo     flutter.png
```

## After

```text
appwrite functions list-runtimes
total  4

runtimes (4)
  runtime           id            base                               image
  [1] Node.js 16.0  node-16.0     node:16.20.2-alpine3.18            openruntimes/node:v5-16.0
  [2] Node.js 18.0  node-18.0     node:18.20.4-alpine3.20            openruntimes/node:v5-18.0
  [3] Python 3.12   python-3.12   python:3.12.6-alpine3.20           openruntimes/python:v5-3.12
  [4] Flutter 3.41  flutter-3.41  ghcr.io/cirruslabs/flutter:3.41.0  openruntimes/flutter:v5-3.41
```
