### PR TITLE
Add Flutter client factory surface

### DIFF
--- a/src/SDK/Language/Flutter.php
+++ b/src/SDK/Language/Flutter.php
@@ -33,7 +33,7 @@ class Flutter extends Dart
             [
                 'scope'         => 'default',
                 'destination'   => '/lib/src/service.dart',
-                'template'      => 'dart/lib/src/service.dart.twig',
+                'template'      => 'flutter/lib/src/service.dart.twig',
             ],
             [
                 'scope'         => 'default',

--- a/templates/flutter/base/requests/api.twig
+++ b/templates/flutter/base/requests/api.twig
@@ -8,7 +8,7 @@
             {{~ utils.map_headers(method.headers) }}
         };
 
-        final res = await client.call(HttpMethod.{{ method.method | caseLower }}, path: apiPath, params: apiParams, headers: apiHeaders);
+        final res = await _client.call(HttpMethod.{{ method.method | caseLower }}, path: apiPath, params: apiParams, headers: apiHeaders);
 
 {% set responseModels = method | getValidResponseModels %}
 {% set hasResponseDiscriminator = method.responseDiscriminator is defined and method.responseDiscriminator is not empty %}

--- a/templates/flutter/base/requests/file.twig
+++ b/templates/flutter/base/requests/file.twig
@@ -18,7 +18,7 @@
         idParamName = '{{ parameter.name }}';
 {% endif %}
 {% endfor %}
-        final res = await client.chunkedUpload(
+        final res = await _client.chunkedUpload(
             path: apiPath,
             params: apiParams,
             paramName: paramName,

--- a/templates/flutter/base/requests/location.twig
+++ b/templates/flutter/base/requests/location.twig
@@ -4,11 +4,11 @@
             {{ utils.map_parameter(method.parameters.body) }}
 {% if method.auth|length > 0 %}{% for node in method.auth %}
 {% for key,header in node|keys %}
-            '{{header|caseLower}}': client.config['{{header|caseLower}}'],
+            '{{header|caseLower}}': _client.config['{{header|caseLower}}'],
 {% endfor %}
 {% endfor %}
 {% endif %}
         };
 
-        final res = await client.call(HttpMethod.{{ method.method | caseLower }}, path: apiPath, params: params, responseType: ResponseType.bytes);
+        final res = await _client.call(HttpMethod.{{ method.method | caseLower }}, path: apiPath, params: params, responseType: ResponseType.bytes);
         return res.data;

--- a/templates/flutter/base/requests/oauth.twig
+++ b/templates/flutter/base/requests/oauth.twig
@@ -5,7 +5,7 @@
 {% if method.auth|length > 0 %}
 {% for node in method.auth %}
 {% for key,header in node|keys %}
-            '{{header|caseLower}}': client.config['{{header|caseLower}}'],
+            '{{header|caseLower}}': _client.config['{{header|caseLower}}'],
 {% endfor %}
 {% endfor %}
 {% endif %}
@@ -24,7 +24,7 @@
           }
         });
 
-        Uri endpoint = Uri.parse(client.endPoint);
+        Uri endpoint = Uri.parse(_client.endPoint);
         Uri url = Uri(scheme: endpoint.scheme,
           host: endpoint.host,
           port: endpoint.port,
@@ -32,4 +32,4 @@
           query: query.join('&')
         );
 
-        return client.webAuth(url, callbackUrlScheme: success);
+        return _client.webAuth(url, callbackUrlScheme: success);

--- a/templates/flutter/lib/package.dart.twig
+++ b/templates/flutter/lib/package.dart.twig
@@ -12,6 +12,7 @@ import 'dart:convert';
 
 import 'src/enums.dart';
 import 'src/service.dart';
+import 'src/client.dart';
 import 'src/input_file.dart';
 import 'models.dart' as models;
 import 'enums.dart' as enums;

