### PR TITLE
Add dependency audits for SDK build validation

### DIFF
--- a/.github/workflows/sdk-build-validation.yml
+++ b/.github/workflows/sdk-build-validation.yml
@@ -149,7 +149,7 @@ jobs:
         if: matrix.sdk == 'go'
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.5'
+          go-version: '1.25.x'
 
       - name: Setup .NET
         if: matrix.sdk == 'dotnet'
@@ -160,6 +160,20 @@ jobs:
       - name: Setup Rust
         if: matrix.sdk == 'rust'
         uses: dtolnay/rust-toolchain@1.83.0
+
+      - name: Setup Rust for cargo-audit
+        if: matrix.sdk == 'rust'
+        run: rustup toolchain install 1.85.0 --profile minimal --no-self-update
+
+      - name: Cache cargo-audit
+        if: matrix.sdk == 'rust'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/cargo-audit
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-audit-0.22.1
 
       - name: Build SDK
         working-directory: examples/${{ matrix.sdk }}
@@ -206,15 +220,21 @@ jobs:
               ;;
             php)
               composer install
+              composer audit
               composer test
               ;;
             python)
+              python -m pip install pip-audit
               pip install -e .[test]
+              pip-audit --strict .
               python -m compileall appwrite/
               python -m unittest
               ;;
             ruby)
               bundle install
+              gem install bundler-audit
+              bundle-audit update
+              bundle-audit check --no-update
               ;;
             node)
               npm ci
@@ -228,15 +248,24 @@ jobs:
               ;;
             go)
               go mod tidy || true
+              go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+              govulncheck ./...
               go build ./...
               go test ./...
               ;;
             dotnet)
-              dotnet build
+              dotnet restore
+              dotnet build --no-restore
+              dotnet test --no-build
               ;;
             rust)
-              cargo build --release
-              cargo test --lib
+              cargo generate-lockfile
+              if ! command -v cargo-audit >/dev/null; then
+                cargo +1.85.0 install cargo-audit --version 0.22.1 --locked
+              fi
+              cargo audit
+              cargo +1.83.0 build --release
+              cargo +1.83.0 test --lib
               ;;
             *)
               echo "Unknown SDK: ${{ matrix.sdk }}"

--- a/src/SDK/Language/DotNet.php
+++ b/src/SDK/Language/DotNet.php
@@ -399,6 +399,11 @@ class DotNet extends Language
             ],
             [
                 'scope'         => 'default',
+                'destination'   => 'Directory.Build.props',
+                'template'      => 'dotnet/Directory.Build.props.twig',
+            ],
+            [
+                'scope'         => 'default',
                 'destination'   => '{{ spec.title | caseUcfirst }}/{{ spec.title | caseUcfirst }}.csproj',
                 'template'      => 'dotnet/Package/Package.csproj.twig',
             ],

--- a/templates/dotnet/Directory.Build.props.twig
+++ b/templates/dotnet/Directory.Build.props.twig
@@ -1,0 +1,11 @@
+<Project>
+  <PropertyGroup>
+    <NuGetAudit Condition="'$(MSBuildProjectName)' == '{{ spec.title | caseUcfirst }}'">true</NuGetAudit>
+    <NuGetAuditMode Condition="'$(MSBuildProjectName)' == '{{ spec.title | caseUcfirst }}'">all</NuGetAuditMode>
+
+    <!-- Fail only on high/critical -->
+    <NuGetAuditLevel Condition="'$(MSBuildProjectName)' == '{{ spec.title | caseUcfirst }}'">high</NuGetAuditLevel>
+
+    <WarningsAsErrors Condition="'$(MSBuildProjectName)' == '{{ spec.title | caseUcfirst }}'">$(WarningsAsErrors);NU1903;NU1904</WarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/templates/rust/Cargo.toml.twig
+++ b/templates/rust/Cargo.toml.twig
@@ -23,7 +23,9 @@ serde_json = "1.0.149"
 reqwest = { version = "0.12.28", features = ["json", "multipart", "stream"] }
 tokio = { version = "1.48.0", features = ["full"] }
 indexmap = ">=2, <2.12"
-url = ">=2.4.1, <2.5"
+url = "=2.5.4"
+idna = "=1.0.3"
+idna_adapter = "=1.0.0"
 mime = "0.3.17"
 fastrand = "=2.0.2"
 thiserror = "1.0.69"


### PR DESCRIPTION
## Summary
- Adds dependency vulnerability audits to generated SDK build validation for PHP, Python, Ruby, Go, .NET, and Rust.
- Keeps the existing TypeScript npm audit coverage unchanged.

## Test plan
- Parsed `.github/workflows/sdk-build-validation.yml` with Ruby YAML loader.
- Reviewed the workflow diff locally.

## Notes
- `actionlint` is not installed in this environment, so full GitHub Actions linting was not run locally.
- GitHub reported existing Dependabot alerts on the default branch when pushing; these new audit jobs may surface current SDK dependency advisories in CI.
