### PR TITLE
Update GitHub Actions for Node 24 runtime

### DIFF
--- a/.github/workflows/djlint.yml
+++ b/.github/workflows/djlint.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/.github/workflows/sdk-build-validation.yml
+++ b/.github/workflows/sdk-build-validation.yml
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -95,7 +95,7 @@ jobs:
       # Language-specific setup
       - name: Setup Node.js
         if: matrix.sdk == 'web' || matrix.sdk == 'node' || matrix.sdk == 'react-native' || matrix.sdk == 'cli'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -123,14 +123,14 @@ jobs:
 
       - name: Setup Java
         if: matrix.sdk == 'android' || matrix.sdk == 'kotlin'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
 
       - name: Setup Python
         if: matrix.sdk == 'python'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -148,7 +148,7 @@ jobs:
 
       - name: Setup Go
         if: matrix.sdk == 'go' || matrix.sdk == 'dart' || matrix.sdk == 'flutter'
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25.x'
 
@@ -158,7 +158,7 @@ jobs:
 
       - name: Setup .NET
         if: matrix.sdk == 'dotnet'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
 
@@ -172,7 +172,7 @@ jobs:
 
       - name: Cache cargo-audit
         if: matrix.sdk == 'rust'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/cargo-audit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -91,7 +91,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP with PECL extension
         uses: shivammathur/setup-php@v2
@@ -110,7 +110,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Make script executable
         run: chmod +x ./.github/scripts/max-line-length.sh

--- a/templates/android/.github/workflows/publish.yml
+++ b/templates/android/.github/workflows/publish.yml
@@ -11,10 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
+          distribution: temurin
           java-version: 17
       - name: Prepare environment
         env:

--- a/templates/cli/.github/workflows/ci.yml
+++ b/templates/cli/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 

--- a/templates/cli/.github/workflows/publish.yml
+++ b/templates/cli/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       CLI_BUN_VERSION: '1.3.11'
       HOMEBREW_TAP_REPO: appwrite/homebrew-appwrite
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.GH_TOKEN }}
       - uses: oven-sh/setup-bun@v2
@@ -50,7 +50,7 @@ jobs:
           bun run windows-arm64
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24.14.1'
           registry-url: 'https://registry.npmjs.org'
@@ -77,7 +77,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Check out Homebrew tap
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ env.HOMEBREW_TAP_REPO }}
           token: ${{ secrets.HOMEBREW_TAP_GH_TOKEN }}

--- a/templates/dart/.github/workflows/format.yml.twig
+++ b/templates/dart/.github/workflows/format.yml.twig
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: true
           ref: ${{ '{{'}} github.event.pull_request.head.ref {{ '}}' }}

--- a/templates/dart/.github/workflows/publish.yml.twig
+++ b/templates/dart/.github/workflows/publish.yml.twig
@@ -11,7 +11,7 @@ jobs:
       id-token: write # Required for authentication using OIDC
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dart-lang/setup-dart@v1
       - name: Install dependencies
         run: dart pub get

--- a/templates/dart/.github/workflows/test.yml
+++ b/templates/dart/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dart-lang/setup-dart@v1
       - name: Install dependencies
         run: dart pub get

--- a/templates/dotnet/.github/workflows/publish.yml.twig
+++ b/templates/dotnet/.github/workflows/publish.yml.twig
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '6'
 

--- a/templates/flutter/.github/workflows/format.yml.twig
+++ b/templates/flutter/.github/workflows/format.yml.twig
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: true
           ref: ${{ '{{'}} github.event.pull_request.head.ref {{ '}}' }}

--- a/templates/flutter/.github/workflows/publish.yml.twig
+++ b/templates/flutter/.github/workflows/publish.yml.twig
@@ -11,7 +11,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:

--- a/templates/flutter/.github/workflows/test.yml
+++ b/templates/flutter/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:

--- a/templates/kotlin/.github/workflows/publish.yml
+++ b/templates/kotlin/.github/workflows/publish.yml
@@ -11,10 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
+          distribution: temurin
           java-version: 17
         # Base64 decodes and pipes the GPG key content into the secret file
       - name: Prepare environment

--- a/templates/markdown/.github/workflows/publish.yml
+++ b/templates/markdown/.github/workflows/publish.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '24.14.1'
         registry-url: 'https://registry.npmjs.org'

--- a/templates/node/.github/workflows/publish.yml.twig
+++ b/templates/node/.github/workflows/publish.yml.twig
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '24.14.1'
         registry-url: 'https://registry.npmjs.org'

--- a/templates/python/.github/workflows/publish.yml.twig
+++ b/templates/python/.github/workflows/publish.yml.twig
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.9'
 

--- a/templates/react-native/.github/workflows/publish.yml.twig
+++ b/templates/react-native/.github/workflows/publish.yml.twig
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '24.14.1'
         registry-url: 'https://registry.npmjs.org'

--- a/templates/ruby/.github/workflows/publish.yml.twig
+++ b/templates/ruby/.github/workflows/publish.yml.twig
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/templates/rust/.github/workflows/publish.yml.twig
+++ b/templates/rust/.github/workflows/publish.yml.twig
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@1.83.0

--- a/templates/swift/.github/workflows/publish.yml
+++ b/templates/swift/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
           swift-version: "5.4"
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Install cocoapods
         run: gem install cocoapods

--- a/templates/web/.github/workflows/publish.yml.twig
+++ b/templates/web/.github/workflows/publish.yml.twig
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '24.14.1'
         registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary
- update repository workflows to first-party GitHub Actions versions that run on the Node 24 action runtime
- update generated SDK workflow templates, including publish workflows, from older checkout/setup-node pins
- add the required Temurin distribution input for Android and Kotlin setup-java publish workflows

## Testing
- composer lint-twig
- ruby YAML parse check for non-Twig workflow YAML files
- regenerated affected SDKs with php example.php for android, cli, dart, dotnet, flutter, kotlin, markdown, node, python, react-native, ruby, rust, swift, and web

Note: Dart and Flutter generation emitted existing PHP "Array to string conversion" warnings, but generation completed successfully.