--- a/templates/flutter/lib/services/service.dart.twig
+++ b/templates/flutter/lib/services/service.dart.twig
@@ -11,8 +11,13 @@ part of '../{{ language.params.packageName }}.dart';
 {{- service.description|dartComment | split('    ///') | join('///')}}
 {% endif %}
 class {{ service.name | caseUcfirst }} extends Service {
+  final ClientAuth _client;
+
   /// Initializes a [{{ service.name | caseUcfirst }}] service
-  {{ service.name | caseUcfirst }}(super.client);
+  // ignore: use_super_parameters
+  {{ service.name | caseUcfirst }}(ClientAuth client)
+      : _client = client,
+        super(client);
 {% for method in service.methods %}
 
 {%~ if method.description %}

--- a/templates/flutter/lib/src/client.dart.twig
+++ b/templates/flutter/lib/src/client.dart.twig
@@ -79,18 +79,36 @@ abstract class Client implements ClientAuth {
   }) {
     final client = createClient(endPoint: endPoint, selfSigned: selfSigned);
 
-    // ignore: deprecated_member_use_from_same_package
-    client.setProject(projectId);
+    _setHeader(
+      client,
+      'project',
+      'X-{{ spec.title | caseUcfirst }}-Project',
+      projectId,
+    );
     if (endPointRealtime != null) {
       // ignore: deprecated_member_use_from_same_package
       client.setEndPointRealtime(endPointRealtime);
     }
     if (locale != null) {
-      // ignore: deprecated_member_use_from_same_package
-      client.setLocale(locale);
+      _setHeader(
+        client,
+        'locale',
+        'X-{{ spec.title | caseUcfirst }}-Locale',
+        locale,
+      );
     }
 
     return client;
+  }
+
+  static void _setHeader(
+    Client client,
+    String configKey,
+    String header,
+    String value,
+  ) {
+    client.config[configKey] = value;
+    client.addHeader(header, value);
   }
 
   /// Initializes a client with a user session.
@@ -110,8 +128,12 @@ abstract class Client implements ClientAuth {
       selfSigned: selfSigned,
     );
 
-    // ignore: deprecated_member_use_from_same_package
-    client.setSession(session);
+    _setHeader(
+      client,
+      'session',
+      'X-{{ spec.title | caseUcfirst }}-Session',
+      session,
+    );
     return client;
   }
 
@@ -132,8 +154,12 @@ abstract class Client implements ClientAuth {
       selfSigned: selfSigned,
     );
 
-    // ignore: deprecated_member_use_from_same_package
-    client.setDevKey(devKey);
+    _setHeader(
+      client,
+      'devKey',
+      'X-{{ spec.title | caseUcfirst }}-Dev-Key',
+      devKey,
+    );
     return client;
   }
 
@@ -164,18 +190,34 @@ abstract class Client implements ClientAuth {
       selfSigned: selfSigned,
     );
 
-    // ignore: deprecated_member_use_from_same_package
-    client.setSession(session);
+    _setHeader(
+      client,
+      'session',
+      'X-{{ spec.title | caseUcfirst }}-Session',
+      session,
+    );
 
     if (userId != null) {
-      // ignore: deprecated_member_use_from_same_package
-      client.setImpersonateUserId(userId);
+      _setHeader(
+        client,
+        'impersonateUserId',
+        'X-{{ spec.title | caseUcfirst }}-Impersonate-User-Id',
+        userId,
+      );
     } else if (userEmail != null) {
-      // ignore: deprecated_member_use_from_same_package
-      client.setImpersonateUserEmail(userEmail);
+      _setHeader(
+        client,
+        'impersonateUserEmail',
+        'X-{{ spec.title | caseUcfirst }}-Impersonate-User-Email',
+        userEmail,
+      );
     } else if (userPhone != null) {
-      // ignore: deprecated_member_use_from_same_package
-      client.setImpersonateUserPhone(userPhone);
+      _setHeader(
+        client,
+        'impersonateUserPhone',
+        'X-{{ spec.title | caseUcfirst }}-Impersonate-User-Phone',
+        userPhone,
+      );
     }
 
     return client;

