### PR TITLE
fix(web): remove duplicate session field in console SDK config

### DIFF
--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -358,7 +358,6 @@ class Client {
 {%~ endfor %}
 {%~ if sdk.platform == 'console' %}
         selfSigned: boolean;
-        session?: string;
 {%~ endif %}
     } = {
         endpoint: '{{ spec.endpoint }}',
@@ -368,7 +367,6 @@ class Client {
 {%~ endfor %}
 {%~ if sdk.platform == 'console' %}
         selfSigned: false,
-        session: undefined,
 {%~ endif %}
     };
     /**


### PR DESCRIPTION
## Summary
- Generated console-platform Web SDK fails to compile with `TS2300: Duplicate identifier 'session'` because `session` is declared twice in the `Client.config` shape: once by the `spec.global.headers` loop (`session: string`) and again by the console-only block (`session?: string`).
- The duplicate was reintroduced in commit `1f56d99` ("undefined param") after being removed in `0c2a7ba` ("fix web validation"), specifically scoped to the console branch.
- This PR removes the explicit `session?: string` and `session: undefined` lines from the console conditional. The header loop already produces `session: string` with `''` default, and the realtime auth check (`if (!session)`) handles both `''` and `undefined` identically — no runtime behavior change.

## Reproduction (before the fix)

```bash
docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php web
# then in the generated console SDK
npm run build
# src/client.ts:362:9 - error TS2300: Duplicate identifier 'session'.
# src/client.ts:369:9 - error TS2300: Duplicate identifier 'session'.
# ... 8 errors total
```

## Test plan
- [x] Regenerate web SDK on the console platform: `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php web`
- [x] Inspect `examples/web/src/client.ts` and confirm only one `session: string` field with `''` default is present
- [x] Run `composer lint-twig` (0 errors)
- [ ] In the generated console SDK directory, run `npm run build` and confirm the TS build succeeds