### PR TITLE
Fix CLI tmp audit vulnerability

### DIFF
--- a/.github/workflows/sdk-build-validation.yml
+++ b/.github/workflows/sdk-build-validation.yml
@@ -167,7 +167,7 @@ jobs:
           case "${{ matrix.sdk }}" in
             web)
               npm ci
-              npm audit --audit-level=moderate
+              npm audit
               npm run build
               ;;
             cli)
@@ -180,13 +180,13 @@ jobs:
               bun run windows-arm64
 
               npm ci
-              npm audit --audit-level=moderate
+              npm audit
               npm run build
               node dist/cli.cjs --help
               ;;
             react-native)
               npm ci
-              npm audit --audit-level=moderate
+              npm audit
               npm run build
               ;;
             flutter)
@@ -218,7 +218,7 @@ jobs:
               ;;
             node)
               npm ci
-              npm audit --audit-level=moderate
+              npm audit
               npm run build
               npm run test
               ;;

--- a/templates/cli/bun.lock.twig
+++ b/templates/cli/bun.lock.twig
@@ -48,6 +48,7 @@
   "overrides": {
     "@xmldom/xmldom": "^0.9.10",
     "phin": "3.7.1",
+    "tmp": "0.2.5",
   },
   "packages": {
     "@appwrite.io/console": ["@appwrite.io/console@11.0.0", "", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-7w2MNVDP5cNLExJlEOttfBAvOFd1GA+rAUBoqhtvd81GLZZrMZck7QZv4cyhz3LO54jUg5zBWbyC1lsXCRWiEg=="],
@@ -248,7 +249,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@roberts_lando/vfs": ["@roberts_lando/vfs@0.3.2", "", {}, "sha512-whXj9v78S4n3t0RvoTGj8vui27VVtK/oy8YfBL+gDWdlfRFkKpPjry+U8p+3XM++5rAIpXEtXcTUgUAEHZVoFA=="],
+    "@roberts_lando/vfs": ["@roberts_lando/vfs@0.3.3", "", {}, "sha512-YjkxVSLw5WMZQoARaryRAjcxA+GbBzWMJdwYZX5oLUt9cC/gew9as4Dn7tcLzPp7BPoR221VpTZ+78TRPawnjg=="],
 
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 
@@ -294,7 +295,7 @@
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.9.10", "", {}, "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw=="],
 
-    "@yao-pkg/pkg": ["@yao-pkg/pkg@6.18.2", "", { "dependencies": { "@babel/generator": "^7.23.0", "@babel/parser": "^7.23.0", "@babel/traverse": "^7.23.0", "@babel/types": "^7.23.0", "@roberts_lando/vfs": "^0.3.2", "@yao-pkg/pkg-fetch": "3.5.33", "esbuild": "^0.27.3", "into-stream": "^9.1.0", "minimist": "^1.2.6", "multistream": "^4.1.0", "picocolors": "^1.1.0", "picomatch": "^4.0.2", "postject": "^1.0.0-alpha.6", "prebuild-install": "^7.1.1", "resolve": "^1.22.10", "resolve.exports": "^2.0.3", "stream-meter": "^1.0.4", "tar": "^7.5.7", "tinyglobby": "^0.2.11", "unzipper": "^0.12.3" }, "bin": { "pkg": "lib-es5/bin.js" } }, "sha512-lo+fNeV10ldTeTrDbgK2eYTIhKDqCUVVq7a4W3s7LiTwd9/8UKYdxBodVNNCbEd2JBtqKA4BZpevitfsOzyXig=="],
+    "@yao-pkg/pkg": ["@yao-pkg/pkg@6.19.0", "", { "dependencies": { "@babel/generator": "^7.23.0", "@babel/parser": "^7.23.0", "@babel/traverse": "^7.23.0", "@babel/types": "^7.23.0", "@roberts_lando/vfs": "^0.3.3", "@yao-pkg/pkg-fetch": "3.5.33", "esbuild": "^0.27.3", "into-stream": "^9.1.0", "multistream": "^4.1.0", "picocolors": "^1.1.0", "picomatch": "^4.0.2", "postject": "^1.0.0-alpha.6", "prebuild-install": "^7.1.1", "resolve": "^1.22.10", "resolve.exports": "^2.0.3", "stream-meter": "^1.0.4", "tar": "^7.5.7", "tinyglobby": "^0.2.11", "unzipper": "^0.12.3" }, "bin": { "pkg": "lib-es5/bin.js" } }, "sha512-Ys9Fn/F44C3nOTlNyhwviLyMxydgFzsB13jAAXKxEuIR7aAz8PrFlUpxTUlwaXUU847nlmg5mnaGIyOJpnVtRw=="],
 
     "@yao-pkg/pkg-fetch": ["@yao-pkg/pkg-fetch@3.5.33", "", { "dependencies": { "https-proxy-agent": "^5.0.0", "node-fetch": "^2.6.6", "picocolors": "^1.1.0", "progress": "^2.0.3", "semver": "^7.3.5", "tar-fs": "^3.1.1", "yargs": "^16.2.0" }, "bin": { "pkg-fetch": "lib-es5/bin.js" } }, "sha512-j2UoH+eP4VobfovQg1gkWwDoB4O/tv8rlLnEjUEEHuWXJ5eBLNUIrobMSEp773/2pgUJUfqqPUFIhS1pN8OZuQ=="],
 
@@ -304,7 +305,7 @@
 
     "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
-    "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+    "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
     "ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
@@ -684,8 +685,6 @@
 
     "ora": ["ora@5.4.1", "", { "dependencies": { "bl": "^4.1.0", "chalk": "^4.1.0", "cli-cursor": "^3.1.0", "cli-spinners": "^2.5.0", "is-interactive": "^1.0.0", "is-unicode-supported": "^0.1.0", "log-symbols": "^4.1.0", "strip-ansi": "^6.0.0", "wcwidth": "^1.0.1" } }, "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ=="],
 
-    "os-tmpdir": ["os-tmpdir@1.0.2", "", {}, "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="],
-
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
@@ -836,7 +835,7 @@
 
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
-    "tmp": ["tmp@0.0.33", "", { "dependencies": { "os-tmpdir": "~1.0.2" } }, "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw=="],
+    "tmp": ["tmp@0.2.5", "", {}, "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 

--- a/templates/cli/package-lock.json.twig
+++ b/templates/cli/package-lock.json.twig
@@ -2021,9 +2021,9 @@
       }
     },
     "node_modules/@roberts_lando/vfs": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@roberts_lando/vfs/-/vfs-0.3.2.tgz",
-      "integrity": "sha512-whXj9v78S4n3t0RvoTGj8vui27VVtK/oy8YfBL+gDWdlfRFkKpPjry+U8p+3XM++5rAIpXEtXcTUgUAEHZVoFA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@roberts_lando/vfs/-/vfs-0.3.3.tgz",
+      "integrity": "sha512-YjkxVSLw5WMZQoARaryRAjcxA+GbBzWMJdwYZX5oLUt9cC/gew9as4Dn7tcLzPp7BPoR221VpTZ+78TRPawnjg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2379,9 +2379,9 @@
       }
     },
     "node_modules/@yao-pkg/pkg": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/@yao-pkg/pkg/-/pkg-6.18.2.tgz",
