### PR TITLE
Add ergonomic CLI query flags

### DIFF
--- a/mock-server/app/http.php
+++ b/mock-server/app/http.php
@@ -494,6 +494,24 @@ App::get('/v1/mock/tests/general/empty')
         $response->noContent();
     });
 
+App::get('/v1/mock/tests/general/list-rows')
+    ->desc('List Rows')
+    ->groups(['mock'])
+    ->label('scope', 'public')
+    ->label('sdk.auth', [APP_AUTH_TYPE_SESSION, APP_AUTH_TYPE_KEY, APP_AUTH_TYPE_JWT])
+    ->label('sdk.namespace', 'general')
+    ->label('sdk.method', 'listRows')
+    ->label('sdk.description', 'Mock a queryable list request.')
+    ->label('sdk.response.code', Response::STATUS_CODE_OK)
+    ->label('sdk.response.type', Response::CONTENT_TYPE_JSON)
+    ->label('sdk.response.model', Response::MODEL_MOCK)
+    ->label('sdk.mock', true)
+    ->param('queries', [], new ArrayList(new Text(4096), APP_LIMIT_ARRAY_PARAMS_SIZE), 'Array of query strings generated using the Query class provided by the SDK.')
+    ->inject('response')
+    ->action(function (array $queries, UtopiaSwooleResponse $response) {
+        $response->json(['result' => \json_encode($queries)]);
+    });
+
 App::post('/v1/mock/tests/general/nullable')
     ->desc('Nullable Test')
     ->groups(['mock'])

--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\SDK\Language;
 
+use Twig\TwigFilter;
 use Twig\TwigFunction;
 
 class CLI extends Node
@@ -191,6 +192,92 @@ class CLI extends Node
             return 'x' . ucfirst($name);
         }
         return $name;
