### PR TITLE
Fix optional CLI JSON object flags

### DIFF
--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -912,7 +912,7 @@ class CLI extends Node
                 $type = $parameter['type'] ?? 'string';
 
                 if ($type === 'object') {
-                    return "JSON.parse({$varName})";
+                    return "parseJsonObject({$varName}, \"--{$optionName}\")";
                 } elseif ($type === 'file') {
                     return "{$varName} !== undefined ? await resolveFileParam({$varName}) : undefined";
                 } else {

--- a/templates/cli/lib/commands/services/services.ts.twig
+++ b/templates/cli/lib/commands/services/services.ts.twig
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 {% set hasLocationMethod = false %}
 {% set hasFileParam = false %}
+{% set hasObjectParam = false %}
 {% set hasQueryParam = service | hasCliQueryParam %}
 {% set enumNames = [] %}
 {% for method in service.methods %}
@@ -10,6 +11,9 @@ import { Command } from "commander";
 {% for parameter in method.parameters.all %}
 {% if parameter.type == 'file' %}
 {% set hasFileParam = true %}
+{% endif %}
+{% if parameter.type == 'object' %}
+{% set hasObjectParam = true %}
 {% endif %}
 {% if parameter.enumName is defined and parameter.enumName not in enumNames %}
 {% set enumNames = enumNames|merge([parameter.enumName]) %}
@@ -41,6 +45,9 @@ import {
   parse,
   parseBool,
   parseInteger,
+{% if hasObjectParam %}
+  parseJsonObject,
+{% endif %}
 {% if service.name == 'teams' %}
   hint,
 {% endif %}
@@ -149,7 +156,7 @@ const {{ commandVar }} = {{ service.name | caseCamel }}
 {% endfor %}
 {% if method.type == 'location' %}
       async ({{ actionParams }}) => {
-        const url = await (await get{{ service.name | caseUcfirst }}Client()).{{ method.name | caseCamel }}({{ argExpressions | join(', ') }});
+        const url = await (await get{{ service.name | caseUcfirst }}Client()).{{ method.name | caseCamel }}({{ argExpressions | join(', ') | raw }});
         const response = await fetch(url);
         const buffer = Buffer.from(await response.arrayBuffer());
         fs.writeFileSync(destination, buffer);
@@ -157,12 +164,12 @@ const {{ commandVar }} = {{ service.name | caseCamel }}
       },
 {% elseif method.type == 'webAuth' %}
       async ({{ actionParams }}) => {
-        const url = (await get{{ service.name | caseUcfirst }}Client()).{{ method.name | caseCamel }}({{ argExpressions | join(', ') }});
+        const url = (await get{{ service.name | caseUcfirst }}Client()).{{ method.name | caseCamel }}({{ argExpressions | join(', ') | raw }});
         if (url) console.log(url);
       },
 {% elseif hasParams %}
       async ({{ actionParams }}) =>
-        parse(await (await get{{ service.name | caseUcfirst }}Client()).{{ method.name | caseCamel }}({{ argExpressions | join(', ') }})),
+        parse(await (await get{{ service.name | caseUcfirst }}Client()).{{ method.name | caseCamel }}({{ argExpressions | join(', ') | raw }})),
 {% else %}
       async () => parse(await (await get{{ service.name | caseUcfirst }}Client()).{{ method.name | caseCamel }}()),
 {% endif %}

--- a/templates/cli/lib/parser.ts
+++ b/templates/cli/lib/parser.ts
@@ -762,6 +762,29 @@ export const parseBool = (value: string): boolean => {
   throw new InvalidArgumentError("Not a boolean.");
 };
 
+export const parseJsonObject = (
+  value: string | undefined,
+  optionName: string,
+): Record<string, unknown> | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    throw new InvalidArgumentError(
+      `${optionName} must be a valid JSON object.`,
+    );
+  }
+
+  throw new InvalidArgumentError(`${optionName} must be a JSON object.`);
+};
+
 export const log = (message?: string): void => {
   console.log(`${chalk.cyan.bold("ℹ Info:")} ${chalk.cyan(message ?? "")}`);
 };

--- a/templates/cli/lib/parser.ts
+++ b/templates/cli/lib/parser.ts
@@ -782,7 +782,7 @@ export const parseJsonObject = (
     );
   }
 
-  throw new InvalidArgumentError(`${optionName} must be a JSON object.`);
+  throw new InvalidArgumentError(`${optionName} must be a valid JSON object.`);
 };
 
 export const log = (message?: string): void => {

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -217,10 +217,14 @@ abstract class Base extends TestCase
         'x-sdk-name: cli; x-sdk-platform: server; x-sdk-language: cli; x-sdk-version: 0.0.1',
     ];
 
+    protected const CLI_FUNCTION_RESPONSES = [
+        'POST:/v1/functions/{functionId}/executions:passed',
+    ];
+
     protected const CLI_COMPLETION_RESPONSES = [
         'compdef _appwrite appwrite',
         'complete -F _appwrite_completion appwrite',
-        'complete -c \'appwrite\' -f -n \'__appwrite_using_command\' -a \'bar client completion foo general\'',
+        'complete -c \'appwrite\' -f -n \'__appwrite_using_command\' -a \'bar client completion foo functions general\'',
         '\'foo:get\') context=\'foo get\' ;;',
     ];
 

--- a/tests/CLIBun10Test.php
+++ b/tests/CLIBun10Test.php
@@ -32,6 +32,7 @@ class CLIBun10Test extends Base
         ...Base::CLI_CONSOLE_URL_RESPONSES,
         ...Base::UPLOAD_RESPONSES,
         ...Base::CLI_HEADERS_RESPONSES,