-      "integrity": "sha512-lo+fNeV10ldTeTrDbgK2eYTIhKDqCUVVq7a4W3s7LiTwd9/8UKYdxBodVNNCbEd2JBtqKA4BZpevitfsOzyXig==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@yao-pkg/pkg/-/pkg-6.19.0.tgz",
+      "integrity": "sha512-Ys9Fn/F44C3nOTlNyhwviLyMxydgFzsB13jAAXKxEuIR7aAz8PrFlUpxTUlwaXUU847nlmg5mnaGIyOJpnVtRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2389,11 +2389,10 @@
         "@babel/parser": "^7.23.0",
         "@babel/traverse": "^7.23.0",
         "@babel/types": "^7.23.0",
-        "@roberts_lando/vfs": "^0.3.2",
+        "@roberts_lando/vfs": "^0.3.3",
         "@yao-pkg/pkg-fetch": "3.5.33",
         "esbuild": "^0.27.3",
         "into-stream": "^9.1.0",
-        "minimist": "^1.2.6",
         "multistream": "^4.1.0",
         "picocolors": "^1.1.0",
         "picomatch": "^4.0.2",
@@ -2469,9 +2468,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5487,15 +5486,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -6684,15 +6674,12 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {

--- a/templates/cli/package.json.twig
+++ b/templates/cli/package.json.twig
@@ -73,7 +73,8 @@
   },
   "overrides": {
     "phin": "3.7.1",
-    "@xmldom/xmldom": "^0.9.10"
+    "@xmldom/xmldom": "^0.9.10",
+    "tmp": "0.2.5"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.0.0",


### PR DESCRIPTION
## What

- Adds a CLI SDK package override for exact `tmp@0.2.5` to avoid the vulnerable transitive `tmp@0.0.33` pulled through `inquirer-search-list`.
- Regenerates the CLI npm and Bun lock templates with the repo lockfile update script.
- Updates SDK build validation so `web`, `cli`, `react-native`, and `node` run normal `npm audit` instead of `npm audit --audit-level=moderate`.

## Why

`bun audit` reported GHSA-52f5-9888-hmc6 through `inquirer-search-list -> inquirer -> external-editor -> tmp`. `inquirer-search-list` has no newer release, so the narrow override keeps the current prompt behavior while resolving to patched `tmp@0.2.5`.

`tmp` has documented behavior changes across its `0.x` line, so the override is exact rather than a range. The affected `external-editor@2.2.0` path only calls `tmpNameSync({})`, which was tested against `tmp@0.2.5`.

The other SDK package templates already pass normal `npm audit`, so the workflow no longer needs the moderate threshold there either.

## Tests

- `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php cli`
- `bun audit` in `examples/cli`
- `npm audit` in `examples/cli`
- Temporary template installs for `web`, `node`, and `react-native`: `npm audit`
- `external-editor@2.2.0` with `tmp@0.2.5`: constructor creates temp file and cleanup removes it
- `composer lint-twig`
