### PR TITLE
Fix Console service variable in web docs examples

### DIFF
--- a/src/SDK/Language/JS.php
+++ b/src/SDK/Language/JS.php
@@ -52,6 +52,7 @@ abstract class JS extends Language
             'catch',
             'char',
             'class', // new in ECMAScript 5 and 6.
+            'console',
             'const',
             'continue',
             'debugger',

--- a/templates/deno/docs/example.md.twig
+++ b/templates/deno/docs/example.md.twig
@@ -11,9 +11,9 @@ const client = new Client()
     {%~ endfor %}
     {%~ endif %}
 
-const {{ service.name | caseCamel }} = new {{service.name | caseUcfirst}}(client{% if service.globalParams | length %}{% for parameter in service.globalParams %}, {{ parameter | paramExample }}{% endfor %}{% endif %});
+const {{ service.name | caseCamel | escapeKeyword }} = new {{service.name | caseUcfirst}}(client{% if service.globalParams | length %}{% for parameter in service.globalParams %}, {{ parameter | paramExample }}{% endfor %}{% endif %});
 
-{% if method.type == 'location' %}const result = {% elseif method.type != 'webAuth' %}const response = await {% endif %}{{ service.name | caseCamel }}.{{ method.name | caseCamel }}({% if method.parameters.all | length == 0 %});
+{% if method.type == 'location' %}const result = {% elseif method.type != 'webAuth' %}const response = await {% endif %}{{ service.name | caseCamel | escapeKeyword }}.{{ method.name | caseCamel }}({% if method.parameters.all | length == 0 %});
 {% else %}{
 {%~ for parameter in method.parameters.all %}
 {%~ if parameter.required %}

--- a/templates/node/docs/example.md.twig
+++ b/templates/node/docs/example.md.twig
@@ -14,9 +14,9 @@ const client = new sdk.Client()
     {%~ endfor %}
     {%~ endif %}
 
-const {{ service.name | caseCamel }} = new sdk.{{service.name | caseUcfirst}}(client);
+const {{ service.name | caseCamel | escapeKeyword }} = new sdk.{{service.name | caseUcfirst}}(client);
 
-const result = await {{ service.name | caseCamel }}.{{ method.name | caseCamel }}({% if method.parameters.all | length == 0 %});
+const result = await {{ service.name | caseCamel | escapeKeyword }}.{{ method.name | caseCamel }}({% if method.parameters.all | length == 0 %});
 {% else %}{
 {%~ for parameter in method.parameters.all %}
 {%~ if parameter.required %}

--- a/templates/web/docs/example.md.twig
+++ b/templates/web/docs/example.md.twig
@@ -11,9 +11,9 @@ const client = new Client()
     {%~ endfor %}
     {%~ endif %}
 
-const {{ service.name | caseCamel }} = new {{service.name | caseUcfirst}}(client{% if service.globalParams | length %}{% for parameter in service.globalParams %}, {{ parameter | paramExample }}{% endfor %}{% endif %});
+const {{ service.name | caseCamel | escapeKeyword }} = new {{service.name | caseUcfirst}}(client{% if service.globalParams | length %}{% for parameter in service.globalParams %}, {{ parameter | paramExample }}{% endfor %}{% endif %});
 
-{% if method.type == 'location' %}const result = {% elseif method.type != 'webAuth' %}const result = await {% endif %}{{ service.name | caseCamel }}.{{ method.name | caseCamel }}({% if method.parameters.all | length == 0 %});
+{% if method.type == 'location' %}const result = {% elseif method.type != 'webAuth' %}const result = await {% endif %}{{ service.name | caseCamel | escapeKeyword }}.{{ method.name | caseCamel }}({% if method.parameters.all | length == 0 %});
 {% else %}{
 {%~ for parameter in method.parameters.all %}
 {%~ if parameter.required %}


### PR DESCRIPTION
## What\n- Avoid generating `const console` in web docs examples for the Console service\n- Use `consoleService` for that service so `console.log(result)` still references the global console\n\n## Why\nThe generated Console SDK PR appwrite/sdk-for-console#89 received feedback that docs/examples/console/suggest-queries.md shadows the global `console` object and breaks the example at runtime.\n\n## Verification\n- `php example.php web`\n- `composer lint-twig`