+        ...Base::CLI_FUNCTION_RESPONSES,
         ...Base::CLI_LOCAL_FUNCTION_EMULATION_RESPONSES,
         ...Base::CLI_RUNTIME_RENDERING_RESPONSES,
         ...Base::CLI_QUERY_HELPER_RESPONSES,

--- a/tests/CLIBun11Test.php
+++ b/tests/CLIBun11Test.php
@@ -32,6 +32,7 @@ class CLIBun11Test extends Base
         ...Base::CLI_CONSOLE_URL_RESPONSES,
         ...Base::UPLOAD_RESPONSES,
         ...Base::CLI_HEADERS_RESPONSES,
+        ...Base::CLI_FUNCTION_RESPONSES,
         ...Base::CLI_LOCAL_FUNCTION_EMULATION_RESPONSES,
         ...Base::CLI_RUNTIME_RENDERING_RESPONSES,
         ...Base::CLI_QUERY_HELPER_RESPONSES,

--- a/tests/CLIBun13Test.php
+++ b/tests/CLIBun13Test.php
@@ -32,6 +32,7 @@ class CLIBun13Test extends Base
         ...Base::CLI_CONSOLE_URL_RESPONSES,
         ...Base::UPLOAD_RESPONSES,
         ...Base::CLI_HEADERS_RESPONSES,
+        ...Base::CLI_FUNCTION_RESPONSES,
         ...Base::CLI_LOCAL_FUNCTION_EMULATION_RESPONSES,
         ...Base::CLI_RUNTIME_RENDERING_RESPONSES,
         ...Base::CLI_QUERY_HELPER_RESPONSES,

--- a/tests/languages/cli/test.js
+++ b/tests/languages/cli/test.js
@@ -358,6 +358,12 @@ output = execSync("bun ./dist/cli.cjs general headers", {
 }).toString();
 console.log(extractFirstValue(output));
 
+output = execSync(
+  "bun ./dist/cli.cjs functions create-execution --function-id sample-function",
+  { stdio: "pipe" },
+).toString();
+console.log(extractFirstValue(output));
+
 if (openRuntimesVersion !== "v5") {
   throw new Error(
     `Expected local function emulation to use OpenRuntimes v5, got ${openRuntimesVersion}`,

--- a/tests/resources/spec.json
+++ b/tests/resources/spec.json
@@ -1791,6 +1791,106 @@
         ]
       }
     },
+    "\/functions\/{functionId}\/executions": {
+      "post": {
+        "summary": "Create execution",
+        "operationId": "functionsCreateExecution",
+        "consumes": [
+          "application\/json"
+        ],
+        "produces": [
+          "application\/json"
+        ],
+        "tags": [
+          "functions"
+        ],
+        "description": "Create a new function execution.",
+        "responses": {
+          "200": {
+            "description": "Mock",
+            "schema": {
+              "$ref": "#\/definitions\/mock"
+            }
+          }
+        },
+        "x-appwrite": {
+          "method": "createExecution",
+          "weight": 1,
+          "cookies": false,
+          "type": "",
+          "demo": "functions\/create-execution.md",
+          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterCreate a new function execution.",
+          "rate-limit": 0,
+          "rate-time": 3600,
+          "rate-key": "url:{url},ip:{ip}",
+          "scope": "functions.write",
+          "platforms": [
+            "server"
+          ],
+          "packaging": false,
+          "offline-model": "",
+          "offline-key": "",
+          "offline-response-key": "$id",
+          "auth": {
+            "Project": []
+          }
+        },
+        "security": [
+          {
+            "Project": [],
+            "Key": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "functionId",
+            "description": "Function ID.",
+            "required": true,
+            "type": "string",
+            "in": "path"
+          },
+          {
+            "name": "payload",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "body": {
+                  "type": "string",
+                  "description": "HTTP body of execution.",
+                  "default": null
+                },
+                "async": {
+                  "type": "boolean",
+                  "description": "Execute asynchronously.",
+                  "default": null
+                },
+                "path": {
+                  "type": "string",
+                  "description": "HTTP path of execution.",
+                  "default": null
+                },
+                "method": {
+                  "type": "string",
+                  "description": "HTTP method of execution.",
+                  "default": null
+                },
+                "headers": {
+                  "type": "object",
+                  "description": "HTTP headers of execution. Defaults to empty.",
+                  "default": null
+                },
+                "scheduledAt": {
+                  "type": "string",
+                  "description": "Scheduled execution time.",
+                  "default": null
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
     "\/mock\/tests\/general\/redirect": {
       "get": {
         "summary": "Redirect",


### PR DESCRIPTION
## What

- Replaces generated CLI service `JSON.parse(...)` object argument handling with `parseJsonObject(...)`.
- Allows omitted optional JSON object flags, including `functions create-execution --headers`, to pass through as `undefined` instead of crashing on `JSON.parse(undefined)`.
- Converts malformed JSON object flag values into clear `InvalidArgumentError` messages like `--headers must be a valid JSON object.`
- Adds a mock `functions create-execution` fixture and CLI regression coverage for invoking it without `--headers`.

## Testing

- `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php cli`
- `composer lint-twig`
- `npm run build:types` in `examples/cli`
- `npm run build:runtime` in `examples/cli`
- `vendor/bin/phpunit tests/CLIBun13Test.php`
- Manual malformed flag check in the generated CLI fixture: `functions create-execution --function-id fn --headers invalid` exits with `--headers must be a valid JSON object.`

Note: the generated CLI fixture still prints an existing `bun run build:types` failure for `"sites"` resource typing during `CLIBun13Test`; the PHPUnit test harness continues and the test passes.
