### PR TITLE
Add concurrent chunked uploads to SDKs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 .envrc
 .hatch
 
+tmp-upload-tests/
+
 # exclude everything
 examples/*
 tests/tmp

--- a/mock-server/app/http.php
+++ b/mock-server/app/http.php
@@ -389,6 +389,15 @@ App::post('/v1/mock/tests/general/upload')
                     'chunksTotal' => (int) ceil($size / ($end + 1 - $start)),
                     'chunksUploaded' => ceil($start / $chunkSize) + 1
                 ]);
+            } else {
+                $chunksTotal = (int) ceil($size / $chunkSize);
+
+                $response->json([
+                    '$id' => ID::custom('newfileid'),
+                    'chunksTotal' => $chunksTotal,
+                    'chunksUploaded' => $chunksTotal,
+                    'result' => 'POST:/v1/mock/tests/general/upload:passed',
+                ]);
             }
         } else {
             $file['tmp_name'] = (\is_array($file['tmp_name'])) ? $file['tmp_name'][0] : $file['tmp_name'];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "sdk-generator",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}

--- a/templates/android/library/src/main/java/io/package/Client.kt.twig
+++ b/templates/android/library/src/main/java/io/package/Client.kt.twig
@@ -428,6 +428,7 @@ class Client @JvmOverloads constructor(
             val chunksUploaded = current["chunksUploaded"] as Long
             offset = chunksUploaded * CHUNK_SIZE
             uploadId = params[idParamName]?.toString()
+            result = current
         }
 
         fun readChunk(start: Long, end: Long): ByteArray {
@@ -446,6 +447,14 @@ class Client @JvmOverloads constructor(
                 }
                 else -> throw UnsupportedOperationException()
             }
+        }
+
+        val totalChunks = (size + CHUNK_SIZE - 1) / CHUNK_SIZE
+
+        fun isUploadComplete(chunkResult: Map<*, *>): Boolean {
+            val chunksUploaded = chunkResult["chunksUploaded"]?.toString()?.toLongOrNull() ?: return false
+            val chunksTotal = chunkResult["chunksTotal"]?.toString()?.toLongOrNull() ?: totalChunks
+            return chunksUploaded >= chunksTotal
         }
 
         suspend fun uploadChunk(index: Int, start: Long, end: Long, includeUploadId: Boolean): Map<*, *> {
@@ -521,7 +530,7 @@ class Client @JvmOverloads constructor(
                             val chunksUploaded = completedChunks.incrementAndGet()
                             val sizeUploaded = uploadedBytes.addAndGet(end - start)
 
-                            if (index == ((size - 1) / CHUNK_SIZE).toInt()) {
+                            if (isUploadComplete(chunkResult)) {
                                 result = chunkResult
                             }
 
@@ -538,19 +547,6 @@ class Client @JvmOverloads constructor(
                     }
                 }.awaitAll()
             }
-        }
-
-        if (uploadId != null) {
-            val finalHeaders = headers.toMutableMap()
-            finalHeaders.remove("content-type")
-
-            result = call(
-                method = "GET",
-                path = "$path/$uploadId",
-                headers = finalHeaders,
-                params = emptyMap(),
-                responseType = Map::class.java,
-            )
         }
 
         return converter(result as Map<String, Any>)

--- a/templates/android/library/src/main/java/io/package/Client.kt.twig
+++ b/templates/android/library/src/main/java/io/package/Client.kt.twig
@@ -13,6 +13,9 @@ import {{ sdk.namespace | caseDot }}.models.UploadProgress
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.*
 import okhttp3.Headers.Companion.toHeaders
@@ -30,6 +33,8 @@ import java.net.CookieManager
 import java.net.CookiePolicy
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLSocketFactory
 import javax.net.ssl.TrustManager
@@ -49,6 +54,7 @@ class Client @JvmOverloads constructor(
          * The size for chunked uploads in bytes.
          */
         internal const val CHUNK_SIZE = 5*1024*1024; // 5MB
+        internal const val MAX_CONCURRENT_UPLOADS = 8
         internal const val GLOBAL_PREFS = "{{ sdk.namespace | caseDot }}"
         internal const val COOKIE_PREFS = "myCookie"
     }
