### PR TITLE
Code-sign CLI Windows binaries before release

### DIFF
--- a/templates/cli/.github/workflows/publish.yml
+++ b/templates/cli/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ on:
     types: [published]
 
 permissions:
+  actions: read
   id-token: write
   contents: write
 
@@ -18,6 +19,9 @@ jobs:
       # upstream fix (oven-sh/bun#29122).
       CLI_BUN_VERSION: '1.3.11'
       HOMEBREW_TAP_REPO: appwrite/homebrew-appwrite
+      WINDOWS_SIGNING_PROJECT_SLUG: ${{ vars.WINDOWS_SIGNING_PROJECT_SLUG || 'sdk-for-cli' }}
+      WINDOWS_SIGNING_POLICY_SLUG: ${{ vars.WINDOWS_SIGNING_POLICY_SLUG || 'release-signing' }}
+      WINDOWS_SIGNING_ARTIFACT_CONFIGURATION_SLUG: ${{ vars.WINDOWS_SIGNING_ARTIFACT_CONFIGURATION_SLUG || 'initial' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -29,7 +33,7 @@ jobs:
       - name: Setup binfmt with QEMU
         run: | 
           sudo apt update
-          sudo apt install qemu-system binfmt-support qemu-user-static
+          sudo apt install qemu-system binfmt-support qemu-user-static osslsigncode
           update-binfmts --display
 
       - name: Setup ldid
@@ -48,6 +52,65 @@ jobs:
           bun run mac-arm64
           bun run windows-x64
           bun run windows-arm64
+
+      - name: Upload unsigned Windows binaries
+        id: upload-windows-unsigned
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-unsigned
+          path: |
+            build/appwrite-cli-win-x64.exe
+            build/appwrite-cli-win-arm64.exe
+
+      - name: Submit Windows binaries for signing
+        uses: signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd # v2
+        with:
+          api-token: ${{ secrets.WINDOWS_SIGNING_API_TOKEN }}
+          organization-id: ${{ vars.WINDOWS_SIGNING_ORGANIZATION_ID }}
+          project-slug: ${{ env.WINDOWS_SIGNING_PROJECT_SLUG }}
+          signing-policy-slug: ${{ env.WINDOWS_SIGNING_POLICY_SLUG }}
+          artifact-configuration-slug: ${{ env.WINDOWS_SIGNING_ARTIFACT_CONFIGURATION_SLUG }}
+          github-artifact-id: ${{ steps.upload-windows-unsigned.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: build-signed
+          parameters: |
+            version: ${{ github.event.release.tag_name }}
+
+      - name: Replace unsigned Windows binaries
+        run: |
+          set -euo pipefail
+
+          signed_x64="$(find build-signed -type f -name 'appwrite-cli-win-x64.exe' -print -quit)"
+          signed_arm64="$(find build-signed -type f -name 'appwrite-cli-win-arm64.exe' -print -quit)"
+
+          if [ -z "$signed_x64" ] || [ -z "$signed_arm64" ]; then
+            echo "Signed Windows binaries were not found in build-signed"
+            find build-signed -type f -print
+            exit 1
+          fi
+
+          cp "$signed_x64" build/appwrite-cli-win-x64.exe
+          cp "$signed_arm64" build/appwrite-cli-win-arm64.exe
+
+      - name: Verify Windows signatures
+        run: |
+          set -euo pipefail
+
+          verify_signature() {
+            local file="$1"
+            local output
+
+            output="$(osslsigncode verify -in "$file" 2>&1)"
+            echo "$output"
+
+            if ! grep -Fq "Succeeded" <<< "$output"; then
+              echo "$file signature verification failed"
+              exit 1
+            fi
+          }
+
+          verify_signature build/appwrite-cli-win-x64.exe
+          verify_signature build/appwrite-cli-win-arm64.exe
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

- Add Windows code-signing to the CLI publish workflow before GitHub release asset upload.
- Upload unsigned Windows CLI binaries as a GitHub Actions artifact, submit them to the configured signing provider, and replace the release assets with the signed outputs.
- Pin the current signing provider action to an immutable commit SHA and verify the returned Windows binaries with osslsigncode before publishing.

## Configuration required

- `WINDOWS_SIGNING_API_TOKEN` repository secret
- `WINDOWS_SIGNING_ORGANIZATION_ID` repository variable
- `WINDOWS_SIGNING_POLICY_SLUG` repository variable, e.g. `test-signing`
- Optional repository variables: `WINDOWS_SIGNING_PROJECT_SLUG`, `WINDOWS_SIGNING_ARTIFACT_CONFIGURATION_SLUG`

## Tests

- `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php cli`
- `composer lint-twig`
- `ruby -e 'require "yaml"; YAML.load_file("templates/cli/.github/workflows/publish.yml"); puts "YAML ok"'
