### PR TITLE
Fix Rust SDK review issues

### DIFF
--- a/src/SDK/Language/Rust.php
+++ b/src/SDK/Language/Rust.php
@@ -795,7 +795,7 @@ class Rust extends Language
                 $value = $this->getIdentifierOverrides()[$value];
             }
 
-            return ($param["required"] ?? false) ? $value : "Some({$value})";
+            return (($param["required"] ?? false) && !($param["nullable"] ?? false)) ? $value : "Some({$value})";
         }
 
         if (!empty($param["enumValues"]) || !empty($param["enumName"])) {
@@ -804,7 +804,7 @@ class Rust extends Language
             $value = $this->getParamExample($param);
         }
 
-        return ($param["required"] ?? false) ? $value : "Some({$value})";
+        return (($param["required"] ?? false) && !($param["nullable"] ?? false)) ? $value : "Some({$value})";
     }
 
     /**

--- a/templates/rust/Cargo.toml.twig
+++ b/templates/rust/Cargo.toml.twig
@@ -23,9 +23,9 @@ serde_json = "1.0.149"
 reqwest = { version = "0.12.28", features = ["json", "multipart", "stream"] }
 tokio = { version = "1.48.0", features = ["full"] }
 indexmap = ">=2, <2.14"
-url = "=2.5.4"
-idna = "=1.0.3"
-idna_adapter = "=1.0.0"
+url = ">=2.5.4, <2.6"
+idna = ">=1.0.3, <1.2"
+idna_adapter = ">=1.0.0, <1.1"
 mime = "0.3.17"
 fastrand = "=2.0.2"
 thiserror = "1.0.69"


### PR DESCRIPTION
## What

- Fix Rust docs examples for nullable parameters so generated examples pass `Some(...)` when the Rust method signature expects `Option<T>`.
- Relax Rust `url`, `idna`, and `idna_adapter` dependencies from exact pins to bounded ranges that still respect Rust 1.83 compatibility.

## Why

Greptile flagged Rust SDK release review issues in appwrite/sdk-for-rust#13: optional policy examples did not compile, and exact dependency pins were too strict for a library crate.

The email-template PATCH route was checked against the current Appwrite route/spec and still correctly uses `/project/templates/email` with `templateId` in the body. The password-history typo is left untouched because it comes from the upstream spec.

## Testing

- `php example.php rust`
- `composer lint-twig`
- `vendor/bin/phpunit tests/Rust183Test.php`
