### PR TITLE
Preserve CLI include paths for empty resources

### DIFF
--- a/templates/cli/lib/config.ts
+++ b/templates/cli/lib/config.ts
@@ -343,7 +343,6 @@ function writeResolvedLocalConfig(
     ...rootData,
     ...sanitizedData,
   };
-  const nextIncludePaths: ConfigIncludePaths = { ...includePaths };
 
   for (const [resource, includePath] of Object.entries(includePaths)) {
     const resourceData = sanitizedData[resource] ?? [];
@@ -356,13 +355,10 @@ function writeResolvedLocalConfig(
       resourceData,
     );
     delete rootOutput[resource];
-    if (resourceData.length === 0) {
-      delete nextIncludePaths[resource as ConfigResourceKey];
-    }
   }
 
-  if (Object.keys(nextIncludePaths).length > 0) {
-    rootOutput.includes = nextIncludePaths;
+  if (Object.keys(includePaths).length > 0) {
+    rootOutput.includes = includePaths;
   } else {
     delete rootOutput.includes;
   }


### PR DESCRIPTION
## What does this PR do?

Preserves configured CLI `includes` entries when an included resource array becomes empty during config writes.

Previously `writeResolvedLocalConfig` removed an include path when the corresponding resource data was empty. That left the empty include file behind but removed the root config hint, so future CLI sessions would write new resources inline instead of back into the previously configured include file.

This addresses the P1 review comment from appwrite/sdk-for-cli#305.

## Test Plan

- `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php cli`
- `composer lint-twig`
- `git diff --check`
