### PR TITLE
Fix CLI resource directory config reads

### DIFF
--- a/templates/cli/lib/commands/schema.ts
+++ b/templates/cli/lib/commands/schema.ts
@@ -7,7 +7,7 @@ import { parseWithBetterErrors } from "./utils/error-formatter.js";
 import * as path from "path";
 import { TypeScriptDatabasesGenerator } from "./generators/typescript/databases.js";
 import {
-  getLocalConfigResourceDirname,
+  getLocalConfigResourceDirnames,
   readLocalConfigFile,
   resolveLocalConfigResourcePaths,
   writeLocalConfigFile,
@@ -149,10 +149,7 @@ export class Schema {
 
     return {
       ...options,
-      resourceDirectories: {
-        functions: getLocalConfigResourceDirname(configPath, "functions"),
-        sites: getLocalConfigResourceDirname(configPath, "sites"),
-      },
+      resourceDirectories: getLocalConfigResourceDirnames(configPath),
     };
   }
 }

--- a/templates/cli/lib/config.ts
+++ b/templates/cli/lib/config.ts
@@ -255,17 +255,33 @@ export function getLocalConfigResourceDirname(
   filePath: string,
   resource: "functions" | "sites",
 ): string {
+  return getLocalConfigResourceDirnames(filePath)[resource];
+}
+
+export function getLocalConfigResourceDirnames(filePath: string): Record<
+  "functions" | "sites",
+  string
+> {
   const rootData = fs.existsSync(filePath)
     ? readJsonFile<Record<string, unknown>>(filePath)
     : {};
-  const includePath = getConfigIncludePaths(rootData)[resource];
-  if (!includePath) {
-    return _path.dirname(filePath);
-  }
+  const includePaths = getConfigIncludePaths(rootData);
 
-  return _path.dirname(
-    assertIncludePathInsideProject(filePath, resource, includePath),
-  );
+  const getResourceDirname = (resource: "functions" | "sites"): string => {
+    const includePath = includePaths[resource];
+    if (!includePath) {
+      return _path.dirname(filePath);
+    }
+
+    return _path.dirname(
+      assertIncludePathInsideProject(filePath, resource, includePath),
+    );
+  };
+
+  return {
+    functions: getResourceDirname("functions"),
+    sites: getResourceDirname("sites"),
+  };
 }
 
 export function resolveLocalConfigResourcePaths(


### PR DESCRIPTION
## What does this PR do?

Fixes the CLI SDK generator templates so `Schema.withResourceDirectories` derives function and site resource directories from a single config file read/parse instead of calling `getLocalConfigResourceDirname` separately for each resource.

This addresses the review comment from appwrite/sdk-for-cli#305 about duplicate config reads in `lib/commands/schema.ts`.

## Test Plan

- `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php cli`
- `composer lint-twig`
- `git diff --check`