--- a/templates/flutter/lib/src/client.dart.twig
+++ b/templates/flutter/lib/src/client.dart.twig
@@ -8,26 +8,15 @@ import 'upload_progress.dart';
 /// [Client] that handles requests to {{spec.title | caseUcfirst}}.
 ///
 /// The [Client] is also responsible for managing user's sessions.
-abstract class Client {
-  /// The size for chunked uploads in bytes.
-  static const int chunkSize = 5 * 1024 * 1024;
-
+abstract class ClientAuth {
   /// Holds configuration such as project.
-  late Map<String, String> config;
-  late String _endPoint;
-  late String? _endPointRealtime;
+  Map<String, String> get config;
 
   /// {{spec.title | caseUcfirst}} endpoint.
-  String get endPoint => _endPoint;
+  String get endPoint;
 
   /// {{spec.title | caseUcfirst}} realtime endpoint.
-  String? get endPointRealtime => _endPointRealtime;
-
-  /// Initializes a [Client].
-  factory Client({
-    String endPoint = '{{ spec.endpoint }}',
-    bool selfSigned = false,
-  }) => createClient(endPoint: endPoint, selfSigned: selfSigned);
+  String? get endPointRealtime;
 
   /// Handle OAuth2 session creation.
   Future webAuth(Uri url, {String? callbackUrlScheme});
@@ -42,34 +31,6 @@ abstract class Client {
     Function(UploadProgress)? onProgress,
   });
 
-  /// Set self signed to [status].
-  ///
-  /// If self signed is true, [Client] will ignore invalid certificates.
-  /// This is helpful in environments where your {{spec.title | caseUcfirst}}
-  /// instance does not have a valid SSL certificate.
-  Client setSelfSigned({bool status = true});
-
-  /// Set the {{spec.title | caseUcfirst}} endpoint.
-  Client setEndpoint(String endPoint);
-
-  /// Set the {{spec.title | caseUcfirst}} realtime endpoint.
-  Client setEndPointRealtime(String endPoint);
-
-{% for header in spec.global.headers %}
-  /// Set {{header.key | caseUcfirst}}.
-{% if header.description %}
-  ///
-  /// {{header.description}}.
-{% endif %}
-  Client set{{header.key | caseUcfirst}}(String value);
-
-{% endfor %}
-  /// Add headers that should be sent with all API calls.
-  Client addHeader(String key, String value);
-
-  /// Get the current request headers.
-  Map<String, String> getHeaders();
-
   /// Sends a "ping" request to Appwrite to verify connectivity.
   Future<String> ping();
 
@@ -81,4 +42,174 @@ abstract class Client {
     Map<String, dynamic> params = const {},
     ResponseType? responseType,
   });
