### PR TITLE
Fix CLI push review tables for local-only config fields

### DIFF
--- a/templates/cli/lib/commands/utils/change-approval.ts
+++ b/templates/cli/lib/commands/utils/change-approval.ts
@@ -59,6 +59,22 @@ interface ObjectChange {
 }
 
 type ComparableValue = boolean | number | string | unknown[] | undefined;
+const LOCAL_ONLY_RESOURCE_KEYS = new Set(["ignore", "path"]);
+
+const getComparableKeys = (
+  remote: Record<string, ComparableValue>,
+  local: Record<string, ComparableValue>,
+  skipKeys: string[],
+): string[] => {
+  const skippedKeys = new Set([
+    ...skipKeys,
+    ...Array.from(LOCAL_ONLY_RESOURCE_KEYS),
+  ]);
+
+  return [...new Set([...Object.keys(remote), ...Object.keys(local)])].filter(
+    (key) => !skippedKeys.has(key),
+  );
+};
 
 export const getObjectChanges = <T extends Record<string, unknown>>(
   remote: T,
@@ -71,35 +87,37 @@ export const getObjectChanges = <T extends Record<string, unknown>>(
   const remoteNested = remote[index];
   const localNested = local[index];
 
-  if (
+  const remoteObj =
     remoteNested &&
-    localNested &&
     typeof remoteNested === "object" &&
-    !Array.isArray(remoteNested) &&
+    !Array.isArray(remoteNested)
+      ? (remoteNested as Record<string, ComparableValue>)
+      : {};
+  const localObj =
+    localNested &&
     typeof localNested === "object" &&
     !Array.isArray(localNested)
-  ) {
-    const remoteObj = remoteNested as Record<string, ComparableValue>;
-    const localObj = localNested as Record<string, ComparableValue>;
+      ? (localNested as Record<string, ComparableValue>)
+      : {};
 
-    for (const [service, status] of Object.entries(remoteObj)) {
-      const localValue = localObj[service];
-      let valuesEqual = false;
+  for (const key of getComparableKeys(remoteObj, localObj, [])) {
+    const remoteValue = remoteObj[key];
+    const localValue = localObj[key];
+    let valuesEqual = false;
 
-      if (Array.isArray(status) && Array.isArray(localValue)) {
-        valuesEqual = JSON.stringify(status) === JSON.stringify(localValue);
-      } else {
-        valuesEqual = status === localValue;
-      }
+    if (Array.isArray(remoteValue) && Array.isArray(localValue)) {
+      valuesEqual = JSON.stringify(remoteValue) === JSON.stringify(localValue);
+    } else {
+      valuesEqual = remoteValue === localValue;
+    }
 
-      if (!valuesEqual) {
-        changes.push({
-          group: what,
-          setting: service,
-          remote: chalk.red(String(status ?? "")),
-          local: chalk.green(String(localValue ?? "")),
-        });
-      }
+    if (!valuesEqual) {
+      changes.push({
+        group: what,
+        setting: key,
+        remote: chalk.red(String(remoteValue ?? "")),
+        local: chalk.green(String(localValue ?? "")),
+      });
     }
   }
 
@@ -137,19 +155,26 @@ export const approveChanges = async (
         }
 
         const remoteResource = await resourceGetFunction(options);
+        const remoteComparable = whitelistKeys(
+          remoteResource,
+          keys,
+        ) as Record<string, ComparableValue>;
+        const localComparable = whitelistKeys(
+          localResource,
+          keys,
+        ) as Record<string, ComparableValue>;
 
-        for (const [key, value] of Object.entries(
-          whitelistKeys(remoteResource, keys),
+        for (const key of getComparableKeys(
+          remoteComparable,
+          localComparable,
+          skipKeys,
         )) {
-          if (skipKeys.includes(key)) {
+          const value = remoteComparable[key];
+          const localValue = localComparable[key];
+
+          if (isEmpty(value) && isEmpty(localValue)) {
             continue;
           }
-
-          if (isEmpty(value) && isEmpty(localResource[key])) {
-            continue;
-          }
-
-          const localValue = localResource[key];
 
           if (Array.isArray(value) && Array.isArray(localValue)) {
             if (JSON.stringify(value) !== JSON.stringify(localValue)) {


### PR DESCRIPTION
## Summary
- compare the union of remote and local keys when building push review tables
- exclude local-only CLI metadata fields like `path` and `ignore` from those review diffs
- apply the same missing-key handling to project settings review output

## Why
`appwrite push site` was only diffing keys returned by the remote `get(...)` call. If a configurable field was present locally but omitted from the fetched payload, the review table missed it even though the subsequent push still applied the change. `outputDirectory` is one concrete example.

Because the same helper powers the review step for sites, functions, tables, collections, buckets, teams, webhooks, and topics, the fix applies across those push commands as well. The settings review path had the same remote-only iteration pattern, so it is covered too.

## Validation
- `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php cli`
- `composer lint-twig`
- `npm run build` in `examples/cli`
- `npx eslint lib/commands/utils/change-approval.ts` in `examples/cli`
- smoke test in `examples/cli` confirming `approveChanges(...)` now prints an `outputDirectory` row when the value exists only in local config
