### PR TITLE
Fix CLI Homebrew tap updates

### DIFF
--- a/templates/cli/lib/commands/update.ts
+++ b/templates/cli/lib/commands/update.ts
@@ -11,6 +11,7 @@ import {
   getLatestVersionForInstallation,
   compareVersions,
   getErrorMessage,
+  getInstalledHomebrewFormula,
 } from "../utils.js";
 import {
   EXECUTABLE_NAME,
@@ -136,6 +137,31 @@ const execCommand = (
   });
 };
 
+const getHomebrewFormulaForUpdate = (): string => {
+  return getInstalledHomebrewFormula() ?? HOMEBREW_FORMULA;
+};
+
+const getHomebrewFormulaForManualInstructions = (): string => {
+  if (process.platform === "win32") {
+    return HOMEBREW_FORMULA;
+  }
+
+  return getHomebrewFormulaForUpdate();
+};
+
+const showHomebrewTapRecommendation = (formulaName: string): void => {
+  if (formulaName === HOMEBREW_FORMULA) {
+    return;
+  }
+
+  warn(
+    `Detected ${chalk.bold(formulaName)} from Homebrew. For faster native binaries, we recommend using the official Appwrite tap.`,
+  );
+  hint(
+    `To use the official Appwrite tap, run: brew install ${HOMEBREW_FORMULA}`,
+  );
+};
+
 /**
  * Update via npm
  */
