### PR TITLE
Relax Rust indexmap dependency bound

### DIFF
--- a/templates/rust/Cargo.toml.twig
+++ b/templates/rust/Cargo.toml.twig
@@ -22,7 +22,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 reqwest = { version = "0.12.28", features = ["json", "multipart", "stream"] }
 tokio = { version = "1.48.0", features = ["full"] }
-indexmap = ">=2, <2.12"
+indexmap = ">=2, <2.14"
 url = "=2.5.4"
 idna = "=1.0.3"
 idna_adapter = "=1.0.0"


### PR DESCRIPTION
## What

Relaxes the generated Rust SDK `indexmap` dependency bound from `>=2, <2.12` to `>=2, <2.14`.

## Why

The current upper bound prevents generated Rust SDKs from being used in downstream workspaces that already resolve `indexmap` 2.12 or 2.13. In particular, the Open Runtimes Rust image pins `indexmap = 2.13.0`, which conflicts with the generated SDK.

The new bound keeps compatibility with Rust 1.83 by excluding `indexmap` 2.14+, whose manifest requires Edition 2024 / newer Cargo, while allowing the 2.13 series needed by downstream runtimes.

## Testing

- `docker run --rm -v "$PWD:/app" -w /app rust:1.83 sh -c "cd tests/languages/rust && ./test.sh"`
- `./vendor/bin/phpunit --filter Rust183Test --testdox`
