### PR TITLE
Add Apple SDK compression toggle

### DIFF
--- a/templates/apple/Sources/Client.swift.twig
+++ b/templates/apple/Sources/Client.swift.twig
@@ -38,6 +38,10 @@ open class Client {
 
     internal var selfSigned: Bool = false
 
+    internal var compression: Bool = true
+
+    internal var compressionHeaderInjected: Bool = false
+
     internal var http: HTTPClient
 
     private static let boundaryChars = "abcdefghijklmnopqrstuvwxyz1234567890"
@@ -56,6 +60,7 @@ open class Client {
 
     private static func createHTTP(
         selfSigned: Bool = false,
+        compression: Bool = true,
         maxRedirects: Int = 5,
         alloweRedirectCycles: Bool = false,
         connectTimeout: TimeAmount = .seconds(30),
@@ -82,7 +87,7 @@ open class Client {
                 tlsConfiguration: tls,
                 redirectConfiguration: redirect,
                 timeout: timeout,
-                decompression: .enabled(limit: .none)
+                decompression: compression ? .enabled(limit: .none) : .disabled
             )
         )
     }
@@ -125,7 +130,37 @@ open class Client {
     open func setSelfSigned(_ status: Bool = true) -> Client {
         self.selfSigned = status
         try! http.syncShutdown()
-        http = Client.createHTTP(selfSigned: status)
+        http = Client.createHTTP(selfSigned: status, compression: compression)
+        return self
+    }
+
+    ///
+    /// Enable or disable automatic response decompression.
+    ///
+    /// When disabled, the client asks the server for an identity response
+    /// encoding and does not attempt to decompress response bodies. This can
+    /// be useful when a server or proxy returns compressed responses that the
+    /// underlying HTTP client cannot decode.
+    ///
+    /// @param Bool status Whether response decompression should be enabled.
+    ///
+    /// @return Client The same client instance.
+    ///
+    open func setCompression(_ status: Bool = true) -> Client {
+        self.compression = status
+
+        if status {
+            if compressionHeaderInjected && self.headers["accept-encoding"] == "identity" {
+                self.headers.removeValue(forKey: "accept-encoding")
+            }
+            self.compressionHeaderInjected = false
+        } else {
+            self.headers["accept-encoding"] = "identity"
+            self.compressionHeaderInjected = true
+        }
+
+        try! http.syncShutdown()
+        http = Client.createHTTP(selfSigned: selfSigned, compression: status)
         return self
     }
 
@@ -174,6 +209,10 @@ open class Client {
     /// @return Client
     ///
     open func addHeader(key: String, value: String) -> Client {
+        if key.caseInsensitiveCompare("accept-encoding") == .orderedSame {
+            self.compressionHeaderInjected = false
+        }
+
         self.headers[key] = value
         return self
     }


### PR DESCRIPTION
## What does this PR do?

Adds an Apple SDK client compression toggle so users can opt out of automatic response decompression when a server/proxy combination returns gzip responses that fail in AsyncHTTPClient/NIO decompression.

When disabled, the generated Apple client:
- rebuilds `HTTPClient` with `decompression: .disabled`
- sends `accept-encoding: identity` to avoid Appwrite response compression
- preserves the current default behavior by keeping compression enabled unless explicitly disabled

Fixes appwrite/sdk-for-apple#97.

## Test Plan

- `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php apple`
- `composer lint-twig`
- `git diff --check`
- `swift build` in `examples/apple` was attempted after regeneration, but fails on existing generated model errors unrelated to this change: `DetectionFramework.swift` and `DetectionRuntime.swift` call `toMap()` on `[DetectionVariable]`.
