### PR TITLE
Fix CLI standalone update release URL

### DIFF
--- a/templates/cli/lib/constants.ts.twig
+++ b/templates/cli/lib/constants.ts.twig
@@ -21,7 +21,7 @@ export const NPM_PACKAGE_NAME = '{{ language.params.npmPackage|caseDash }}';
 export const NPM_REGISTRY_URL = `https://registry.npmjs.org/${NPM_PACKAGE_NAME}/latest`;
 
 // GitHub
-export const GITHUB_REPO = 'appwrite/{{ language.params.npmPackage|caseDash }}';
+export const GITHUB_REPO = '{{ sdk.gitUserName }}/{{ sdk.gitRepoName|caseDash }}';
 export const GITHUB_RELEASES_URL = `https://github.com/${GITHUB_REPO}/releases`;
 
 // API


### PR DESCRIPTION
## Summary

- Fix CLI standalone update downloads to use the SDK GitHub release repository instead of deriving it from the npm package name.
- Keeps the asset name based on the npm package (`appwrite-cli-*`), which matches the published release assets.

## Verification

- `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php cli`
- `composer lint-twig`
- `curl -I -L -s -o /dev/null -w "%{http_code}\n" https://github.com/appwrite/sdk-for-cli/releases/latest/download/appwrite-cli-darwin-arm64` returned `200`.
