### PR TITLE
Add OSV audit for Dart and Flutter SDKs

### DIFF
--- a/.github/workflows/sdk-build-validation.yml
+++ b/.github/workflows/sdk-build-validation.yml
@@ -15,6 +15,7 @@ jobs:
       # LC_CODE_SIGNATURE blob on cross-compiled Darwin binaries (oven-sh/bun#29120).
       # Unpin once a Bun release includes the upstream fix (oven-sh/bun#29122).
       CLI_BUN_VERSION: '1.3.11'
+      OSV_SCANNER_VERSION: 'v2.3.1'
     strategy:
       fail-fast: false
       matrix:
@@ -146,10 +147,14 @@ jobs:
           sdk: 'stable'
 
       - name: Setup Go
-        if: matrix.sdk == 'go'
+        if: matrix.sdk == 'go' || matrix.sdk == 'dart' || matrix.sdk == 'flutter'
         uses: actions/setup-go@v5
         with:
           go-version: '1.25.x'
+
+      - name: Install OSV Scanner
+        if: matrix.sdk == 'dart' || matrix.sdk == 'flutter'
+        run: go install github.com/google/osv-scanner/v2/cmd/osv-scanner@${{ env.OSV_SCANNER_VERSION }}
 
       - name: Setup .NET
         if: matrix.sdk == 'dotnet'
@@ -205,6 +210,7 @@ jobs:
               ;;
             flutter)
               flutter pub get
+              osv-scanner scan source --lockfile=pubspec.lock
               dart analyze --no-fatal-warnings
               ;;
             apple|swift)
@@ -244,6 +250,7 @@ jobs:
               ;;
             dart)
               dart pub get
+              osv-scanner scan source --lockfile=pubspec.lock
               dart analyze --no-fatal-warnings
               ;;
             go)


### PR DESCRIPTION
## Summary
- Install a pinned OSV Scanner in SDK build validation for Dart and Flutter jobs.
- Scan generated `pubspec.lock` files after `dart pub get` / `flutter pub get`.

## Testing
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/sdk-build-validation.yml'); puts 'yaml ok'"`
- `$(go env GOPATH)/bin/actionlint .github/workflows/sdk-build-validation.yml`
- `go install github.com/google/osv-scanner/v2/cmd/osv-scanner@v2.3.1 && $(go env GOPATH)/bin/osv-scanner scan source --help`
