### PR TITLE
docs: document CLI account switching in agent skill

### DIFF
--- a/templates/agent-skills/cli.md.twig
+++ b/templates/agent-skills/cli.md.twig
@@ -37,6 +37,9 @@ appwrite login
 # Login to a self-hosted instance
 appwrite login --endpoint "https://your-instance.com/v1"
 
+# Switch to a different saved account
+appwrite login --switch
+
 # Initialize a project (creates appwrite.config.json)
 appwrite init project
 


### PR DESCRIPTION
## Summary
- Add an `appwrite login --switch` usage example to the AgentSkills CLI template

## Context
This updates the sdk-generator source for the generated AgentSkills docs and addresses the missing `appwrite login --switch` coverage noted on appwrite/agent-skills#12.

The changelog comment from that PR is generated from the injected `sdk.changelog` release text, not from a dedicated AgentSkills template in this repository.

## Testing
- docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php agent-skills
- composer lint-twig
- git diff --check