+}
+
+/// Legacy client with mutable setter methods.
+abstract class Client implements ClientAuth {
+  /// The size for chunked uploads in bytes.
+  static const int chunkSize = 5 * 1024 * 1024;
+
+  /// Initializes a [Client].
+  factory Client({
+    String endPoint = '{{ spec.endpoint }}',
+    bool selfSigned = false,
+  }) => createClient(endPoint: endPoint, selfSigned: selfSigned);
+
+  /// Initializes a client for browser/mobile session authentication.
+  static ClientAuth fromBrowser({
+    String endPoint = '{{ spec.endpoint }}',
+    required String projectId,
+    String? endPointRealtime,
+    String? locale,
+    bool selfSigned = false,
+  }) => _fromBrowserClient(
+        endPoint: endPoint,
+        projectId: projectId,
+        endPointRealtime: endPointRealtime,
+        locale: locale,
+        selfSigned: selfSigned,
+      );
+
+  static Client _fromBrowserClient({
+    required String endPoint,
+    required String projectId,
+    String? endPointRealtime,
+    String? locale,
+    required bool selfSigned,
+  }) {
+    final client = createClient(endPoint: endPoint, selfSigned: selfSigned);
+
+    // ignore: deprecated_member_use_from_same_package
+    client.setProject(projectId);
+    if (endPointRealtime != null) {
+      // ignore: deprecated_member_use_from_same_package
+      client.setEndPointRealtime(endPointRealtime);
+    }
+    if (locale != null) {
+      // ignore: deprecated_member_use_from_same_package
+      client.setLocale(locale);
+    }
+
+    return client;
+  }
+
+  /// Initializes a client with a user session.
+  static ClientAuth fromSession({
+    String endPoint = '{{ spec.endpoint }}',
+    required String projectId,
+    required String session,
+    String? endPointRealtime,
+    String? locale,
+    bool selfSigned = false,
+  }) {
+    final client = _fromBrowserClient(
+      endPoint: endPoint,
+      projectId: projectId,
+      endPointRealtime: endPointRealtime,
+      locale: locale,
+      selfSigned: selfSigned,
+    );
+
+    // ignore: deprecated_member_use_from_same_package
+    client.setSession(session);
+    return client;
+  }
+
+  /// Initializes a client with a development key.
+  static ClientAuth fromDevKey({
+    String endPoint = '{{ spec.endpoint }}',
+    required String projectId,
+    required String devKey,
+    String? endPointRealtime,
+    String? locale,
+    bool selfSigned = false,
+  }) {
+    final client = _fromBrowserClient(
+      endPoint: endPoint,
+      projectId: projectId,
+      endPointRealtime: endPointRealtime,
+      locale: locale,
+      selfSigned: selfSigned,
+    );
+
+    // ignore: deprecated_member_use_from_same_package
+    client.setDevKey(devKey);
+    return client;
+  }
+
+  /// Initializes a client with user impersonation.
+  static ClientAuth fromImpersonation({
+    String endPoint = '{{ spec.endpoint }}',
+    required String projectId,
+    required String session,
+    String? userId,
+    String? userEmail,
+    String? userPhone,
+    String? endPointRealtime,
+    String? locale,
+    bool selfSigned = false,
+  }) {
+    final targets = [userId, userEmail, userPhone].whereType<String>().length;
+    if (targets != 1) {
+      throw ArgumentError(
+        'Exactly one of userId, userEmail, or userPhone must be provided.',
+      );
+    }
+
+    final client = _fromBrowserClient(
+      endPoint: endPoint,
+      projectId: projectId,
+      endPointRealtime: endPointRealtime,
+      locale: locale,
+      selfSigned: selfSigned,
+    );
+
+    // ignore: deprecated_member_use_from_same_package
+    client.setSession(session);
+
+    if (userId != null) {
+      // ignore: deprecated_member_use_from_same_package
+      client.setImpersonateUserId(userId);
+    } else if (userEmail != null) {
+      // ignore: deprecated_member_use_from_same_package
+      client.setImpersonateUserEmail(userEmail);
+    } else if (userPhone != null) {
+      // ignore: deprecated_member_use_from_same_package
+      client.setImpersonateUserPhone(userPhone);
+    }
+
+    return client;
+  }
+
+  /// Set self signed to [status].
+  ///
+  /// If self signed is true, [Client] will ignore invalid certificates.
+  /// This is helpful in environments where your {{spec.title | caseUcfirst}}
+  /// instance does not have a valid SSL certificate.
+  @Deprecated('Use Client.fromBrowser or another factory constructor instead.')
+  Client setSelfSigned({bool status = true});
+
+  /// Set the {{spec.title | caseUcfirst}} endpoint.
+  @Deprecated('Use Client.fromBrowser or another factory constructor instead.')
+  Client setEndpoint(String endPoint);
+
+  /// Set the {{spec.title | caseUcfirst}} realtime endpoint.
+  @Deprecated('Use Client.fromBrowser or another factory constructor instead.')
+  Client setEndPointRealtime(String endPoint);
+
+{% for header in spec.global.headers %}
+  /// Set {{header.key | caseUcfirst}}.
+{% if header.description %}
+  ///
+  /// {{header.description}}.
+{% endif %}
+  @Deprecated('Use Client.fromBrowser or another factory constructor instead.')
+  Client set{{header.key | caseUcfirst}}(String value);
+
+{% endfor %}
+  /// Add headers that should be sent with all API calls.
+  Client addHeader(String key, String value);
+
+  /// Get the current request headers.
+  Map<String, String> getHeaders();
 }

