### PR TITLE
Fix SDK validation action pinning

### DIFF
--- a/.github/workflows/sdk-build-validation.yml
+++ b/.github/workflows/sdk-build-validation.yml
@@ -107,9 +107,10 @@ jobs:
 
       - name: Setup Flutter
         if: matrix.sdk == 'flutter'
-        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
-        with:
-          channel: 'stable'
+        run: |
+          git clone --depth 1 --branch stable https://github.com/flutter/flutter.git "$RUNNER_TOOL_CACHE/flutter"
+          echo "$RUNNER_TOOL_CACHE/flutter/bin" >> "$GITHUB_PATH"
+          "$RUNNER_TOOL_CACHE/flutter/bin/flutter" --version
 
       - name: Setup Swift
         if: matrix.sdk == 'apple' || matrix.sdk == 'swift'
@@ -172,7 +173,7 @@ jobs:
 
       - name: Cache cargo-audit
         if: matrix.sdk == 'rust'
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: |
             ~/.cargo/bin/cargo-audit

--- a/.github/workflows/sdk-build-validation.yml
+++ b/.github/workflows/sdk-build-validation.yml
@@ -15,6 +15,7 @@ jobs:
       # LC_CODE_SIGNATURE blob on cross-compiled Darwin binaries (oven-sh/bun#29120).
       # Unpin once a Bun release includes the upstream fix (oven-sh/bun#29122).
       CLI_BUN_VERSION: '1.3.11'
+      FLUTTER_VERSION: '3.35.7'
       OSV_SCANNER_VERSION: 'v2.3.1'
     strategy:
       fail-fast: false
@@ -105,10 +106,19 @@ jobs:
         with:
           bun-version: ${{ env.CLI_BUN_VERSION }}
 
+      - name: Cache Flutter SDK
+        if: matrix.sdk == 'flutter'
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ${{ runner.tool_cache }}/flutter
+          key: ${{ runner.os }}-flutter-${{ env.FLUTTER_VERSION }}
+
       - name: Setup Flutter
         if: matrix.sdk == 'flutter'
         run: |
-          git clone --depth 1 --branch stable https://github.com/flutter/flutter.git "$RUNNER_TOOL_CACHE/flutter"
+          if [ ! -d "$RUNNER_TOOL_CACHE/flutter/bin" ]; then
+            git clone --depth 1 --branch "$FLUTTER_VERSION" https://github.com/flutter/flutter.git "$RUNNER_TOOL_CACHE/flutter"
+          fi
           echo "$RUNNER_TOOL_CACHE/flutter/bin" >> "$GITHUB_PATH"
           "$RUNNER_TOOL_CACHE/flutter/bin/flutter" --version
 


### PR DESCRIPTION
## Summary
- Replace the Flutter setup composite action because it references actions/cache@v5 internally, which violates the repository action pinning policy.
- Keep Rust cargo-audit caching, pinned to the stable actions/cache v4.2.4 commit SHA.

## Testing
- Verified on PR #1516 that validation jobs no longer fail immediately during action resolution after removing the nested unpinned cache action.