### PR TITLE
Add CLI shell completion command

### DIFF
--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -411,6 +411,11 @@ class CLI extends Node
                 'template'      => 'cli/lib/config.ts',
             ],
             [
+                'scope'         => 'copy',
+                'destination'   => 'lib/completions.ts',
+                'template'      => 'cli/lib/completions.ts',
+            ],
+            [
                 'scope'         => 'default',
                 'destination'   => 'lib/constants.ts',
                 'template'      => 'cli/lib/constants.ts.twig',

--- a/templates/cli/README.md.twig
+++ b/templates/cli/README.md.twig
@@ -57,6 +57,27 @@ $ brew install {{ language.params.homebrewTapOwner }}/{{ language.params.homebre
 
 Homebrew pulls the formula from the [`{{ language.params.homebrewTapOwner }}/homebrew-{{ language.params.homebrewTapName }}`](https://github.com/{{ language.params.homebrewTapOwner }}/homebrew-{{ language.params.homebrewTapName }}) tap and downloads the native binary for your platform.
 
+### Shell completion
+
+Install completion for your current shell:
+
+```bash
+{{ language.params.executableName|caseLower }} completion install
+```
+
+You can also generate or install completion scripts manually:
+
+```bash
+# zsh
+{{ language.params.executableName|caseLower }} completion install zsh
+# bash
+{{ language.params.executableName|caseLower }} completion install bash
+# fish
+{{ language.params.executableName|caseLower }} completion install fish
+```
+
+For zsh, ensure `~/.zfunc` is in your `fpath` and `compinit` is loaded from your shell config.
+
 ### Windows
 Via Powershell
 ```powershell

--- a/templates/cli/cli.ts.twig
+++ b/templates/cli/cli.ts.twig
@@ -18,6 +18,11 @@ import {
     syncVersionCheckCache,
 } from './lib/utils.js';
 import inquirerSearchList from 'inquirer-search-list';
+import {
+    createCompletionCommand,
+    isCompletionCommand,
+    isCompletionInvocation,
+} from './lib/completions.js';
 
 import { client } from './lib/commands/generic.js';
 {% if sdk.test != "true" %}
@@ -40,7 +45,6 @@ import { {{ service.name }} } from './lib/commands/services/{{ service.name | ca
 const { version } = packageJson;
 inquirer.registerPrompt('search-list', inquirerSearchList);
 const VERSION_CHECK_TIMEOUT_MS = 5000;
-
 function writeUpdateAvailableNotice(currentVersion: string, latestVersion: string, toStderr: boolean = false): void {
     const stream = toStderr ? process.stderr : process.stdout;
 
@@ -119,7 +123,9 @@ if (process.argv.includes('-v') || process.argv.includes('--version')) {
     })();
 } else {
     void (async () => {
-        await maybeShowUpdateNotice();
+        if (!isCompletionInvocation()) {
+            await maybeShowUpdateNotice();
+        }
 
         program
             .name('{{ language.params.executableName|caseLower }}')
@@ -134,7 +140,13 @@ if (process.argv.includes('-v') || process.argv.includes('--version')) {
             .option('-j, --json', 'Output filtered JSON without empty values')
             .option('-R, --raw', 'Output full JSON response (secrets still redacted unless --show-secrets is set)')
             .option('--show-secrets', 'Display sensitive values like secrets and tokens in output')
-            .hook('preAction', migrate)
+            .hook('preAction', async (_thisCommand, actionCommand) => {
+                if (isCompletionCommand(actionCommand)) {
+                    return;
+                }
+
+                await migrate();
+            })
             .option('-f,--force', 'Flag to confirm all warnings')
             .option('-a,--all', 'Flag to push all resources')
             .option('--id [id...]', 'Flag to pass a list of ids for a given action')
@@ -190,6 +202,7 @@ if (process.argv.includes('-v') || process.argv.includes('--version')) {
 {% for service in spec.services %}
             .addCommand({{ service.name }})
 {% endfor %}
+            .addCommand(createCompletionCommand(program))
             .addCommand(client)
             .parse(process.argv);
 

--- a/templates/cli/install.sh.twig
+++ b/templates/cli/install.sh.twig
@@ -37,6 +37,7 @@ ARCH=""
 # Add some color to life
 RED='\033[0;31m'
 GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
 greeting() {
@@ -49,7 +50,7 @@ EOF
 }
 
 getSystemInfo() {
-    echo "[1/4] Getting System Info ..."
+    echo "[1/5] Getting System Info ..."
     
     ARCH=$(uname -m)
     case $ARCH in
@@ -87,6 +88,10 @@ printSuccess() {
     printf "${GREEN}✅ Done ... ${NC}\n\n"
 }
 
+printSkipped() {
+    printf "${YELLOW}ℹ️  $1 ${NC}\n"
+}
+
 verifyMacOSCodeSignature() {
     if [ "$OS" != "darwin" ]; then
         return
@@ -107,7 +112,7 @@ verifyMacOSCodeSignature() {
 }
 
 downloadBinary() {
-    echo "[2/4] Downloading executable for $OS ($ARCH) ..."
+    echo "[2/5] Downloading executable for $OS ($ARCH) ..."
 
     GITHUB_LATEST_VERSION="{{ sdk.version }}"
     GITHUB_FILE="{{ language.params.npmPackage }}-${OS}-${ARCH}"
@@ -124,7 +129,7 @@ downloadBinary() {
 }
 
 install() {
-    echo "[3/4] Installing ..."
+    echo "[3/5] Installing ..."
 
     printf "${GREEN}🚧 Setting Permissions ${NC}\n"
     chmod +x ${{ spec.title | upper }}_TEMP_NAME
@@ -145,6 +150,22 @@ install() {
     printSuccess
 }
 
+installCompletions() {
+    echo "[4/5] Installing shell completions ..."
+
+    if ${{ spec.title | upper }}_EXECUTABLE_FILEPATH completion install; then
+        printSuccess
+        return
+    fi
+
+    printSkipped "Skipped shell completion installation. To install manually, run:"
+    echo "  ${{ spec.title | upper }}_EXECUTABLE_NAME completion install"
+    echo "  ${{ spec.title | upper }}_EXECUTABLE_NAME completion install zsh"
+    echo "  ${{ spec.title | upper }}_EXECUTABLE_NAME completion install bash"
+    echo "  ${{ spec.title | upper }}_EXECUTABLE_NAME completion install fish"
+    echo ""
+}
+
 cleanup() {
     printf "${GREEN}🧹 Cleaning up mess ... ${NC}\n"
     rm ${{ spec.title | upper }}_TEMP_NAME 
@@ -157,7 +178,7 @@ cleanup() {
 }
 
 installCompleted() {
-    echo "[4/4] Wrapping up installation ... "
+    echo "[5/5] Wrapping up installation ... "
     cleanup
     echo "🚀 To get started with {{ spec.title | caseUcfirst }} CLI, please visit {{ sdk.url }}/docs/command-line"
     echo "As first step, you can login to your {{ spec.title | caseUcfirst }} account using 'appwrite login'"
@@ -168,4 +189,5 @@ greeting
 getSystemInfo
 downloadBinary
 install
+installCompletions
 installCompleted

--- a/templates/cli/lib/completions.ts
+++ b/templates/cli/lib/completions.ts
@@ -1,0 +1,567 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { Command } from "commander";
+import type { Option } from "commander";
+import { EXECUTABLE_NAME } from "./constants.js";
+
+const SUPPORTED_COMPLETION_SHELLS = ["zsh", "bash", "fish"] as const;
+
+type CompletionShell = (typeof SUPPORTED_COMPLETION_SHELLS)[number];
+
+type CompletionOption = {
+  flags: string[];
+  required: boolean;
+  optional: boolean;
+};
+
+type CompletionCommand = {
+  name: string;
+  aliases: string[];
+  options: CompletionOption[];
+  commands: CompletionCommand[];
+  path: string[];
+};
+
+type CompletionContext = {
+  path: string[];
+  commands: string[];
+  options: string[];
+};
+
+type CompletionTransition = {
+  from: string;
+  token: string;
+  to: string;
+};
+
+function uniq(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function commandPath(path: string[]): string {
+  return path.join(" ");
+}
+
+function optionToCompletion(option: Option): CompletionOption {
+  return {
+    flags: uniq(
+      [option.short, option.long].filter((flag): flag is string =>
+        Boolean(flag),
+      ),
+    ),
+    required: option.required,
+    optional: option.optional,
+  };
+}
+
+function commandToCompletion(
+  command: Command,
+  path: string[] = [],
+): CompletionCommand {
+  const helper = command.createHelp();
+  const commands = helper
+    .visibleCommands(command)
+    .filter((childCommand) => childCommand.name() !== "help")
+    .map((childCommand) =>
+      commandToCompletion(childCommand, [...path, childCommand.name()]),
+    );
+
+  return {
+    name: command.name(),
+    aliases: command.aliases(),
+    options: helper.visibleOptions(command).map(optionToCompletion),
+    commands,
+    path,
+  };
+}
+
+function commandCompletionNames(command: CompletionCommand): string[] {
+  return uniq([command.name, ...command.aliases]);
+}
+
+function collectCompletionContexts(
+  command: CompletionCommand,
+  rootOptions: CompletionOption[],
+  contexts: CompletionContext[] = [],
+): CompletionContext[] {
+  const options =
+    command.path.length === 0
+      ? command.options
+      : [...rootOptions, ...command.options];
+
+  contexts.push({
+    path: command.path,
+    commands: command.commands.flatMap(commandCompletionNames),
+    options: uniq(options.flatMap((option) => option.flags)),
+  });
+
+  for (const childCommand of command.commands) {
+    collectCompletionContexts(childCommand, rootOptions, contexts);
+  }
+
+  return contexts;
+}
+
+function collectCompletionTransitions(
+  command: CompletionCommand,
+  transitions: CompletionTransition[] = [],
+): CompletionTransition[] {
+  const from = commandPath(command.path);
+
+  for (const childCommand of command.commands) {
+    const to = commandPath(childCommand.path);
+
+    for (const name of commandCompletionNames(childCommand)) {
+      transitions.push({ from, token: name, to });
+    }
+
+    collectCompletionTransitions(childCommand, transitions);
+  }
+
+  return transitions;
+}
+
+function completionSpec(command: Command): {
+  contexts: CompletionContext[];
+  transitions: CompletionTransition[];
+  root: CompletionCommand;
+} {
+  const root = commandToCompletion(command);
+
+  return {
+    contexts: collectCompletionContexts(root, root.options),
+    transitions: collectCompletionTransitions(root),
+    root,
+  };
+}
+
+function renderZshCompletion(command: Command): string {
+  const spec = completionSpec(command);
+  const commandName = EXECUTABLE_NAME;
+  const transitionCases = spec.transitions
+    .map(
+      (transition) =>
+        `        ${shellQuote(`${transition.from}:${transition.token}`)}) context=${shellQuote(transition.to)} ;;`,
+    )
+    .join("\n");
+  const contextCases = spec.contexts
+    .map((context) => {
+      const completions = uniq([...context.commands, ...context.options])
+        .map(shellQuote)
+        .join(" ");
+
+      return `        ${shellQuote(commandPath(context.path))})
+            completions=( ${completions} )
+            ;;`;
+    })
+    .join("\n");
+
+  return `#compdef ${commandName}
+
+_${commandName}() {
+    local context word
+    local -a completions
+
+    context=''
+    for (( i = 2; i < CURRENT; i++ )); do
+        word="\${words[i]}"
+        [[ "\${word}" == -* ]] && continue
+
+        case "\${context}:\${word}" in
+${transitionCases}
+        esac
+    done
+
+    case "\${context}" in
+${contextCases}
+    esac
+
+    compadd -- "\${completions[@]}"
+}
+
+if (( $+functions[compdef] )); then
+    compdef _${commandName} ${commandName}
+fi
+`;
+}
+
+function renderBashCompletion(command: Command): string {
+  const spec = completionSpec(command);
+  const commandName = EXECUTABLE_NAME;
+  const transitionCases = spec.transitions
+    .map(
+      (transition) =>
+        `            ${shellQuote(`${transition.from}:${transition.token}`)}) context=${shellQuote(transition.to)} ;;`,
+    )
+    .join("\n");
+  const contextCases = spec.contexts
+    .map((context) => {
+      const completions = uniq([...context.commands, ...context.options]).join(
+        " ",
+      );
+
+      return `        ${shellQuote(commandPath(context.path))})
+            completions=${shellQuote(completions)}
+            ;;`;
+    })
+    .join("\n");
+
+  return `_${commandName}_completion() {
+    local cur context completions word i
+
+    cur="\${COMP_WORDS[COMP_CWORD]}"
+    context=''
+    completions=''
+
+    for (( i = 1; i < COMP_CWORD; i++ )); do
+        word="\${COMP_WORDS[i]}"
+        [[ "\${word}" == -* ]] && continue
+
+        case "\${context}:\${word}" in
+${transitionCases}
+        esac
+    done
+
+    case "\${context}" in
+${contextCases}
+    esac
+
+    COMPREPLY=( $(compgen -W "\${completions}" -- "\${cur}") )
+}
+
+if type complete >/dev/null 2>&1; then
+    complete -F _${commandName}_completion ${commandName}
+fi
+`;
+}
+
+function fishCondition(commandName: string, path: string[]): string {
+  const pathText = commandPath(path);
+
+  return pathText
+    ? `__${commandName}_using_command ${pathText}`
+    : `__${commandName}_using_command`;
+}
+
+function fishOptionLine(
+  commandName: string,
+  path: string[],
+  option: CompletionOption,
+): string | null {
+  const shortFlag = option.flags.find((flag) => /^-[^-]$/.test(flag));
+  const longFlag = option.flags.find((flag) => /^--/.test(flag));
+
+  if (!shortFlag && !longFlag) {
+    return null;
+  }
+
+  const parts = [
+    "complete",
+    "-c",
+    shellQuote(commandName),
+    "-f",
+    "-n",
+    shellQuote(fishCondition(commandName, path)),
+  ];
+
+  if (shortFlag) {
+    parts.push("-s", shellQuote(shortFlag.slice(1)));
+  }
+
+  if (longFlag) {
+    parts.push("-l", shellQuote(longFlag.slice(2)));
+  }
+
+  if (option.required) {
+    parts.push("-r");
+  } else if (option.optional) {
+    parts.push("-x");
+  }
+
+  return parts.join(" ");
+}
+
+function renderFishCompletion(command: Command): string {
+  const commandName = EXECUTABLE_NAME;
+  const spec = completionSpec(command);
+  const transitionCases = spec.transitions
+    .map(
+      (transition) =>
+        `            case ${shellQuote(`${transition.from}:${transition.token}`)}
+                set context ${shellQuote(transition.to)}`,
+    )
+    .join("\n");
+  const contextLines = spec.contexts
+    .flatMap((context) => {
+      const lines: string[] = [];
+      const commandNames = uniq(context.commands);
+
+      if (commandNames.length > 0) {
+        lines.push(
+          `complete -c ${shellQuote(commandName)} -f -n ${shellQuote(fishCondition(commandName, context.path))} -a ${shellQuote(commandNames.join(" "))}`,
+        );
+      }
+
+      const commandNode =
+        context.path.length === 0
+          ? spec.root
+          : findCompletionCommand(spec.root, context.path);
+      const rootOptions = spec.root.options;
+      const optionSource =
+        context.path.length === 0 || !commandNode
+          ? rootOptions
+          : [...rootOptions, ...commandNode.options];
+
+      for (const option of dedupeCompletionOptions(optionSource)) {
+        const line = fishOptionLine(commandName, context.path, option);
+
+        if (line) {
+          lines.push(line);
+        }
+      }
+
+      return lines;
+    })
+    .join("\n");
+
+  return `function __${commandName}_using_command
+    set -l tokens (commandline -opc)
+    set -l context ''
+    set -l expected (string join ' ' $argv)
+
+    if test (count $tokens) -gt 0
+        set -e tokens[1]
+    end
+
+    for token in $tokens
+        if string match -qr '^-' -- $token
+            continue
+        end
+
+        switch "$context:$token"
+${transitionCases}
+        end
+    end
+
+    test "$context" = "$expected"
+end
+
+${contextLines}
+`;
+}
+
+function findCompletionCommand(
+  command: CompletionCommand,
+  path: string[],
+): CompletionCommand | null {
+  if (commandPath(command.path) === commandPath(path)) {
+    return command;
+  }
+
+  for (const childCommand of command.commands) {
+    const found = findCompletionCommand(childCommand, path);
+
+    if (found) {
+      return found;
+    }
+  }
+
+  return null;
+}
+
+function dedupeCompletionOptions(
+  options: CompletionOption[],
+): CompletionOption[] {
+  const seen = new Set<string>();
+  const deduped: CompletionOption[] = [];
+
+  for (const option of options) {
+    const key = option.flags.join(",");
+
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    deduped.push(option);
+  }
+
+  return deduped;
+}
+
+function renderCompletion(command: Command, shell: CompletionShell): string {
+  if (shell === "zsh") {
+    return renderZshCompletion(command);
+  }
+
+  if (shell === "bash") {
+    return renderBashCompletion(command);
+  }
+
+  return renderFishCompletion(command);
+}
+
+function normalizeShell(value: string | undefined): CompletionShell | null {
+  if (!value) {
+    return null;
+  }
+
+  const shellName = path.basename(value).toLowerCase();
+
+  if (shellName === "zsh" || shellName === "bash" || shellName === "fish") {
+    return shellName;
+  }
+
+  return null;
+}
+
+function detectShell(): CompletionShell | null {
+  return normalizeShell(process.env.SHELL);
+}
+
+function xdgPath(envName: string, fallback: string): string {
+  const configuredPath = process.env[envName];
+
+  if (configuredPath) {
+    return configuredPath;
+  }
+
+  return fallback;
+}
+
+function completionInstallPath(
+  commandName: string,
+  shell: CompletionShell,
+): string {
+  const homeDir = os.homedir();
+
+  if (shell === "zsh") {
+    return path.join(
+      xdgPath("ZSH_COMPLETION_DIR", path.join(homeDir, ".zfunc")),
+      `_${commandName}`,
+    );
+  }
+
+  if (shell === "bash") {
+    return path.join(
+      xdgPath(
+        "BASH_COMPLETION_DIR",
+        path.join(homeDir, ".local", "share", "bash-completion", "completions"),
+      ),
+      commandName,
+    );
+  }
+
+  return path.join(
+    xdgPath(
+      "FISH_COMPLETION_DIR",
+      path.join(homeDir, ".config", "fish", "completions"),
+    ),
+    `${commandName}.fish`,
+  );
+}
+
+function installCompletion(
+  rootCommand: Command,
+  shell: CompletionShell,
+): string {
+  const installPath = completionInstallPath(EXECUTABLE_NAME, shell);
+
+  fs.mkdirSync(path.dirname(installPath), { recursive: true });
+  fs.writeFileSync(installPath, renderCompletion(rootCommand, shell));
+
+  return installPath;
+}
+
+export function isCompletionInvocation(): boolean {
+  return findTopLevelCommandArg(process.argv.slice(2)) === "completion";
+}
+
+function findTopLevelCommandArg(args: string[]): string | undefined {
+  let consumesIdValues = false;
+
+  for (const arg of args) {
+    if (arg === "--") {
+      return undefined;
+    }
+
+    if (consumesIdValues) {
+      if (!arg.startsWith("-")) {
+        continue;
+      }
+
+      consumesIdValues = false;
+    }
+
+    if (arg === "--id") {
+      consumesIdValues = true;
+      continue;
+    }
+
+    if (arg.startsWith("--id=")) {
+      continue;
+    }
+
+    if (arg.startsWith("-")) {
+      continue;
+    }
+
+    return arg;
+  }
+
+  return undefined;
+}
+
+export function isCompletionCommand(command: Command): boolean {
+  let currentCommand: Command | undefined = command;
+
+  while (currentCommand) {
+    if (currentCommand.name() === "completion") {
+      return true;
+    }
+
+    currentCommand = currentCommand.parent;
+  }
+
+  return false;
+}
+
+export function createCompletionCommand(rootCommand: Command): Command {
+  const completionCommand = new Command("completion").description(
+    "Generate shell completion scripts",
+  );
+
+  completionCommand
+    .command("install [shell]")
+    .description("Install shell completion script")
+    .action((requestedShell?: string) => {
+      const shell = normalizeShell(requestedShell) ?? detectShell();
+
+      if (!shell) {
+        process.stderr.write(
+          `Unable to detect shell. Run ${EXECUTABLE_NAME} completion install zsh, bash, or fish.\n`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      const installPath = installCompletion(rootCommand, shell);
+      process.stdout.write(`Installed ${shell} completion to ${installPath}\n`);
+    });
+
+  for (const shell of SUPPORTED_COMPLETION_SHELLS) {
+    completionCommand
+      .command(shell)
+      .description(`Generate ${shell} completion script`)
+      .action(() => {
+        process.stdout.write(renderCompletion(rootCommand, shell));
+      });
+  }
+
+  return completionCommand;
+}

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -217,6 +217,13 @@ abstract class Base extends TestCase
         'x-sdk-name: cli; x-sdk-platform: server; x-sdk-language: cli; x-sdk-version: 0.0.1',
     ];
 
+    protected const CLI_COMPLETION_RESPONSES = [
+        'compdef _appwrite appwrite',
+        'complete -F _appwrite_completion appwrite',
+        'complete -c \'appwrite\' -f -n \'__appwrite_using_command\' -a \'bar client completion foo general\'',
+        '\'foo:get\') context=\'foo get\' ;;',
+    ];
+
     protected const CLI_TYPEGEN_RESPONSES = [
         'CLI_TYPEGEN:passed',
     ];

--- a/tests/CLIBun10Test.php
+++ b/tests/CLIBun10Test.php
@@ -25,6 +25,7 @@ class CLIBun10Test extends Base
         'docker run --network="mockapi" --rm -v $(pwd):/app -w /app/tests/sdks/cli oven/bun:1.0 bun test.js';
 
     protected array $expectedOutput = [
+        ...Base::CLI_COMPLETION_RESPONSES,
         ...Base::FOO_RESPONSES,
         ...Base::BAR_RESPONSES,
         ...Base::GENERAL_RESPONSES,

--- a/tests/CLIBun11Test.php
+++ b/tests/CLIBun11Test.php
@@ -25,6 +25,7 @@ class CLIBun11Test extends Base
         'docker run --network="mockapi" --rm -v $(pwd):/app -w /app/tests/sdks/cli oven/bun:1.1 bun test.js';
 
     protected array $expectedOutput = [
+        ...Base::CLI_COMPLETION_RESPONSES,
         ...Base::FOO_RESPONSES,
         ...Base::BAR_RESPONSES,
         ...Base::GENERAL_RESPONSES,

--- a/tests/CLIBun13Test.php
+++ b/tests/CLIBun13Test.php
@@ -25,6 +25,7 @@ class CLIBun13Test extends Base
         'docker run --network="mockapi" --rm -v $(pwd):/app -w /app/tests/sdks/cli oven/bun:1.3 bun test.js';
 
     protected array $expectedOutput = [
+        ...Base::CLI_COMPLETION_RESPONSES,
         ...Base::FOO_RESPONSES,
         ...Base::BAR_RESPONSES,
         ...Base::GENERAL_RESPONSES,

--- a/tests/languages/cli/test.js
+++ b/tests/languages/cli/test.js
@@ -1,5 +1,6 @@
 const { execFileSync, execSync } = require("child_process");
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 const Client = require("./lib/client.ts").default;
 const { parse } = require("./lib/parser.ts");
@@ -15,6 +16,8 @@ const {
   getFunctionDeploymentConsoleUrl,
   getSiteDeploymentConsoleUrl,
 } = require("./lib/utils.ts");
+const { EXECUTABLE_NAME } = require("./lib/constants.ts");
+const { isCompletionInvocation } = require("./lib/completions.ts");
 
 const extractFirstValue = (output) => {
   const firstLine =
@@ -34,6 +37,34 @@ const extractFirstValue = (output) => {
 };
 
 const stripAnsi = (value) => value.replace(/\u001b\[[0-9;]*m/g, "");
+
+const extractHelpCommands = (helpOutput) => {
+  const commandsIndex = helpOutput.indexOf("Commands:");
+
+  if (commandsIndex === -1) {
+    throw new Error(
+      `Expected help output to include a Commands section.\n${helpOutput}`,
+    );
+  }
+
+  return helpOutput
+    .slice(commandsIndex)
+    .split("\n")
+    .map((line) => line.match(/^\s{2}([a-zA-Z0-9-]+)\b/)?.[1])
+    .filter((commandName) => commandName && commandName !== "help");
+};
+
+const extractLineContaining = (output, token) => {
+  const line = output
+    .split("\n")
+    .find((candidate) => candidate.includes(token));
+
+  if (!line) {
+    throw new Error(`Expected output to include ${JSON.stringify(token)}.`);
+  }
+
+  return line.trim();
+};
 
 // Sync-only capture helper. The callback must complete all writes before it
 // returns, and async callbacks are rejected explicitly to avoid misleading
@@ -71,16 +102,144 @@ const captureStdoutSync = (callback) => {
   return stripAnsi(output).replace(/\r/g, "");
 };
 
+const withArgv = (args, callback) => {
+  const originalArgv = process.argv;
+
+  process.argv = ["bun", "./dist/cli.cjs", ...args];
+
+  try {
+    return callback();
+  } finally {
+    process.argv = originalArgv;
+  }
+};
+
 execSync(
   "bun ./dist/cli.cjs client --endpoint 'http://mockapi/v1' --project-id console --key=35y3h5h345 --self-signed true",
   { stdio: "inherit" },
 );
+
+const zshCompletionOutput = execSync("bun ./dist/cli.cjs completion zsh", {
+  stdio: "pipe",
+}).toString();
+const bashCompletionOutput = execSync("bun ./dist/cli.cjs completion bash", {
+  stdio: "pipe",
+}).toString();
+const fishCompletionOutput = execSync("bun ./dist/cli.cjs completion fish", {
+  stdio: "pipe",
+}).toString();
+const helpOutput = execSync("bun ./dist/cli.cjs --help", {
+  stdio: "pipe",
+}).toString();
+const completionFunctionName = `_${EXECUTABLE_NAME}`;
+const zshRegistrationToken = `compdef ${completionFunctionName} ${EXECUTABLE_NAME}`;
+const bashRegistrationToken =
+  `complete -F ${completionFunctionName}_completion ${EXECUTABLE_NAME}`;
+const fishRegistrationToken = `complete -c '${EXECUTABLE_NAME}'`;
+
+for (const commandName of extractHelpCommands(helpOutput)) {
+  if (!zshCompletionOutput.includes(`'${commandName}'`)) {
+    throw new Error(
+      `Expected zsh completion output to include top-level command ${commandName}.`,
+    );
+  }
+}
+
+for (const [shell, completionOutput, expectedToken] of [
+  ["zsh", zshCompletionOutput, zshRegistrationToken],
+  ["bash", bashCompletionOutput, bashRegistrationToken],
+  ["fish", fishCompletionOutput, fishRegistrationToken],
+]) {
+  if (!completionOutput.includes(expectedToken)) {
+    throw new Error(
+      `Expected ${shell} completion output to include ${JSON.stringify(expectedToken)}.`,
+    );
+  }
+}
+
+if (
+  !zshCompletionOutput.includes("'foo:get'") ||
+  !zshCompletionOutput.includes("'--verbose'") ||
+  !zshCompletionOutput.includes("'--x'")
+) {
+  throw new Error(
+    "Expected zsh completion output to include nested commands and flags.",
+  );
+}
+
+if (withArgv(["--id", "completion"], isCompletionInvocation)) {
+  throw new Error(
+    "Expected --id completion to be parsed as an id value, not a completion command.",
+  );
+}
+
+if (!withArgv(["--id=foo", "completion"], isCompletionInvocation)) {
+  throw new Error("Expected completion command after --id=foo to be detected.");
+}
+
+const completionHome = fs.mkdtempSync(
+  path.join(os.tmpdir(), `${EXECUTABLE_NAME}-completion-`),
+);
+try {
+  const installOutput = execFileSync(
+    "bun",
+    ["./dist/cli.cjs", "completion", "install"],
+    {
+      env: {
+        ...process.env,
+        HOME: completionHome,
+        SHELL: "/bin/zsh",
+      },
+      stdio: "pipe",
+    },
+  ).toString();
+  const installedCompletionPath = path.join(
+    completionHome,
+    ".zfunc",
+    completionFunctionName,
+  );
+  const installedCompletion = fs.readFileSync(installedCompletionPath, "utf8");
+
+  if (
+    !installOutput.includes(
+      `Installed zsh completion to ${installedCompletionPath}`,
+    )
+  ) {
+    throw new Error(`Unexpected completion install output: ${installOutput}`);
+  }
+
+  if (!installedCompletion.includes(zshRegistrationToken)) {
+    throw new Error(
+      "Expected completion install to write zsh completion script.",
+    );
+  }
+} finally {
+  fs.rmSync(completionHome, { recursive: true, force: true });
+}
 
 var output;
 console.log("\nTest Started");
 const sdkHeaders = new Client().getHeaders();
 console.log(
   `x-sdk-name: ${sdkHeaders["x-sdk-name"]}; x-sdk-platform: ${sdkHeaders["x-sdk-platform"]}; x-sdk-language: ${sdkHeaders["x-sdk-language"]}; x-sdk-version: ${sdkHeaders["x-sdk-version"]}`,
+);
+console.log(
+  extractLineContaining(zshCompletionOutput, zshRegistrationToken),
+);
+console.log(
+  extractLineContaining(
+    bashCompletionOutput,
+    bashRegistrationToken,
+  ),
+);
+console.log(
+  extractLineContaining(
+    fishCompletionOutput,
+    `${fishRegistrationToken} -f -n '__${EXECUTABLE_NAME}_using_command' -a`,
+  ),
+);
+console.log(
+  extractLineContaining(zshCompletionOutput, "'foo:get') context='foo get'"),
 );
 
 // Foo
@@ -359,13 +518,7 @@ console.log(extractFirstValue(output));
 try {
   execFileSync(
     "bun",
-    [
-      "./dist/cli.cjs",
-      "general",
-      "list-rows",
-      "--where",
-      "count>1e999",
-    ],
+    ["./dist/cli.cjs", "general", "list-rows", "--where", "count>1e999"],
     { stdio: "pipe" },
   );
   throw new Error("Expected non-finite numeric where values to be rejected.");
@@ -378,13 +531,7 @@ try {
 try {
   execFileSync(
     "bun",
-    [
-      "./dist/cli.cjs",
-      "general",
-      "list-rows",
-      "--where",
-      "count=[1e999]",
-    ],
+    ["./dist/cli.cjs", "general", "list-rows", "--where", "count=[1e999]"],
     { stdio: "pipe" },
   );
   throw new Error("Expected non-finite array where values to be rejected.");


### PR DESCRIPTION
## Summary
- add `appwrite completion zsh|bash|fish` to emit shell completion scripts from the live Commander command tree
- move completion generation into `lib/completions.ts` and register the copied template for CLI generation
- document shell completion installation and add CLI regression coverage for top-level commands, nested commands, and flags

## Testing
- `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php cli`
- `composer lint-twig`
- `npm run build:types && npm run build:cli && npx eslint cli.ts lib/completions.ts` from `examples/cli`
- `bun ./dist/cli.cjs completion zsh|bash|fish` smoke checks from `examples/cli`
- `vendor/bin/phpunit --filter CLIBun13Test`