@@ -163,9 +189,16 @@ const updateViaNpm = async (): Promise<void> => {
 /**
  * Update via Homebrew
  */
-const updateViaHomebrew = async (): Promise<void> => {
+const updateViaHomebrew = async (
+  formulaName: string = getHomebrewFormulaForUpdate(),
+  options: { showRecommendation?: boolean } = {},
+): Promise<void> => {
   try {
-    await execCommand("brew", ["upgrade", HOMEBREW_FORMULA]);
+    if (options.showRecommendation ?? true) {
+      showHomebrewTapRecommendation(formulaName);
+    }
+
+    await execCommand("brew", ["upgrade", formulaName]);
     console.log("");
     success("Updated to latest version via Homebrew!");
     hint(`Run '${EXECUTABLE_NAME} --version' to verify the new version.`);
@@ -184,7 +217,7 @@ const updateViaHomebrew = async (): Promise<void> => {
     } else {
       console.log("");
       error(`Failed to update via Homebrew: ${message}`);
-      hint(`Try running: brew upgrade ${HOMEBREW_FORMULA}`);
+      hint(`Try running: brew upgrade ${formulaName}`);
     }
   }
 };
@@ -196,7 +229,7 @@ const updateViaStandaloneBinary = async (
   latestVersion: string,
 ): Promise<void> => {
   if (process.platform === "win32") {
-    showManualInstructions(latestVersion);
+    showManualInstructions(latestVersion, HOMEBREW_FORMULA);
     return;
   }
 
@@ -252,7 +285,10 @@ const updateViaStandaloneBinary = async (
 /**
  * Show manual update instructions
  */
-const showManualInstructions = (latestVersion: string): void => {
+const showManualInstructions = (
+  latestVersion: string,
+  homebrewFormula: string = getHomebrewFormulaForManualInstructions(),
+): void => {
   log("Manual update options:");
   console.log("");
 
@@ -261,7 +297,13 @@ const showManualInstructions = (latestVersion: string): void => {
   console.log("");
 
   log(`${chalk.bold("Option 2: Homebrew")}`);
-  console.log(`  brew upgrade ${HOMEBREW_FORMULA}`);
+  console.log(`  brew upgrade ${homebrewFormula}`);
+  if (homebrewFormula !== HOMEBREW_FORMULA) {
+    console.log("");
+    hint(
+      `For faster native binaries from the official Appwrite tap, run: brew install ${HOMEBREW_FORMULA}`,
+    );
+  }
   console.log("");
 
   if (process.platform !== "win32") {
@@ -347,8 +389,14 @@ interface UpdateOptions {
 const updateCli = async ({ manual }: UpdateOptions = {}): Promise<void> => {
   try {
     const installationMethod = detectInstallationMethod();
-    const latestVersion =
-      await getLatestVersionForInstallation(installationMethod);
+    const homebrewFormula =
+      installationMethod === "homebrew" ? getHomebrewFormulaForUpdate() : null;
+    const latestVersion = await getLatestVersionForInstallation(
+      installationMethod,
+      {
+        homebrewFormula: homebrewFormula ?? undefined,
+      },
+    );
 
     const comparison = compareVersions(version, latestVersion);
 
@@ -365,22 +413,28 @@ const updateCli = async ({ manual }: UpdateOptions = {}): Promise<void> => {
       return;
     }
 
+    if (manual) {
+      showManualInstructions(latestVersion, homebrewFormula ?? undefined);
+      return;
+    }
+
+    if (homebrewFormula) {
+      showHomebrewTapRecommendation(homebrewFormula);
+    }
+
     log(
       `Updating from ${chalk.blue(version)} to ${chalk.green(latestVersion)}...`,
     );
     console.log("");
-
-    if (manual) {
-      showManualInstructions(latestVersion);
-      return;
-    }
 
     switch (installationMethod) {
       case "npm":
         await updateViaNpm();
         break;
       case "homebrew":
-        await updateViaHomebrew();
+        await updateViaHomebrew(homebrewFormula ?? undefined, {
+          showRecommendation: false,
+        });
         break;
       case "standalone":
         await updateViaStandaloneBinary(latestVersion);

--- a/templates/cli/lib/utils.ts
+++ b/templates/cli/lib/utils.ts
@@ -94,8 +94,13 @@ export const getErrorMessage = (error: unknown): string => {
 
 export type InstallationMethod = "npm" | "homebrew" | "standalone";
 type LatestVersionSource = "npm" | "homebrew";
+type LatestVersionOptions = {
+  timeoutMs?: number;
+  homebrewFormula?: string;
+};
 type HomebrewInfoResponse = {
   formulae?: Array<{
+    full_name?: string;
     versions?: {
       stable?: string;
     };
@@ -221,17 +226,55 @@ const normalizeHomebrewVersion = (version: string): string => {
   return version.split("_")[0].trim();
 };
 
-const getHomebrewLatestVersion = async (
+const DEFAULT_HOMEBREW_COMMAND_TIMEOUT_MS = 15000;
+
+export const getInstalledHomebrewFormula = (
   options: { timeoutMs?: number } = {},
-): Promise<string> => {
+): string | null => {
   try {
     const output = childProcess.execFileSync(
       "brew",
-      ["info", "--json=v2", HOMEBREW_FORMULA],
+      ["list", "--formula", "--full-name"],
       {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
-        timeout: options.timeoutMs,
+        timeout: options.timeoutMs ?? DEFAULT_HOMEBREW_COMMAND_TIMEOUT_MS,
+        env: {
+          ...process.env,
+          HOMEBREW_NO_AUTO_UPDATE: "1",
+        },
+      },
+    );
+    const formulaName = EXECUTABLE_NAME.toLowerCase();
+    const supportedFormulas = new Set([HOMEBREW_FORMULA, formulaName]);
+
+    return (
+      output
+        .split(/\r?\n/)
+        .map((formula) => formula.trim())
+        .find((formula) => supportedFormulas.has(formula)) ?? null
+    );
+  } catch (_error) {
+    return null;
+  }
+};
+
+const getHomebrewLatestVersion = async (
+  options: LatestVersionOptions = {},
+): Promise<string> => {
+  const formulaName =
+    options.homebrewFormula ??
+    getInstalledHomebrewFormula(options) ??
+    HOMEBREW_FORMULA;
+
+  try {
+    const output = childProcess.execFileSync(
+      "brew",
+      ["info", "--json=v2", formulaName],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: options.timeoutMs ?? DEFAULT_HOMEBREW_COMMAND_TIMEOUT_MS,
         env: {
           ...process.env,
           HOMEBREW_NO_AUTO_UPDATE: "1",
@@ -240,10 +283,16 @@ const getHomebrewLatestVersion = async (
     );
 
     const parsed = JSON.parse(output) as HomebrewInfoResponse;
-    const stableVersion = parsed.formulae?.[0]?.versions?.stable;
+    const formula =
+      parsed.formulae?.find((formula) => {
+        return formula.full_name === formulaName;
+      }) ?? parsed.formulae?.[0];
+    const stableVersion = formula?.versions?.stable;
 
     if (typeof stableVersion !== "string" || stableVersion.trim() === "") {
-      throw new Error("Homebrew did not return a stable formula version.");
+      throw new Error(
+        `Homebrew did not return a stable version for ${formulaName}.`,
+      );
     }
 
     return normalizeHomebrewVersion(stableVersion);
@@ -492,7 +541,7 @@ export async function getLatestVersion(
 
 export async function getLatestVersionForInstallation(
   method: InstallationMethod | null,
-  options: { timeoutMs?: number } = {},
+  options: LatestVersionOptions = {},
 ): Promise<string> {
   switch (getLatestVersionSource(method)) {
     case "homebrew":
@@ -557,10 +606,17 @@ export async function getCachedUpdateNotification(
   }
 
   try {
+    const homebrewFormula =
+      installationMethod === "homebrew"
+        ? (getInstalledHomebrewFormula({
+            timeoutMs: DEFAULT_UPDATE_CHECK_TIMEOUT_MS,
+          }) ?? HOMEBREW_FORMULA)
+        : undefined;
     const latestVersion = await getLatestVersionForInstallation(
       installationMethod,
       {
         timeoutMs: DEFAULT_UPDATE_CHECK_TIMEOUT_MS,
+        homebrewFormula,
       },
     );
     const updateAvailable = compareVersions(currentVersion, latestVersion) > 0;


### PR DESCRIPTION
## Summary

- Detect the actually installed Homebrew formula and use it consistently for latest-version checks, automatic updates, and manual instructions.
- Warn when the installed formula is not the official Appwrite tap, recommend the tap for faster native binaries, and keep updating the currently installed formula.
- Avoid automatic formula migration; users get an explicit migration command instead.

## Verification

- `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php cli`
- `composer lint-twig`
- `bun run build:types` in `examples/cli`
