### PR TITLE
Fix CLI completion install errors and Homebrew tap detection

### DIFF
--- a/templates/cli/lib/completions.ts
+++ b/templates/cli/lib/completions.ts
@@ -550,8 +550,18 @@ export function createCompletionCommand(rootCommand: Command): Command {
         return;
       }
 
-      const installPath = installCompletion(rootCommand, shell);
-      process.stdout.write(`Installed ${shell} completion to ${installPath}\n`);
+      try {
+        const installPath = installCompletion(rootCommand, shell);
+        process.stdout.write(
+          `Installed ${shell} completion to ${installPath}\n`,
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        process.stderr.write(
+          `Failed to install ${shell} completion: ${message}\n`,
+        );
+        process.exitCode = 1;
+      }
     });
 
   for (const shell of SUPPORTED_COMPLETION_SHELLS) {

--- a/templates/cli/lib/utils.ts
+++ b/templates/cli/lib/utils.ts
@@ -246,14 +246,25 @@ export const getInstalledHomebrewFormula = (
       },
     );
     const formulaName = EXECUTABLE_NAME.toLowerCase();
-    const supportedFormulas = new Set([HOMEBREW_FORMULA, formulaName]);
+    const preferredFormulas = new Set([HOMEBREW_FORMULA, formulaName]);
+    const installedFormulas = output
+      .split(/\r?\n/)
+      .map((formula) => formula.trim())
+      .filter((formula) => formula.length > 0);
 
-    return (
-      output
-        .split(/\r?\n/)
-        .map((formula) => formula.trim())
-        .find((formula) => supportedFormulas.has(formula)) ?? null
+    const preferred = installedFormulas.find((formula) =>
+      preferredFormulas.has(formula),
     );
+    if (preferred) {
+      return preferred;
+    }
+
+    const tapMatch = installedFormulas.find((formula) => {
+      const segments = formula.split("/");
+      return segments[segments.length - 1] === formulaName;
+    });
+
+    return tapMatch ?? null;
   } catch (_error) {
     return null;
   }


### PR DESCRIPTION
Addresses two findings from the Greptile review on https://github.com/appwrite/sdk-for-cli/pull/304.

## What's Changed

* **P1 — `templates/cli/lib/completions.ts`**: Wrap the `completion install` action handler in a try/catch. `installCompletion` calls `fs.mkdirSync` and `fs.writeFileSync` synchronously, so an `EACCES` on `~/.zfunc` (or any other filesystem error) used to crash the process with a raw stack trace. We now print `Failed to install <shell> completion: <message>` to stderr and exit with a non-zero code.
* **P2 — `templates/cli/lib/utils.ts`**: Broaden `getInstalledHomebrewFormula` so users who installed via a non-official tap (e.g. `homebrew/core/appwrite`, or a personal tap whose formula tail is `appwrite`) are detected correctly. Previously the lookup only matched `appwrite/appwrite/appwrite` and the bare name `appwrite`; anything else fell through to the official tap formula, and the subsequent `brew upgrade appwrite/appwrite/appwrite` would fail with "formula not installed". The official tap is still preferred when it's installed; the recommendation hint to switch to the official tap continues to fire as before.

## Verification

* Regenerated `examples/cli/` via `php example.php cli` — both fixes are reflected in the regenerated `examples/cli/lib/completions.ts` and `examples/cli/lib/utils.ts`.
* Templates only — no language class or `getFiles()` changes required.

## Follow-up

After merge, cut a new sdk-generator release and regenerate `appwrite/sdk-for-cli` so 19.2.0 ships with these fixes.