--- a/templates/flutter/lib/src/client_base.dart.twig
+++ b/templates/flutter/lib/src/client_base.dart.twig
@@ -7,16 +7,20 @@ abstract class ClientBase implements Client {
 {% if header.description %}
   /// {{header.description}}
 {% endif %}
+  @Deprecated('Use Client.fromBrowser or another factory constructor instead.')
   @override
   ClientBase set{{header.key | caseUcfirst}}(value);
 {% endfor %}
 
+  @Deprecated('Use Client.fromBrowser or another factory constructor instead.')
   @override
   ClientBase setSelfSigned({bool status = true});
 
+  @Deprecated('Use Client.fromBrowser or another factory constructor instead.')
   @override
   ClientBase setEndpoint(String endPoint);
 
+  @Deprecated('Use Client.fromBrowser or another factory constructor instead.')
   @override
   Client setEndPointRealtime(String endPoint);
 

--- a/templates/flutter/lib/src/client_browser.dart.twig
+++ b/templates/flutter/lib/src/client_browser.dart.twig
@@ -62,6 +62,7 @@ class ClientBrowser extends ClientBase with ClientMixin {
 {% if header.description %}
   /// {{header.description}}
 {% endif %}
+  @Deprecated('Use Client.fromBrowser or another factory constructor instead.')
   @override
   ClientBrowser set{{header.key | caseUcfirst}}(value) {
     config['{{ header.key | caseCamel }}'] = value;
@@ -70,11 +71,13 @@ class ClientBrowser extends ClientBase with ClientMixin {
   }
 {% endfor %}
 
+  @Deprecated('Use Client.fromBrowser or another factory constructor instead.')
   @override
   ClientBrowser setSelfSigned({bool status = true}) {
     return this;
   }
 
+  @Deprecated('Use Client.fromBrowser or another factory constructor instead.')
   @override
   ClientBrowser setEndpoint(String endPoint) {
     if (!endPoint.startsWith('http://') && !endPoint.startsWith('https://')) {
@@ -89,6 +92,7 @@ class ClientBrowser extends ClientBase with ClientMixin {
     return this;
   }
 
+  @Deprecated('Use Client.fromBrowser or another factory constructor instead.')
   @override
   ClientBrowser setEndPointRealtime(String endPoint) {
     if (!endPoint.startsWith('ws://') && !endPoint.startsWith('wss://')) {

--- a/templates/flutter/lib/src/client_io.dart.twig
+++ b/templates/flutter/lib/src/client_io.dart.twig
@@ -88,6 +88,7 @@ class ClientIO extends ClientBase with ClientMixin {
 {% if header.description %}
   /// {{header.description}}
 {% endif %}
+  @Deprecated('Use Client.fromBrowser or another factory constructor instead.')
   @override
   ClientIO set{{header.key | caseUcfirst}}(value) {
     config['{{ header.key | caseCamel }}'] = value;
@@ -96,6 +97,7 @@ class ClientIO extends ClientBase with ClientMixin {
   }
 {% endfor %}
 
+  @Deprecated('Use Client.fromBrowser or another factory constructor instead.')
   @override
   ClientIO setSelfSigned({bool status = true}) {
     selfSigned = status;
@@ -104,6 +106,7 @@ class ClientIO extends ClientBase with ClientMixin {
     return this;
   }
 
+  @Deprecated('Use Client.fromBrowser or another factory constructor instead.')
   @override
   ClientIO setEndpoint(String endPoint) {
     if (!endPoint.startsWith('http://') && !endPoint.startsWith('https://')) {
@@ -118,6 +121,7 @@ class ClientIO extends ClientBase with ClientMixin {
     return this;
   }
 
+  @Deprecated('Use Client.fromBrowser or another factory constructor instead.')
   @override
   ClientIO setEndPointRealtime(String endPoint) {
     if (!endPoint.startsWith('ws://') && !endPoint.startsWith('wss://')) {

--- a/templates/flutter/lib/src/realtime.dart.twig
+++ b/templates/flutter/lib/src/realtime.dart.twig
@@ -8,7 +8,7 @@ import 'client.dart';
 /// Realtime allows you to listen to any events on the server-side in realtime using the subscribe method.
 abstract class Realtime extends Service {
   /// Initializes a [Realtime] service
-  factory Realtime(Client client) => createRealtime(client);
+  factory Realtime(ClientAuth client) => createRealtime(client);
 
   /// Subscribes to Appwrite events and returns a `RealtimeSubscription` object, which can be used 
   /// to listen to events on the channels in realtime and to close the subscription to stop listening.

--- a/templates/flutter/lib/src/realtime_browser.dart.twig
+++ b/templates/flutter/lib/src/realtime_browser.dart.twig
@@ -15,6 +15,14 @@ class RealtimeBrowser extends RealtimeBase with RealtimeMixin {
   Map<String, dynamic>? lastMessage;
 
   RealtimeBrowser(ClientAuth client) {
+    if (client is! ClientBrowser) {
+      throw ArgumentError.value(
+        client,
+        'client',
+        'RealtimeBrowser requires a ClientBrowser instance.',
+      );
+    }
+
     this.client = client;
     getWebSocket = _getWebSocket;
     getFallbackCookie = _getFallbackCookie;

--- a/templates/flutter/lib/src/realtime_browser.dart.twig
+++ b/templates/flutter/lib/src/realtime_browser.dart.twig
@@ -9,12 +9,12 @@ import 'client.dart';
 import 'client_browser.dart';
 import 'realtime_mixin.dart';
 
-RealtimeBase createRealtime(Client client) => RealtimeBrowser(client);
+RealtimeBase createRealtime(ClientAuth client) => RealtimeBrowser(client);
 
 class RealtimeBrowser extends RealtimeBase with RealtimeMixin {
   Map<String, dynamic>? lastMessage;
 
-  RealtimeBrowser(Client client) {
+  RealtimeBrowser(ClientAuth client) {
     this.client = client;
     getWebSocket = _getWebSocket;
     getFallbackCookie = _getFallbackCookie;

--- a/templates/flutter/lib/src/realtime_io.dart.twig
+++ b/templates/flutter/lib/src/realtime_io.dart.twig
@@ -17,6 +17,14 @@ RealtimeBase createRealtime(ClientAuth client) => RealtimeIO(client);
 class RealtimeIO extends RealtimeBase with RealtimeMixin {
 
   RealtimeIO(ClientAuth client) {
+    if (client is! ClientIO) {
+      throw ArgumentError.value(
+        client,
+        'client',
+        'RealtimeIO requires a ClientIO instance.',
+      );
+    }
+
     this.client = client;
     getWebSocket = _getWebSocket;
   }

--- a/templates/flutter/lib/src/realtime_io.dart.twig
+++ b/templates/flutter/lib/src/realtime_io.dart.twig
@@ -12,11 +12,11 @@ import 'realtime_mixin.dart';
 import 'client.dart';
 import 'client_io.dart';
 
-RealtimeBase createRealtime(Client client) => RealtimeIO(client);
+RealtimeBase createRealtime(ClientAuth client) => RealtimeIO(client);
 
 class RealtimeIO extends RealtimeBase with RealtimeMixin {
 
-  RealtimeIO(Client client) {
+  RealtimeIO(ClientAuth client) {
     this.client = client;
     getWebSocket = _getWebSocket;
   }

--- a/templates/flutter/lib/src/realtime_mixin.dart.twig
+++ b/templates/flutter/lib/src/realtime_mixin.dart.twig
@@ -27,7 +27,7 @@ String _uniqueSubscriptionId() {
 }
 
 mixin RealtimeMixin {
-  late Client client;
+  late ClientAuth client;
   final Map<String, RealtimeSubscription> _subscriptions = {};
   final Map<String, Map<String, dynamic>> _pendingSubscribes = {};
   WebSocketChannel? _websok;

--- a/templates/flutter/lib/src/realtime_stub.dart.twig
+++ b/templates/flutter/lib/src/realtime_stub.dart.twig
@@ -2,6 +2,6 @@ import 'realtime_base.dart';
 import 'client.dart';
 
 /// Implemented in `realtime_browser.dart` and `realtime_io.dart`.
-RealtimeBase createRealtime(Client client) => throw UnsupportedError(
+RealtimeBase createRealtime(ClientAuth client) => throw UnsupportedError(
   'Cannot create a client without dart:html or dart:io.',
 );

--- a/templates/flutter/lib/src/service.dart.twig
+++ b/templates/flutter/lib/src/service.dart.twig
@@ -1,5 +1,5 @@
 import 'client.dart';
 
 class Service {
-  const Service(ClientAuth client);
+  const Service(ClientAuth _);
 }

--- a/templates/flutter/lib/src/service.dart.twig
+++ b/templates/flutter/lib/src/service.dart.twig
@@ -1,0 +1,5 @@
+import 'client.dart';
+
+class Service {
+  const Service(ClientAuth client);
+}


### PR DESCRIPTION
## Summary

Adds the same client-side auth factory pattern to the generated Flutter SDK, scoped only to Flutter client output. The new factories provide a narrower public `ClientAuth` surface for factory-created clients while preserving the existing `Client()` constructor/setter style for compatibility.

The recommended Flutter setup is now:

```dart
import 'package:appwrite/appwrite.dart';

final client = Client.fromBrowser(
  endPoint: 'https://<REGION>.cloud.appwrite.io/v1',
  projectId: '<PROJECT_ID>',
);

final account = Account(client);
```

The old syntax is still supported:

```dart
final client = Client()
  ..setEndpoint('https://<REGION>.cloud.appwrite.io/v1')
  ..setProject('<PROJECT_ID>');
```

Those legacy setter methods are now marked `@Deprecated`. They remain available from `Client()`, but factory-created clients are inferred as `ClientAuth` and do not expose legacy setters.

## Auth Factories

All factories use named parameters. Common fields include `endPoint`, `projectId`, `endPointRealtime`, `locale`, and `selfSigned`.

Available Flutter client factories:

| Factory | Auth/runtime | Notes |
|---|---|---|
| `Client.fromBrowser(...)` | browser/mobile client | Normal Flutter client setup. Sets endpoint and project, and optionally realtime endpoint, locale, and self-signed behavior. |
| `Client.fromSession(...)` | session client | Sends `X-Appwrite-Session`; useful when a session secret is explicitly available. |
| `Client.fromDevKey(...)` | dev key client | Client-tier dev key usage. |
| `Client.fromImpersonation(...)` | impersonation client | Requires `session` and exactly one of `userId`, `userEmail`, or `userPhone`. |

This PR intentionally does not add server-side factories such as API key, JWT, or cookie factories to Flutter. It only updates the client-side Flutter SDK surface.

## Type Safety

Dart does not have the same conditional type machinery used by the Web SDK, so this PR uses nominal interfaces instead:

```dart
abstract class ClientAuth {
  Map<String, String> get config;
  String get endPoint;
  String? get endPointRealtime;

  Future<Response> call(...);
  Future<Response> chunkedUpload(...);
  Future webAuth(...);
  Future<String> ping();
}

abstract class Client implements ClientAuth {
  factory Client(...);

  static ClientAuth fromBrowser(...);
  static ClientAuth fromSession(...);
  static ClientAuth fromDevKey(...);
  static ClientAuth fromImpersonation(...);

  @Deprecated(...)
  Client setProject(String value);
}
```

That means:

- `Client()` keeps the full legacy `Client` type and can still call setters.
- `Client.fromBrowser(...)` and the other factories return `ClientAuth`, so setters are not visible on inferred factory clients.
- Generated services accept `ClientAuth`, so both legacy and factory-created clients keep the same service construction syntax.
- Generated services store their client as private `_client`, so public `.client` access is hidden.
- Realtime also accepts `ClientAuth`, so factory-created clients work with `Realtime(client)`.

Examples:

```dart
final oldClient = Client()
  ..setEndpoint(endPoint)
  ..setProject(projectId); // OK, deprecated

final browserClient = Client.fromBrowser(
  endPoint: endPoint,
  projectId: projectId,
);

Account(oldClient);      // OK
Account(browserClient);  // OK
Realtime(browserClient); // OK

browserClient.setProject('other'); // Analyzer error
Account(browserClient).client;     // Analyzer error
```

## Implementation Details

| File | Change |
|---|---|
| `templates/flutter/lib/src/client.dart.twig` | Adds `ClientAuth`, static client factories, deprecated legacy setters, and keeps `Client()` compatibility. |
| `templates/flutter/lib/src/client_base.dart.twig` | Marks generated setter overrides as deprecated while keeping chainable legacy behavior. |
| `templates/flutter/lib/src/client_browser.dart.twig` | Marks browser runtime setters as deprecated. |
| `templates/flutter/lib/src/client_io.dart.twig` | Marks IO runtime setters as deprecated. |
| `templates/flutter/lib/src/service.dart.twig` | Adds a Flutter-specific service base that accepts `ClientAuth` and does not expose a public `client` field. |
| `src/SDK/Language/Flutter.php` | Switches Flutter to the Flutter-specific service base template instead of the shared Dart service base. |
| `templates/flutter/lib/services/service.dart.twig` | Generates services with private `_client` and `ClientAuth` constructors while preserving `Service(client)` syntax. |
| `templates/flutter/base/requests/*.twig` | Updates generated service request code to use private `_client`. |
| `templates/flutter/lib/src/realtime*.twig` | Updates Realtime factory/base/mixin implementations to accept `ClientAuth`. |
| `templates/flutter/lib/package.dart.twig` | Imports `src/client.dart` into the library so service part files can reference `ClientAuth`. |

## Compatibility Notes

- `Client().setEndpoint(...).setProject(...)` still works.
- Legacy setters are deprecated to guide new code toward static factories.
- Legacy setters are intentionally not visible on `Client.fromBrowser(...)`, `Client.fromSession(...)`, `Client.fromDevKey(...)`, or `Client.fromImpersonation(...)` results.
- Generated service construction syntax stays unchanged: `Account(client)`, `TablesDB(client)`, `Realtime(client)`, etc.
- Generated services no longer expose a public `.client` property.
- This PR is Flutter-client-only. It does not modify the generated Dart server SDK behavior and does not introduce server auth factories for Flutter.

## Validation

Validation performed on this branch:

- `php example.php flutter client`
- `composer lint-twig`
- `php -l src/SDK/Language/Flutter.php`
- `git diff --check`
- `flutter analyze --no-fatal-warnings --no-fatal-infos` in `examples/flutter`
  - no analyzer errors from this change
  - existing warnings/infos remain in generated Flutter output
- Focused Dart analyzer smoke checks covering:
  - legacy setters remain valid from `Client()` and are reported as deprecated
  - factory-created clients can be passed to generated services
  - factory-created clients can be passed to `Realtime`
  - `Client.fromBrowser(...).setProject(...)` is rejected
  - `Account(Client.fromBrowser(...)).client` is rejected

Full `flutter test` was also run. It currently fails in two generated OAuth service fixture tests:

- `Account.createOAuth2Session()` expects `Session` but mocked `webAuth` returns `null`
- `Account.createOAuth2Token()` expects `Token` but mocked `webAuth` returns `null`

Those failures are unrelated to the client surface changes in this PR.