@@ -374,12 +380,10 @@ class Client @JvmOverloads constructor(
         idParamName: String? = null,
         onProgress: ((UploadProgress) -> Unit)? = null,
     ): T {
-        var file: RandomAccessFile? = null
         val input = params[paramName] as InputFile
         val size: Long = when(input.sourceType) {
             "path", "file" -> {
-                file = RandomAccessFile(input.path, "r")
-                file.length()
+                File(input.path).length()
             }
             "bytes" -> {
                 (input.data as ByteArray).size.toLong()
@@ -408,9 +412,9 @@ class Client @JvmOverloads constructor(
             )
         }
 
-        val buffer = ByteArray(CHUNK_SIZE)
         var offset = 0L
         var result: Map<*, *>? = null
+        var uploadId: String? = null
 
         if (idParamName?.isNotEmpty() == true) {
             // Make a request to check if a file already exists
@@ -423,57 +427,117 @@ class Client @JvmOverloads constructor(
             )
             val chunksUploaded = current["chunksUploaded"] as Long
             offset = chunksUploaded * CHUNK_SIZE
+            uploadId = params[idParamName]?.toString()
         }
 
-        while (offset < size) {
-            when(input.sourceType) {
+        fun readChunk(start: Long, end: Long): ByteArray {
+            val length = (end - start).toInt()
+            return when(input.sourceType) {
                 "file", "path" -> {
-                    file!!.seek(offset)
-                    file!!.read(buffer)
+                    RandomAccessFile(input.path, "r").use { chunkFile ->
+                        val chunk = ByteArray(length)
+                        chunkFile.seek(start)
+                        chunkFile.readFully(chunk)
+                        chunk
+                    }
                 }
                 "bytes" -> {
-                    val end = if (offset + CHUNK_SIZE < size) {
-                        offset + CHUNK_SIZE - 1
-                    } else {
-                        size - 1
-                    }
-                    (input.data as ByteArray).copyInto(
-                        buffer,
-                        startIndex = offset.toInt(),
-                        endIndex = end.toInt()
-                    )
+                    (input.data as ByteArray).copyOfRange(start.toInt(), end.toInt())
                 }
                 else -> throw UnsupportedOperationException()
             }
+        }
 
-            params[paramName] = MultipartBody.Part.createFormData(
+        suspend fun uploadChunk(index: Int, start: Long, end: Long, includeUploadId: Boolean): Map<*, *> {
+            val chunkParams = params.toMutableMap()
+            val chunkHeaders = headers.toMutableMap()
+
+            if (includeUploadId && uploadId != null) {
+                chunkHeaders["x-{{ spec.title | caseLower }}-id"] = uploadId!!
+            }
+
+            chunkHeaders["Content-Range"] = "bytes $start-${end - 1}/$size"
+            chunkParams[paramName] = MultipartBody.Part.createFormData(
                 paramName,
                 input.filename,
-                buffer.toRequestBody()
+                readChunk(start, end).toRequestBody()
             )
 
-            headers["Content-Range"] =
-                "bytes $offset-${((offset + CHUNK_SIZE) - 1).coerceAtMost(size - 1)}/$size"
-
-            result = call(
+            val chunkResult = call(
                 method = "POST",
                 path,
-                headers,
-                params,
+                chunkHeaders,
+                chunkParams,
                 responseType = Map::class.java
             )
 
-            offset += CHUNK_SIZE
-            headers["x-{{ spec.title | caseLower }}-id"] = result["\$id"].toString()
+            if (index == 0 || uploadId == null) {
+                uploadId = chunkResult["\$id"].toString()
+            }
+
+            return chunkResult
+        }
+
+        if (offset == 0L) {
+            val firstChunkEnd = CHUNK_SIZE.toLong().coerceAtMost(size)
+            result = uploadChunk(0, 0, firstChunkEnd, false)
+            offset = firstChunkEnd
             onProgress?.invoke(
                 UploadProgress(
-                    id = result["\$id"].toString(),
+                    id = uploadId ?: result!!["\$id"].toString(),
                     progress = offset.coerceAtMost(size).toDouble() / size * 100,
                     sizeUploaded = offset.coerceAtMost(size),
-                    chunksTotal = result["chunksTotal"].toString().toInt(),
-                    chunksUploaded = result["chunksUploaded"].toString().toInt(),
+                    chunksTotal = result!!["chunksTotal"].toString().toInt(),
+                    chunksUploaded = result!!["chunksUploaded"].toString().toInt(),
                 )
             )
+        }
+
+        val chunks = mutableListOf<Triple<Int, Long, Long>>()
+        var chunkOffset = offset
+        while (chunkOffset < size) {
+            val end = (chunkOffset + CHUNK_SIZE).coerceAtMost(size)
+            chunks.add(Triple((chunkOffset / CHUNK_SIZE).toInt(), chunkOffset, end))
+            chunkOffset = end
+        }
+
+        if (chunks.isNotEmpty()) {
+            val nextChunk = AtomicInteger(0)
+            val completedChunks = AtomicInteger((offset / CHUNK_SIZE).toInt())
+            val uploadedBytes = AtomicLong(offset.coerceAtMost(size))
+
+            coroutineScope {
+                List(MAX_CONCURRENT_UPLOADS.coerceAtMost(chunks.size)) {
+                    async {
+                        while (true) {
+                            val chunkIndex = nextChunk.getAndIncrement()
+                            if (chunkIndex >= chunks.size) {
+                                break
+                            }
+
+                            val (index, start, end) = chunks[chunkIndex]
+                            val chunkResult = uploadChunk(index, start, end, true)
+
+                            val chunksUploaded = completedChunks.incrementAndGet()
+                            val sizeUploaded = uploadedBytes.addAndGet(end - start)
+
+                            if (index == ((size - 1) / CHUNK_SIZE).toInt()) {
+                                result = chunkResult
+                            }
+
+                            onProgress?.invoke(
+                                UploadProgress(
+                                    id = uploadId ?: chunkResult["\$id"].toString(),
+                                    progress = sizeUploaded.coerceAtMost(size).toDouble() / size * 100,
+                                    sizeUploaded = sizeUploaded.coerceAtMost(size),
+                                    chunksTotal = chunkResult["chunksTotal"].toString().toInt(),
+                                    chunksUploaded = chunksUploaded,
+                                )
+                            )
+                        }
+                    }
+                }.awaitAll()
+            }
         }
 
         return converter(result as Map<String, Any>)

--- a/templates/android/library/src/main/java/io/package/Client.kt.twig
+++ b/templates/android/library/src/main/java/io/package/Client.kt.twig
@@ -540,6 +540,19 @@ class Client @JvmOverloads constructor(
             }
         }
 
+        if (uploadId != null) {
+            val finalHeaders = headers.toMutableMap()
+            finalHeaders.remove("content-type")
+
+            result = call(
+                method = "GET",
+                path = "$path/$uploadId",
+                headers = finalHeaders,
+                params = emptyMap(),
+                responseType = Map::class.java,
+            )
+        }
+
         return converter(result as Map<String, Any>)
     }
 

--- a/templates/apple/Sources/Client.swift.twig
+++ b/templates/apple/Sources/Client.swift.twig
@@ -545,6 +545,21 @@ open class Client {
             }
         }
 
+        if let uploadId = uploadId {
+            var finalHeaders = headers
+            finalHeaders.removeValue(forKey: "content-type")
+
+            let finalResult = try await call(
+                method: "GET",
+                path: path + "/" + uploadId,
+                headers: finalHeaders,
+                params: [:],
+                converter: { return $0 as! [String: Any] }
+            )
+
+            return try converter!(finalResult)
+        }
+
         return try converter!(result)
     }
 

--- a/templates/apple/Sources/Client.swift.twig
+++ b/templates/apple/Sources/Client.swift.twig
@@ -455,6 +455,7 @@ open class Client {
                 )
                 let chunksUploaded = map["chunksUploaded"] as! Int
                 offset = chunksUploaded * Client.chunkSize
+                result = map
             } catch {
                 // File does not exist yet, swallow exception
             }
@@ -466,6 +467,15 @@ open class Client {
         var uploadedBytes = min(offset, size)
         let baseParams = params
         let baseHeaders = headers
+
+        func isUploadComplete(_ response: [String: Any]) -> Bool {
+            guard let chunksUploaded = response["chunksUploaded"] as? Int else {
+                return false
+            }
+
+            let chunksTotal = response["chunksTotal"] as? Int ?? totalChunks
+            return chunksUploaded >= chunksTotal
+        }
 
         func uploadChunk(index: Int, uploadId: String?) async throws -> (Int, Int, [String: Any]) {
             let chunkOffset = index * Client.chunkSize
@@ -523,7 +533,7 @@ open class Client {
                 inFlight -= 1
                 completedChunks += 1
                 uploadedBytes += chunk.1
-                if chunk.0 == totalChunks - 1 {
+                if isUploadComplete(chunk.2) {
                     result = chunk.2
                 }
 
@@ -543,21 +553,6 @@ open class Client {
                     inFlight += 1
                 }
             }
-        }
-
-        if let uploadId = uploadId {
-            var finalHeaders = headers
-            finalHeaders.removeValue(forKey: "content-type")
-
-            let finalResult = try await call(
-                method: "GET",
-                path: path + "/" + uploadId,
-                headers: finalHeaders,
-                params: [:],
-                converter: { return $0 as! [String: Any] }
-            )
-
-            return try converter!(finalResult)
         }
 
         return try converter!(result)

--- a/templates/apple/Sources/Client.swift.twig
+++ b/templates/apple/Sources/Client.swift.twig
@@ -464,13 +464,15 @@ open class Client {
         var nextChunk = offset / Client.chunkSize
         var completedChunks = nextChunk
         var uploadedBytes = min(offset, size)
+        let baseParams = params
+        let baseHeaders = headers
 
         func uploadChunk(index: Int, uploadId: String?) async throws -> (Int, Int, [String: Any]) {
             let chunkOffset = index * Client.chunkSize
             let chunkLength = min(Client.chunkSize, size - chunkOffset)
             let slice = (input.data as! ByteBuffer).getSlice(at: chunkOffset, length: chunkLength)!
-            var chunkParams = params
-            var chunkHeaders = headers
+            var chunkParams = baseParams
+            var chunkHeaders = baseHeaders
             chunkParams[paramName] = InputFile.fromBuffer(slice, filename: input.filename, mimeType: input.mimeType)
             chunkHeaders["content-range"] = "bytes \(chunkOffset)-\(chunkOffset + chunkLength - 1)/\(size)"
             if let uploadId = uploadId {

--- a/templates/apple/Sources/Client.swift.twig
+++ b/templates/apple/Sources/Client.swift.twig
@@ -441,6 +441,7 @@ open class Client {
 
         var offset = 0
         var result = [String:Any]()
+        var uploadId = idParamName != nil ? params[idParamName!] as? String : nil
 
         if idParamName != nil {
             // Make a request to check if a file already exists
@@ -459,30 +460,87 @@ open class Client {
             }
         }
 
-        while offset < size {
-            let slice = (input.data as! ByteBuffer).getSlice(at: offset, length: Client.chunkSize)
-                ?? (input.data as! ByteBuffer).getSlice(at: offset, length: Int(size - offset))
+        let totalChunks = Int(ceil(Double(size) / Double(Client.chunkSize)))
+        var nextChunk = offset / Client.chunkSize
+        var completedChunks = nextChunk
+        var uploadedBytes = min(offset, size)
 
-            params[paramName] = InputFile.fromBuffer(slice!, filename: input.filename, mimeType: input.mimeType)
-            headers["content-range"] = "bytes \(offset)-\(min((offset + Client.chunkSize) - 1, size - 1))/\(size)"
+        func uploadChunk(index: Int, uploadId: String?) async throws -> (Int, Int, [String: Any]) {
+            let chunkOffset = index * Client.chunkSize
+            let chunkLength = min(Client.chunkSize, size - chunkOffset)
+            let slice = (input.data as! ByteBuffer).getSlice(at: chunkOffset, length: chunkLength)!
+            var chunkParams = params
+            var chunkHeaders = headers
+            chunkParams[paramName] = InputFile.fromBuffer(slice, filename: input.filename, mimeType: input.mimeType)
+            chunkHeaders["content-range"] = "bytes \(chunkOffset)-\(chunkOffset + chunkLength - 1)/\(size)"
+            if let uploadId = uploadId {
+                chunkHeaders["x-{{ spec.title | caseLower }}-id"] = uploadId
+            }
 
-            result = try await call(
+            let chunkResult = try await call(
                 method: "POST",
                 path: path,
-                headers: headers,
-                params: params,
+                headers: chunkHeaders,
+                params: chunkParams,
                 converter: { return $0 as! [String: Any] }
             )
 
-            offset += Client.chunkSize
-            headers["x-{{ spec.title | caseLower }}-id"] = result["$id"] as? String
+            return (index, chunkLength, chunkResult)
+        }
+
+        if nextChunk == 0 {
+            let first = try await uploadChunk(index: 0, uploadId: uploadId)
+            result = first.2
+            uploadId = result["$id"] as? String
+            nextChunk = 1
+            completedChunks = 1
+            uploadedBytes = first.1
             onProgress?(UploadProgress(
-                id: result["$id"] as? String ?? "",
-                progress: Double(min(offset, size))/Double(size) * 100.0,
-                sizeUploaded: min(offset, size),
-                chunksTotal: result["chunksTotal"] as? Int ?? -1,
-                chunksUploaded: result["chunksUploaded"] as? Int ?? -1
+                id: uploadId ?? "",
+                progress: Double(uploadedBytes)/Double(size) * 100.0,
+                sizeUploaded: uploadedBytes,
+                chunksTotal: result["chunksTotal"] as? Int ?? totalChunks,
+                chunksUploaded: result["chunksUploaded"] as? Int ?? completedChunks
             ))
+        }
+
+        let maxConcurrency = 8
+
+        try await withThrowingTaskGroup(of: (Int, Int, [String: Any]).self) { group in
+            var inFlight = 0
+
+            while inFlight < maxConcurrency && nextChunk < totalChunks {
+                let index = nextChunk
+                let currentUploadId = uploadId
+                group.addTask { try await uploadChunk(index: index, uploadId: currentUploadId) }
+                nextChunk += 1
+                inFlight += 1
+            }
+
+            while let chunk = try await group.next() {
+                inFlight -= 1
+                completedChunks += 1
+                uploadedBytes += chunk.1
+                if chunk.0 == totalChunks - 1 {
+                    result = chunk.2
+                }
+
+                onProgress?(UploadProgress(
+                    id: uploadId ?? "",
+                    progress: Double(min(uploadedBytes, size))/Double(size) * 100.0,
+                    sizeUploaded: min(uploadedBytes, size),
+                    chunksTotal: chunk.2["chunksTotal"] as? Int ?? totalChunks,
+                    chunksUploaded: chunk.2["chunksUploaded"] as? Int ?? completedChunks
+                ))
+
+                while inFlight < maxConcurrency && nextChunk < totalChunks {
+                    let index = nextChunk
+                    let currentUploadId = uploadId
+                    group.addTask { try await uploadChunk(index: index, uploadId: currentUploadId) }
+                    nextChunk += 1
+                    inFlight += 1
+                }
+            }
         }
 
         return try converter!(result)

--- a/templates/dart/lib/src/client_browser.dart.twig
+++ b/templates/dart/lib/src/client_browser.dart.twig
@@ -223,6 +223,16 @@ class ClientBrowser extends ClientBase with ClientMixin {
     final concurrency = min(8, chunks.length);
     await Future.wait(List.generate(concurrency, (_) => uploadNext()));
 
+    if (uploadId != null && uploadId.isNotEmpty) {
+      final finalHeaders = Map<String, String>.from(headers);
+      finalHeaders.remove('content-type');
+      return call(
+        HttpMethod.get,
+        path: '$path/$uploadId',
+        headers: finalHeaders,
+      );
+    }
+
     return lastResponse;
   }
 

--- a/templates/dart/lib/src/client_browser.dart.twig
+++ b/templates/dart/lib/src/client_browser.dart.twig
@@ -122,6 +122,7 @@ class ClientBrowser extends ClientBase with ClientMixin {
     }
 
     var offset = 0;
+    String? uploadId;
     if (idParamName.isNotEmpty) {
       //make a request to check if a file already exists
       try {
@@ -132,33 +133,97 @@ class ClientBrowser extends ClientBase with ClientMixin {
         );
         final int chunksUploaded = res.data['chunksUploaded'] as int;
         offset = chunksUploaded * chunkSize;
+        uploadId = res.data['\$id'] ?? params[idParamName]?.toString();
       } on {{spec.title | caseUcfirst}}Exception catch (_) {}
     }
 
-    while (offset < size) {
-      List<int> chunk = [];
-      final end = min(offset + chunkSize, size);
-      chunk = file.bytes!.getRange(offset, end).toList();
-      params[paramName] =
-          http.MultipartFile.fromBytes(paramName, chunk, filename: file.filename);
-      headers['content-range'] =
-          'bytes $offset-${min<int>((offset + chunkSize - 1), size - 1)}/$size';
-      res = await call(HttpMethod.post,
-          path: path, headers: headers, params: params);
-      offset += chunkSize;
-      if (offset < size) {
-        headers['x-{{spec.title | caseLower }}-id'] = res.data['\$id'];
-      }
-      final progress = UploadProgress(
-        $id: res.data['\$id'] ?? '',
-        progress: min(offset, size) / size * 100,
-        sizeUploaded: min(offset, size),
-        chunksTotal: res.data['chunksTotal'] ?? 0,
-        chunksUploaded: res.data['chunksUploaded'] ?? 0,
-      );
-      onProgress?.call(progress);
+    if (offset >= size) {
+      return res;
     }
-    return res;
+
+    final totalChunks = (size / chunkSize).ceil();
+
+    Future<Response> uploadChunk(int index, int start, int end, String? id) async {
+      List<int> chunk = [];
+      chunk = file.bytes!.getRange(start, end).toList();
+
+      final chunkParams = Map<String, dynamic>.from(params);
+      chunkParams[paramName] =
+          http.MultipartFile.fromBytes(paramName, chunk, filename: file.filename);
+      final chunkHeaders = Map<String, String>.from(headers);
+      if (id != null && id.isNotEmpty) {
+        chunkHeaders['x-{{spec.title | caseLower }}-id'] = id;
+      }
+      chunkHeaders['content-range'] = 'bytes $start-${end - 1}/$size';
+
+      return call(
+        HttpMethod.post,
+        path: path,
+        headers: chunkHeaders,
+        params: chunkParams,
+      );
+    }
+
+    final firstStart = offset;
+    final firstEnd = min(firstStart + chunkSize, size);
+    final firstIndex = firstStart ~/ chunkSize;
+    res = await uploadChunk(firstIndex, firstStart, firstEnd, uploadId);
+    uploadId = res.data['\$id'] ?? uploadId;
+
+    var completedChunks = firstIndex + 1;
+    var uploadedBytes = firstEnd;
+    var lastResponse = res;
+
+    final progress = UploadProgress(
+      $id: uploadId ?? '',
+      progress: min(uploadedBytes, size) / size * 100,
+      sizeUploaded: min(uploadedBytes, size),
+      chunksTotal: totalChunks,
+      chunksUploaded: completedChunks,
+    );
+    onProgress?.call(progress);
+
+    final chunks = <Map<String, int>>[];
+    for (var start = firstEnd; start < size; start += chunkSize) {
+      final end = min(start + chunkSize, size);
+      chunks.add({
+        'index': start ~/ chunkSize,
+        'start': start,
+        'end': end,
+      });
+    }
+
+    var nextChunk = 0;
+    Future<void> uploadNext() async {
+      while (nextChunk < chunks.length) {
+        final chunk = chunks[nextChunk++];
+        final chunkResponse = await uploadChunk(
+          chunk['index']!,
+          chunk['start']!,
+          chunk['end']!,
+          uploadId,
+        );
+        completedChunks++;
+        uploadedBytes += chunk['end']! - chunk['start']!;
+        if (chunk['index'] == totalChunks - 1) {
+          lastResponse = chunkResponse;
+        }
+
+        final progress = UploadProgress(
+          $id: uploadId ?? '',
+          progress: min(uploadedBytes, size) / size * 100,
+          sizeUploaded: min(uploadedBytes, size),
+          chunksTotal: totalChunks,
+          chunksUploaded: completedChunks,
+        );
+        onProgress?.call(progress);
+      }
+    }
+
+    final concurrency = min(8, chunks.length);
+    await Future.wait(List.generate(concurrency, (_) => uploadNext()));
+
+    return lastResponse;
   }
 
   @override

--- a/templates/dart/lib/src/client_browser.dart.twig
+++ b/templates/dart/lib/src/client_browser.dart.twig
@@ -174,6 +174,12 @@ class ClientBrowser extends ClientBase with ClientMixin {
     var uploadedBytes = firstEnd;
     var lastResponse = res;
 
+    bool isUploadComplete(Response response) {
+      final chunksUploaded = response.data['chunksUploaded'];
+      final chunksTotal = response.data['chunksTotal'] ?? totalChunks;
+      return chunksUploaded is num && chunksTotal is num && chunksUploaded >= chunksTotal;
+    }
+
     final progress = UploadProgress(
       $id: uploadId ?? '',
       progress: min(uploadedBytes, size) / size * 100,
@@ -205,7 +211,7 @@ class ClientBrowser extends ClientBase with ClientMixin {
         );
         completedChunks++;
         uploadedBytes += chunk['end']! - chunk['start']!;
-        if (chunk['index'] == totalChunks - 1) {
+        if (isUploadComplete(chunkResponse)) {
           lastResponse = chunkResponse;
         }
 
@@ -222,16 +228,6 @@ class ClientBrowser extends ClientBase with ClientMixin {
 
     final concurrency = min(8, chunks.length);
     await Future.wait(List.generate(concurrency, (_) => uploadNext()));
-
-    if (uploadId != null && uploadId.isNotEmpty) {
-      final finalHeaders = Map<String, String>.from(headers);
-      finalHeaders.remove('content-type');
-      return call(
-        HttpMethod.get,
-        path: '$path/$uploadId',
-        headers: finalHeaders,
-      );
-    }
 
     return lastResponse;
   }

--- a/templates/dart/lib/src/client_io.dart.twig
+++ b/templates/dart/lib/src/client_io.dart.twig
@@ -143,6 +143,7 @@ class ClientIO extends ClientBase with ClientMixin {
     }
 
     var offset = 0;
+    String? uploadId;
     if (idParamName.isNotEmpty) {
       //make a request to check if a file already exists
       try {
@@ -153,45 +154,107 @@ class ClientIO extends ClientBase with ClientMixin {
         );
         final int chunksUploaded = res.data['chunksUploaded'] as int;
         offset = chunksUploaded * chunkSize;
+        uploadId = res.data['\$id'] ?? params[idParamName]?.toString();
       } on {{spec.title | caseUcfirst}}Exception catch (_) {}
     }
 
-    RandomAccessFile? raf;
-    // read chunk and upload each chunk
-    if (iofile != null) {
-      raf = await iofile.open(mode: FileMode.read);
+    if (offset >= size) {
+      return res;
     }
 
-    while (offset < size) {
+    final totalChunks = (size / chunkSize).ceil();
+
+    Future<Response> uploadChunk(int index, int start, int end, String? id) async {
       List<int> chunk = [];
       if (file.bytes != null) {
-        final end = min(offset + chunkSize, size);
-        chunk = file.bytes!.getRange(offset, end).toList();
+        chunk = file.bytes!.getRange(start, end).toList();
       } else {
-        raf!.setPositionSync(offset);
-        chunk = raf.readSync(chunkSize);
+        final raf = await iofile!.open(mode: FileMode.read);
+        try {
+          await raf.setPosition(start);
+          chunk = await raf.read(end - start);
+        } finally {
+          await raf.close();
+        }
       }
-      params[paramName] =
+
+      final chunkParams = Map<String, dynamic>.from(params);
+      chunkParams[paramName] =
           http.MultipartFile.fromBytes(paramName, chunk, filename: file.filename);
-      headers['content-range'] =
-          'bytes $offset-${min<int>((offset + chunkSize - 1), size - 1)}/$size';
-      res = await call(HttpMethod.post,
-          path: path, headers: headers, params: params);
-      offset += chunkSize;
-      if (offset < size) {
-        headers['x-{{spec.title | caseLower }}-id'] = res.data['\$id'];
+      final chunkHeaders = Map<String, String>.from(headers);
+      if (id != null && id.isNotEmpty) {
+        chunkHeaders['x-{{spec.title | caseLower }}-id'] = id;
       }
-      final progress = UploadProgress(
-        $id: res.data['\$id'] ?? '',
-        progress: min(offset, size) / size * 100,
-        sizeUploaded: min(offset, size),
-        chunksTotal: res.data['chunksTotal'] ?? 0,
-        chunksUploaded: res.data['chunksUploaded'] ?? 0,
+      chunkHeaders['content-range'] = 'bytes $start-${end - 1}/$size';
+
+      return call(
+        HttpMethod.post,
+        path: path,
+        headers: chunkHeaders,
+        params: chunkParams,
       );
-      onProgress?.call(progress);
     }
-    raf?.close();
-    return res;
+
+    final firstStart = offset;
+    final firstEnd = min(firstStart + chunkSize, size);
+    final firstIndex = firstStart ~/ chunkSize;
+    res = await uploadChunk(firstIndex, firstStart, firstEnd, uploadId);
+    uploadId = res.data['\$id'] ?? uploadId;
+
+    var completedChunks = firstIndex + 1;
+    var uploadedBytes = firstEnd;
+    var lastResponse = res;
+
+    final progress = UploadProgress(
+      $id: uploadId ?? '',
+      progress: min(uploadedBytes, size) / size * 100,
+      sizeUploaded: min(uploadedBytes, size),
+      chunksTotal: totalChunks,
+      chunksUploaded: completedChunks,
+    );
+    onProgress?.call(progress);
+
+    final chunks = <Map<String, int>>[];
+    for (var start = firstEnd; start < size; start += chunkSize) {
+      final end = min(start + chunkSize, size);
+      chunks.add({
+        'index': start ~/ chunkSize,
+        'start': start,
+        'end': end,
+      });
+    }
+
+    var nextChunk = 0;
+    Future<void> uploadNext() async {
+      while (nextChunk < chunks.length) {
+        final chunk = chunks[nextChunk++];
+        final chunkResponse = await uploadChunk(
+          chunk['index']!,
+          chunk['start']!,
+          chunk['end']!,
+          uploadId,
+        );
+        completedChunks++;
+        uploadedBytes += chunk['end']! - chunk['start']!;
+        if (chunk['index'] == totalChunks - 1) {
+          lastResponse = chunkResponse;
+        }
+
+        final progress = UploadProgress(
+          $id: uploadId ?? '',
+          progress: min(uploadedBytes, size) / size * 100,
+          sizeUploaded: min(uploadedBytes, size),
+          chunksTotal: totalChunks,
+          chunksUploaded: completedChunks,
+        );
+        onProgress?.call(progress);
+      }
+    }
+
+    final concurrency = min(8, chunks.length);
+    await Future.wait(List.generate(concurrency, (_) => uploadNext()));
+
+    return lastResponse;
   }
 
   @override

--- a/templates/dart/lib/src/client_io.dart.twig
+++ b/templates/dart/lib/src/client_io.dart.twig
@@ -254,6 +254,16 @@ class ClientIO extends ClientBase with ClientMixin {
     final concurrency = min(8, chunks.length);
     await Future.wait(List.generate(concurrency, (_) => uploadNext()));
 
+    if (uploadId != null && uploadId.isNotEmpty) {
+      final finalHeaders = Map<String, String>.from(headers);
+      finalHeaders.remove('content-type');
+      return call(
+        HttpMethod.get,
+        path: '$path/$uploadId',
+        headers: finalHeaders,
+      );
+    }
+
     return lastResponse;
   }
 

--- a/templates/dart/lib/src/client_io.dart.twig
+++ b/templates/dart/lib/src/client_io.dart.twig
@@ -205,6 +205,12 @@ class ClientIO extends ClientBase with ClientMixin {
     var uploadedBytes = firstEnd;
     var lastResponse = res;
 
+    bool isUploadComplete(Response response) {
+      final chunksUploaded = response.data['chunksUploaded'];
+      final chunksTotal = response.data['chunksTotal'] ?? totalChunks;
+      return chunksUploaded is num && chunksTotal is num && chunksUploaded >= chunksTotal;
+    }
+
     final progress = UploadProgress(
       $id: uploadId ?? '',
       progress: min(uploadedBytes, size) / size * 100,
@@ -236,7 +242,7 @@ class ClientIO extends ClientBase with ClientMixin {
         );
         completedChunks++;
         uploadedBytes += chunk['end']! - chunk['start']!;
-        if (chunk['index'] == totalChunks - 1) {
+        if (isUploadComplete(chunkResponse)) {
           lastResponse = chunkResponse;
         }
 
@@ -253,16 +259,6 @@ class ClientIO extends ClientBase with ClientMixin {
 
     final concurrency = min(8, chunks.length);
     await Future.wait(List.generate(concurrency, (_) => uploadNext()));
-
-    if (uploadId != null && uploadId.isNotEmpty) {
-      final finalHeaders = Map<String, String>.from(headers);
-      finalHeaders.remove('content-type');
-      return call(
-        HttpMethod.get,
-        path: '$path/$uploadId',
-        headers: finalHeaders,
-      );
-    }
 
     return lastResponse;
   }

--- a/templates/deno/src/services/service.ts.twig
+++ b/templates/deno/src/services/service.ts.twig
@@ -125,6 +125,7 @@ export class {{ service.name | caseUcfirst }} extends Service {
 
 {% for parameter in method.parameters.all %}
 {% if parameter.isUploadID %}
+        id = {{ parameter.name }};
         try {
             response = await this.client.call(
                 'get',
@@ -137,80 +138,133 @@ export class {{ service.name | caseUcfirst }} extends Service {
 {% endif %}
 {% endfor %}
 
-        let currentChunk = 1;
+        const totalChunks = Math.ceil(size / Client.CHUNK_SIZE);
+        const chunks: { index: number; start: number; end: number; data: Uint8Array }[] = [];
+        let currentChunk = 0;
         let currentPosition = 0;
         let uploadableChunk = new Uint8Array(Client.CHUNK_SIZE);
 
-        const uploadChunk = async (lastUpload = false) => {
-            if(currentChunk <= chunksUploaded) {
+        const queueChunk = () => {
+            if (currentChunk < chunksUploaded) {
+                currentChunk++;
+                currentPosition = 0;
+                uploadableChunk = new Uint8Array(Client.CHUNK_SIZE);
                 return;
             }
 
-            const start = ((currentChunk - 1) * Client.CHUNK_SIZE);
-            let end = start + currentPosition;
+            const start = currentChunk * Client.CHUNK_SIZE;
+            const end = Math.min(start + currentPosition, size);
+            const data = currentPosition >= Client.CHUNK_SIZE
+                ? uploadableChunk
+                : uploadableChunk.slice(0, currentPosition);
 
-            if (end === size) {
-                end -= 1;
-            }
-
-            if(!lastUpload || currentChunk !== 1) {
-                apiHeaders['content-range'] = 'bytes ' + start + '-' + end + '/' + size;
-            }
-
-            let uploadableChunkTrimmed: Uint8Array;
-
-            if(currentPosition + 1 >= Client.CHUNK_SIZE) {
-                uploadableChunkTrimmed = uploadableChunk;
-            } else {
-                uploadableChunkTrimmed = new Uint8Array(currentPosition);
-                for(let i = 0; i <= currentPosition; i++) {
-                    uploadableChunkTrimmed[i] = uploadableChunk[i];
-                }
-            }
-
-            if (id) {
-                apiHeaders['x-{{spec.title | caseLower }}-id'] = id;
-            }
-
-            payload['{{ parameter.name }}'] = { type: 'file', file: new File([uploadableChunkTrimmed], {{ parameter.name | caseCamel | escapeKeyword }}.filename), filename: {{ parameter.name | caseCamel | escapeKeyword }}.filename };
-
-            response = await this.client.call('{{ method.method | caseLower }}', apiPath, apiHeaders, payload{% if method.type == 'location' %}, 'arraybuffer'{% elseif method.type == 'webAuth' %}, 'location'{% endif %});
-
-            if (!id) {
-                id = response['$id'];
-            }
-
-            if (onProgress !== null) {
-                onProgress({
-                    $id: response['$id'],
-                    progress: Math.min((currentChunk) * Client.CHUNK_SIZE, size) / size * 100,
-                    sizeUploaded: end+1,
-                    chunksTotal: response['chunksTotal'],
-                    chunksUploaded: response['chunksUploaded']
-                });
-            }
-
-            uploadableChunk = new Uint8Array(Client.CHUNK_SIZE);
-            currentPosition = 0;
+            chunks.push({ index: currentChunk, start, end, data });
             currentChunk++;
-        }
+            currentPosition = 0;
+            uploadableChunk = new Uint8Array(Client.CHUNK_SIZE);
+        };
 
         for await (const chunk of {{ parameter.name | caseCamel | escapeKeyword }}.stream) {
             let i = 0;
             for(const b of chunk) {
                 uploadableChunk[currentPosition] = chunk[i];
+                currentPosition++;
 
-                if(currentPosition + 1 >= Client.CHUNK_SIZE) {
-                    await uploadChunk();
-                    currentPosition--;
+                if(currentPosition >= Client.CHUNK_SIZE) {
+                    queueChunk();
                 }
 
                 i++;
-                currentPosition++;
             }
         }
 
-        await uploadChunk(true);
+        if (currentPosition > 0) {
+            queueChunk();
+        }
+
+        if (chunks.length === 0) {
+            return response;
+        }
+
+        if (chunks.length === 1 && chunks[0].index === 0) {
+            payload['{{ parameter.name }}'] = { type: 'file', file: new File([chunks[0].data], {{ parameter.name | caseCamel | escapeKeyword }}.filename), filename: {{ parameter.name | caseCamel | escapeKeyword }}.filename };
+            response = await this.client.call('{{ method.method | caseLower }}', apiPath, apiHeaders, payload{% if method.type == 'location' %}, 'arraybuffer'{% elseif method.type == 'webAuth' %}, 'location'{% endif %});
+
+            if (onProgress !== null) {
+                onProgress({
+                    $id: response['$id'],
+                    progress: 100,
+                    sizeUploaded: size,
+                    chunksTotal: response['chunksTotal'] ?? totalChunks,
+                    chunksUploaded: response['chunksUploaded'] ?? 1
+                });
+            }
+
+            return response;
+        }
+
+        const uploadChunk = async (chunk: typeof chunks[0]) => {
+            const chunkHeaders = { ...apiHeaders };
+            chunkHeaders['content-range'] = 'bytes ' + chunk.start + '-' + (chunk.end - 1) + '/' + size;
+            if (id) {
+                chunkHeaders['x-{{spec.title | caseLower }}-id'] = id;
+            }
+
+            const chunkPayload = { ...payload };
+            chunkPayload['{{ parameter.name }}'] = { type: 'file', file: new File([chunk.data], {{ parameter.name | caseCamel | escapeKeyword }}.filename), filename: {{ parameter.name | caseCamel | escapeKeyword }}.filename };
+
+            return await this.client.call('{{ method.method | caseLower }}', apiPath, chunkHeaders, chunkPayload{% if method.type == 'location' %}, 'arraybuffer'{% elseif method.type == 'webAuth' %}, 'location'{% endif %});
+        };
+
+        response = await uploadChunk(chunks[0]);
+
+        if (!id) {
+            id = response['$id'];
+        }
+
+        let completedCount = chunks[0].index + 1;
+        let uploadedBytes = chunks[0].end;
+
+        if (onProgress !== null) {
+            onProgress({
+                $id: response['$id'],
+                progress: uploadedBytes / size * 100,
+                sizeUploaded: uploadedBytes,
+                chunksTotal: response['chunksTotal'] ?? totalChunks,
+                chunksUploaded: response['chunksUploaded'] ?? completedCount
+            });
+        }
+
+        const CONCURRENCY = 8;
+        let nextChunk = 1;
+        let lastResponse = response;
+
+        const uploadNext = async () => {
+            while (nextChunk < chunks.length) {
+                const chunk = chunks[nextChunk++];
+                const chunkResponse = await uploadChunk(chunk);
+                completedCount++;
+                uploadedBytes += chunk.end - chunk.start;
+
+                if (chunk.index === totalChunks - 1) {
+                    lastResponse = chunkResponse;
+                }
+
+                if (onProgress !== null) {
+                    onProgress({
+                        $id: id!,
+                        progress: uploadedBytes / size * 100,
+                        sizeUploaded: uploadedBytes,
+                        chunksTotal: chunkResponse['chunksTotal'] ?? totalChunks,
+                        chunksUploaded: chunkResponse['chunksUploaded'] ?? completedCount
+                    });
+                }
+            }
+        };
+
+        await Promise.all(Array.from({ length: Math.min(CONCURRENCY, chunks.length - 1) }, uploadNext));
+
+        response = lastResponse;
 
         return response;
 {% endif %}

--- a/templates/deno/src/services/service.ts.twig
+++ b/templates/deno/src/services/service.ts.twig
@@ -239,6 +239,12 @@ export class {{ service.name | caseUcfirst }} extends Service {
         let nextChunk = 1;
         let lastResponse = response;
 
+        const isUploadComplete = (chunkResponse: any) => {
+            const chunksUploaded = chunkResponse?.chunksUploaded;
+            const chunksTotal = chunkResponse?.chunksTotal ?? totalChunks;
+            return typeof chunksUploaded === 'number' && typeof chunksTotal === 'number' && chunksUploaded >= chunksTotal;
+        };
+
         const uploadNext = async () => {
             while (nextChunk < chunks.length) {
                 const chunk = chunks[nextChunk++];
@@ -246,7 +252,7 @@ export class {{ service.name | caseUcfirst }} extends Service {
                 completedCount++;
                 uploadedBytes += chunk.end - chunk.start;
 
-                if (chunk.index === totalChunks - 1) {
+                if (isUploadComplete(chunkResponse)) {
                     lastResponse = chunkResponse;
                 }
 

--- a/templates/dotnet/Package/Client.cs.twig
+++ b/templates/dotnet/Package/Client.cs.twig
@@ -456,6 +456,7 @@ namespace {{ spec.title | caseUcfirst }}
                     {
                         offset = Convert.ToInt64(chunksUploadedValue) * ChunkSize;
                     }
+                    result = current;
                     uploadId = parameters[idParamName!]?.ToString() ?? string.Empty;
                 }
                 catch
@@ -574,6 +575,7 @@ namespace {{ spec.title | caseUcfirst }}
 
             var chunks = new List<(int Index, long Start, long End)>();
             var chunkOffset = offset;
+            var totalChunks = (long)Math.Ceiling(size / (double)ChunkSize);
             while (chunkOffset < size)
             {
                 var end = Math.Min(chunkOffset + ChunkSize, size);
@@ -586,7 +588,22 @@ namespace {{ spec.title | caseUcfirst }}
                 var nextChunk = -1;
                 var completedChunks = (long)(offset / ChunkSize);
                 var uploadedBytes = offset;
-                var lastChunkIndex = (int)((size - 1) / ChunkSize);
+                var resultLock = new object();
+
+                bool IsUploadComplete(Dictionary<string, object?> chunkResult)
+                {
+                    if (!chunkResult.TryGetValue("chunksUploaded", out var chunksUploadedValue) || chunksUploadedValue == null)
+                    {
+                        return false;
+                    }
+
+                    var chunksUploaded = Convert.ToInt64(chunksUploadedValue);
+                    var chunksTotal = chunkResult.TryGetValue("chunksTotal", out var chunksTotalValue) && chunksTotalValue != null
+                        ? Convert.ToInt64(chunksTotalValue)
+                        : totalChunks;
+
+                    return chunksUploaded >= chunksTotal;
+                }
 
                 var workers = Enumerable.Range(0, Math.Min(MaxConcurrentUploads, chunks.Count))
                     .Select(async _ =>
@@ -600,9 +617,12 @@ namespace {{ spec.title | caseUcfirst }}
                             var chunk = chunks[chunkIndex];
                             var chunkResult = await UploadChunkAsync(chunk.Index, chunk.Start, chunk.End, true);
 
-                            if (chunk.Index == lastChunkIndex)
+                            if (IsUploadComplete(chunkResult))
                             {
-                                result = chunkResult;
+                                lock (resultLock)
+                                {
+                                    result = chunkResult;
+                                }
                             }
 
                             var chunksUploaded = Interlocked.Increment(ref completedChunks);

--- a/templates/dotnet/Package/Client.cs.twig
+++ b/templates/dotnet/Package/Client.cs.twig
@@ -474,7 +474,7 @@ namespace {{ spec.title | caseUcfirst }}
                 switch(input.SourceType)
                 {
                     case "path":
-                        using (var chunkStream = File.OpenRead(input.Path))
+                        using (var chunkStream = System.IO.File.OpenRead(input.Path))
                         {
                             chunkStream.Seek(start, SeekOrigin.Begin);
                             var read = 0;

--- a/templates/dotnet/Package/Client.cs.twig
+++ b/templates/dotnet/Package/Client.cs.twig
@@ -7,6 +7,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 using {{ spec.title | caseUcfirst }}.Converters;
 using {{ spec.title | caseUcfirst }}.Extensions;
@@ -26,6 +27,7 @@ namespace {{ spec.title | caseUcfirst }}
         private string _endpoint;
 
         private static readonly int ChunkSize = 5 * 1024 * 1024;
+        private static readonly int MaxConcurrentUploads = 8;
 
         public static JsonSerializerOptions DeserializerOptions { get; set; } = new JsonSerializerOptions
         {
@@ -195,14 +197,14 @@ namespace {{ spec.title | caseUcfirst }}
             {
                 if (header.Key.Equals("content-type", StringComparison.OrdinalIgnoreCase))
                 {
-                    _http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(header.Value));
+                    request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(header.Value));
                 }
                 else
                 {
-                    if (_http.DefaultRequestHeaders.Contains(header.Key)) {
-                        _http.DefaultRequestHeaders.Remove(header.Key);
+                    if (request.Headers.Contains(header.Key)) {
+                        request.Headers.Remove(header.Key);
                     }
-                    _http.DefaultRequestHeaders.Add(header.Key, header.Value);
+                    request.Headers.Add(header.Key, header.Value);
                 }
             }
 
@@ -437,69 +439,123 @@ namespace {{ spec.title | caseUcfirst }}
                 );
             }
 
+            var uploadId = string.Empty;
+
             if (!string.IsNullOrEmpty(idParamName))
             {
                 try
                 {
-                // Make a request to check if a file already exists
-                var current = await Call<Dictionary<string, object?>>(
-                    method: "GET",
-                    path: $"{path}/{parameters[idParamName!]}",
-                    new Dictionary<string, string> { { "content-type", "application/json" } },
-                    parameters: new Dictionary<string, object?>()
-                );
-                if (current.TryGetValue("chunksUploaded", out var chunksUploadedValue) && chunksUploadedValue != null)
-                {
-                    offset = Convert.ToInt64(chunksUploadedValue) * ChunkSize;
+                    // Make a request to check if a file already exists
+                    var current = await Call<Dictionary<string, object?>>(
+                        method: "GET",
+                        path: $"{path}/{parameters[idParamName!]}",
+                        new Dictionary<string, string> { { "content-type", "application/json" } },
+                        parameters: new Dictionary<string, object?>()
+                    );
+                    if (current.TryGetValue("chunksUploaded", out var chunksUploadedValue) && chunksUploadedValue != null)
+                    {
+                        offset = Convert.ToInt64(chunksUploadedValue) * ChunkSize;
+                    }
+                    uploadId = parameters[idParamName!]?.ToString() ?? string.Empty;
                 }
-            }
                 catch
                 {
                     // ignored as it mostly means file not found
                 }
             }
 
-            while (offset < size)
+            var readLock = new object();
+
+            async Task<byte[]> ReadChunkAsync(long start, long end)
             {
+                var length = (int)(end - start);
+                var chunk = new byte[length];
+
                 switch(input.SourceType)
                 {
                     case "path":
+                        using (var chunkStream = File.OpenRead(input.Path))
+                        {
+                            chunkStream.Seek(start, SeekOrigin.Begin);
+                            var read = 0;
+                            while (read < length)
+                            {
+                                var count = await chunkStream.ReadAsync(chunk, read, length - read);
+                                if (count == 0)
+                                    break;
+                                read += count;
+                            }
+                        }
+                        break;
                     case "stream":
                         var stream = input.Data as Stream;
                         if (stream == null)
                             throw new InvalidOperationException("Stream data is null");
-                        stream.Seek(offset, SeekOrigin.Begin);
-                        await stream.ReadAsync(buffer, 0, ChunkSize);
+                        lock (readLock)
+                        {
+                            stream.Seek(start, SeekOrigin.Begin);
+                            var read = 0;
+                            while (read < length)
+                            {
+                                var count = stream.Read(chunk, read, length - read);
+                                if (count == 0)
+                                    break;
+                                read += count;
+                            }
+                        }
                         break;
                     case "bytes":
-                        buffer = ((byte[])input.Data)
-                            .Skip((int)offset)
-                            .Take((int)Math.Min(size - offset, ChunkSize - 1))
-                            .ToArray();
+                        Buffer.BlockCopy((byte[])input.Data, (int)start, chunk, 0, length);
                         break;
                 }
 
-                var content = new MultipartFormDataContent {
-                    { new ByteArrayContent(buffer), paramName, input.Filename }
+                return chunk;
+            }
+
+            async Task<Dictionary<string, object?>> UploadChunkAsync(int index, long start, long end, bool includeUploadId)
+            {
+                var chunkHeaders = new Dictionary<string, string>(headers)
+                {
+                    ["Content-Range"] = $"bytes {start}-{end - 1}/{size}"
                 };
 
-                parameters[paramName] = content;
+                if (includeUploadId && !string.IsNullOrEmpty(uploadId))
+                {
+                    chunkHeaders["x-appwrite-id"] = uploadId;
+                }
 
-                headers["Content-Range"] =
-                    $"bytes {offset}-{Math.Min(offset + ChunkSize - 1, size - 1)}/{size}";
+                var content = new MultipartFormDataContent {
+                    { new ByteArrayContent(await ReadChunkAsync(start, end)), paramName, input.Filename }
+                };
 
-                result = await Call<Dictionary<string, object?>>(
+                var chunkParameters = new Dictionary<string, object?>(parameters)
+                {
+                    [paramName] = content
+                };
+
+                var chunkResult = await Call<Dictionary<string, object?>>(
                     method: "POST",
                     path,
-                    headers,
-                    parameters
+                    chunkHeaders,
+                    chunkParameters
                 );
 
-                offset += ChunkSize;
+                if (index == 0 || string.IsNullOrEmpty(uploadId))
+                {
+                    uploadId = chunkResult.ContainsKey("$id")
+                        ? chunkResult["$id"]?.ToString() ?? string.Empty
+                        : string.Empty;
+                }
 
-                var id = result.ContainsKey("$id")
-                    ? result["$id"]?.ToString() ?? string.Empty
-                    : string.Empty;
+                return chunkResult;
+            }
+
+            if (offset == 0)
+            {
+                var firstChunkEnd = Math.Min(ChunkSize, size);
+                result = await UploadChunkAsync(0, 0, firstChunkEnd, false);
+                offset = firstChunkEnd;
+
                 var chunksTotal = result.TryGetValue("chunksTotal", out var chunksTotalValue) && chunksTotalValue != null
                     ? Convert.ToInt64(chunksTotalValue)
                     : 0L;
@@ -507,15 +563,65 @@ namespace {{ spec.title | caseUcfirst }}
                     ? Convert.ToInt64(chunksUploadedValue)
                     : 0L;
 
-                headers["x-appwrite-id"] = id;
-
                 onProgress?.Invoke(
                     new UploadProgress(
-                        id: id,
-                        progress: Math.Min(offset, size) / size * 100,
+                        id: uploadId,
+                        progress: Math.Min(offset, size) / (double)size * 100,
                         sizeUploaded: Math.Min(offset, size),
                         chunksTotal: chunksTotal,
                         chunksUploaded: chunksUploaded));
+            }
+
+            var chunks = new List<(int Index, long Start, long End)>();
+            var chunkOffset = offset;
+            while (chunkOffset < size)
+            {
+                var end = Math.Min(chunkOffset + ChunkSize, size);
+                chunks.Add(((int)(chunkOffset / ChunkSize), chunkOffset, end));
+                chunkOffset = end;
+            }
+
+            if (chunks.Count > 0)
+            {
+                var nextChunk = -1;
+                var completedChunks = (long)(offset / ChunkSize);
+                var uploadedBytes = offset;
+                var lastChunkIndex = (int)((size - 1) / ChunkSize);
+
+                var workers = Enumerable.Range(0, Math.Min(MaxConcurrentUploads, chunks.Count))
+                    .Select(async _ =>
+                    {
+                        while (true)
+                        {
+                            var chunkIndex = Interlocked.Increment(ref nextChunk);
+                            if (chunkIndex >= chunks.Count)
+                                break;
+
+                            var chunk = chunks[chunkIndex];
+                            var chunkResult = await UploadChunkAsync(chunk.Index, chunk.Start, chunk.End, true);
+
+                            if (chunk.Index == lastChunkIndex)
+                            {
+                                result = chunkResult;
+                            }
+
+                            var chunksUploaded = Interlocked.Increment(ref completedChunks);
+                            var sizeUploaded = Interlocked.Add(ref uploadedBytes, chunk.End - chunk.Start);
+                            var chunksTotal = chunkResult.TryGetValue("chunksTotal", out var chunksTotalValue) && chunksTotalValue != null
+                                ? Convert.ToInt64(chunksTotalValue)
+                                : 0L;
+
+                            onProgress?.Invoke(
+                                new UploadProgress(
+                                    id: uploadId,
+                                    progress: Math.Min(sizeUploaded, size) / (double)size * 100,
+                                    sizeUploaded: Math.Min(sizeUploaded, size),
+                                    chunksTotal: chunksTotal,
+                                    chunksUploaded: chunksUploaded));
+                        }
+                    });
+
+                await Task.WhenAll(workers);
             }
 
             // Convert to non-nullable dictionary for converter

--- a/templates/dotnet/Package/Client.cs.twig
+++ b/templates/dotnet/Package/Client.cs.twig
@@ -629,7 +629,7 @@ namespace {{ spec.title | caseUcfirst }}
                             var sizeUploaded = Interlocked.Add(ref uploadedBytes, chunk.End - chunk.Start);
                             var chunksTotal = chunkResult.TryGetValue("chunksTotal", out var chunksTotalValue) && chunksTotalValue != null
                                 ? Convert.ToInt64(chunksTotalValue)
-                                : 0L;
+                                : totalChunks;
 
                             onProgress?.Invoke(
                                 new UploadProgress(

--- a/templates/dotnet/Package/Client.cs.twig
+++ b/templates/dotnet/Package/Client.cs.twig
@@ -559,7 +559,7 @@ namespace {{ spec.title | caseUcfirst }}
 
                 var chunksTotal = result.TryGetValue("chunksTotal", out var chunksTotalValue) && chunksTotalValue != null
                     ? Convert.ToInt64(chunksTotalValue)
-                    : 0L;
+                    : (long)Math.Ceiling(size / (double)ChunkSize);
                 var chunksUploaded = result.TryGetValue("chunksUploaded", out var chunksUploadedValue) && chunksUploadedValue != null
                     ? Convert.ToInt64(chunksUploadedValue)
                     : 0L;

--- a/templates/dotnet/Package/Client.cs.twig
+++ b/templates/dotnet/Package/Client.cs.twig
@@ -522,7 +522,7 @@ namespace {{ spec.title | caseUcfirst }}
 
                 if (includeUploadId && !string.IsNullOrEmpty(uploadId))
                 {
-                    chunkHeaders["x-appwrite-id"] = uploadId;
+                    chunkHeaders["x-{{ spec.title | caseLower }}-id"] = uploadId;
                 }
 
                 var content = new MultipartFormDataContent {

--- a/templates/flutter/lib/src/client_browser.dart.twig
+++ b/templates/flutter/lib/src/client_browser.dart.twig
@@ -254,6 +254,16 @@ class ClientBrowser extends ClientBase with ClientMixin {
     final concurrency = min(8, chunks.length);
     await Future.wait(List.generate(concurrency, (_) => uploadNext()));
 
+    if (uploadId != null && uploadId.isNotEmpty) {
+      final finalHeaders = Map<String, String>.from(headers);
+      finalHeaders.remove('content-type');
+      return call(
+        HttpMethod.get,
+        path: '$path/$uploadId',
+        headers: finalHeaders,
+      );
+    }
+
     return lastResponse;
   }
 

--- a/templates/flutter/lib/src/client_browser.dart.twig
+++ b/templates/flutter/lib/src/client_browser.dart.twig
@@ -205,6 +205,12 @@ class ClientBrowser extends ClientBase with ClientMixin {
     var uploadedBytes = firstEnd;
     var lastResponse = res;
 
+    bool isUploadComplete(Response response) {
+      final chunksUploaded = response.data['chunksUploaded'];
+      final chunksTotal = response.data['chunksTotal'] ?? totalChunks;
+      return chunksUploaded is num && chunksTotal is num && chunksUploaded >= chunksTotal;
+    }
+
     final progress = UploadProgress(
       $id: uploadId ?? '',
       progress: min(uploadedBytes, size) / size * 100,
@@ -236,7 +242,7 @@ class ClientBrowser extends ClientBase with ClientMixin {
         );
         completedChunks++;
         uploadedBytes += chunk['end']! - chunk['start']!;
-        if (chunk['index'] == totalChunks - 1) {
+        if (isUploadComplete(chunkResponse)) {
           lastResponse = chunkResponse;
         }
 
@@ -253,16 +259,6 @@ class ClientBrowser extends ClientBase with ClientMixin {
 
     final concurrency = min(8, chunks.length);
     await Future.wait(List.generate(concurrency, (_) => uploadNext()));
-
-    if (uploadId != null && uploadId.isNotEmpty) {
-      final finalHeaders = Map<String, String>.from(headers);
-      finalHeaders.remove('content-type');
-      return call(
-        HttpMethod.get,
-        path: '$path/$uploadId',
-        headers: finalHeaders,
-      );
-    }
 
     return lastResponse;
   }

--- a/templates/flutter/lib/src/client_browser.dart.twig
+++ b/templates/flutter/lib/src/client_browser.dart.twig
@@ -150,6 +150,7 @@ class ClientBrowser extends ClientBase with ClientMixin {
     }
 
     var offset = 0;
+    String? uploadId;
     if (idParamName.isNotEmpty) {
       //make a request to check if a file already exists
       try {
@@ -160,40 +161,100 @@ class ClientBrowser extends ClientBase with ClientMixin {
         );
         final int chunksUploaded = res.data['chunksUploaded'] as int;
         offset = chunksUploaded * chunkSize;
+        uploadId = res.data['\$id'] ?? params[idParamName]?.toString();
       } on {{spec.title | caseUcfirst}}Exception catch (_) {}
     }
 
-    while (offset < size) {
+    if (offset >= size) {
+      return res;
+    }
+
+    final totalChunks = (size / chunkSize).ceil();
+
+    Future<Response> uploadChunk(int index, int start, int end, String? id) async {
       List<int> chunk = [];
-      final end = min(offset + chunkSize, size);
-      chunk = file.bytes!.getRange(offset, end).toList();
-      params[paramName] = http.MultipartFile.fromBytes(
+      chunk = file.bytes!.getRange(start, end).toList();
+
+      final chunkParams = Map<String, dynamic>.from(params);
+      chunkParams[paramName] = http.MultipartFile.fromBytes(
         paramName,
         chunk,
         filename: file.filename,
       );
-      headers['content-range'] =
-          'bytes $offset-${min<int>((offset + chunkSize - 1), size - 1)}/$size';
-      res = await call(
+      final chunkHeaders = Map<String, String>.from(headers);
+      if (id != null && id.isNotEmpty) {
+        chunkHeaders['x-{{spec.title | caseLower }}-id'] = id;
+      }
+      chunkHeaders['content-range'] = 'bytes $start-${end - 1}/$size';
+
+      return call(
         HttpMethod.post,
         path: path,
-        headers: headers,
-        params: params,
+        headers: chunkHeaders,
+        params: chunkParams,
       );
-      offset += chunkSize;
-      if (offset < size) {
-        headers['x-{{spec.title | caseLower }}-id'] = res.data['\$id'];
-      }
-      final progress = UploadProgress(
-        $id: res.data['\$id'] ?? '',
-        progress: min(offset, size) / size * 100,
-        sizeUploaded: min(offset, size),
-        chunksTotal: res.data['chunksTotal'] ?? 0,
-        chunksUploaded: res.data['chunksUploaded'] ?? 0,
-      );
-      onProgress?.call(progress);
     }
-    return res;
+
+    final firstStart = offset;
+    final firstEnd = min(firstStart + chunkSize, size);
+    final firstIndex = firstStart ~/ chunkSize;
+    res = await uploadChunk(firstIndex, firstStart, firstEnd, uploadId);
+    uploadId = res.data['\$id'] ?? uploadId;
+
+    var completedChunks = firstIndex + 1;
+    var uploadedBytes = firstEnd;
+    var lastResponse = res;
+
+    final progress = UploadProgress(
+      $id: uploadId ?? '',
+      progress: min(uploadedBytes, size) / size * 100,
+      sizeUploaded: min(uploadedBytes, size),
+      chunksTotal: totalChunks,
+      chunksUploaded: completedChunks,
+    );
+    onProgress?.call(progress);
+
+    final chunks = <Map<String, int>>[];
+    for (var start = firstEnd; start < size; start += chunkSize) {
+      final end = min(start + chunkSize, size);
+      chunks.add({
+        'index': start ~/ chunkSize,
+        'start': start,
+        'end': end,
+      });
+    }
+
+    var nextChunk = 0;
+    Future<void> uploadNext() async {
+      while (nextChunk < chunks.length) {
+        final chunk = chunks[nextChunk++];
+        final chunkResponse = await uploadChunk(
+          chunk['index']!,
+          chunk['start']!,
+          chunk['end']!,
+          uploadId,
+        );
+        completedChunks++;
+        uploadedBytes += chunk['end']! - chunk['start']!;
+        if (chunk['index'] == totalChunks - 1) {
+          lastResponse = chunkResponse;
+        }
+
+        final progress = UploadProgress(
+          $id: uploadId ?? '',
+          progress: min(uploadedBytes, size) / size * 100,
+          sizeUploaded: min(uploadedBytes, size),
+          chunksTotal: totalChunks,
+          chunksUploaded: completedChunks,
+        );
+        onProgress?.call(progress);
+      }
+    }
+
+    final concurrency = min(8, chunks.length);
+    await Future.wait(List.generate(concurrency, (_) => uploadNext()));
+
+    return lastResponse;
   }
 
   @override

--- a/templates/flutter/lib/src/client_io.dart.twig
+++ b/templates/flutter/lib/src/client_io.dart.twig
@@ -385,6 +385,16 @@ class ClientIO extends ClientBase with ClientMixin {
     final concurrency = min(8, chunks.length);
     await Future.wait(List.generate(concurrency, (_) => uploadNext()));
 
+    if (uploadId != null && uploadId.isNotEmpty) {
+      final finalHeaders = Map<String, String>.from(headers);
+      finalHeaders.remove('content-type');
+      return call(
+        HttpMethod.get,
+        path: '$path/$uploadId',
+        headers: finalHeaders,
+      );
+    }
+
     return lastResponse;
   }
 

--- a/templates/flutter/lib/src/client_io.dart.twig
+++ b/templates/flutter/lib/src/client_io.dart.twig
@@ -271,6 +271,7 @@ class ClientIO extends ClientBase with ClientMixin {
     }
 
     var offset = 0;
+    String? uploadId;
     if (idParamName.isNotEmpty) {
       //make a request to check if a file already exists
       try {
@@ -281,52 +282,110 @@ class ClientIO extends ClientBase with ClientMixin {
         );
         final int chunksUploaded = res.data['chunksUploaded'] as int;
         offset = chunksUploaded * chunkSize;
+        uploadId = res.data['\$id'] ?? params[idParamName]?.toString();
       } on {{spec.title | caseUcfirst}}Exception catch (_) {}
     }
 
-    RandomAccessFile? raf;
-    // read chunk and upload each chunk
-    if (iofile != null) {
-      raf = await iofile.open(mode: FileMode.read);
+    if (offset >= size) {
+      return res;
     }
 
-    while (offset < size) {
+    final totalChunks = (size / chunkSize).ceil();
+
+    Future<Response> uploadChunk(int index, int start, int end, String? id) async {
       List<int> chunk = [];
       if (file.bytes != null) {
-        final end = min(offset + chunkSize, size);
-        chunk = file.bytes!.getRange(offset, end).toList();
+        chunk = file.bytes!.getRange(start, end).toList();
       } else {
-        raf!.setPositionSync(offset);
-        chunk = raf.readSync(chunkSize);
+        final raf = await iofile!.open(mode: FileMode.read);
+        try {
+          await raf.setPosition(start);
+          chunk = await raf.read(end - start);
+        } finally {
+          await raf.close();
+        }
       }
-      params[paramName] = http.MultipartFile.fromBytes(
+
+      final chunkParams = Map<String, dynamic>.from(params);
+      chunkParams[paramName] = http.MultipartFile.fromBytes(
         paramName,
         chunk,
         filename: file.filename,
       );
-      headers['content-range'] =
-          'bytes $offset-${min<int>((offset + chunkSize - 1), size - 1)}/$size';
-      res = await call(
+      final chunkHeaders = Map<String, String>.from(headers);
+      if (id != null && id.isNotEmpty) {
+        chunkHeaders['x-{{spec.title | caseLower }}-id'] = id;
+      }
+      chunkHeaders['content-range'] = 'bytes $start-${end - 1}/$size';
+
+      return call(
         HttpMethod.post,
         path: path,
-        headers: headers,
-        params: params,
+        headers: chunkHeaders,
+        params: chunkParams,
       );
-      offset += chunkSize;
-      if (offset < size) {
-        headers['x-{{spec.title | caseLower }}-id'] = res.data['\$id'];
-      }
-      final progress = UploadProgress(
-        $id: res.data['\$id'] ?? '',
-        progress: min(offset, size) / size * 100,
-        sizeUploaded: min(offset, size),
-        chunksTotal: res.data['chunksTotal'] ?? 0,
-        chunksUploaded: res.data['chunksUploaded'] ?? 0,
-      );
-      onProgress?.call(progress);
     }
-    raf?.close();
-    return res;
+
+    final firstStart = offset;
+    final firstEnd = min(firstStart + chunkSize, size);
+    final firstIndex = firstStart ~/ chunkSize;
+    res = await uploadChunk(firstIndex, firstStart, firstEnd, uploadId);
+    uploadId = res.data['\$id'] ?? uploadId;
+
+    var completedChunks = firstIndex + 1;
+    var uploadedBytes = firstEnd;
+    var lastResponse = res;
+
+    final progress = UploadProgress(
+      $id: uploadId ?? '',
+      progress: min(uploadedBytes, size) / size * 100,
+      sizeUploaded: min(uploadedBytes, size),
+      chunksTotal: totalChunks,
+      chunksUploaded: completedChunks,
+    );
+    onProgress?.call(progress);
+
+    final chunks = <Map<String, int>>[];
+    for (var start = firstEnd; start < size; start += chunkSize) {
+      final end = min(start + chunkSize, size);
+      chunks.add({
+        'index': start ~/ chunkSize,
+        'start': start,
+        'end': end,
+      });
+    }
+
+    var nextChunk = 0;
+    Future<void> uploadNext() async {
+      while (nextChunk < chunks.length) {
+        final chunk = chunks[nextChunk++];
+        final chunkResponse = await uploadChunk(
+          chunk['index']!,
+          chunk['start']!,
+          chunk['end']!,
+          uploadId,
+        );
+        completedChunks++;
+        uploadedBytes += chunk['end']! - chunk['start']!;
+        if (chunk['index'] == totalChunks - 1) {
+          lastResponse = chunkResponse;
+        }
+
+        final progress = UploadProgress(
+          $id: uploadId ?? '',
+          progress: min(uploadedBytes, size) / size * 100,
+          sizeUploaded: min(uploadedBytes, size),
+          chunksTotal: totalChunks,
+          chunksUploaded: completedChunks,
+        );
+        onProgress?.call(progress);
+      }
+    }
+
+    final concurrency = min(8, chunks.length);
+    await Future.wait(List.generate(concurrency, (_) => uploadNext()));
+
+    return lastResponse;
   }
 
   bool get _customSchemeAllowed => Platform.isWindows || Platform.isLinux;

--- a/templates/flutter/lib/src/client_io.dart.twig
+++ b/templates/flutter/lib/src/client_io.dart.twig
@@ -336,6 +336,12 @@ class ClientIO extends ClientBase with ClientMixin {
     var uploadedBytes = firstEnd;
     var lastResponse = res;
 
+    bool isUploadComplete(Response response) {
+      final chunksUploaded = response.data['chunksUploaded'];
+      final chunksTotal = response.data['chunksTotal'] ?? totalChunks;
+      return chunksUploaded is num && chunksTotal is num && chunksUploaded >= chunksTotal;
+    }
+
     final progress = UploadProgress(
       $id: uploadId ?? '',
       progress: min(uploadedBytes, size) / size * 100,
@@ -367,7 +373,7 @@ class ClientIO extends ClientBase with ClientMixin {
         );
         completedChunks++;
         uploadedBytes += chunk['end']! - chunk['start']!;
-        if (chunk['index'] == totalChunks - 1) {
+        if (isUploadComplete(chunkResponse)) {
           lastResponse = chunkResponse;
         }
 
@@ -384,16 +390,6 @@ class ClientIO extends ClientBase with ClientMixin {
 
     final concurrency = min(8, chunks.length);
     await Future.wait(List.generate(concurrency, (_) => uploadNext()));
-
-    if (uploadId != null && uploadId.isNotEmpty) {
-      final finalHeaders = Map<String, String>.from(headers);
-      finalHeaders.remove('content-type');
-      return call(
-        HttpMethod.get,
-        path: '$path/$uploadId',
-        headers: finalHeaders,
-      );
-    }
 
     return lastResponse;
   }

--- a/templates/go/client.go.twig
+++ b/templates/go/client.go.twig
@@ -295,6 +295,9 @@ func (client *Client) FileUpload(url string, headers map[string]interface{}, par
 
 	remainingChunks := numChunks - currentChunk
 	if remainingChunks <= 0 {
+		if uploadId != "" {
+			return client.Call("GET", url+"/"+uploadId, nil, nil)
+		}
 		return result, nil
 	}
 
@@ -337,6 +340,9 @@ func (client *Client) FileUpload(url string, headers map[string]interface{}, par
 	}
 	if firstErr != nil {
 		return nil, firstErr
+	}
+	if uploadId != "" {
+		return client.Call("GET", url+"/"+uploadId, nil, nil)
 	}
 	return result, nil
 }

--- a/templates/go/client.go.twig
+++ b/templates/go/client.go.twig
@@ -211,7 +211,7 @@ func (client *Client) FileUpload(url string, headers map[string]interface{}, par
 
 	if fileInfo.Size() <= client.ChunkSize {
 		if uploadId != "" {
-			headers["x-appwrite-id"] = uploadId
+			headers["x-{{ spec.title | caseLower }}-id"] = uploadId
 		}
 		inputFile.Data = make([]byte, fileInfo.Size())
 		_, err := file.Read(inputFile.Data)
@@ -293,7 +293,7 @@ func (client *Client) FileUpload(url string, headers map[string]interface{}, par
 		chunkParams[paramName] = chunkFile
 		chunkHeaders := copyHeaders(headers)
 		if id != "" {
-			chunkHeaders["x-appwrite-id"] = id
+			chunkHeaders["x-{{ spec.title | caseLower }}-id"] = id
 		}
 
 		totalSize := fileInfo.Size()

--- a/templates/go/client.go.twig
+++ b/templates/go/client.go.twig
@@ -196,6 +196,7 @@ func (client *Client) FileUpload(url string, headers map[string]interface{}, par
 	if uploadId != "" {
 		resp, err := client.Call("GET", url+"/"+uploadId, nil, nil)
 		if err == nil {
+			result = resp
 			var result map[string]interface{}
 			if resStr, ok := resp.Result.(string); ok {
 				_ = json.Unmarshal([]byte(resStr), &result)
@@ -247,6 +248,33 @@ func (client *Client) FileUpload(url string, headers map[string]interface{}, par
 		return ""
 	}
 
+	isUploadComplete := func(resp *ClientResponse) bool {
+		if resp == nil || !strings.HasPrefix(resp.Type, "application/json") {
+			return false
+		}
+
+		var parsed map[string]interface{}
+		if resStr, ok := resp.Result.(string); ok {
+			_ = json.Unmarshal([]byte(resStr), &parsed)
+		} else {
+			parsed, _ = resp.Result.(map[string]interface{})
+		}
+		if parsed == nil || parsed["chunksUploaded"] == nil {
+			return false
+		}
+
+		chunksUploaded, ok := parsed["chunksUploaded"].(float64)
+		if !ok {
+			return false
+		}
+		chunksTotal := float64(numChunks)
+		if value, ok := parsed["chunksTotal"].(float64); ok {
+			chunksTotal = value
+		}
+
+		return chunksUploaded >= chunksTotal
+	}
+
 	uploadChunk := func(i int64, id string) (*ClientResponse, error) {
 		chunkSize := client.ChunkSize
 		offset := i * client.ChunkSize
@@ -295,9 +323,6 @@ func (client *Client) FileUpload(url string, headers map[string]interface{}, par
 
 	remainingChunks := numChunks - currentChunk
 	if remainingChunks <= 0 {
-		if uploadId != "" {
-			return client.Call("GET", url+"/"+uploadId, nil, nil)
-		}
 		return result, nil
 	}
 
@@ -334,15 +359,12 @@ func (client *Client) FileUpload(url string, headers map[string]interface{}, par
 			}
 			continue
 		}
-		if chunk.index == numChunks-1 {
+		if isUploadComplete(chunk.resp) {
 			result = chunk.resp
 		}
 	}
 	if firstErr != nil {
 		return nil, firstErr
-	}
-	if uploadId != "" {
-		return client.Call("GET", url+"/"+uploadId, nil, nil)
 	}
 	return result, nil
 }

--- a/templates/go/client.go.twig
+++ b/templates/go/client.go.twig
@@ -150,6 +150,22 @@ func isFileUpload(headers map[string]interface{}) bool {
 	return false
 }
 
+func copyHeaders(headers map[string]interface{}) map[string]interface{} {
+	clone := make(map[string]interface{}, len(headers))
+	for key, value := range headers {
+		clone[key] = value
+	}
+	return clone
+}
+
+func copyParams(params map[string]interface{}) map[string]interface{} {
+	clone := make(map[string]interface{}, len(params))
+	for key, value := range params {
+		clone[key] = value
+	}
+	return clone
+}
+
 func (client *Client) FileUpload(url string, headers map[string]interface{}, params map[string]interface{}, paramName string, uploadId string) (*ClientResponse, error) {
 	inputFile, ok := params[paramName].(file.InputFile)
 	if !ok {
@@ -219,40 +235,108 @@ func (client *Client) FileUpload(url string, headers map[string]interface{}, par
 		return result, nil
 	}
 
-	for i := currentChunk; i < numChunks; i++ {
+	parseUploadId := func(resp *ClientResponse) string {
+		var parsed map[string]interface{}
+		if resp != nil && strings.HasPrefix(resp.Type, "application/json") {
+			err = json.Unmarshal([]byte(resp.Result.(string)), &parsed)
+			if err == nil {
+				id, _ := parsed["$id"].(string)
+				return id
+			}
+		}
+		return ""
+	}
+
+	uploadChunk := func(i int64, id string) (*ClientResponse, error) {
 		chunkSize := client.ChunkSize
-		offset := int64(i) * chunkSize
+		offset := i * client.ChunkSize
 		if i == numChunks-1 {
 			chunkSize = fileInfo.Size() - offset
-			inputFile.Data = make([]byte, chunkSize)
 		}
-		_, err := file.ReadAt(inputFile.Data, offset)
+
+		chunkFile := inputFile
+		chunkFile.Data = make([]byte, chunkSize)
+		_, err := file.ReadAt(chunkFile.Data, offset)
 		if err != nil && err != io.EOF {
 			return nil, err
 		}
-		params[paramName] = inputFile
-		if uploadId != "" {
-			headers["x-appwrite-id"] = uploadId
+
+		chunkParams := copyParams(params)
+		chunkParams[paramName] = chunkFile
+		chunkHeaders := copyHeaders(headers)
+		if id != "" {
+			chunkHeaders["x-appwrite-id"] = id
 		}
+
 		totalSize := fileInfo.Size()
 		start := offset
-		end := offset + client.ChunkSize - 1
-		if end >= totalSize {
-			end = totalSize - 1
-		}
-		headers["content-range"] = fmt.Sprintf("bytes %d-%d/%d", start, end, totalSize)
-		result, err = client.Call("POST", url, headers, params)
+		end := offset + chunkSize - 1
+		chunkHeaders["content-range"] = fmt.Sprintf("bytes %d-%d/%d", start, end, totalSize)
+
+		return client.Call("POST", url, chunkHeaders, chunkParams)
+	}
+
+	if currentChunk == 0 {
+		result, err = uploadChunk(0, uploadId)
 		if err != nil {
 			return nil, err
 		}
-
-		var parsed map[string]interface{}
-		if strings.HasPrefix(result.Type, "application/json") {
-			err = json.Unmarshal([]byte(result.Result.(string)), &parsed)
-			if err == nil {
-				uploadId, _ = parsed["$id"].(string)
-			}
+		if id := parseUploadId(result); id != "" {
+			uploadId = id
 		}
+		currentChunk = 1
+	}
+
+	type chunkResult struct {
+		index int64
+		resp  *ClientResponse
+		err   error
+	}
+
+	remainingChunks := numChunks - currentChunk
+	if remainingChunks <= 0 {
+		return result, nil
+	}
+
+	concurrency := int64(8)
+	if remainingChunks < concurrency {
+		concurrency = remainingChunks
+	}
+
+	jobs := make(chan int64)
+	results := make(chan chunkResult, int(remainingChunks))
+
+	for worker := int64(0); worker < concurrency; worker++ {
+		go func() {
+			for i := range jobs {
+				resp, err := uploadChunk(i, uploadId)
+				results <- chunkResult{index: i, resp: resp, err: err}
+			}
+		}()
+	}
+
+	go func() {
+		for i := currentChunk; i < numChunks; i++ {
+			jobs <- i
+		}
+		close(jobs)
+	}()
+
+	var firstErr error
+	for i := int64(0); i < remainingChunks; i++ {
+		chunk := <-results
+		if chunk.err != nil {
+			if firstErr == nil {
+				firstErr = chunk.err
+			}
+			continue
+		}
+		if chunk.index == numChunks-1 {
+			result = chunk.resp
+		}
+	}
+	if firstErr != nil {
+		return nil, firstErr
 	}
 	return result, nil
 }

--- a/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
@@ -409,6 +409,7 @@ class Client @JvmOverloads constructor(
             val chunksUploaded = current["chunksUploaded"] as Long
             offset = chunksUploaded * CHUNK_SIZE
             uploadId = params[idParamName]?.toString()
+            result = current
         }
 
         fun readChunk(start: Long, end: Long): ByteArray {
@@ -427,6 +428,14 @@ class Client @JvmOverloads constructor(
                 }
                 else -> throw UnsupportedOperationException()
             }
+        }
+
+        val totalChunks = (size + CHUNK_SIZE - 1) / CHUNK_SIZE
+
+        fun isUploadComplete(chunkResult: Map<*, *>): Boolean {
+            val chunksUploaded = chunkResult["chunksUploaded"]?.toString()?.toLongOrNull() ?: return false
+            val chunksTotal = chunkResult["chunksTotal"]?.toString()?.toLongOrNull() ?: totalChunks
+            return chunksUploaded >= chunksTotal
         }
 
         suspend fun uploadChunk(index: Int, start: Long, end: Long, includeUploadId: Boolean): Map<*, *> {
@@ -502,7 +511,7 @@ class Client @JvmOverloads constructor(
                             val chunksUploaded = completedChunks.incrementAndGet()
                             val sizeUploaded = uploadedBytes.addAndGet(end - start)
 
-                            if (index == ((size - 1) / CHUNK_SIZE).toInt()) {
+                            if (isUploadComplete(chunkResult)) {
                                 result = chunkResult
                             }
 
@@ -519,19 +528,6 @@ class Client @JvmOverloads constructor(
                     }
                 }.awaitAll()
             }
-        }
-
-        if (uploadId != null) {
-            val finalHeaders = headers.toMutableMap()
-            finalHeaders.remove("content-type")
-
-            result = call(
-                method = "GET",
-                path = "$path/$uploadId",
-                headers = finalHeaders,
-                params = emptyMap(),
-                responseType = Map::class.java,
-            )
         }
 
         return converter(result as Map<String, Any>)

--- a/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
@@ -521,6 +521,19 @@ class Client @JvmOverloads constructor(
             }
         }
 
+        if (uploadId != null) {
+            val finalHeaders = headers.toMutableMap()
+            finalHeaders.remove("content-type")
+
+            result = call(
+                method = "GET",
+                path = "$path/$uploadId",
+                headers = finalHeaders,
+                params = emptyMap(),
+                responseType = Map::class.java,
+            )
+        }
+
         return converter(result as Map<String, Any>)
     }
 

--- a/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
@@ -8,6 +8,9 @@ import {{ sdk.namespace | caseDot }}.models.UploadProgress
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.*
 import okhttp3.Headers.Companion.toHeaders
@@ -24,6 +27,8 @@ import java.io.IOException
 import java.lang.IllegalArgumentException
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLSocketFactory
@@ -39,6 +44,7 @@ class Client @JvmOverloads constructor(
 
     companion object {
         const val CHUNK_SIZE = 5*1024*1024; // 5MB
+        const val MAX_CONCURRENT_UPLOADS = 8
     }
 
     override val coroutineContext: CoroutineContext
@@ -355,12 +361,10 @@ class Client @JvmOverloads constructor(
         idParamName: String? = null,
         onProgress: ((UploadProgress) -> Unit)? = null,
     ): T {
-        var file: RandomAccessFile? = null
         val input = params[paramName] as InputFile
         val size: Long = when(input.sourceType) {
             "path", "file" -> {
-                file = RandomAccessFile(input.path, "r")
-                file.length()
+                File(input.path).length()
             }
             "bytes" -> {
                 (input.data as ByteArray).size.toLong()
@@ -389,9 +393,9 @@ class Client @JvmOverloads constructor(
             )
         }
 
-        val buffer = ByteArray(CHUNK_SIZE)
         var offset = 0L
         var result: Map<*, *>? = null
+        var uploadId: String? = null
 
         if (idParamName?.isNotEmpty() == true) {
             // Make a request to check if a file already exists
@@ -404,57 +408,117 @@ class Client @JvmOverloads constructor(
             )
             val chunksUploaded = current["chunksUploaded"] as Long
             offset = chunksUploaded * CHUNK_SIZE
+            uploadId = params[idParamName]?.toString()
         }
 
-        while (offset < size) {
-            when(input.sourceType) {
+        fun readChunk(start: Long, end: Long): ByteArray {
+            val length = (end - start).toInt()
+            return when(input.sourceType) {
                 "file", "path" -> {
-                    file!!.seek(offset)
-                    file!!.read(buffer)
+                    RandomAccessFile(input.path, "r").use { chunkFile ->
+                        val chunk = ByteArray(length)
+                        chunkFile.seek(start)
+                        chunkFile.readFully(chunk)
+                        chunk
+                    }
                 }
                 "bytes" -> {
-                    val end = if (offset + CHUNK_SIZE < size) {
-                        offset + CHUNK_SIZE - 1
-                    } else {
-                        size - 1
-                    }
-                    (input.data as ByteArray).copyInto(
-                        buffer,
-                        startIndex = offset.toInt(),
-                        endIndex = end.toInt()
-                    )
+                    (input.data as ByteArray).copyOfRange(start.toInt(), end.toInt())
                 }
                 else -> throw UnsupportedOperationException()
             }
+        }
 
-            params[paramName] = MultipartBody.Part.createFormData(
+        suspend fun uploadChunk(index: Int, start: Long, end: Long, includeUploadId: Boolean): Map<*, *> {
+            val chunkParams = params.toMutableMap()
+            val chunkHeaders = headers.toMutableMap()
+
+            if (includeUploadId && uploadId != null) {
+                chunkHeaders["x-{{ spec.title | caseLower }}-id"] = uploadId!!
+            }
+
+            chunkHeaders["Content-Range"] = "bytes $start-${end - 1}/$size"
+            chunkParams[paramName] = MultipartBody.Part.createFormData(
                 paramName,
                 input.filename,
-                buffer.toRequestBody()
+                readChunk(start, end).toRequestBody()
             )
 
-            headers["Content-Range"] =
-                "bytes $offset-${((offset + CHUNK_SIZE) - 1).coerceAtMost(size - 1)}/$size"
-
-            result = call(
+            val chunkResult = call(
                 method = "POST",
                 path,
-                headers,
-                params,
+                chunkHeaders,
+                chunkParams,
                 responseType = Map::class.java
             )
 
-            offset += CHUNK_SIZE
-            headers["x-{{ spec.title | caseLower }}-id"] = result!!["\$id"].toString()
+            if (index == 0 || uploadId == null) {
+                uploadId = chunkResult["\$id"].toString()
+            }
+
+            return chunkResult
+        }
+
+        if (offset == 0L) {
+            val firstChunkEnd = CHUNK_SIZE.toLong().coerceAtMost(size)
+            result = uploadChunk(0, 0, firstChunkEnd, false)
+            offset = firstChunkEnd
             onProgress?.invoke(
                 UploadProgress(
-                    id = result!!["\$id"].toString(),
+                    id = uploadId ?: result!!["\$id"].toString(),
                     progress = offset.coerceAtMost(size).toDouble() / size * 100,
                     sizeUploaded = offset.coerceAtMost(size),
                     chunksTotal = result!!["chunksTotal"].toString().toInt(),
                     chunksUploaded = result!!["chunksUploaded"].toString().toInt(),
                 )
             )
+        }
+
+        val chunks = mutableListOf<Triple<Int, Long, Long>>()
+        var chunkOffset = offset
+        while (chunkOffset < size) {
+            val end = (chunkOffset + CHUNK_SIZE).coerceAtMost(size)
+            chunks.add(Triple((chunkOffset / CHUNK_SIZE).toInt(), chunkOffset, end))
+            chunkOffset = end
+        }
+
+        if (chunks.isNotEmpty()) {
+            val nextChunk = AtomicInteger(0)
+            val completedChunks = AtomicInteger((offset / CHUNK_SIZE).toInt())
+            val uploadedBytes = AtomicLong(offset.coerceAtMost(size))
+
+            coroutineScope {
+                List(MAX_CONCURRENT_UPLOADS.coerceAtMost(chunks.size)) {
+                    async {
+                        while (true) {
+                            val chunkIndex = nextChunk.getAndIncrement()
+                            if (chunkIndex >= chunks.size) {
+                                break
+                            }
+
+                            val (index, start, end) = chunks[chunkIndex]
+                            val chunkResult = uploadChunk(index, start, end, true)
+
+                            val chunksUploaded = completedChunks.incrementAndGet()
+                            val sizeUploaded = uploadedBytes.addAndGet(end - start)
+
+                            if (index == ((size - 1) / CHUNK_SIZE).toInt()) {
+                                result = chunkResult
+                            }
+
+                            onProgress?.invoke(
+                                UploadProgress(
+                                    id = uploadId ?: chunkResult["\$id"].toString(),
+                                    progress = sizeUploaded.coerceAtMost(size).toDouble() / size * 100,
+                                    sizeUploaded = sizeUploaded.coerceAtMost(size),
+                                    chunksTotal = chunkResult["chunksTotal"].toString().toInt(),
+                                    chunksUploaded = chunksUploaded,
+                                )
+                            )
+                        }
+                    }
+                }.awaitAll()
+            }
         }
 
         return converter(result as Map<String, Any>)

--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -315,6 +315,12 @@ class Client {
             let uploadedBytes = firstChunkEnd;
             let lastResponse = response;
 
+            const isUploadComplete = (chunkResponse: any) => {
+                const chunksUploaded = chunkResponse?.chunksUploaded;
+                const chunksTotal = chunkResponse?.chunksTotal ?? totalChunks;
+                return typeof chunksUploaded === 'number' && typeof chunksTotal === 'number' && chunksUploaded >= chunksTotal;
+            };
+
             const uploadChunk = async (chunk: typeof chunks[0]) => {
                 const chunkHeaders = { ...headers };
                 if (uploadId) {
@@ -331,7 +337,7 @@ class Client {
                 completedCount++;
                 uploadedBytes += (chunk.end - chunk.start);
                 
-                if (chunk.index === totalChunks - 1) {
+                if (isUploadComplete(chunkResponse)) {
                     lastResponse = chunkResponse;
                 }
 
@@ -365,12 +371,6 @@ class Client {
             }
 
             await Promise.all(workers);
-
-            if (uploadId) {
-                const finalHeaders = { ...headers };
-                delete finalHeaders['content-type'];
-                return await this.call('GET', new URL(`${url.toString().replace(/\/$/, '')}/${encodeURIComponent(uploadId)}`), finalHeaders);
-            }
 
             return lastResponse;
         }
@@ -419,6 +419,12 @@ class Client {
         let uploadedBytes = firstChunkEnd;
         let lastResponse = response;
 
+        const isUploadComplete = (chunkResponse: any) => {
+            const chunksUploaded = chunkResponse?.chunksUploaded;
+            const chunksTotal = chunkResponse?.chunksTotal ?? totalChunks;
+            return typeof chunksUploaded === 'number' && typeof chunksTotal === 'number' && chunksUploaded >= chunksTotal;
+        };
+
         const uploadChunk = async (chunk: typeof chunks[0]) => {
             const chunkHeaders = { ...headers };
             if (uploadId) {
@@ -435,7 +441,7 @@ class Client {
             completedCount++;
             uploadedBytes += (chunk.end - chunk.start);
             
-            if (chunk.index === totalChunks - 1) {
+            if (isUploadComplete(chunkResponse)) {
                 lastResponse = chunkResponse;
             }
 
@@ -469,12 +475,6 @@ class Client {
         }
 
         await Promise.all(workers);
-
-        if (uploadId) {
-            const finalHeaders = { ...headers };
-            delete finalHeaders['content-type'];
-            return await this.call('GET', new URL(`${url.toString().replace(/\/$/, '')}/${encodeURIComponent(uploadId)}`), finalHeaders);
-        }
 
         return lastResponse;
     }

--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -351,8 +351,9 @@ class Client {
             // Process with limited concurrency using a worker pool
             const queue = [...chunks];
             const workers: Promise<void>[] = [];
+            const workerCount = Math.min(CONCURRENCY, queue.length);
 
-            for (let i = 0; i < Math.min(CONCURRENCY, queue.length); i++) {
+            for (let i = 0; i < workerCount; i++) {
                 workers.push(
                     (async () => {
                         while (queue.length > 0) {
@@ -364,6 +365,12 @@ class Client {
             }
 
             await Promise.all(workers);
+
+            if (uploadId) {
+                const finalHeaders = { ...headers };
+                delete finalHeaders['content-type'];
+                return await this.call('GET', new URL(`${url.toString().replace(/\/$/, '')}/${encodeURIComponent(uploadId)}`), finalHeaders);
+            }
 
             return lastResponse;
         }
@@ -448,8 +455,9 @@ class Client {
         // Process with limited concurrency using a worker pool
         const queue = [...chunks];
         const workers: Promise<void>[] = [];
+        const workerCount = Math.min(CONCURRENCY, queue.length);
 
-        for (let i = 0; i < Math.min(CONCURRENCY, queue.length); i++) {
+        for (let i = 0; i < workerCount; i++) {
             workers.push(
                 (async () => {
                     while (queue.length > 0) {
@@ -461,6 +469,12 @@ class Client {
         }
 
         await Promise.all(workers);
+
+        if (uploadId) {
+            const finalHeaders = { ...headers };
+            delete finalHeaders['content-type'];
+            return await this.call('GET', new URL(`${url.toString().replace(/\/$/, '')}/${encodeURIComponent(uploadId)}`), finalHeaders);
+        }
 
         return lastResponse;
     }

--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -275,82 +275,194 @@ class Client {
                 return await this.call(method, url, headers, payload);
             }
 
-            let start = 0;
-            let response = null;
+            const totalChunks = Math.ceil(size / Client.CHUNK_SIZE);
 
-            while (start < size) {
-                let end = start + Client.CHUNK_SIZE;
-                if (end >= size) {
-                    end = size;
+            // Upload first chunk alone to get the upload ID
+            const firstChunkEnd = Math.min(Client.CHUNK_SIZE, size);
+            const firstChunkHeaders = { ...headers, 'content-range': `bytes 0-${firstChunkEnd - 1}/${size}` };
+            const firstChunk = await file.slice(0, firstChunkEnd);
+            const firstPayload = { ...originalPayload };
+            firstPayload[fileParam] = new File([firstChunk], file.filename);
+
+            let response = await this.call(method, url, firstChunkHeaders, firstPayload);
+            const uploadId = response?.$id;
+
+            if (onProgress && typeof onProgress === 'function') {
+                onProgress({
+                    $id: uploadId,
+                    progress: Math.round((firstChunkEnd / size) * 100),
+                    sizeUploaded: firstChunkEnd,
+                    chunksTotal: totalChunks,
+                    chunksUploaded: 1
+                });
+            }
+
+            if (totalChunks === 1) {
+                return response;
+            }
+
+            // Prepare remaining chunks
+            const chunks: { index: number; start: number; end: number }[] = [];
+            for (let i = 1; i < totalChunks; i++) {
+                const start = i * Client.CHUNK_SIZE;
+                const end = Math.min(start + Client.CHUNK_SIZE, size);
+                chunks.push({ index: i, start, end });
+            }
+
+            // Upload remaining chunks with max concurrency of 8
+            const CONCURRENCY = 8;
+            let completedCount = 1;
+            let uploadedBytes = firstChunkEnd;
+            let lastResponse = response;
+
+            const uploadChunk = async (chunk: typeof chunks[0]) => {
+                const chunkHeaders = { ...headers };
+                if (uploadId) {
+                    chunkHeaders['x-{{spec.title | caseLower }}-id'] = uploadId;
                 }
+                chunkHeaders['content-range'] = `bytes ${chunk.start}-${chunk.end - 1}/${size}`;
+                
+                const chunkBlob = await file.slice(chunk.start, chunk.end);
+                const chunkPayload = { ...originalPayload };
+                chunkPayload[fileParam] = new File([chunkBlob], file.filename);
 
-                headers['content-range'] = `bytes ${start}-${end - 1}/${size}`;
-                const chunk = await file.slice(start, end);
-
-                const payload = { ...originalPayload };
-                payload[fileParam] = new File([chunk], file.filename);
-
-                response = await this.call(method, url, headers, payload);
+                const chunkResponse = await this.call(method, url, chunkHeaders, chunkPayload);
+                
+                completedCount++;
+                uploadedBytes += (chunk.end - chunk.start);
+                
+                if (chunk.index === totalChunks - 1) {
+                    lastResponse = chunkResponse;
+                }
 
                 if (onProgress && typeof onProgress === 'function') {
                     onProgress({
-                        $id: response.$id,
-                        progress: Math.round((end / size) * 100),
-                        sizeUploaded: end,
-                        chunksTotal: Math.ceil(size / Client.CHUNK_SIZE),
-                        chunksUploaded: Math.ceil(end / Client.CHUNK_SIZE)
+                        $id: uploadId,
+                        progress: Math.round((uploadedBytes / size) * 100),
+                        sizeUploaded: uploadedBytes,
+                        chunksTotal: totalChunks,
+                        chunksUploaded: completedCount
                     });
                 }
 
-                if (response && response.$id) {
-                    headers['x-{{spec.title | caseLower }}-id'] = response.$id;
-                }
+                return chunkResponse;
+            };
 
-                start = end;
+            // Process with limited concurrency using a worker pool
+            const queue = [...chunks];
+            const workers: Promise<void>[] = [];
+
+            for (let i = 0; i < Math.min(CONCURRENCY, queue.length); i++) {
+                workers.push(
+                    (async () => {
+                        while (queue.length > 0) {
+                            const chunk = queue.shift()!;
+                            await uploadChunk(chunk);
+                        }
+                    })()
+                );
             }
 
-            return response;
+            await Promise.all(workers);
+
+            return lastResponse;
         }
 
         if (file.size <= Client.CHUNK_SIZE) {
             return await this.call(method, url, headers, originalPayload);
         }
 
-        let start = 0;
-        let response = null;
+        const totalChunks = Math.ceil(file.size / Client.CHUNK_SIZE);
 
-        while (start < file.size) {
-            let end = start + Client.CHUNK_SIZE; // Prepare end for the next chunk
-            if (end >= file.size) {
-                end = file.size; // Adjust for the last chunk to include the last byte
+        // Upload first chunk alone to get the upload ID
+        const firstChunkEnd = Math.min(Client.CHUNK_SIZE, file.size);
+        const firstChunkHeaders = { ...headers, 'content-range': `bytes 0-${firstChunkEnd - 1}/${file.size}` };
+        const firstChunk = file.slice(0, firstChunkEnd);
+        const firstPayload = { ...originalPayload };
+        firstPayload[fileParam] = new File([firstChunk], file.name);
+
+        let response = await this.call(method, url, firstChunkHeaders, firstPayload);
+        const uploadId = response?.$id;
+
+        if (onProgress && typeof onProgress === 'function') {
+            onProgress({
+                $id: uploadId,
+                progress: Math.round((firstChunkEnd / file.size) * 100),
+                sizeUploaded: firstChunkEnd,
+                chunksTotal: totalChunks,
+                chunksUploaded: 1
+            });
+        }
+
+        if (totalChunks === 1) {
+            return response;
+        }
+
+        // Prepare remaining chunks
+        const chunks: { index: number; start: number; end: number }[] = [];
+        for (let i = 1; i < totalChunks; i++) {
+            const start = i * Client.CHUNK_SIZE;
+            const end = Math.min(start + Client.CHUNK_SIZE, file.size);
+            chunks.push({ index: i, start, end });
+        }
+
+        // Upload remaining chunks with max concurrency of 8
+        const CONCURRENCY = 8;
+        let completedCount = 1;
+        let uploadedBytes = firstChunkEnd;
+        let lastResponse = response;
+
+        const uploadChunk = async (chunk: typeof chunks[0]) => {
+            const chunkHeaders = { ...headers };
+            if (uploadId) {
+                chunkHeaders['x-{{spec.title | caseLower }}-id'] = uploadId;
             }
+            chunkHeaders['content-range'] = `bytes ${chunk.start}-${chunk.end - 1}/${file.size}`;
+            
+            const chunkBlob = file.slice(chunk.start, chunk.end);
+            const chunkPayload = { ...originalPayload };
+            chunkPayload[fileParam] = new File([chunkBlob], file.name);
 
-            headers['content-range'] = `bytes ${start}-${end-1}/${file.size}`;
-            const chunk = file.slice(start, end);
-
-            let payload = { ...originalPayload };
-            payload[fileParam] = new File([chunk], file.name);
-
-            response = await this.call(method, url, headers, payload);
+            const chunkResponse = await this.call(method, url, chunkHeaders, chunkPayload);
+            
+            completedCount++;
+            uploadedBytes += (chunk.end - chunk.start);
+            
+            if (chunk.index === totalChunks - 1) {
+                lastResponse = chunkResponse;
+            }
 
             if (onProgress && typeof onProgress === 'function') {
                 onProgress({
-                    $id: response.$id,
-                    progress: Math.round((end / file.size) * 100),
-                    sizeUploaded: end,
-                    chunksTotal: Math.ceil(file.size / Client.CHUNK_SIZE),
-                    chunksUploaded: Math.ceil(end / Client.CHUNK_SIZE)
+                    $id: uploadId,
+                    progress: Math.round((uploadedBytes / file.size) * 100),
+                    sizeUploaded: uploadedBytes,
+                    chunksTotal: totalChunks,
+                    chunksUploaded: completedCount
                 });
             }
 
-            if (response && response.$id) {
-                headers['x-{{spec.title | caseLower }}-id'] = response.$id;
-            }
+            return chunkResponse;
+        };
 
-            start = end;
+        // Process with limited concurrency using a worker pool
+        const queue = [...chunks];
+        const workers: Promise<void>[] = [];
+
+        for (let i = 0; i < Math.min(CONCURRENCY, queue.length); i++) {
+            workers.push(
+                (async () => {
+                    while (queue.length > 0) {
+                        const chunk = queue.shift()!;
+                        await uploadChunk(chunk);
+                    }
+                })()
+            );
         }
 
-        return response;
+        await Promise.all(workers);
+
+        return lastResponse;
     }
 
     async ping(): Promise<string> {

--- a/templates/php/base/requests/file.twig
+++ b/templates/php/base/requests/file.twig
@@ -152,8 +152,8 @@
                     '$id' => $response['$id'],
                     'progress' => $uploadedSize / $size * 100,
                     'sizeUploaded' => $uploadedSize,
-                    'chunksTotal' => $response['chunksTotal'] ?? $totalChunks,
-                    'chunksUploaded' => $response['chunksUploaded'] ?? $completedCount,
+                    'chunksTotal' => $totalChunks,
+                    'chunksUploaded' => $completedCount,
                 ]);
             }
 
@@ -187,7 +187,7 @@
                 }
 
                 $ch = curl_init($endpoint . $apiPath);
-                $responseHeaders[(int) $ch] = [];
+                $responseHeaders[spl_object_id($ch)] = [];
                 curl_setopt($ch, CURLOPT_CUSTOMREQUEST, Client::METHOD_POST);
                 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
                 curl_setopt($ch, CURLOPT_USERAGENT, php_uname('s') . '-' . php_uname('r') . ':{{ language.name | caseLower }}-' . phpversion());
@@ -198,7 +198,7 @@
                     $length = strlen($header);
                     $header = explode(':', strtolower($header), 2);
                     if (count($header) >= 2) {
-                        $responseHeaders[(int) $curl][strtolower(trim($header[0]))] = trim($header[1]);
+                        $responseHeaders[spl_object_id($curl)][strtolower(trim($header[0]))] = trim($header[1]);
                     }
 
                     return $length;
@@ -224,7 +224,7 @@
                 for ($i = 0; $i < 8 && $nextChunk < count($remainingChunks); $i++, $nextChunk++) {
                     $chunk = $remainingChunks[$nextChunk];
                     $ch = $makeHandle($chunk);
-                    $handles[(int) $ch] = ['handle' => $ch, 'chunk' => $chunk];
+                    $handles[spl_object_id($ch)] = ['handle' => $ch, 'chunk' => $chunk];
                     curl_multi_add_handle($multiHandle, $ch);
                 }
 
@@ -239,7 +239,7 @@
                     $ch = $handleInfo['handle'];
                     $body = curl_multi_getcontent($ch);
                     $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-                    $contentType = $responseHeaders[(int) $ch]['content-type'] ?? '';
+                    $contentType = $responseHeaders[spl_object_id($ch)]['content-type'] ?? '';
 
                     if (curl_errno($ch)) {
                         throw new {{ spec.namespace | split('\\') | last | caseUcfirst}}Exception(curl_error($ch), $statusCode, '', $body);
@@ -265,8 +265,8 @@
                             '$id' => $uploadId,
                             'progress' => $uploadedSize / $size * 100,
                             'sizeUploaded' => $uploadedSize,
-                            'chunksTotal' => $chunkResponse['chunksTotal'] ?? $totalChunks,
-                            'chunksUploaded' => $chunkResponse['chunksUploaded'] ?? $completedCount,
+                            'chunksTotal' => $totalChunks,
+                            'chunksUploaded' => $completedCount,
                         ]);
                     }
 
@@ -274,6 +274,10 @@
                 }
 
                 curl_multi_close($multiHandle);
+            }
+
+            if(!empty($uploadId)) {
+                $response = $this->client->call(Client::METHOD_GET, $apiPath . '/' . $uploadId);
             }
         }
         if(!empty($handle)) {

--- a/templates/php/base/requests/file.twig
+++ b/templates/php/base/requests/file.twig
@@ -140,6 +140,14 @@
             return $this->client->call(Client::METHOD_POST, $apiPath, $chunkHeaders, $chunkParams);
         };
 
+        $isUploadComplete = function($chunkResponse) use ($totalChunks): bool {
+            if(!is_array($chunkResponse) || !isset($chunkResponse['chunksUploaded'])) {
+                return false;
+            }
+
+            return (int) $chunkResponse['chunksUploaded'] >= (int) ($chunkResponse['chunksTotal'] ?? $totalChunks);
+        };
+
         if (!empty($chunks)) {
             $response = $uploadChunk($chunks[0], $uploadId);
             if(empty($uploadId)) {
@@ -257,7 +265,7 @@
 
                     $completedCount++;
                     $uploadedSize += $handleInfo['chunk']['end'] - $handleInfo['chunk']['start'];
-                    if($handleInfo['chunk']['index'] === $totalChunks - 1) {
+                    if($isUploadComplete($chunkResponse)) {
                         $response = $chunkResponse;
                     }
                     if($onProgress !== null) {
@@ -276,9 +284,6 @@
                 curl_multi_close($multiHandle);
             }
 
-            if(!empty($uploadId)) {
-                $response = $this->client->call(Client::METHOD_GET, $apiPath . '/' . $uploadId);
-            }
         }
         if(!empty($handle)) {
             @fclose($handle);

--- a/templates/php/base/requests/file.twig
+++ b/templates/php/base/requests/file.twig
@@ -101,34 +101,179 @@
             $handle = @fopen(${{parameter.name}}->getPath(), "rb");
         }
 
+        $uploadId = '';
+        {% for parameter in method.parameters.all %}{% if parameter.isUploadID %}
+        $uploadId = ${{ parameter.name }} ?? '';
+        {% endif %}{% endfor %}
+        $totalChunks = (int) ceil($size / Client::CHUNK_SIZE);
+        $chunks = [];
         $start = $counter * Client::CHUNK_SIZE;
         while ($start < $size) {
-            $chunk = '';
-            if(!empty($handle)) {
-                fseek($handle, $start);
-                $chunk = @fread($handle, Client::CHUNK_SIZE);
-            } else {
-                $chunk = substr(${{ parameter.name | caseCamel }}->getData(), $start, Client::CHUNK_SIZE);
-            }
-            $apiParams['{{ parameter.name }}'] = new \CURLFile('data://' . $mimeType . ';base64,' . base64_encode($chunk), $mimeType, $postedName);
-            $apiHeaders['content-range'] = 'bytes ' . ($counter * Client::CHUNK_SIZE) . '-' . min(((($counter * Client::CHUNK_SIZE) + Client::CHUNK_SIZE) - 1), $size - 1) . '/' . $size;
-            if(!empty($id)) {
-                $apiHeaders['x-{{spec.title | caseLower }}-id'] = $id;
-            }
-            $response = $this->client->call(Client::METHOD_POST, $apiPath, $apiHeaders, $apiParams);
+            $chunks[] = [
+                'index' => $counter,
+                'start' => $start,
+                'end' => min($start + Client::CHUNK_SIZE, $size),
+            ];
             $counter++;
             $start += Client::CHUNK_SIZE;
-            if(empty($id)) {
-                $id = $response['$id'];
+        }
+
+        $readChunk = function(int $start, int $end) use ($handle, ${{ parameter.name | caseCamel }}) {
+            if(!empty($handle)) {
+                fseek($handle, $start);
+                return @fread($handle, $end - $start);
             }
+
+            return substr(${{ parameter.name | caseCamel }}->getData(), $start, $end - $start);
+        };
+
+        $uploadChunk = function(array $chunk, string $currentUploadId = '') use ($readChunk, $apiPath, $apiHeaders, $apiParams, $mimeType, $postedName, $size) {
+            $chunkParams = $apiParams;
+            $chunkHeaders = $apiHeaders;
+            $data = $readChunk($chunk['start'], $chunk['end']);
+            $chunkParams['{{ parameter.name }}'] = new \CURLFile('data://' . $mimeType . ';base64,' . base64_encode($data), $mimeType, $postedName);
+            $chunkHeaders['content-range'] = 'bytes ' . $chunk['start'] . '-' . ($chunk['end'] - 1) . '/' . $size;
+            if(!empty($currentUploadId)) {
+                $chunkHeaders['x-{{spec.title | caseLower }}-id'] = $currentUploadId;
+            }
+
+            return $this->client->call(Client::METHOD_POST, $apiPath, $chunkHeaders, $chunkParams);
+        };
+
+        if (!empty($chunks)) {
+            $response = $uploadChunk($chunks[0], $uploadId);
+            if(empty($uploadId)) {
+                $uploadId = $response['$id'];
+            }
+            $completedCount = $chunks[0]['index'] + 1;
+            $uploadedSize = $chunks[0]['end'];
             if($onProgress !== null) {
                 $onProgress([
                     '$id' => $response['$id'],
-                    'progress' => min(((($counter * Client::CHUNK_SIZE) + Client::CHUNK_SIZE)), $size) / $size * 100,
-                    'sizeUploaded' => min($counter * Client::CHUNK_SIZE),
-                    'chunksTotal' => $response['chunksTotal'],
-                    'chunksUploaded' => $response['chunksUploaded'],
+                    'progress' => $uploadedSize / $size * 100,
+                    'sizeUploaded' => $uploadedSize,
+                    'chunksTotal' => $response['chunksTotal'] ?? $totalChunks,
+                    'chunksUploaded' => $response['chunksUploaded'] ?? $completedCount,
                 ]);
+            }
+
+            $remainingChunks = array_slice($chunks, 1);
+            $clientConfig = \Closure::bind(function() {
+                if (property_exists($this, 'key') && $this->key !== null) {
+                    $this->headers['authorization'] = $this->getAuthorization();
+                }
+
+                return [$this->endpoint, $this->headers, $this->selfSigned, $this->timeout, $this->connectTimeout];
+            }, $this->client, Client::class);
+            $flattenParams = \Closure::bind(function(array $params): array {
+                return $this->flatten($params);
+            }, $this->client, Client::class);
+            [$endpoint, $globalHeaders, $selfSigned, $timeout, $connectTimeout] = $clientConfig();
+            $responseHeaders = [];
+
+            $makeHandle = function(array $chunk) use ($readChunk, $apiPath, $apiHeaders, $apiParams, $mimeType, $postedName, $size, $uploadId, $endpoint, $globalHeaders, $selfSigned, $timeout, $connectTimeout, $flattenParams, &$responseHeaders) {
+                $chunkParams = $apiParams;
+                $chunkHeaders = array_merge($globalHeaders, $apiHeaders);
+                $data = $readChunk($chunk['start'], $chunk['end']);
+                $chunkParams['{{ parameter.name }}'] = new \CURLFile('data://' . $mimeType . ';base64,' . base64_encode($data), $mimeType, $postedName);
+                $chunkHeaders['content-range'] = 'bytes ' . $chunk['start'] . '-' . ($chunk['end'] - 1) . '/' . $size;
+                if(!empty($uploadId)) {
+                    $chunkHeaders['x-{{spec.title | caseLower }}-id'] = $uploadId;
+                }
+
+                $headers = [];
+                foreach ($chunkHeaders as $key => $value) {
+                    $headers[] = $key . ':' . $value;
+                }
+
+                $ch = curl_init($endpoint . $apiPath);
+                $responseHeaders[(int) $ch] = [];
+                curl_setopt($ch, CURLOPT_CUSTOMREQUEST, Client::METHOD_POST);
+                curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+                curl_setopt($ch, CURLOPT_USERAGENT, php_uname('s') . '-' . php_uname('r') . ':{{ language.name | caseLower }}-' . phpversion());
+                curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+                curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+                curl_setopt($ch, CURLOPT_POSTFIELDS, $flattenParams($chunkParams));
+                curl_setopt($ch, CURLOPT_HEADERFUNCTION, function($curl, $header) use (&$responseHeaders) {
+                    $length = strlen($header);
+                    $header = explode(':', strtolower($header), 2);
+                    if (count($header) >= 2) {
+                        $responseHeaders[(int) $curl][strtolower(trim($header[0]))] = trim($header[1]);
+                    }
+
+                    return $length;
+                });
+                if($selfSigned) {
+                    curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+                    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+                }
+                if($timeout !== null) {
+                    curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
+                }
+                if($connectTimeout !== null) {
+                    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $connectTimeout);
+                }
+
+                return $ch;
+            };
+
+            $nextChunk = 0;
+            while ($nextChunk < count($remainingChunks)) {
+                $multiHandle = curl_multi_init();
+                $handles = [];
+                for ($i = 0; $i < 8 && $nextChunk < count($remainingChunks); $i++, $nextChunk++) {
+                    $chunk = $remainingChunks[$nextChunk];
+                    $ch = $makeHandle($chunk);
+                    $handles[(int) $ch] = ['handle' => $ch, 'chunk' => $chunk];
+                    curl_multi_add_handle($multiHandle, $ch);
+                }
+
+                do {
+                    $status = curl_multi_exec($multiHandle, $active);
+                    if ($active) {
+                        curl_multi_select($multiHandle);
+                    }
+                } while ($active && $status == CURLM_OK);
+
+                foreach ($handles as $handleInfo) {
+                    $ch = $handleInfo['handle'];
+                    $body = curl_multi_getcontent($ch);
+                    $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+                    $contentType = $responseHeaders[(int) $ch]['content-type'] ?? '';
+
+                    if (curl_errno($ch)) {
+                        throw new {{ spec.namespace | split('\\') | last | caseUcfirst}}Exception(curl_error($ch), $statusCode, '', $body);
+                    }
+
+                    $chunkResponse = str_starts_with($contentType, 'application/json') ? json_decode($body, true) : $body;
+
+                    if($statusCode >= 400) {
+                        if(is_array($chunkResponse)) {
+                            throw new {{ spec.namespace | split('\\') | last | caseUcfirst}}Exception($chunkResponse['message'], $statusCode, $chunkResponse['type'] ?? '', json_encode($chunkResponse));
+                        }
+
+                        throw new {{ spec.namespace | split('\\') | last | caseUcfirst}}Exception($chunkResponse, $statusCode, '', $chunkResponse);
+                    }
+
+                    $completedCount++;
+                    $uploadedSize += $handleInfo['chunk']['end'] - $handleInfo['chunk']['start'];
+                    if($handleInfo['chunk']['index'] === $totalChunks - 1) {
+                        $response = $chunkResponse;
+                    }
+                    if($onProgress !== null) {
+                        $onProgress([
+                            '$id' => $uploadId,
+                            'progress' => $uploadedSize / $size * 100,
+                            'sizeUploaded' => $uploadedSize,
+                            'chunksTotal' => $chunkResponse['chunksTotal'] ?? $totalChunks,
+                            'chunksUploaded' => $chunkResponse['chunksUploaded'] ?? $completedCount,
+                        ]);
+                    }
+
+                    curl_multi_remove_handle($multiHandle, $ch);
+                }
+
+                curl_multi_close($multiHandle);
             }
         }
         if(!empty($handle)) {

--- a/templates/python/package/client.py.twig
+++ b/templates/python/package/client.py.twig
@@ -227,8 +227,8 @@ class Client:
                 "$id": result["$id"],
                 "progress": uploaded_size / size * 100,
                 "sizeUploaded": uploaded_size,
-                "chunksTotal": result.get("chunksTotal", total_chunks),
-                "chunksUploaded": result.get("chunksUploaded", completed_count),
+                "chunksTotal": total_chunks,
+                "chunksUploaded": completed_count,
             })
 
         def upload_remaining_chunk(chunk):
@@ -244,14 +244,19 @@ class Client:
                         "$id": upload_id_header,
                         "progress": uploaded_size / size * 100,
                         "sizeUploaded": uploaded_size,
-                        "chunksTotal": chunk_result.get("chunksTotal", total_chunks),
-                        "chunksUploaded": chunk_result.get("chunksUploaded", completed_count),
+                        "chunksTotal": total_chunks,
+                        "chunksUploaded": completed_count,
                     })
 
         with ThreadPoolExecutor(max_workers=8) as executor:
             futures = [executor.submit(upload_remaining_chunk, chunk) for chunk in chunks[1:]]
             for future in as_completed(futures):
                 future.result()
+
+        if upload_id_header:
+            final_headers = {**headers}
+            final_headers.pop("content-type", None)
+            return self.call('get', path + '/' + upload_id_header, final_headers)
 
         return last_result
 

--- a/templates/python/package/client.py.twig
+++ b/templates/python/package/client.py.twig
@@ -195,6 +195,13 @@ class Client:
         progress_lock = Lock()
         last_result = None
 
+        def is_upload_complete(chunk_result):
+            chunks_uploaded = chunk_result.get('chunksUploaded')
+            if chunks_uploaded is None:
+                return False
+            chunks_total = chunk_result.get('chunksTotal', total_chunks)
+            return int(chunks_uploaded) >= int(chunks_total)
+
         def upload_chunk(chunk, current_upload_id):
             chunk_input = InputFile.from_bytes(
                 read_chunk(chunk['start'], chunk['end']),
@@ -237,7 +244,7 @@ class Client:
             with progress_lock:
                 completed_count = completed_count + 1
                 uploaded_size = uploaded_size + (chunk['end'] - chunk['start'])
-                if chunk['index'] == total_chunks - 1:
+                if is_upload_complete(chunk_result):
                     last_result = chunk_result
                 if on_progress is not None:
                     on_progress({
@@ -252,11 +259,6 @@ class Client:
             futures = [executor.submit(upload_remaining_chunk, chunk) for chunk in chunks[1:]]
             for future in as_completed(futures):
                 future.result()
-
-        if upload_id_header:
-            final_headers = {**headers}
-            final_headers.pop("content-type", None)
-            return self.call('get', path + '/' + upload_id_header, final_headers)
 
         return last_result
 

--- a/templates/python/package/client.py.twig
+++ b/templates/python/package/client.py.twig
@@ -4,6 +4,8 @@ import os
 import platform
 import sys
 import requests
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from threading import Lock
 from .input_file import InputFile
 from .exception import {{spec.title | caseUcfirst}}Exception
 from .encoders.value_class_encoder import ValueClassEncoder
@@ -162,46 +164,96 @@ class Client:
 
         if counter > 0:
             offset = counter * self._chunk_size
-            input.seek(offset)
-
-        while offset < size:
             if input_file.source_type == 'path':
-                input_file.data = input.read(self._chunk_size) or input.read(size - offset)
-            elif input_file.source_type == 'bytes':
-                if offset + self._chunk_size < size:
-                    end = offset + self._chunk_size
-                else:
-                    end = size
-                input_file.data = input[offset:end]
+                input.seek(offset)
 
-            params[param_name] = input_file
-            headers["content-range"] = f'bytes {offset}-{min((offset + self._chunk_size) - 1, size - 1)}/{size}'
-
-            result = self.call(
-                'post',
-                path,
-                headers,
-                params,
-            )
-
-            offset = offset + self._chunk_size
-
-            if "$id" in result:
-                headers["x-{{ spec.title | caseLower }}-id"] = result["$id"]
-
-            if on_progress is not None:
-                end = min((((counter * self._chunk_size) + self._chunk_size) - 1), size - 1)
-                on_progress({
-                    "$id": result["$id"],
-                    "progress": min(offset, size)/size * 100,
-                    "sizeUploaded": end+1,
-                    "chunksTotal": result["chunksTotal"],
-                    "chunksUploaded": result["chunksUploaded"],
-                })
-
+        total_chunks = (size + self._chunk_size - 1) // self._chunk_size
+        chunks = []
+        while offset < size:
+            end = min(offset + self._chunk_size, size)
+            chunks.append({
+                'index': counter,
+                'start': offset,
+                'end': end,
+            })
+            offset = end
             counter = counter + 1
 
-        return result
+        if not chunks:
+            return result
+
+        def read_chunk(start, end):
+            if input_file.source_type == 'path':
+                with open(input_file.path, 'rb') as chunk_file:
+                    chunk_file.seek(start)
+                    return chunk_file.read(end - start)
+            return input[start:end]
+
+        upload_id_header = upload_id
+        completed_count = chunks[0]['index']
+        uploaded_size = chunks[0]['start']
+        progress_lock = Lock()
+        last_result = None
+
+        def upload_chunk(chunk, current_upload_id):
+            chunk_input = InputFile.from_bytes(
+                read_chunk(chunk['start'], chunk['end']),
+                input_file.filename,
+                getattr(input_file, 'mime_type', None)
+            )
+            chunk_params = {**params, param_name: chunk_input}
+            chunk_headers = {**headers}
+            chunk_headers["content-range"] = f"bytes {chunk['start']}-{chunk['end'] - 1}/{size}"
+            if current_upload_id:
+                chunk_headers["x-{{ spec.title | caseLower }}-id"] = current_upload_id
+
+            return self.call(
+                'post',
+                path,
+                chunk_headers,
+                chunk_params,
+            )
+
+        result = upload_chunk(chunks[0], upload_id_header)
+        last_result = result
+        if "$id" in result:
+            upload_id_header = result["$id"]
+
+        completed_count = chunks[0]['index'] + 1
+        uploaded_size = chunks[0]['end']
+
+        if on_progress is not None:
+            on_progress({
+                "$id": result["$id"],
+                "progress": uploaded_size / size * 100,
+                "sizeUploaded": uploaded_size,
+                "chunksTotal": result.get("chunksTotal", total_chunks),
+                "chunksUploaded": result.get("chunksUploaded", completed_count),
+            })
+
+        def upload_remaining_chunk(chunk):
+            nonlocal completed_count, uploaded_size, last_result
+            chunk_result = upload_chunk(chunk, upload_id_header)
+            with progress_lock:
+                completed_count = completed_count + 1
+                uploaded_size = uploaded_size + (chunk['end'] - chunk['start'])
+                if chunk['index'] == total_chunks - 1:
+                    last_result = chunk_result
+                if on_progress is not None:
+                    on_progress({
+                        "$id": upload_id_header,
+                        "progress": uploaded_size / size * 100,
+                        "sizeUploaded": uploaded_size,
+                        "chunksTotal": chunk_result.get("chunksTotal", total_chunks),
+                        "chunksUploaded": chunk_result.get("chunksUploaded", completed_count),
+                    })
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            futures = [executor.submit(upload_remaining_chunk, chunk) for chunk in chunks[1:]]
+            for future in as_completed(futures):
+                future.result()
+
+        return last_result
 
     def flatten(self, data, prefix='', stringify=False):
         output = {}

--- a/templates/react-native/src/services/template.ts.twig
+++ b/templates/react-native/src/services/template.ts.twig
@@ -233,6 +233,12 @@ export class {{ service.name | caseUcfirst }} extends Service {
         let completedCount = startChunkIndex;
         let uploadedBytes = offset;
 
+        const isUploadComplete = (chunkResponse: any) => {
+            const chunksUploaded = chunkResponse?.chunksUploaded;
+            const chunksTotal = chunkResponse?.chunksTotal ?? totalChunks;
+            return typeof chunksUploaded === 'number' && typeof chunksTotal === 'number' && chunksUploaded >= chunksTotal;
+        };
+
         const uploadChunk = async (chunk: typeof chunks[0]) => {
             const chunkHeaders = { ...apiHeaders };
             if (uploadId) {
@@ -260,7 +266,7 @@ export class {{ service.name | caseUcfirst }} extends Service {
             completedCount++;
             uploadedBytes += (chunk.end - chunk.start);
 
-            if (chunk.index === totalChunks - 1) {
+            if (isUploadComplete(chunkResponse)) {
                 response = chunkResponse;
             }
 
@@ -294,10 +300,6 @@ export class {{ service.name | caseUcfirst }} extends Service {
         }
 
         await Promise.all(workers);
-
-        if (uploadId) {
-            response = await this.client.call('GET', new URL(this.client.config.endpoint + apiPath + '/' + encodeURIComponent(uploadId)), apiHeaders);
-        }
 
         return response;
 {% endif %}

--- a/templates/react-native/src/services/template.ts.twig
+++ b/templates/react-native/src/services/template.ts.twig
@@ -181,41 +181,119 @@ export class {{ service.name | caseUcfirst }} extends Service {
 {% endif %}
 {% endfor %}
 
-        let timestamp = new Date().getTime();
-        while (offset < size) {
-            let end = Math.min(offset + Service.CHUNK_SIZE - 1, size - 1);
+        const totalChunks = Math.ceil(size / Service.CHUNK_SIZE);
 
-            apiHeaders['content-range'] = 'bytes ' + offset + '-' + end + '/' + size;
-            if (response && response.$id) {
-                apiHeaders['x-{{spec.title | caseLower }}-id'] = response.$id;
-            }
+        // Upload first chunk alone to get the upload ID
+        if (offset === 0) {
+            const firstChunkEnd = Math.min(Service.CHUNK_SIZE, size);
+            const firstChunkHeaders = { ...apiHeaders, 'content-range': 'bytes 0-' + (firstChunkEnd - 1) + '/' + size };
 
-            let chunk = await FileSystem.readAsStringAsync({{ parameter.name | caseCamel | escapeKeyword }}.uri, {
+            let firstChunk = await FileSystem.readAsStringAsync({{ parameter.name | caseCamel | escapeKeyword }}.uri, {
                 encoding: FileSystem.EncodingType.Base64,
-                position: offset,
+                position: 0,
                 length: Service.CHUNK_SIZE
             });
-            var path = `data:${{'{'}}{{ parameter.name | caseCamel | escapeKeyword }}.type{{'}'}};base64,${{'{'}}chunk{{'}'}}`;
+            var firstPath = `data:${{'{'}}{{ parameter.name | caseCamel | escapeKeyword }}.type{{'}'}};base64,${{'{'}}firstChunk{{'}'}}`;
             if (RNPlatform.OS.toLowerCase() === 'android') {
-                path = FileSystem.cacheDirectory + '/tmp_chunk_' + timestamp;
-                await FileSystem.writeAsStringAsync(path, chunk, {encoding: FileSystem.EncodingType.Base64});
+                firstPath = FileSystem.cacheDirectory + '/tmp_chunk_' + new Date().getTime();
+                await FileSystem.writeAsStringAsync(firstPath, firstChunk, {encoding: FileSystem.EncodingType.Base64});
             }
 
-            payload['{{ parameter.name }}'] = {{ '{' }} uri: path, name: {{ parameter.name | caseCamel | escapeKeyword }}.name, type: {{ parameter.name | caseCamel | escapeKeyword }}.type {{ '}' }};
+            payload['{{ parameter.name }}'] = {{ '{' }} uri: firstPath, name: {{ parameter.name | caseCamel | escapeKeyword }}.name, type: {{ parameter.name | caseCamel | escapeKeyword }}.type {{ '}' }};
 
-            response = await this.client.call('{{ method.method | caseLower }}', uri, apiHeaders, payload);
+            response = await this.client.call('{{ method.method | caseLower }}', uri, firstChunkHeaders, payload);
+            offset = firstChunkEnd;
 
             if (onProgress) {
                 onProgress({
                     $id: response.$id,
                     progress: (offset / size) * 100,
                     sizeUploaded: offset,
-                    chunksTotal: response.chunksTotal,
-                    chunksUploaded: response.chunksUploaded
+                    chunksTotal: totalChunks,
+                    chunksUploaded: 1
                 });
             }
-            offset += Service.CHUNK_SIZE;
         }
+
+        if (offset >= size) {
+            return response;
+        }
+
+        const uploadId = response?.$id;
+        const chunks: { index: number; start: number; end: number }[] = [];
+        const startChunkIndex = Math.ceil(offset / Service.CHUNK_SIZE);
+        for (let i = startChunkIndex; i < totalChunks; i++) {
+            const start = i * Service.CHUNK_SIZE;
+            const end = Math.min(start + Service.CHUNK_SIZE, size);
+            chunks.push({ index: i, start, end });
+        }
+
+        // Upload remaining chunks with max concurrency of 8
+        const CONCURRENCY = 8;
+        let completedCount = startChunkIndex;
+        let uploadedBytes = offset;
+
+        const uploadChunk = async (chunk: typeof chunks[0]) => {
+            const chunkHeaders = { ...apiHeaders };
+            if (uploadId) {
+                chunkHeaders['x-{{spec.title | caseLower }}-id'] = uploadId;
+            }
+            chunkHeaders['content-range'] = 'bytes ' + chunk.start + '-' + (chunk.end - 1) + '/' + size;
+
+            const chunkData = await FileSystem.readAsStringAsync({{ parameter.name | caseCamel | escapeKeyword }}.uri, {
+                encoding: FileSystem.EncodingType.Base64,
+                position: chunk.start,
+                length: chunk.end - chunk.start
+            });
+
+            let chunkPath = `data:${{'{'}}{{ parameter.name | caseCamel | escapeKeyword }}.type{{'}'}};base64,${{'{'}}chunkData{{'}'}}`;
+            if (RNPlatform.OS.toLowerCase() === 'android') {
+                chunkPath = FileSystem.cacheDirectory + '/tmp_chunk_' + new Date().getTime() + '_' + chunk.index;
+                await FileSystem.writeAsStringAsync(chunkPath, chunkData, {encoding: FileSystem.EncodingType.Base64});
+            }
+
+            const chunkPayload = { ...payload };
+            chunkPayload['{{ parameter.name }}'] = {{ '{' }} uri: chunkPath, name: {{ parameter.name | caseCamel | escapeKeyword }}.name, type: {{ parameter.name | caseCamel | escapeKeyword }}.type {{ '}' }};
+
+            const chunkResponse = await this.client.call('{{ method.method | caseLower }}', uri, chunkHeaders, chunkPayload);
+
+            completedCount++;
+            uploadedBytes += (chunk.end - chunk.start);
+
+            if (chunk.index === totalChunks - 1) {
+                response = chunkResponse;
+            }
+
+            if (onProgress) {
+                onProgress({
+                    $id: uploadId,
+                    progress: (uploadedBytes / size) * 100,
+                    sizeUploaded: uploadedBytes,
+                    chunksTotal: totalChunks,
+                    chunksUploaded: completedCount
+                });
+            }
+
+            return chunkResponse;
+        };
+
+        // Process with limited concurrency using a worker pool
+        const queue = [...chunks];
+        const workers: Promise<void>[] = [];
+
+        for (let i = 0; i < Math.min(CONCURRENCY, queue.length); i++) {
+            workers.push(
+                (async () => {
+                    while (queue.length > 0) {
+                        const chunk = queue.shift()!;
+                        await uploadChunk(chunk);
+                    }
+                })()
+            );
+        }
+
+        await Promise.all(workers);
+
         return response;
 {% endif %}
 {% endfor %}

--- a/templates/react-native/src/services/template.ts.twig
+++ b/templates/react-native/src/services/template.ts.twig
@@ -280,8 +280,9 @@ export class {{ service.name | caseUcfirst }} extends Service {
         // Process with limited concurrency using a worker pool
         const queue = [...chunks];
         const workers: Promise<void>[] = [];
+        const workerCount = Math.min(CONCURRENCY, queue.length);
 
-        for (let i = 0; i < Math.min(CONCURRENCY, queue.length); i++) {
+        for (let i = 0; i < workerCount; i++) {
             workers.push(
                 (async () => {
                     while (queue.length > 0) {
@@ -293,6 +294,10 @@ export class {{ service.name | caseUcfirst }} extends Service {
         }
 
         await Promise.all(workers);
+
+        if (uploadId) {
+            response = await this.client.call('GET', new URL(this.client.config.endpoint + apiPath + '/' + encodeURIComponent(uploadId)), apiHeaders);
+        }
 
         return response;
 {% endif %}

--- a/templates/ruby/lib/container/client.rb.twig
+++ b/templates/ruby/lib/container/client.rb.twig
@@ -206,6 +206,14 @@ module {{ spec.title | caseUcfirst }}
             completed_count = chunks.first[:index] + 1
             uploaded_size = chunks.first[:ending]
 
+            upload_complete = lambda do |chunk_result|
+                chunks_uploaded = chunk_result['chunksUploaded']
+                return false if chunks_uploaded.nil?
+
+                chunks_total = chunk_result['chunksTotal'] || total_chunks
+                chunks_uploaded.to_i >= chunks_total.to_i
+            end
+
             on_progress.call({
                 id: result['$id'],
                 progress: uploaded_size.to_f/size.to_f * 100.0,
@@ -228,7 +236,7 @@ module {{ spec.title | caseUcfirst }}
                         mutex.synchronize do
                             completed_count += 1
                             uploaded_size += chunk[:ending] - chunk[:start]
-                            result = chunk_result if chunk[:index] == total_chunks - 1
+                            result = chunk_result if upload_complete.call(chunk_result)
                             on_progress.call({
                                 id: upload_id,
                                 progress: uploaded_size.to_f/size.to_f * 100.0,
@@ -242,15 +250,6 @@ module {{ spec.title | caseUcfirst }}
             end
 
             workers.each(&:value)
-
-            if upload_id
-                result = call(
-                    method: "GET",
-                    path: "#{path}/#{upload_id}",
-                    headers: headers,
-                    params: {}
-                )
-            end
 
             return result unless response_type.respond_to?("from")
 

--- a/templates/ruby/lib/container/client.rb.twig
+++ b/templates/ruby/lib/container/client.rb.twig
@@ -143,17 +143,22 @@ module {{ spec.title | caseUcfirst }}
             offset = 0
             id_param_name = id_param_name.to_sym if id_param_name
             upload_id = nil
+            chunks_uploaded = 0
             if id_param_name&.empty? == false
                 upload_id = params[id_param_name]
                 # Make a request to check if a file already exists
-                current = call(
-                    method: "GET",
-                    path: "#{path}/#{params[id_param_name]}",
-                    headers: headers,
-                    params: {}
-                )
-                chunks_uploaded = current['chunksUploaded'].to_i
-                offset = chunks_uploaded * @chunk_size
+                begin
+                    current = call(
+                        method: "GET",
+                        path: "#{path}/#{params[id_param_name]}",
+                        headers: headers,
+                        params: {}
+                    )
+                    chunks_uploaded = current['chunksUploaded'].to_i
+                    offset = chunks_uploaded * @chunk_size
+                rescue {{spec.title | caseUcfirst}}::Exception => error
+                    raise error unless error.code.to_i == 404
+                end
             end
 
             total_chunks = (size.to_f / @chunk_size).ceil
@@ -238,6 +243,15 @@ module {{ spec.title | caseUcfirst }}
 
             workers.each(&:value)
 
+            if upload_id
+                result = call(
+                    method: "GET",
+                    path: "#{path}/#{upload_id}",
+                    headers: headers,
+                    params: {}
+                )
+            end
+
             return result unless response_type.respond_to?("from")
 
             response_type.from(map: result)
@@ -308,7 +322,7 @@ module {{ spec.title | caseUcfirst }}
                 end
 
                 if response.code.to_i >= 400
-                    raise {{spec.title | caseUcfirst}}::Exception.new(result['message'], result['status'], result['type'], response.body)
+                    raise {{spec.title | caseUcfirst}}::Exception.new(result['message'], response.code, result['type'], response.body)
                 end
 
                 unless response_type.respond_to?("from")

--- a/templates/ruby/lib/container/client.rb.twig
+++ b/templates/ruby/lib/container/client.rb.twig
@@ -142,7 +142,9 @@ module {{ spec.title | caseUcfirst }}
 
             offset = 0
             id_param_name = id_param_name.to_sym if id_param_name
+            upload_id = nil
             if id_param_name&.empty? == false
+                upload_id = params[id_param_name]
                 # Make a request to check if a file already exists
                 current = call(
                     method: "GET",
@@ -154,43 +156,87 @@ module {{ spec.title | caseUcfirst }}
                 offset = chunks_uploaded * @chunk_size
             end
 
+            total_chunks = (size.to_f / @chunk_size).ceil
+            chunks = []
             while offset < size
+                chunks << {
+                    index: chunks_uploaded.to_i,
+                    start: offset,
+                    ending: [offset + @chunk_size, size].min
+                }
+                offset += @chunk_size
+                chunks_uploaded = chunks_uploaded.to_i + 1
+            end
+
+            result = current if defined?(current)
+            return result unless chunks.any?
+
+            upload_chunk = lambda do |chunk, current_upload_id|
                 case input_file.source_type
                 when 'path'
-                    string = IO.read(input_file.path, @chunk_size, offset)
+                    string = IO.read(input_file.path, chunk[:ending] - chunk[:start], chunk[:start])
                 when 'string'
-                    string = input_file.data.byteslice(offset, [@chunk_size, size - offset].min)
+                    string = input_file.data.byteslice(chunk[:start], chunk[:ending] - chunk[:start])
                 end
 
-                params[param_name.to_sym] = InputFile::from_string(
+                chunk_params = params.merge(param_name.to_sym => InputFile::from_string(
                     string,
                     filename: input_file.filename,
                     mime_type: input_file.mime_type
-                )
+                ))
 
-                headers['content-range'] = "bytes #{offset}-#{[offset + @chunk_size - 1, size - 1].min}/#{size}"
+                chunk_headers = headers.merge('content-range' => "bytes #{chunk[:start]}-#{chunk[:ending] - 1}/#{size}")
+                chunk_headers['x-{{ spec.title | caseLower }}-id'] = current_upload_id if current_upload_id
 
-                result = call(
+                call(
                     method: 'POST',
                     path: path,
-                    headers: headers,
-                    params: params,
+                    headers: chunk_headers,
+                    params: chunk_params,
                 )
-
-                offset += @chunk_size
-
-                if defined? result['$id']
-                    headers['x-{{ spec.title | caseLower }}-id'] = result['$id']
-                end
-
-                on_progress.call({
-                    id: result['$id'],
-                    progress: ([offset, size].min).to_f/size.to_f * 100.0,
-                    size_uploaded: [offset, size].min,
-                    chunks_total: result['chunksTotal'],
-                    chunks_uploaded: result['chunksUploaded']
-                }) unless on_progress.nil?
             end
+
+            result = upload_chunk.call(chunks.first, upload_id)
+            upload_id = result['$id'] if result['$id']
+            completed_count = chunks.first[:index] + 1
+            uploaded_size = chunks.first[:ending]
+
+            on_progress.call({
+                id: result['$id'],
+                progress: uploaded_size.to_f/size.to_f * 100.0,
+                size_uploaded: uploaded_size,
+                chunks_total: result['chunksTotal'] || total_chunks,
+                chunks_uploaded: result['chunksUploaded'] || completed_count
+            }) unless on_progress.nil?
+
+            mutex = Mutex.new
+            queue = Queue.new
+            chunks.drop(1).each { |chunk| queue << chunk }
+
+            workers = [8, queue.size].min.times.map do
+                Thread.new do
+                    loop do
+                        chunk = queue.pop(true) rescue nil
+                        break unless chunk
+
+                        chunk_result = upload_chunk.call(chunk, upload_id)
+                        mutex.synchronize do
+                            completed_count += 1
+                            uploaded_size += chunk[:ending] - chunk[:start]
+                            result = chunk_result if chunk[:index] == total_chunks - 1
+                            on_progress.call({
+                                id: upload_id,
+                                progress: uploaded_size.to_f/size.to_f * 100.0,
+                                size_uploaded: uploaded_size,
+                                chunks_total: chunk_result['chunksTotal'] || total_chunks,
+                                chunks_uploaded: chunk_result['chunksUploaded'] || completed_count
+                            }) unless on_progress.nil?
+                        end
+                    end
+                end
+            end
+
+            workers.each(&:value)
 
             return result unless response_type.respond_to?("from")
 
@@ -209,8 +255,8 @@ module {{ spec.title | caseUcfirst }}
         )
             raise ArgumentError, 'Too Many HTTP Redirects' if limit == 0
 
-            @http = Net::HTTP.new(uri.host, uri.port) unless defined? @http
-            @http.use_ssl = !@self_signed
+            http = Net::HTTP.new(uri.host, uri.port)
+            http.use_ssl = !@self_signed
             payload = ''
 
             headers = @headers.merge(headers)
@@ -231,7 +277,7 @@ module {{ spec.title | caseUcfirst }}
             end
 
             begin
-                response = @http.send_request(method, uri.request_uri, payload, headers)
+                response = http.send_request(method, uri.request_uri, payload, headers)
             rescue => error
                 raise {{spec.title | caseUcfirst}}::Exception.new(error.message)
             end

--- a/templates/rust/src/client.rs.twig
+++ b/templates/rust/src/client.rs.twig
@@ -736,6 +736,7 @@ impl Client {
         let total_chunks = file_size.div_ceil(chunk_size as u64);
         let mut current_upload_id = options.upload_id;
         let mut start_chunk = 0u64;
+        let mut last_response = None;
         if let Some(ref id) = current_upload_id {
             if let Ok(response) = self.call::<Value>(
                 Method::GET,
@@ -746,13 +747,25 @@ impl Client {
                 if let Some(chunks_uploaded) = response.get("chunksUploaded").and_then(|v| v.as_u64()) {
                     start_chunk = chunks_uploaded;
                 }
+                last_response = Some(response.clone());
             }
         }
 
-        let mut last_response = None;
         let mut next_chunk = start_chunk;
         let mut uploaded_chunks = start_chunk;
         let mut uploaded_bytes = (start_chunk * chunk_size as u64).min(file_size);
+
+        let is_upload_complete = |response: &Value| -> bool {
+            let Some(chunks_uploaded) = response.get("chunksUploaded").and_then(|v| v.as_u64()) else {
+                return false;
+            };
+            let chunks_total = response
+                .get("chunksTotal")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(total_chunks);
+
+            chunks_uploaded >= chunks_total
+        };
 
         if next_chunk == 0 {
             let result = self.upload_file_chunk(
@@ -822,7 +835,7 @@ impl Client {
             let (chunk_index, result) = joined
                 .map_err(|e| {{ spec.title | caseUcfirst }}Error::new(0, format!("Chunk upload task failed: {}", e), None, String::new()))??;
 
-            if chunk_index == total_chunks - 1 {
+            if is_upload_complete(&result) {
                 last_response = Some(result.clone());
             }
 
@@ -867,20 +880,6 @@ impl Client {
                 });
                 next_chunk += 1;
             }
-        }
-
-        if let Some(ref upload_id) = current_upload_id {
-            let mut final_headers = headers.clone();
-            if let Some(headers) = final_headers.as_mut() {
-                headers.remove("content-type");
-            }
-
-            return self.call::<T>(
-                Method::GET,
-                &format!("{}/{}", path, upload_id),
-                final_headers,
-                None,
-            ).await;
         }
 
         last_response

--- a/templates/rust/src/client.rs.twig
+++ b/templates/rust/src/client.rs.twig
@@ -869,6 +869,20 @@ impl Client {
             }
         }
 
+        if let Some(ref upload_id) = current_upload_id {
+            let mut final_headers = headers.clone();
+            if let Some(headers) = final_headers.as_mut() {
+                headers.remove("content-type");
+            }
+
+            return self.call::<T>(
+                Method::GET,
+                &format!("{}/{}", path, upload_id),
+                final_headers,
+                None,
+            ).await;
+        }
+
         last_response
             .ok_or_else(|| {{ spec.title | caseUcfirst }}Error::new(0, "No chunks uploaded", None, String::new()))
             .and_then(|v| serde_json::from_value(v).map_err(Into::into))

--- a/templates/rust/src/client.rs.twig
+++ b/templates/rust/src/client.rs.twig
@@ -949,7 +949,7 @@ impl Client {
         }
 
         if let Some(id) = upload_id {
-            request_builder = request_builder.header("x-appwrite-id", id);
+            request_builder = request_builder.header("x-{{ spec.title | caseLower }}-id", id);
         }
 
         let chunk_end = start + actual_chunk_size as u64 - 1;

--- a/templates/rust/src/client.rs.twig
+++ b/templates/rust/src/client.rs.twig
@@ -10,6 +10,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::task::JoinSet;
 use url::Url;
 
 /// Default request timeout in seconds
@@ -748,99 +749,206 @@ impl Client {
             }
         }
 
-        let mut reader = input_file.chunked_reader().await?;
-
-        if start_chunk > 0 {
-            let resume_offset = start_chunk * chunk_size as u64;
-            reader.seek(resume_offset).await?;
-        }
-
         let mut last_response = None;
+        let mut next_chunk = start_chunk;
+        let mut uploaded_chunks = start_chunk;
+        let mut uploaded_bytes = (start_chunk * chunk_size as u64).min(file_size);
 
-        for chunk_index in start_chunk..total_chunks {
-            let chunk_data = match reader.read_next(chunk_size).await? {
-                Some(data) => data,
-                None => break,
-            };
-            let actual_chunk_size = chunk_data.len();
-            let start = reader.position() - actual_chunk_size as u64;
+        if next_chunk == 0 {
+            let result = self.upload_file_chunk(
+                path,
+                headers.clone(),
+                params.clone(),
+                param_name,
+                input_file,
+                current_upload_id.clone(),
+                0,
+                file_size,
+                chunk_size,
+            ).await?;
 
-            if actual_chunk_size == 0 {
-                break;
+            if let Some(id) = result.get("$id").and_then(|v| v.as_str()) {
+                current_upload_id = Some(id.to_string());
             }
 
-            let state = self.state.load_full();
-            let mut form = multipart::Form::new();
-            let mut file_part = multipart::Part::stream_with_length(chunk_data, actual_chunk_size as u64)
-                .file_name(input_file.filename().to_string());
-
-            if let Some(mime_type) = input_file.mime_type() {
-                file_part = file_part.mime_str(mime_type)
-                    .map_err(|e| {{ spec.title | caseUcfirst }}Error::new(0, format!("Invalid MIME type: {}", e), None, String::new()))?;
-            }
-
-            form = form.part(param_name.to_string(), file_part);
-
-            let mut params_to_flatten = HashMap::new();
-            for (key, value) in &params {
-                if key != param_name {
-                    params_to_flatten.insert(key.clone(), value.clone());
-                }
-            }
-
-            for (key, value_str) in Self::flatten_multipart_params(&params_to_flatten, "") {
-                form = form.text(key, value_str);
-            }
-
-            let url = format!("{}{}", state.config.endpoint, path);
-            let mut request_builder = state.http.post(url).headers(state.config.headers.clone());
-
-            if let Some(ref custom_headers) = headers {
-                for (key, value) in custom_headers {
-                    // Skip content-type for multipart - reqwest sets it automatically with boundary
-                    if key.to_lowercase() != "content-type" {
-                        request_builder = request_builder.header(key, value);
-                    }
-                }
-            }
-
-            if let Some(ref id) = current_upload_id {
-                request_builder = request_builder.header("x-appwrite-id", id);
-            }
-
-            let chunk_end = start + actual_chunk_size as u64 - 1;
-            let content_range = format!("bytes {}-{}/{}", start, chunk_end, file_size);
-            request_builder = request_builder.header("content-range", content_range);
-
-            let response = request_builder
-                .multipart(form)
-                .send()
-                .await
-                ?;
-
-            let result: Value = self.handle_response(response).await?;
-
-            if current_upload_id.is_none() {
-                if let Some(id) = result.get("$id").and_then(|v| v.as_str()) {
-                    current_upload_id = Some(id.to_string());
-                }
-            }
-
-            last_response = Some(result);
+            uploaded_chunks = 1;
+            uploaded_bytes = (chunk_size as u64).min(file_size);
+            last_response = Some(result.clone());
 
             if let Some(ref callback) = options.on_progress {
                 callback(UploadProgress {
-                    bytes_uploaded: start + actual_chunk_size as u64,
+                    bytes_uploaded: uploaded_bytes,
                     total_bytes: file_size,
-                    chunks_uploaded: chunk_index + 1,
+                    chunks_uploaded: uploaded_chunks,
                     total_chunks,
                 });
+            }
+
+            next_chunk = 1;
+        }
+
+        let max_concurrency = 8usize;
+        let mut tasks = JoinSet::new();
+
+        while tasks.len() < max_concurrency && next_chunk < total_chunks {
+            let client = self.clone();
+            let path = path.to_string();
+            let headers = headers.clone();
+            let params = params.clone();
+            let param_name = param_name.to_string();
+            let input_file = input_file.clone();
+            let upload_id = current_upload_id.clone();
+            let chunk_index = next_chunk;
+
+            tasks.spawn(async move {
+                let result = client.upload_file_chunk(
+                    &path,
+                    headers,
+                    params,
+                    &param_name,
+                    &input_file,
+                    upload_id,
+                    chunk_index,
+                    file_size,
+                    chunk_size,
+                ).await?;
+
+                Ok::<_, {{ spec.title | caseUcfirst }}Error>((chunk_index, result))
+            });
+            next_chunk += 1;
+        }
+
+        while let Some(joined) = tasks.join_next().await {
+            let (chunk_index, result) = joined
+                .map_err(|e| {{ spec.title | caseUcfirst }}Error::new(0, format!("Chunk upload task failed: {}", e), None, String::new()))??;
+
+            if chunk_index == total_chunks - 1 {
+                last_response = Some(result.clone());
+            }
+
+            uploaded_chunks += 1;
+            let chunk_start = chunk_index * chunk_size as u64;
+            let chunk_end = (chunk_start + chunk_size as u64).min(file_size);
+            uploaded_bytes += chunk_end - chunk_start;
+
+            if let Some(ref callback) = options.on_progress {
+                callback(UploadProgress {
+                    bytes_uploaded: uploaded_bytes.min(file_size),
+                    total_bytes: file_size,
+                    chunks_uploaded: uploaded_chunks,
+                    total_chunks,
+                });
+            }
+
+            while tasks.len() < max_concurrency && next_chunk < total_chunks {
+                let client = self.clone();
+                let path = path.to_string();
+                let headers = headers.clone();
+                let params = params.clone();
+                let param_name = param_name.to_string();
+                let input_file = input_file.clone();
+                let upload_id = current_upload_id.clone();
+                let chunk_index = next_chunk;
+
+                tasks.spawn(async move {
+                    let result = client.upload_file_chunk(
+                        &path,
+                        headers,
+                        params,
+                        &param_name,
+                        &input_file,
+                        upload_id,
+                        chunk_index,
+                        file_size,
+                        chunk_size,
+                    ).await?;
+
+                    Ok::<_, {{ spec.title | caseUcfirst }}Error>((chunk_index, result))
+                });
+                next_chunk += 1;
             }
         }
 
         last_response
             .ok_or_else(|| {{ spec.title | caseUcfirst }}Error::new(0, "No chunks uploaded", None, String::new()))
             .and_then(|v| serde_json::from_value(v).map_err(Into::into))
+    }
+
+    async fn upload_file_chunk(
+        &self,
+        path: &str,
+        headers: Option<HashMap<String, String>>,
+        params: HashMap<String, Value>,
+        param_name: &str,
+        input_file: &InputFile,
+        upload_id: Option<String>,
+        chunk_index: u64,
+        file_size: u64,
+        chunk_size: usize,
+    ) -> Result<Value> {
+        let start = chunk_index * chunk_size as u64;
+        let mut reader = input_file.chunked_reader().await?;
+        reader.seek(start).await?;
+
+        let chunk_data = reader
+            .read_next(chunk_size)
+            .await?
+            .ok_or_else(|| {{ spec.title | caseUcfirst }}Error::new(0, "Chunk data not found", None, String::new()))?;
+        let actual_chunk_size = chunk_data.len();
+
+        if actual_chunk_size == 0 {
+            return Err({{ spec.title | caseUcfirst }}Error::new(0, "Chunk data is empty", None, String::new()));
+        }
+
+        let state = self.state.load_full();
+        let mut form = multipart::Form::new();
+        let mut file_part = multipart::Part::stream_with_length(chunk_data, actual_chunk_size as u64)
+            .file_name(input_file.filename().to_string());
+
+        if let Some(mime_type) = input_file.mime_type() {
+            file_part = file_part.mime_str(mime_type)
+                .map_err(|e| {{ spec.title | caseUcfirst }}Error::new(0, format!("Invalid MIME type: {}", e), None, String::new()))?;
+        }
+
+        form = form.part(param_name.to_string(), file_part);
+
+        let mut params_to_flatten = HashMap::new();
+        for (key, value) in &params {
+            if key != param_name {
+                params_to_flatten.insert(key.clone(), value.clone());
+            }
+        }
+
+        for (key, value_str) in Self::flatten_multipart_params(&params_to_flatten, "") {
+            form = form.text(key, value_str);
+        }
+
+        let url = format!("{}{}", state.config.endpoint, path);
+        let mut request_builder = state.http.post(url).headers(state.config.headers.clone());
+
+        if let Some(custom_headers) = headers {
+            for (key, value) in custom_headers {
+                // Skip content-type for multipart - reqwest sets it automatically with boundary
+                if key.to_lowercase() != "content-type" {
+                    request_builder = request_builder.header(key, value);
+                }
+            }
+        }
+
+        if let Some(id) = upload_id {
+            request_builder = request_builder.header("x-appwrite-id", id);
+        }
+
+        let chunk_end = start + actual_chunk_size as u64 - 1;
+        let content_range = format!("bytes {}-{}/{}", start, chunk_end, file_size);
+        request_builder = request_builder.header("content-range", content_range);
+
+        let response = request_builder
+            .multipart(form)
+            .send()
+            .await?;
+
+        self.handle_response(response).await
     }
 
     async fn handle_response<T: DeserializeOwned>(&self, response: Response) -> Result<T> {

--- a/templates/swift/Sources/Client.swift.twig
+++ b/templates/swift/Sources/Client.swift.twig
@@ -457,6 +457,7 @@ open class Client {
                 )
                 let chunksUploaded = map["chunksUploaded"] as! Int
                 offset = chunksUploaded * Client.chunkSize
+                result = map
             } catch {
                 // File does not exist yet, swallow exception
             }
@@ -468,6 +469,15 @@ open class Client {
         var uploadedBytes = min(offset, size)
         let baseParams = params
         let baseHeaders = headers
+
+        func isUploadComplete(_ response: [String: Any]) -> Bool {
+            guard let chunksUploaded = response["chunksUploaded"] as? Int else {
+                return false
+            }
+
+            let chunksTotal = response["chunksTotal"] as? Int ?? totalChunks
+            return chunksUploaded >= chunksTotal
+        }
 
         func uploadChunk(index: Int, uploadId: String?) async throws -> (Int, Int, [String: Any]) {
             let chunkOffset = index * Client.chunkSize
@@ -525,7 +535,7 @@ open class Client {
                 inFlight -= 1
                 completedChunks += 1
                 uploadedBytes += chunk.1
-                if chunk.0 == totalChunks - 1 {
+                if isUploadComplete(chunk.2) {
                     result = chunk.2
                 }
 
@@ -545,21 +555,6 @@ open class Client {
                     inFlight += 1
                 }
             }
-        }
-
-        if let uploadId = uploadId {
-            var finalHeaders = headers
-            finalHeaders.removeValue(forKey: "content-type")
-
-            let finalResult = try await call(
-                method: "GET",
-                path: path + "/" + uploadId,
-                headers: finalHeaders,
-                params: [:],
-                converter: { return $0 as! [String: Any] }
-            )
-
-            return try converter!(finalResult)
         }
 
         return try converter!(result)

--- a/templates/swift/Sources/Client.swift.twig
+++ b/templates/swift/Sources/Client.swift.twig
@@ -443,6 +443,7 @@ open class Client {
 
         var offset = 0
         var result = [String:Any]()
+        var uploadId = idParamName != nil ? params[idParamName!] as? String : nil
 
         if idParamName != nil {
             // Make a request to check if a file already exists
@@ -461,30 +462,87 @@ open class Client {
             }
         }
 
-        while offset < size {
-            let slice = (input.data as! ByteBuffer).getSlice(at: offset, length: Client.chunkSize)
-                ?? (input.data as! ByteBuffer).getSlice(at: offset, length: Int(size - offset))
+        let totalChunks = Int(ceil(Double(size) / Double(Client.chunkSize)))
+        var nextChunk = offset / Client.chunkSize
+        var completedChunks = nextChunk
+        var uploadedBytes = min(offset, size)
 
-            params[paramName] = InputFile.fromBuffer(slice!, filename: input.filename, mimeType: input.mimeType)
-            headers["content-range"] = "bytes \(offset)-\(min((offset + Client.chunkSize) - 1, size - 1))/\(size)"
+        func uploadChunk(index: Int, uploadId: String?) async throws -> (Int, Int, [String: Any]) {
+            let chunkOffset = index * Client.chunkSize
+            let chunkLength = min(Client.chunkSize, size - chunkOffset)
+            let slice = (input.data as! ByteBuffer).getSlice(at: chunkOffset, length: chunkLength)!
+            var chunkParams = params
+            var chunkHeaders = headers
+            chunkParams[paramName] = InputFile.fromBuffer(slice, filename: input.filename, mimeType: input.mimeType)
+            chunkHeaders["content-range"] = "bytes \(chunkOffset)-\(chunkOffset + chunkLength - 1)/\(size)"
+            if let uploadId = uploadId {
+                chunkHeaders["x-{{ spec.title | caseLower }}-id"] = uploadId
+            }
 
-            result = try await call(
+            let chunkResult = try await call(
                 method: "POST",
                 path: path,
-                headers: headers,
-                params: params,
+                headers: chunkHeaders,
+                params: chunkParams,
                 converter: { return $0 as! [String: Any] }
             )
 
-            offset += Client.chunkSize
-            headers["x-{{ spec.title | caseLower }}-id"] = result["$id"] as? String
+            return (index, chunkLength, chunkResult)
+        }
+
+        if nextChunk == 0 {
+            let first = try await uploadChunk(index: 0, uploadId: uploadId)
+            result = first.2
+            uploadId = result["$id"] as? String
+            nextChunk = 1
+            completedChunks = 1
+            uploadedBytes = first.1
             onProgress?(UploadProgress(
-                id: result["$id"] as? String ?? "",
-                progress: Double(min(offset, size))/Double(size) * 100.0,
-                sizeUploaded: min(offset, size),
-                chunksTotal: result["chunksTotal"] as? Int ?? -1,
-                chunksUploaded: result["chunksUploaded"] as? Int ?? -1
+                id: uploadId ?? "",
+                progress: Double(uploadedBytes)/Double(size) * 100.0,
+                sizeUploaded: uploadedBytes,
+                chunksTotal: result["chunksTotal"] as? Int ?? totalChunks,
+                chunksUploaded: result["chunksUploaded"] as? Int ?? completedChunks
             ))
+        }
+
+        let maxConcurrency = 8
+
+        try await withThrowingTaskGroup(of: (Int, Int, [String: Any]).self) { group in
+            var inFlight = 0
+
+            while inFlight < maxConcurrency && nextChunk < totalChunks {
+                let index = nextChunk
+                let currentUploadId = uploadId
+                group.addTask { try await uploadChunk(index: index, uploadId: currentUploadId) }
+                nextChunk += 1
+                inFlight += 1
+            }
+
+            while let chunk = try await group.next() {
+                inFlight -= 1
+                completedChunks += 1
+                uploadedBytes += chunk.1
+                if chunk.0 == totalChunks - 1 {
+                    result = chunk.2
+                }
+
+                onProgress?(UploadProgress(
+                    id: uploadId ?? "",
+                    progress: Double(min(uploadedBytes, size))/Double(size) * 100.0,
+                    sizeUploaded: min(uploadedBytes, size),
+                    chunksTotal: chunk.2["chunksTotal"] as? Int ?? totalChunks,
+                    chunksUploaded: chunk.2["chunksUploaded"] as? Int ?? completedChunks
+                ))
+
+                while inFlight < maxConcurrency && nextChunk < totalChunks {
+                    let index = nextChunk
+                    let currentUploadId = uploadId
+                    group.addTask { try await uploadChunk(index: index, uploadId: currentUploadId) }
+                    nextChunk += 1
+                    inFlight += 1
+                }
+            }
         }
 
         return try converter!(result)

--- a/templates/swift/Sources/Client.swift.twig
+++ b/templates/swift/Sources/Client.swift.twig
@@ -547,6 +547,21 @@ open class Client {
             }
         }
 
+        if let uploadId = uploadId {
+            var finalHeaders = headers
+            finalHeaders.removeValue(forKey: "content-type")
+
+            let finalResult = try await call(
+                method: "GET",
+                path: path + "/" + uploadId,
+                headers: finalHeaders,
+                params: [:],
+                converter: { return $0 as! [String: Any] }
+            )
+
+            return try converter!(finalResult)
+        }
+
         return try converter!(result)
     }
 

--- a/templates/swift/Sources/Client.swift.twig
+++ b/templates/swift/Sources/Client.swift.twig
@@ -466,13 +466,15 @@ open class Client {
         var nextChunk = offset / Client.chunkSize
         var completedChunks = nextChunk
         var uploadedBytes = min(offset, size)
+        let baseParams = params
+        let baseHeaders = headers
 
         func uploadChunk(index: Int, uploadId: String?) async throws -> (Int, Int, [String: Any]) {
             let chunkOffset = index * Client.chunkSize
             let chunkLength = min(Client.chunkSize, size - chunkOffset)
             let slice = (input.data as! ByteBuffer).getSlice(at: chunkOffset, length: chunkLength)!
-            var chunkParams = params
-            var chunkHeaders = headers
+            var chunkParams = baseParams
+            var chunkHeaders = baseHeaders
             chunkParams[paramName] = InputFile.fromBuffer(slice, filename: input.filename, mimeType: input.mimeType)
             chunkHeaders["content-range"] = "bytes \(chunkOffset)-\(chunkOffset + chunkLength - 1)/\(size)"
             if let uploadId = uploadId {

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -822,41 +822,108 @@ class Client {
             return await this.call(method, url, headers, originalPayload);
         }
 
-        let start = 0;
-        let response = null;
+        const totalChunks = Math.ceil(file.size / Client.CHUNK_SIZE);
 
-        while (start < file.size) {
-            let end = start + Client.CHUNK_SIZE; // Prepare end for the next chunk
-            if (end >= file.size) {
-                end = file.size; // Adjust for the last chunk to include the last byte
+        // Upload first chunk alone to get the upload ID
+        const firstChunkEnd = Math.min(Client.CHUNK_SIZE, file.size);
+        const firstChunkHeaders = { ...headers, 'content-range': `bytes 0-${firstChunkEnd - 1}/${file.size}` };
+        const firstChunk = file.slice(0, firstChunkEnd);
+        const firstPayload = { ...originalPayload };
+        firstPayload[fileParam] = new File([firstChunk], file.name);
+
+        let response = await this.call(method, url, firstChunkHeaders, firstPayload);
+        const uploadId = response?.$id;
+
+        if (onProgress && typeof onProgress === 'function') {
+            onProgress({
+                $id: uploadId,
+                progress: Math.round((firstChunkEnd / file.size) * 100),
+                sizeUploaded: firstChunkEnd,
+                chunksTotal: totalChunks,
+                chunksUploaded: 1
+            });
+        }
+
+        if (totalChunks === 1) {
+            return response;
+        }
+
+        // Prepare remaining chunks
+        const chunks: { index: number; start: number; end: number }[] = [];
+        for (let i = 1; i < totalChunks; i++) {
+            const start = i * Client.CHUNK_SIZE;
+            const end = Math.min(start + Client.CHUNK_SIZE, file.size);
+            chunks.push({ index: i, start, end });
+        }
+
+        // Upload remaining chunks with max concurrency of 8
+        const CONCURRENCY = 8;
+        let completedCount = 1;
+        let uploadedBytes = firstChunkEnd;
+        let lastResponse = response;
+
+        const uploadChunk = async (chunk: typeof chunks[0]) => {
+            const chunkHeaders = { ...headers };
+            if (uploadId) {
+                chunkHeaders['x-{{spec.title | caseLower }}-id'] = uploadId;
             }
+            chunkHeaders['content-range'] = `bytes ${chunk.start}-${chunk.end - 1}/${file.size}`;
+            
+            const chunkBlob = file.slice(chunk.start, chunk.end);
+            const chunkPayload = { ...originalPayload };
+            chunkPayload[fileParam] = new File([chunkBlob], file.name);
 
-            headers['content-range'] = `bytes ${start}-${end-1}/${file.size}`;
-            const chunk = file.slice(start, end);
-
-            let payload = { ...originalPayload };
-            payload[fileParam] = new File([chunk], file.name);
-
-            response = await this.call(method, url, headers, payload);
+            const chunkResponse = await this.call(method, url, chunkHeaders, chunkPayload);
+            
+            completedCount++;
+            uploadedBytes += (chunk.end - chunk.start);
+            
+            if (chunk.index === totalChunks - 1) {
+                lastResponse = chunkResponse;
+            }
 
             if (onProgress && typeof onProgress === 'function') {
                 onProgress({
-                    $id: response.$id,
-                    progress: Math.round((end / file.size) * 100),
-                    sizeUploaded: end,
-                    chunksTotal: Math.ceil(file.size / Client.CHUNK_SIZE),
-                    chunksUploaded: Math.ceil(end / Client.CHUNK_SIZE)
+                    $id: uploadId,
+                    progress: Math.round((uploadedBytes / file.size) * 100),
+                    sizeUploaded: uploadedBytes,
+                    chunksTotal: totalChunks,
+                    chunksUploaded: completedCount
                 });
             }
 
-            if (response && response.$id) {
-                headers['x-{{spec.title | caseLower }}-id'] = response.$id;
-            }
+            return chunkResponse;
+        };
 
-            start = end;
-        }
+        await new Promise<void>((resolve, reject) => {
+            let nextChunk = 0;
+            let inFlight = 0;
+            let completed = 0;
 
-        return response;
+            const uploadNext = () => {
+                if (completed === chunks.length) {
+                    resolve();
+                    return;
+                }
+
+                while (inFlight < CONCURRENCY && nextChunk < chunks.length) {
+                    const chunk = chunks[nextChunk++];
+                    inFlight++;
+
+                    uploadChunk(chunk)
+                        .then(() => {
+                            inFlight--;
+                            completed++;
+                            uploadNext();
+                        })
+                        .catch(reject);
+                }
+            };
+
+            uploadNext();
+        });
+
+        return lastResponse;
     }
 
     async ping(): Promise<string> {

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -862,6 +862,12 @@ class Client {
         let uploadedBytes = firstChunkEnd;
         let lastResponse = response;
 
+        const isUploadComplete = (chunkResponse: any) => {
+            const chunksUploaded = chunkResponse?.chunksUploaded;
+            const chunksTotal = chunkResponse?.chunksTotal ?? totalChunks;
+            return typeof chunksUploaded === 'number' && typeof chunksTotal === 'number' && chunksUploaded >= chunksTotal;
+        };
+
         const uploadChunk = async (chunk: typeof chunks[0]) => {
             const chunkHeaders = { ...headers };
             if (uploadId) {
@@ -878,7 +884,7 @@ class Client {
             completedCount++;
             uploadedBytes += (chunk.end - chunk.start);
             
-            if (chunk.index === totalChunks - 1) {
+            if (isUploadComplete(chunkResponse)) {
                 lastResponse = chunkResponse;
             }
 
@@ -922,12 +928,6 @@ class Client {
 
             uploadNext();
         });
-
-        if (uploadId) {
-            const finalHeaders = { ...headers };
-            delete finalHeaders['content-type'];
-            return await this.call('GET', new URL(`${url.toString().replace(/\/$/, '')}/${encodeURIComponent(uploadId)}`), finalHeaders);
-        }
 
         return lastResponse;
     }

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -923,6 +923,12 @@ class Client {
             uploadNext();
         });
 
+        if (uploadId) {
+            const finalHeaders = { ...headers };
+            delete finalHeaders['content-type'];
+            return await this.call('GET', new URL(`${url.toString().replace(/\/$/, '')}/${encodeURIComponent(uploadId)}`), finalHeaders);
+        }
+
         return lastResponse;
     }
 


### PR DESCRIPTION
## Summary
- Adds concurrent chunked upload handling across supported SDK upload clients.
- Uploads the first chunk serially to establish the upload ID, then uploads remaining chunks with a max concurrency of 8.
- Preserves progress callbacks and resumable upload behavior where supported.
- Returns the chunk response that finalizes the upload by checking `chunksUploaded >= chunksTotal`, avoiding an extra final completion `GET`.
- Removes the empty root package lock file.

## SDK templates
- Web, Node, React Native, Deno
- PHP, Ruby, Python
- Dart, Flutter
- Go, Rust
- Swift, Apple, DotNet
- Android, Kotlin

## Behavior
- Initial resume `GET` checks remain in place to discover already-uploaded chunk state.
- Final upload completion is determined from upload response fields, not chunk index or worker completion order.
- Progress reporting remains based on completed worker count and uploaded byte totals.
- If a response omits `chunksTotal`, SDKs fall back to the locally computed total chunk count.

## Verification
- Regenerated affected SDK examples with `php example.php <sdk>`; Deno was regenerated with a one-off generator invocation because `example.php deno` currently does not instantiate the Deno language.
- Ran `composer lint-twig`.
- Confirmed no highest-index completion selection patterns remain in upload templates.
- Confirmed upload `GET` matches are initial resume checks, not final completion fetches.
- Ran local consumer upload tests against Appwrite for Node, Web, Python, PHP, Ruby, Go, Dart, Deno, DotNet, and Rust; all verified `created 8/8` and `fetched 8/8` on a 36MB upload.
- Deno runtime test used `deno run --no-check` because the generated Deno SDK has unrelated type declaration issues.
- DotNet runtime test used an isolated consumer project compiling only the generated client, storage service, and storage-related models because the full generated DotNet project has unrelated model compilation errors.
- `cargo check` passes in `examples/rust`.
- `dart analyze` in `examples/dart` reports existing warnings/infos unrelated to upload code.
- `npm run build` in `examples/node` builds CJS/ESM bundles; DTS fails on unrelated missing generated console models.
- `npm run build` in `examples/web` fails on unrelated missing generated model types in services.
- Android client-platform build is blocked in the available Docker image because it has no Android SDK / `ANDROID_HOME`.
- Flutter analysis/build is blocked because `flutter` is not installed locally.

## Notes
- Local Appwrite test server is 1.9.3 while the generated SDK reports 1.9.4, so upload tests print the expected SDK/server version warning.
- Full generated SDK builds still have pre-existing generated model/dependency issues unrelated to upload changes.