### PR TITLE
Fix CLI Windows ARM64 pkg bytecode warnings

### DIFF
--- a/templates/cli/lib/commands/init.ts
+++ b/templates/cli/lib/commands/init.ts
@@ -136,9 +136,7 @@ const printInitProjectNextSteps = (steps: InitProjectNextStep[]): void => {
 
   for (const step of steps) {
     const spacing = " ".repeat(longestCommand - step.command.length + 4);
-    console.log(
-      `    ${chalk.cyan(step.command)}${spacing}${step.description}`,
-    );
+    console.log(`    ${chalk.cyan(step.command)}${spacing}${step.description}`);
   }
 };
 

--- a/templates/cli/lib/commands/push.ts
+++ b/templates/cli/lib/commands/push.ts
@@ -153,9 +153,7 @@ function getDeploymentProgressSignature(
   const status =
     typeof deployment["status"] === "string" ? deployment["status"] : "";
   const buildLogs =
-    typeof deployment["buildLogs"] === "string"
-      ? deployment["buildLogs"]
-      : "";
+    typeof deployment["buildLogs"] === "string" ? deployment["buildLogs"] : "";
   const updatedAt =
     typeof deployment["$updatedAt"] === "string"
       ? deployment["$updatedAt"]
@@ -173,9 +171,7 @@ function getDeploymentProgressSignature(
   });
 }
 
-function createDeploymentTimeoutTracker(
-  deployment: Record<string, unknown>,
-): {
+function createDeploymentTimeoutTracker(deployment: Record<string, unknown>): {
   touch: (deployment: Record<string, unknown>) => void;
   hasTimedOut: () => boolean;
 } {

--- a/templates/cli/lib/config.ts
+++ b/templates/cli/lib/config.ts
@@ -126,7 +126,10 @@ function ensureDirectoryForFile(filePath: string): void {
   }
 }
 
-function assertValidIncludePath(resource: string, includePath: unknown): string {
+function assertValidIncludePath(
+  resource: string,
+  includePath: unknown,
+): string {
   if (typeof includePath !== "string" || includePath.trim() === "") {
     throw new Error(`Config include for '${resource}' must be a file path.`);
   }
@@ -149,7 +152,9 @@ function assertValidIncludePath(resource: string, includePath: unknown): string 
   }
 
   if (_path.isAbsolute(normalizedPath)) {
-    throw new Error(`Config include '${resource}' must be a relative file path.`);
+    throw new Error(
+      `Config include '${resource}' must be a relative file path.`,
+    );
   }
 
   if (/^[a-z][a-z0-9+.-]*:/i.test(normalizedPath)) {
@@ -163,7 +168,9 @@ function assertValidIncludePath(resource: string, includePath: unknown): string 
   return normalizedPath;
 }
 
-function getConfigIncludePaths(data: Record<string, unknown>): ConfigIncludePaths {
+function getConfigIncludePaths(
+  data: Record<string, unknown>,
+): ConfigIncludePaths {
   const includes = data.includes;
   if (includes === undefined) {
     return {};
@@ -200,7 +207,10 @@ function writeJsonFile(filePath: string, data: unknown): void {
   });
 }
 
-function resolveIncludePath(configFilePath: string, includePath: string): string {
+function resolveIncludePath(
+  configFilePath: string,
+  includePath: string,
+): string {
   return _path.resolve(_path.dirname(configFilePath), includePath);
 }
 
@@ -274,10 +284,9 @@ export function getLocalConfigResourceDirname(
   return getLocalConfigResourceDirnames(filePath)[resource];
 }
 
-export function getLocalConfigResourceDirnames(filePath: string): Record<
-  "functions" | "sites",
-  string
-> {
+export function getLocalConfigResourceDirnames(
+  filePath: string,
+): Record<"functions" | "sites", string> {
   const rootData = fs.existsSync(filePath)
     ? readJsonFile<Record<string, unknown>>(filePath)
     : {};
@@ -722,7 +731,10 @@ class Local extends Config<ConfigType> {
     return _path.dirname(resolveIncludePath(this.path, includePath));
   }
 
-  resolveResourcePath(resource: ConfigResourceKey, resourcePath: string): string {
+  resolveResourcePath(
+    resource: ConfigResourceKey,
+    resourcePath: string,
+  ): string {
     if (_path.isAbsolute(resourcePath)) {
       return resourcePath;
     }

--- a/templates/cli/package.json
+++ b/templates/cli/package.json
@@ -45,7 +45,7 @@
     "mac-x64": "bun build cli.ts --compile --sourcemap=inline --target=bun-darwin-x64 --outfile build/appwrite-cli-darwin-x64",
     "mac-arm64": "bun build cli.ts --compile --sourcemap=inline --target=bun-darwin-arm64 --outfile build/appwrite-cli-darwin-arm64",
     "windows-x64": "bun build cli.ts --compile --sourcemap=inline --target=bun-windows-x64 --outfile build/appwrite-cli-win-x64.exe",
-    "windows-arm64": "esbuild cli.ts --bundle --loader:.hbs=text --platform=node --target=node18 --format=esm --external:fsevents --external:terminal-image --outfile=dist/bundle-win-arm64.mjs && pkg dist/bundle-win-arm64.mjs -t node18-win-arm64 -o build/appwrite-cli-win-arm64.exe"
+    "windows-arm64": "esbuild cli.ts --bundle --loader:.hbs=text --platform=node --target=node18 --format=esm --external:fsevents --external:terminal-image --outfile=dist/bundle-win-arm64.mjs && pkg dist/bundle-win-arm64.mjs --fallback-to-source -t node18-win-arm64 -o build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
     "@appwrite.io/console": "11.0.0",

--- a/templates/cli/package.json.twig
+++ b/templates/cli/package.json.twig
@@ -48,7 +48,7 @@
     "mac-x64": "bun build cli.ts --compile --sourcemap=inline --target=bun-darwin-x64 --outfile build/appwrite-cli-darwin-x64",
     "mac-arm64": "bun build cli.ts --compile --sourcemap=inline --target=bun-darwin-arm64 --outfile build/appwrite-cli-darwin-arm64",
     "windows-x64": "bun build cli.ts --compile --sourcemap=inline --target=bun-windows-x64 --outfile build/appwrite-cli-win-x64.exe",
-    "windows-arm64": "esbuild cli.ts --bundle --loader:.hbs=text --platform=node --target=node18 --format=esm --external:fsevents --external:terminal-image --outfile=dist/bundle-win-arm64.mjs && pkg dist/bundle-win-arm64.mjs -t node18-win-arm64 -o build/appwrite-cli-win-arm64.exe"
+    "windows-arm64": "esbuild cli.ts --bundle --loader:.hbs=text --platform=node --target=node18 --format=esm --external:fsevents --external:terminal-image --outfile=dist/bundle-win-arm64.mjs && pkg dist/bundle-win-arm64.mjs --fallback-to-source -t node18-win-arm64 -o build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
     "@appwrite.io/console": "12.0.0",


### PR DESCRIPTION
## Summary
- add `--fallback-to-source` to the CLI Windows ARM64 `pkg` build path to avoid noisy V8 bytecode generation warnings
- keep the CLI package fixture in sync with the generated package template
- include the CLI formatting-only template changes already present locally

## Testing
- `php example.php cli console`
- `bun install` in `examples/cli`
- `bun run windows-arm64` in `examples/cli` and checked the log had no `Failed to generate V8 bytecode` warnings
- `composer lint-twig`
- `git diff --check`

Note: did not run `npm run build` because the current console spec still hits the expected `suggestQueries` TypeScript error.