+    }
+
+    private function hasArrayQueriesParameter(array $method): bool
+    {
+        foreach ($method['parameters']['all'] ?? [] as $parameter) {
+            if (($parameter['name'] ?? '') === 'queries' && ($parameter['type'] ?? '') === self::TYPE_ARRAY) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasOnlyLimitOffsetQueries(array $method): bool
+    {
+        foreach ($method['parameters']['all'] ?? [] as $parameter) {
+            if (($parameter['name'] ?? '') !== 'queries' || ($parameter['type'] ?? '') !== self::TYPE_ARRAY) {
+                continue;
+            }
+
+            if (str_contains(strtolower($parameter['description'] ?? ''), 'only supported methods are limit and offset')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasCliQueryParam(array $service): bool
+    {
+        foreach ($service['methods'] ?? [] as $method) {
+            if ($this->hasArrayQueriesParameter($method)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function getCliQueryConfig(array $method): array
+    {
+        $hasQueries = $this->hasArrayQueriesParameter($method);
+        $methodName = $method['name'] ?? '';
+        $hasOnlyLimitOffsetQueries = $hasQueries && $this->hasOnlyLimitOffsetQueries($method);
+        $hasSelectQueries = $hasQueries && in_array($methodName, ['listDocuments', 'getDocument', 'listRows', 'getRow'], true);
+        $hasSelectionOnlyQueries = $hasQueries && in_array($methodName, ['getDocument', 'getRow'], true);
+        $hasFilteringQueries = $hasQueries && !$hasOnlyLimitOffsetQueries && !$hasSelectionOnlyQueries;
+        $hasPaginationQueries = $hasQueries && !$hasSelectionOnlyQueries;
+
+        $builderParams = [];
+        if ($hasQueries) {
+            $builderParams[] = 'queries';
+
+            if ($hasFilteringQueries) {
+                array_push($builderParams, 'where', 'sortAsc', 'sortDesc', 'cursorAfter', 'cursorBefore');
+            }
+
+            if ($hasPaginationQueries) {
+                array_push($builderParams, 'limit', 'offset');
+            }
+
+            if ($hasSelectQueries) {
+                $builderParams[] = 'select';
+            }
+        }
+
+        if ($hasOnlyLimitOffsetQueries) {
+            $rawDescriptionPrefix = 'Raw Appwrite JSON query strings (legacy). Use this for advanced queries or automation; for common pagination prefer --limit and --offset. When mixed, raw --queries are sent before generated flag queries.';
+        } elseif ($hasSelectionOnlyQueries) {
+            $rawDescriptionPrefix = 'Raw Appwrite JSON query strings (legacy). Use this for advanced queries or automation; for selecting returned attributes prefer --select. When mixed, raw --queries are sent before generated flag queries.';
+        } elseif ($hasSelectQueries) {
+            $rawDescriptionPrefix = 'Raw Appwrite JSON query strings (legacy). Use this for advanced queries or automation; for common filtering, sorting, pagination, and selection prefer --where, --sort-asc, --sort-desc, --limit, --offset, and --select. When mixed, raw --queries are sent before generated flag queries.';
+        } else {
+            $rawDescriptionPrefix = 'Raw Appwrite JSON query strings (legacy). Use this for advanced queries or automation; for common filtering, sorting, and pagination prefer --where, --sort-asc, --sort-desc, --limit, and --offset. When mixed, raw --queries are sent before generated flag queries.';
+        }
+
+        return [
+            'hasQueries' => $hasQueries,
+            'hasFiltering' => $hasFilteringQueries,
+            'hasPagination' => $hasPaginationQueries,
+            'hasCursors' => $hasFilteringQueries,
+            'hasSelect' => $hasSelectQueries,
+            'builderParams' => $builderParams,
+            'extraParams' => array_values(array_filter($builderParams, fn (string $param): bool => $param !== 'queries')),
+            'rawDescriptionPrefix' => $rawDescriptionPrefix,
+        ];
     }
 
     /**
@@ -531,6 +618,11 @@ class CLI extends Node
                 'destination'   => 'lib/commands/utils/pools.ts',
                 'template'      => 'cli/lib/commands/utils/pools.ts',
             ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'lib/commands/utils/query.ts',
+                'template'      => 'cli/lib/commands/utils/query.ts',
+            ],
 
             // Emulation (lib/emulation/)
             [
@@ -703,6 +795,18 @@ class CLI extends Node
 
     /**
      * Language specific filters.
+     * @return array
+     */
+    public function getFilters(): array
+    {
+        return array_merge(parent::getFilters(), [
+            new TwigFilter('hasCliQueryParam', fn (array $service): bool => $this->hasCliQueryParam($service)),
+            new TwigFilter('cliQueryConfig', fn (array $method): array => $this->getCliQueryConfig($method)),
+        ]);
+    }
+
+    /**
+     * Language specific functions.
      * @return array
      */
     public function getFunctions(): array

--- a/templates/cli/base/mock.twig
+++ b/templates/cli/base/mock.twig
@@ -26,7 +26,10 @@ class {{ service.name | caseUcfirst }} {
 {% endfor %}
 
   async {{ method.name | caseCamel }}({{ params | join(', ') }}): Promise<any> {
-{% if method.name == 'redirect' %}
+{% set query = method | cliQueryConfig %}
+{% if query.hasQueries %}
+    return { result: JSON.stringify(queries ?? []) };
+{% elseif method.name == 'redirect' %}
     return { result: '{{ method.method | upper }}:/v1{{ method.path }}/done:passed' };
 {% elseif method.name == 'headers' %}
     return { result: 'x-sdk-name: {{ sdk.name }}; x-sdk-platform: {{ sdk.platform }}; x-sdk-language: {{ language.name | caseLower }}; x-sdk-version: {{ sdk.version }}' };

--- a/templates/cli/docs/example.md.twig
+++ b/templates/cli/docs/example.md.twig
@@ -1,14 +1,22 @@
 ```bash
 {% set requiredParams = [] %}
+{% set query = method | cliQueryConfig %}
 {% for parameter in method.parameters.all %}
 {% if parameter.required %}
 {% set requiredParams = requiredParams|merge([parameter]) %}
 {% endif %}
 {% endfor %}
-{{ language.params.executableName }} {{ service.name | caseKebab }} {{ method.name | caseKebab }}{% if requiredParams | length > 0 %} \{% endif %}
-
+{% set exampleLines = [] %}
 {% for parameter in requiredParams %}
-    --{{ parameter.name | caseKebab }} {{ parameter | paramExample }}{% if not loop.last %} \{% endif %}
+{% set exampleLines = exampleLines|merge(['--' ~ (parameter.name | caseKebab) ~ ' ' ~ (parameter | paramExample)]) %}
+{% endfor %}
+{% if query.hasPagination %}
+{% set exampleLines = exampleLines|merge(['--limit 25']) %}
+{% endif %}
+{{ language.params.executableName }} {{ service.name | caseKebab }} {{ method.name | caseKebab }}{% if exampleLines | length > 0 %} \{% endif %}
+
+{% for line in exampleLines %}
+    {{ line | raw }}{% if not loop.last %} \{% endif %}
 
 {% endfor %}
 ```

--- a/templates/cli/lib/commands/services/services.ts.twig
+++ b/templates/cli/lib/commands/services/services.ts.twig
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 {% set hasLocationMethod = false %}
 {% set hasFileParam = false %}
+{% set hasQueryParam = service | hasCliQueryParam %}
 {% set enumNames = [] %}
 {% for method in service.methods %}
 {% if method.type == 'location' %}
@@ -20,6 +21,13 @@ import fs from "fs";
 {% endif %}
 {% if hasFileParam %}
 import { resolveFileParam } from "../utils/deployment.js";
+{% endif %}
+{% if hasQueryParam %}
+import {
+  buildQueries,
+  collectQueryValue,
+  parseWhereQuery,
+} from "../utils/query.js";
 {% endif %}
 {% if service.isConsoleOnly %}
 import { sdkForConsole } from "../../sdks.js";
@@ -77,23 +85,46 @@ export const {{ service.name | caseCamel }} = new Command("{{ service.name | cas
 {% if commandName not in seenCommands %}
 {% set seenCommands = seenCommands|merge([commandName]) %}
 {% set commandVar = service.name | caseCamel ~ method.name | caseUcfirst ~ 'Command' %}
+{% set query = method | cliQueryConfig %}
 const {{ commandVar }} = {{ service.name | caseCamel }}
   .command(`{{ commandName }}`)
   .description(`{{ method.description | stripMarkdown | replace({'`': '\\`'}) | raw }}`)
 {% for parameter in method.parameters.all %}
 {% set opt = getCliOption(parameter) %}
+{% set optDescription = parameter.description | stripMarkdown | replace({'`': '\\`'}) %}
+{% if parameter.name == 'queries' and parameter.type == 'array' %}
+{% set optDescription = query.rawDescriptionPrefix ~ ' ' ~ optDescription %}
+{% endif %}
 {% if opt.customParserCode is defined %}
   .{{ opt.method }}(
     `{{ opt.syntax | raw }}`,
-    `{{ parameter.description | stripMarkdown | replace({'`': '\\`'}) | raw }}`,
+    `{{ optDescription | raw }}`,
     {{ opt.customParserCode | raw }},
   )
 {% elseif opt.parser %}
-  .{{ opt.method }}(`{{ opt.syntax | raw }}`, `{{ parameter.description | stripMarkdown | replace({'`': '\\`'}) | raw }}`, {{ opt.parser }})
+  .{{ opt.method }}(`{{ opt.syntax | raw }}`, `{{ optDescription | raw }}`, {{ opt.parser }})
 {% else %}
-  .{{ opt.method }}(`{{ opt.syntax | raw }}`, `{{ parameter.description | stripMarkdown | replace({'`': '\\`'}) | raw }}`)
+  .{{ opt.method }}(`{{ opt.syntax | raw }}`, `{{ optDescription | raw }}`)
 {% endif %}
 {% endfor %}
+{% if query.hasQueries %}
+{% if query.hasFiltering %}
+  .option(`--where <expression>`, `Filter using a simple comparison expression. Repeat for multiple filters. Supports field=value, field!=value, field>value, field>=value, field<value, and field<=value.`, (value: string, previous: string[] | undefined) => collectQueryValue(parseWhereQuery(value), previous))
+  .option(`--sort-asc <attribute>`, `Sort results by an attribute in ascending order. Repeat for multiple sort fields.`, (value: string, previous: string[] | undefined) => collectQueryValue(value, previous))
+  .option(`--sort-desc <attribute>`, `Sort results by an attribute in descending order. Repeat for multiple sort fields.`, (value: string, previous: string[] | undefined) => collectQueryValue(value, previous))
+{% endif %}
+{% if query.hasPagination %}
+  .option(`--limit <limit>`, `Maximum number of results to return.`, parseInteger)
+  .option(`--offset <offset>`, `Number of results to skip.`, parseInteger)
+{% endif %}
+{% if query.hasCursors %}
+  .option(`--cursor-after <id>`, `Return results after this cursor ID.`)
+  .option(`--cursor-before <id>`, `Return results before this cursor ID.`)
+{% endif %}
+{% if query.hasSelect %}
+  .option(`--select <attribute>`, `Attribute to include in the response. Repeat for multiple attributes.`, (value: string, previous: string[] | undefined) => collectQueryValue(value, previous))
+{% endif %}
+{% endif %}
 {% if method.type == 'location' %}
   .requiredOption(`--destination <destination>`, `Path to save the file to.`)
 {% endif %}
@@ -103,11 +134,18 @@ const {{ commandVar }} = {{ service.name | caseCamel }}
 {% for parameter in method.parameters.all %}
 {% set params = params|merge([getCliVarName(parameter)]) %}
 {% endfor %}
+{% if query.hasQueries %}
+{% set params = params|merge(query.extraParams) %}
+{% endif %}
 {% set hasParams = params | length > 0 %}
 {% set actionParams = hasParams ? '{ ' ~ params | join(', ') ~ (method.type == 'location' ? ', destination' : '') ~ ' }' : (method.type == 'location' ? '{ destination }' : '') %}
 {% set argExpressions = [] %}
 {% for parameter in method.parameters.all %}
+{% if parameter.name == 'queries' and parameter.type == 'array' %}
+{% set argExpressions = argExpressions|merge(['buildQueries({ ' ~ query.builderParams | join(', ') ~ ' })']) %}
+{% else %}
 {% set argExpressions = argExpressions|merge([getCliArgExpression(parameter)]) %}
+{% endif %}
 {% endfor %}
 {% if method.type == 'location' %}
       async ({{ actionParams }}) => {

--- a/templates/cli/lib/commands/utils/query.ts
+++ b/templates/cli/lib/commands/utils/query.ts
@@ -1,0 +1,197 @@
+import { InvalidArgumentError } from "commander";
+
+type QueryValue = string | number | boolean | null;
+type QueryValues = QueryValue | QueryValue[];
+
+export type CliQueryOptions = {
+  queries?: string[];
+  limit?: number;
+  offset?: number;
+  cursorAfter?: string;
+  cursorBefore?: string;
+  sortAsc?: string[];
+  sortDesc?: string[];
+  select?: string[];
+  where?: string[];
+};
+
+const stringifyQuery = (
+  method: string,
+  attribute?: string,
+  values?: QueryValues,
+): string => {
+  const query: {
+    method: string;
+    attribute?: string;
+    values?: QueryValue[];
+  } = { method };
+
+  if (attribute !== undefined) {
+    query.attribute = attribute;
+  }
+
+  if (values !== undefined) {
+    query.values = Array.isArray(values) ? values : [values];
+  }
+
+  return JSON.stringify(query);
+};
+
+const parseQueryValue = (value: string): QueryValues => {
+  const normalized = value.trim();
+
+  if (normalized === "true") {
+    return true;
+  }
+
+  if (normalized === "false") {
+    return false;
+  }
+
+  if (normalized === "null") {
+    return null;
+  }
+
+  if (/^-?(?:\d+|\d*\.\d+)(?:e[+-]?\d+)?$/i.test(normalized)) {
+    const parsed = Number(normalized);
+
+    if (!Number.isFinite(parsed)) {
+      throw new InvalidArgumentError(
+        "Numeric filter values must be finite numbers.",
+      );
+    }
+
+    return parsed;
+  }
+
+  if (normalized.startsWith("[") && normalized.endsWith("]")) {
+    try {
+      const parsed = JSON.parse(normalized) as unknown;
+      if (Array.isArray(parsed)) {
+        return parsed.map((item) => {
+          if (
+            item === null ||
+            typeof item === "string" ||
+            typeof item === "boolean"
+          ) {
+            return item;
+          }
+
+          if (typeof item === "number") {
+            if (!Number.isFinite(item)) {
+              throw new InvalidArgumentError(
+                "Array filter values must be finite numbers.",
+              );
+            }
+
+            return item;
+          }
+
+          throw new InvalidArgumentError(
+            "Array filters can only contain strings, numbers, booleans, or null.",
+          );
+        });
+      }
+    } catch (error) {
+      if (error instanceof InvalidArgumentError) {
+        throw error;
+      }
+
+      throw new InvalidArgumentError(
+        "Array filter values must be valid JSON arrays.",
+      );
+    }
+  }
+
+  return normalized;
+};
+
+const whereOperators: Array<[RegExp, string]> = [
+  [/^(.+?)\s*!=\s*(.*)$/, "notEqual"],
+  [/^(.+?)\s*>=\s*(.*)$/, "greaterThanEqual"],
+  [/^(.+?)\s*<=\s*(.*)$/, "lessThanEqual"],
+  [/^(.+?)\s*=\s*(.*)$/, "equal"],
+  [/^(.+?)\s*>\s*(.*)$/, "greaterThan"],
+  [/^(.+?)\s*<\s*(.*)$/, "lessThan"],
+];
+
+export const collectQueryValue = <T>(value: T, previous: T[] = []): T[] => [
+  ...previous,
+  value,
+];
+
+export const parseWhereQuery = (expression: string): string => {
+  for (const [pattern, method] of whereOperators) {
+    const match = expression.match(pattern);
+
+    if (!match) {
+      continue;
+    }
+
+    const attribute = match[1].trim();
+    if (attribute === "") {
+      throw new InvalidArgumentError(
+        "Where filters must include an attribute before the operator.",
+      );
+    }
+
+    return stringifyQuery(method, attribute, parseQueryValue(match[2]));
+  }
+
+  throw new InvalidArgumentError(
+    "Where filters must use one of: field=value, field!=value, field>value, field>=value, field<value, field<=value.",
+  );
+};
+
+export const buildQueries = ({
+  queries,
+  limit,
+  offset,
+  cursorAfter,
+  cursorBefore,
+  sortAsc,
+  sortDesc,
+  select,
+  where,
+}: CliQueryOptions): string[] | undefined => {
+  const builtQueries = [...(queries ?? [])];
+
+  if (where) {
+    // parseWhereQuery returns fully serialized Appwrite query JSON strings.
+    builtQueries.push(...where);
+  }
+
+  if (sortAsc) {
+    builtQueries.push(
+      ...sortAsc.map((attribute) => stringifyQuery("orderAsc", attribute)),
+    );
+  }
+
+  if (sortDesc) {
+    builtQueries.push(
+      ...sortDesc.map((attribute) => stringifyQuery("orderDesc", attribute)),
+    );
+  }
+
+  if (limit !== undefined) {
+    builtQueries.push(stringifyQuery("limit", undefined, limit));
+  }
+
+  if (offset !== undefined) {
+    builtQueries.push(stringifyQuery("offset", undefined, offset));
+  }
+
+  if (cursorAfter !== undefined) {
+    builtQueries.push(stringifyQuery("cursorAfter", undefined, cursorAfter));
+  }
+
+  if (cursorBefore !== undefined) {
+    builtQueries.push(stringifyQuery("cursorBefore", undefined, cursorBefore));
+  }
+
+  if (select && select.length > 0) {
+    builtQueries.push(stringifyQuery("select", undefined, select));
+  }
+
+  return builtQueries.length > 0 ? builtQueries : undefined;
+};

--- a/templates/cli/lib/parser.ts
+++ b/templates/cli/lib/parser.ts
@@ -649,6 +649,20 @@ export const drawJSON = (data: unknown): void => {
   console.log(JSON.stringify(data, null, 2));
 };
 
+const isQueryError = (message: string): boolean =>
+  /Invalid query(?: method)?/i.test(message) ||
+  /query[^.:\n]*syntax error|syntax error[^.:\n]*query/i.test(message);
+
+const printQueryErrorHint = (err: Error): void => {
+  if (!isQueryError(err.message)) {
+    return;
+  }
+
+  hint(
+    `For common list filters, use flags like --limit 25, --sort-desc '$createdAt', or --where 'status=active'. Raw --queries values must be Appwrite JSON query strings, for example: ${EXECUTABLE_NAME} tables-db list-rows --queries '{"method":"limit","values":[25]}'`,
+  );
+};
+
 export const parseError = (err: Error): void => {
   if (cliConfig.report) {
     void (async () => {
@@ -695,6 +709,7 @@ export const parseError = (err: Error): void => {
       log(
         `To report this error you can:\n - Create a support ticket in our Discord server https://appwrite.io/discord \n - Create an issue in our Github\n   ${githubIssueUrl.href}\n`,
       );
+      printQueryErrorHint(err);
 
       error("\n Stack Trace: \n");
       console.error(err);
@@ -703,9 +718,11 @@ export const parseError = (err: Error): void => {
   } else {
     if (cliConfig.verbose) {
       console.error(err);
+      printQueryErrorHint(err);
     } else {
       log("For detailed error pass the --verbose or --report flag");
       error(err.message);
+      printQueryErrorHint(err);
     }
     process.exit(1);
   }

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -230,6 +230,23 @@ abstract class Base extends TestCase
         'CLI_RUNTIME_RENDERING:passed',
     ];
 
+    protected const CLI_QUERY_HELPER_RESPONSES = [
+        '[' .
+        '"{\"method\":\"orderDesc\",\"attribute\":\"rawName\"}",' .
+        '"{\"method\":\"equal\",\"attribute\":\"published\",\"values\":[true]}",' .
+        '"{\"method\":\"greaterThanEqual\",\"attribute\":\"score\",\"values\":[10]}",' .
+        '"{\"method\":\"equal\",\"attribute\":\"status\",\"values\":[\"draft\",\"published\"]}",' .
+        '"{\"method\":\"orderAsc\",\"attribute\":\"title\"}",' .
+        '"{\"method\":\"orderDesc\",\"attribute\":\"$createdAt\"}",' .
+        '"{\"method\":\"limit\",\"values\":[25]}",' .
+        '"{\"method\":\"offset\",\"values\":[50]}",' .
+        '"{\"method\":\"cursorAfter\",\"values\":[\"row-before\"]}",' .
+        '"{\"method\":\"cursorBefore\",\"values\":[\"row-after\"]}",' .
+        '"{\"method\":\"select\",\"values\":[\"$id\",\"title\"]}"' .
+        ']',
+        'CLI_QUERY_HELPERS:passed',
+    ];
+
     protected const CHANNEL_HELPER_RESPONSES = [
         'databases.db1.collections.col1.documents',
         'databases.db1.collections.col1.documents.doc1',

--- a/tests/CLIBun10Test.php
+++ b/tests/CLIBun10Test.php
@@ -33,6 +33,7 @@ class CLIBun10Test extends Base
         ...Base::CLI_HEADERS_RESPONSES,
         ...Base::CLI_LOCAL_FUNCTION_EMULATION_RESPONSES,
         ...Base::CLI_RUNTIME_RENDERING_RESPONSES,
+        ...Base::CLI_QUERY_HELPER_RESPONSES,
         ...Base::CLI_TYPEGEN_RESPONSES,
     ];
 

--- a/tests/CLIBun11Test.php
+++ b/tests/CLIBun11Test.php
@@ -33,6 +33,7 @@ class CLIBun11Test extends Base
         ...Base::CLI_HEADERS_RESPONSES,
         ...Base::CLI_LOCAL_FUNCTION_EMULATION_RESPONSES,
         ...Base::CLI_RUNTIME_RENDERING_RESPONSES,
+        ...Base::CLI_QUERY_HELPER_RESPONSES,
         ...Base::CLI_TYPEGEN_RESPONSES,
     ];
 

--- a/tests/CLIBun13Test.php
+++ b/tests/CLIBun13Test.php
@@ -33,6 +33,7 @@ class CLIBun13Test extends Base
         ...Base::CLI_HEADERS_RESPONSES,
         ...Base::CLI_LOCAL_FUNCTION_EMULATION_RESPONSES,
         ...Base::CLI_RUNTIME_RENDERING_RESPONSES,
+        ...Base::CLI_QUERY_HELPER_RESPONSES,
         ...Base::CLI_TYPEGEN_RESPONSES,
     ];
 

--- a/tests/languages/cli/test.js
+++ b/tests/languages/cli/test.js
@@ -1,4 +1,4 @@
-const { execSync } = require("child_process");
+const { execFileSync, execSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const Client = require("./lib/client.ts").default;
@@ -320,6 +320,81 @@ for (const forbiddenToken of [
 }
 
 console.log("CLI_RUNTIME_RENDERING:passed");
+
+output = execFileSync(
+  "bun",
+  [
+    "./dist/cli.cjs",
+    "general",
+    "list-rows",
+    "--queries",
+    '{"method":"orderDesc","attribute":"rawName"}',
+    "--where",
+    "published=true",
+    "--where",
+    "score>=10",
+    "--where",
+    'status=["draft","published"]',
+    "--sort-asc",
+    "title",
+    "--sort-desc",
+    "$createdAt",
+    "--limit",
+    "25",
+    "--offset",
+    "50",
+    "--cursor-after",
+    "row-before",
+    "--cursor-before",
+    "row-after",
+    "--select",
+    "$id",
+    "--select",
+    "title",
+  ],
+  { stdio: "pipe" },
+).toString();
+console.log(extractFirstValue(output));
+
+try {
+  execFileSync(
+    "bun",
+    [
+      "./dist/cli.cjs",
+      "general",
+      "list-rows",
+      "--where",
+      "count>1e999",
+    ],
+    { stdio: "pipe" },
+  );
+  throw new Error("Expected non-finite numeric where values to be rejected.");
+} catch (error) {
+  if (!String(error.stderr ?? error.message).includes("finite numbers")) {
+    throw error;
+  }
+}
+
+try {
+  execFileSync(
+    "bun",
+    [
+      "./dist/cli.cjs",
+      "general",
+      "list-rows",
+      "--where",
+      "count=[1e999]",
+    ],
+    { stdio: "pipe" },
+  );
+  throw new Error("Expected non-finite array where values to be rejected.");
+} catch (error) {
+  if (!String(error.stderr ?? error.message).includes("finite numbers")) {
+    throw error;
+  }
+}
+
+console.log("CLI_QUERY_HELPERS:passed");
 
 // Type generation regression: generated concrete row query helpers must compile on TS 5.9+
 fs.rmSync(path.join(process.cwd(), "generated"), {

--- a/tests/resources/spec.json
+++ b/tests/resources/spec.json
@@ -1446,6 +1446,72 @@
         ]
       }
     },
+    "\/mock\/tests\/general\/list-rows": {
+      "get": {
+        "summary": "List Rows",
+        "operationId": "generalListRows",
+        "consumes": [],
+        "produces": [
+          "application\/json"
+        ],
+        "tags": [
+          "general"
+        ],
+        "description": "Mock a queryable list request.",
+        "responses": {
+          "200": {
+            "description": "Mock",
+            "schema": {
+              "$ref": "#\/definitions\/mock"
+            }
+          }
+        },
+        "x-appwrite": {
+          "method": "listRows",
+          "weight": 284,
+          "cookies": false,
+          "type": "",
+          "demo": "general\/list-rows.md",
+          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a queryable list request.",
+          "rate-limit": 0,
+          "rate-time": 3600,
+          "rate-key": "url:{url},ip:{ip}",
+          "scope": "public",
+          "platforms": [
+            "client",
+            "server",
+            "server"
+          ],
+          "packaging": false,
+          "offline-model": "",
+          "offline-key": "",
+          "offline-response-key": "$id",
+          "auth": {
+            "Project": []
+          }
+        },
+        "security": [
+          {
+            "Project": [],
+            "Key": [],
+            "JWT": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "queries",
+            "description": "Array of query strings generated using the Query class provided by the SDK.",
+            "required": false,
+            "type": "array",
+            "collectionFormat": "multi",
+            "items": {
+              "type": "string"
+            },
+            "in": "query"
+          }
+        ]
+      }
+    },
     "\/mock\/tests\/general\/enum": {
       "post": {
         "summary": "Enum Test",


### PR DESCRIPTION
Closes #1455

## Summary

This PR adds a shell-friendly query UX to generated CLI commands while preserving the existing raw `--queries` behavior for advanced usage and automation.

Generated CLI commands with array-style `queries` parameters now expose ergonomic flags for common query operations:

- `--limit <limit>`
- `--offset <offset>`
- `--cursor-after <id>`
- `--cursor-before <id>`
- `--sort-asc <attribute>`
- `--sort-desc <attribute>`
- repeatable `--where <expression>` for common comparison filters
- `--select <attribute>` only on row/document commands where the API accepts selection queries

For endpoints whose spec text says only `limit` and `offset` are supported, the generated command only exposes `--limit` and `--offset` to avoid advertising unsupported operations.

TablesDB is treated as the primary service for this UX because Databases is legacy-compatible. The same generation logic still applies to legacy Databases commands where the spec exposes compatible `queries` parameters.

## Implementation

- Adds a shared CLI query utility at `templates/cli/lib/commands/utils/query.ts`.
- Registers that utility in `src/SDK/Language/CLI.php` so it is generated with the CLI SDK.
- Adds CLI language filters for query-capable command configuration, keeping query-mode decisions out of the Twig templates.
- Updates `templates/cli/lib/commands/services/services.ts.twig` to consume that query config and emit ergonomic query flags only for supported commands.
- Merges raw `--queries` with generated query strings deterministically: raw query values are sent first, followed by query strings generated from ergonomic flags.
- Keeps non-array/string `queries` parameters unchanged.
- Limits `--select` to `listDocuments`, `getDocument`, `listRows`, and `getRow`, based on production API behavior.
- Updates generated docs examples to include `--limit 25` for query-capable commands.
- Adds targeted runtime hints for common invalid-query errors, pointing users toward ergonomic flags and valid raw JSON-query syntax. The raw-query example in that hint now uses `tables-db list-rows`.

## `--where` Support

Initial `--where` grammar supports the common comparisons requested in the issue:

- `field=value` -> `equal`
- `field!=value` -> `notEqual`
- `field>value` -> `greaterThan`
- `field>=value` -> `greaterThanEqual`
- `field<value` -> `lessThan`
- `field<=value` -> `lessThanEqual`

Values are normalized for common shell usage: booleans, `null`, numbers, strings, and simple JSON arrays of scalar values.

## Backwards Compatibility

Existing `--queries` usage remains supported. Users can still pass raw Appwrite JSON query strings exactly as before, and can mix raw `--queries` with the new flags where appropriate.

Example raw query usage remains valid:

```bash
appwrite tables-db list-rows \
  --database-id <DATABASE_ID> \
  --table-id <TABLE_ID> \
  --queries '{"method":"limit","values":[25]}'
```

Example ergonomic usage:

```bash
appwrite tables-db list-rows \
  --database-id <DATABASE_ID> \
  --table-id <TABLE_ID> \
  --where 'status=active' \
  --sort-desc '$createdAt' \
  --select '$id' \
  --select title \
  --limit 5
```

## Verification

Template and local CLI checks:

- `php example.php cli`
- `composer lint-twig`
- `cd examples/cli && npm run build`
- `cd examples/cli && npm run build:runtime`
- `cd examples/cli && node dist/cli.cjs generate --output generated --language typescript --server auto`
- `cd examples/cli && node dist/cli.cjs tables-db list-rows --help`
- `cd examples/cli && node dist/cli.cjs tables-db get-row --help`
- `vendor/bin/phpunit tests/CLIBun13Test.php` covering a generated `general list-rows` fixture command with raw `--queries`, `--where`, sort, pagination, cursor, and `--select` flags end to end.

Production SGP project verification against `chirag-project-prod`:

- Rebuilt local generated CLI from `examples/cli`.
- Verified `tables-db list-tables` with `--limit`, `--offset`, `--sort-asc`, `--sort-desc`, and `--cursor-after`.
- Verified `tables-db list-tables --where 'name=posts'` and `tables-db list-tables --where 'enabled=true'`.
- Verified `tables-db list-rows --where 'published=true' --select '$id' --select title --limit 1`.
- Verified `tables-db get-row --select '$id' --select title`.
- Verified raw `tables-db list-rows --queries '{"method":"limit","values":[1]}'` remains accepted.
- Verified mixed raw + ergonomic flags work with `tables-db list-tables --queries '{"method":"orderDesc","attribute":"name"}' --limit 1`.
- Verified invalid raw query syntax now prints a hint using `tables-db list-rows`.
- Also verified non-TablesDB query consumers still work, including `functions list` comparison operators and `storage list-buckets` boolean/JSON-array filter values.


