### PR TITLE
Remove deprecated curl_close calls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,6 @@ sdk-generator/blob/master/example.php:
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         $result = curl_exec($ch);
-        curl_close($ch);
         return $result;
     }
 

--- a/templates/php/src/Client.php.twig
+++ b/templates/php/src/Client.php.twig
@@ -323,7 +323,6 @@ class Client
             throw new {{ spec.namespace | split('\\') | last | caseUcfirst}}Exception(curl_error($ch), $responseStatus, $responseBody['type'] ?? '', $responseBody);
         }
         
-        curl_close($ch);
 
         if($responseStatus >= 400) {
             if(is_array($responseBody)) {

--- a/templates/php/src/Client.php.twig
+++ b/templates/php/src/Client.php.twig
@@ -322,7 +322,6 @@ class Client
         if (curl_errno($ch)) {
             throw new {{ spec.namespace | split('\\') | last | caseUcfirst}}Exception(curl_error($ch), $responseStatus, $responseBody['type'] ?? '', $responseBody);
         }
-        
 
         if($responseStatus >= 400) {
             if(is_array($responseBody)) {


### PR DESCRIPTION
## What does this PR do?

Removes calls to `curl_close()`. Since PHP 8.0, cURL handles are `CurlHandle` objects and `curl_close()` no longer has an effect; handles are released by object lifetime instead. Removing these calls avoids noisy PHP 8.5 deprecation warnings without changing behavior for supported PHP versions.

## Test Plan

- Ran `php -l` on changed PHP files where applicable.
- Confirmed no `curl_close(...)` calls remain in this repository.

## Related PRs and Issues

N/A

### Have you read the Contributing Guidelines on issues?

Yes.
