### PR TITLE
Fix CLI account switching state

### DIFF
--- a/templates/cli/lib/commands/generic.ts
+++ b/templates/cli/lib/commands/generic.ts
@@ -2,7 +2,11 @@ import inquirer from "inquirer";
 import { Command } from "commander";
 import { Client } from "@appwrite.io/console";
 import { sdkForConsole } from "../sdks.js";
-import { globalConfig, localConfig } from "../config.js";
+import {
+  globalConfig,
+  localConfig,
+  normalizeCloudConsoleEndpoint,
+} from "../config.js";
 import { EXECUTABLE_NAME } from "../constants.js";
 import {
   actionRunner,
@@ -16,14 +20,20 @@ import {
   drawTable,
   cliConfig,
 } from "../parser.js";
+import { isCloudHostname } from "../utils.js";
 import ID from "../id.js";
 import {
   questionsLogin,
   questionsLogout,
   questionsListFactors,
   questionsMFAChallenge,
+  questionsSwitchAccount,
 } from "../questions.js";
-import { Account, Client as ConsoleClient } from "@appwrite.io/console";
+import {
+  Account,
+  Client as ConsoleClient,
+  type Models,
+} from "@appwrite.io/console";
 import ClientLegacy from "../client.js";
 
 const DEFAULT_ENDPOINT = "https://cloud.appwrite.io/v1";
@@ -36,6 +46,56 @@ interface AppwriteError {
 const isMfaRequiredError = (err: unknown): err is AppwriteError =>
   (err as AppwriteError)?.type === "user_more_factors_required" ||
   (err as AppwriteError)?.response === "user_more_factors_required";
+
+const isGuestUnauthorizedError = (err: unknown): err is AppwriteError =>
+  (err as AppwriteError)?.type === "general_unauthorized_scope" ||
+  (err as AppwriteError)?.response === "general_unauthorized_scope";
+
+const isRegionalCloudEndpoint = (endpoint: string): boolean => {
+  try {
+    const hostname = new URL(endpoint).hostname;
+    return isCloudHostname(hostname) && hostname !== "cloud.appwrite.io";
+  } catch (_error) {
+    return false;
+  }
+};
+
+const restoreCurrentSession = (sessionId: string): void => {
+  globalConfig.setCurrentSession(
+    globalConfig.getSessionIds().includes(sessionId) ? sessionId : "",
+  );
+};
+
+const removeCurrentSession = (): void => {
+  const current = globalConfig.getCurrentSession();
+  globalConfig.setCurrentSession("");
+  globalConfig.removeSession(current);
+};
+
+const getCurrentAccount = async (): Promise<Models.User | null> => {
+  if (globalConfig.getEndpoint() === "" || globalConfig.getCookie() === "") {
+    return null;
+  }
+
+  const endpoint = normalizeCloudConsoleEndpoint(globalConfig.getEndpoint());
+  if (endpoint !== globalConfig.getEndpoint()) {
+    globalConfig.setEndpoint(endpoint);
+  }
+
+  const client = await sdkForConsole(false);
+  const accountClient = new Account(client);
+
+  try {
+    const account = await accountClient.get();
+    globalConfig.setEmail(account.email);
+    return account;
+  } catch (err) {
+    if (isGuestUnauthorizedError(err)) {
+      removeCurrentSession();
+    }
+    return null;
+  }
+};
 
 const createLegacyConsoleClient = (endpoint: string): ClientLegacy => {
   const legacyClient = new ClientLegacy();
@@ -115,7 +175,9 @@ const getSessionAccountKey = (sessionId: string): string | undefined => {
     | { email?: string; endpoint?: string }
     | undefined;
   if (!session) return undefined;
-  return `${session.email ?? ""}|${session.endpoint ?? ""}`;
+  return `${session.email ?? ""}|${normalizeCloudConsoleEndpoint(
+    session.endpoint ?? "",
+  )}`;
 };
 
 /**
@@ -165,33 +227,62 @@ export const loginCommand = async ({
   endpoint,
   mfa,
   code,
+  switch: switchAccount,
+  new: newAccount,
 }: {
   email?: string;
   password?: string;
   endpoint?: string;
   mfa?: string;
   code?: string;
+  switch?: boolean;
+  new?: boolean;
 }): Promise<void> => {
-  const oldCurrent = globalConfig.getCurrentSession();
+  let oldCurrent = globalConfig.getCurrentSession();
 
-  const configEndpoint =
-    (endpoint ?? globalConfig.getEndpoint()) || DEFAULT_ENDPOINT;
+  if (switchAccount && newAccount) {
+    throw new Error("Use either --switch or --new, not both.");
+  }
+
+  if (endpoint && isRegionalCloudEndpoint(endpoint)) {
+    throw new Error(
+      `Cloud login uses ${DEFAULT_ENDPOINT}. Regional Cloud endpoints are for project API calls, not account login.`,
+    );
+  }
+
+  const configEndpoint = normalizeCloudConsoleEndpoint(
+    (endpoint ?? globalConfig.getEndpoint()) || DEFAULT_ENDPOINT,
+  );
 
   if (globalConfig.getCurrentSession() !== "") {
-    log("You are currently signed in as " + globalConfig.getEmail());
+    const account = await getCurrentAccount();
+    oldCurrent = globalConfig.getCurrentSession();
 
-    if (globalConfig.getSessions().length === 1) {
-      hint("You can sign in and manage multiple accounts with Appwrite CLI");
+    if (account) {
+      if (!email && !password && !endpoint && !switchAccount && !newAccount) {
+        success("Already logged in as " + account.email);
+        hint(`Use '${EXECUTABLE_NAME} login --new' to add another account`);
+        return;
+      }
     }
   }
 
-  const answers =
-    email && password
-      ? { email, password }
-      : await inquirer.prompt(questionsLogin);
+  let answers;
+  if (switchAccount) {
+    if (!globalConfig.getSessions().some((session) => session.email)) {
+      throw new Error(
+        `No signed-in accounts found. Run '${EXECUTABLE_NAME} login' to sign in.`,
+      );
+    }
+    answers = await inquirer.prompt(questionsSwitchAccount);
+  } else if (email && password) {
+    answers = { email, password };
+  } else {
+    answers = await inquirer.prompt(questionsLogin);
+  }
 
   if (!answers.method) {
-    answers.method = "login";
+    answers.method = switchAccount ? "select" : "login";
   }
 
   if (answers.method === "select") {
@@ -201,7 +292,21 @@ export const loginCommand = async ({
       throw Error("Session ID not found");
     }
 
+    if (accountId === oldCurrent) {
+      const account = await getCurrentAccount();
+      if (account) {
+        success(`Already using ${account.email}`);
+        return;
+      }
+      throw new Error(
+        `Selected account session is no longer valid. Run '${EXECUTABLE_NAME} login --switch' again.`,
+      );
+    }
+
     globalConfig.setCurrentSession(accountId);
+    globalConfig.setEndpoint(
+      normalizeCloudConsoleEndpoint(globalConfig.getEndpoint()),
+    );
 
     const client = await sdkForConsole(false);
     const accountClient = new Account(client);
@@ -213,6 +318,10 @@ export const loginCommand = async ({
       await accountClient.get();
     } catch (err) {
       if (!isMfaRequiredError(err)) {
+        if (isGuestUnauthorizedError(err)) {
+          globalConfig.removeSession(accountId);
+        }
+        restoreCurrentSession(oldCurrent);
         throw err;
       }
 
@@ -306,14 +415,8 @@ export const whoami = new Command("whoami")
         return;
       }
 
-      const client = await sdkForConsole(false);
-      const accountClient = new Account(client);
-
-      let account;
-
-      try {
-        account = await accountClient.get();
-      } catch (_) {
+      const account = await getCurrentAccount();
+      if (!account) {
         error("No user is signed in. To sign in, run 'appwrite login'");
         return;
       }
@@ -358,6 +461,8 @@ export const login = new Command("login")
     `Multi-factor authentication login factor: totp, email, phone or recoveryCode`,
   )
   .option(`--code [code]`, `Multi-factor code`)
+  .option(`--switch`, `Switch to another signed-in account`)
+  .option(`--new`, `Sign in to another account`)
   .configureHelp({
     helpWidth: process.stdout.columns || 80,
   })

--- a/templates/cli/lib/config.ts
+++ b/templates/cli/lib/config.ts
@@ -103,6 +103,22 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+export function normalizeCloudConsoleEndpoint(endpoint: string): string {
+  try {
+    const url = new URL(endpoint);
+    if (
+      url.hostname === "cloud.appwrite.io" ||
+      url.hostname.endsWith(".cloud.appwrite.io")
+    ) {
+      return "https://cloud.appwrite.io/v1";
+    }
+  } catch (_error) {
+    return endpoint;
+  }
+
+  return endpoint;
+}
+
 function ensureDirectoryForFile(filePath: string): void {
   const dir = _path.dirname(filePath);
   if (!fs.existsSync(dir)) {
@@ -1201,10 +1217,17 @@ class Global extends Config<GlobalConfigData> {
     sessions.forEach((sessionId) => {
       const sessionData = (this.data as any)[sessionId];
       const email = sessionData[Global.PREFERENCE_EMAIL] ?? "";
-      const endpoint = sessionData[Global.PREFERENCE_ENDPOINT] ?? "";
+      const endpoint = normalizeCloudConsoleEndpoint(
+        sessionData[Global.PREFERENCE_ENDPOINT] ?? "",
+      );
       const key = `${email}|${endpoint}`;
+      const existingSession = sessionMap.get(key);
 
-      if (sessionId === current || !sessionMap.has(key)) {
+      if (
+        !existingSession ||
+        sessionId === current ||
+        existingSession.id !== current
+      ) {
         sessionMap.set(key, {
           id: sessionId,
           endpoint,

--- a/templates/cli/lib/questions.ts
+++ b/templates/cli/lib/questions.ts
@@ -823,16 +823,6 @@ export const questionsPullCollection: Question[] = [
 
 export const questionsLogin: Question[] = [
   {
-    type: "list",
-    name: "method",
-    message: "What would you like to do?",
-    choices: [
-      { name: "Login to an account", value: "login" },
-      { name: "Switch to an account", value: "select" },
-    ],
-    when: () => globalConfig.getSessions().length >= 2,
-  },
-  {
     type: "input",
     name: "email",
     message: "Enter your email",
@@ -842,7 +832,6 @@ export const questionsLogin: Question[] = [
       }
       return true;
     },
-    when: (answers: Answers) => answers.method !== "select",
   },
   {
     type: "password",
@@ -855,38 +844,36 @@ export const questionsLogin: Question[] = [
       }
       return true;
     },
-    when: (answers: Answers) => answers.method !== "select",
   },
+];
+
+export const questionsSwitchAccount: Question[] = [
   {
     type: "list",
     name: "accountId",
-    message: "Select an account to use",
+    message: "Select account:",
     choices() {
       const sessions = globalConfig.getSessions();
       const current = globalConfig.getCurrentSession();
 
       const data: Choice[] = [];
 
-      const longestEmail = sessions.reduce((prev: any, current: any) =>
-        prev && (prev.email ?? "").length > (current.email ?? "").length
-          ? prev
-          : current,
-      ).email.length;
-
       sessions.forEach((session: any) => {
         if (session.email) {
           data.push({
             current: current === session.id,
             value: session.id,
-            short: `${session.email} (${session.endpoint})`,
-            name: `${session.email.padEnd(longestEmail)} ${current === session.id ? chalk.green.bold("current") : " ".repeat(6)} ${session.endpoint}`,
+            short: session.email,
+            name:
+              session.endpoint === DEFAULT_ENDPOINT
+                ? session.email
+                : `${session.email} (${session.endpoint})`,
           });
         }
       });
 
       return data.sort((a, b) => Number(b.current) - Number(a.current));
     },
-    when: (answers: Answers) => answers.method === "select",
   },
 ];
 

--- a/templates/cli/lib/utils.ts
+++ b/templates/cli/lib/utils.ts
@@ -317,7 +317,7 @@ const getHomebrewLatestVersion = async (
   }
 };
 
-const isCloudHostname = (hostname: string): boolean =>
+export const isCloudHostname = (hostname: string): boolean =>
   hostname === "cloud.appwrite.io" || hostname.endsWith(".cloud.appwrite.io");
 
 export const getConsoleBaseUrl = (endpoint: string): string => {


### PR DESCRIPTION
## What changed

- Verify the current CLI account session before reporting that the user is already logged in.
- Add `appwrite login --switch` for explicit account switching, including a no-op success when the current account is selected.
- Normalize Cloud console login sessions to `https://cloud.appwrite.io/v1` and reject regional Cloud endpoints for account login.
- Remove stale guest/unauthorized account sessions and restore the previous current session after failed switches.

## Why

The CLI could show inconsistent account state after switching between saved accounts. Stale duplicate sessions could be selected, regional Cloud endpoints appeared as separate login targets, and `appwrite login` trusted local metadata even when `whoami` could no longer verify the session.

## Testing

- `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php cli`
- `composer lint-twig`
- `npm run build:types` from `examples/cli`
