### PR TITLE
Update CLI console dependency to 12.2.0

### DIFF
--- a/templates/cli/bun.lock.twig
+++ b/templates/cli/bun.lock.twig
@@ -5,7 +5,7 @@
     "": {
       "name": "{{ language.params.npmPackage|caseDash }}",
       "dependencies": {
-        "@appwrite.io/console": "12.1.0",
+        "@appwrite.io/console": "12.2.0",
         "chalk": "4.1.2",
         "chokidar": "^3.6.0",
         "cli-progress": "^3.12.0",
@@ -51,7 +51,7 @@
     "tmp": "0.2.5",
   },
   "packages": {
-    "@appwrite.io/console": ["@appwrite.io/console@12.1.0", "", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-pfI4UYCxEo8sGfub6UDDsQZxBu3b38x4d+SIQsZifRvKqCW+F7WRStxSQie6phw5dQaw/5SyEMEGhzURtj2MfQ=="],
+    "@appwrite.io/console": ["@appwrite.io/console@12.2.0", "", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-kv5CS/pWlSkLzG1mPctUr5fMdisZRrkOYStIvAaNPHv+bl/wFCZMMoRoiPGlBpw2NKwTddGFkkQvHq8GbxehNA=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 

--- a/templates/cli/package-lock.json.twig
+++ b/templates/cli/package-lock.json.twig
@@ -9,7 +9,7 @@
       "version": "{{ sdk.version }}",
       "license": "{{ sdk.license }}",
       "dependencies": {
-        "@appwrite.io/console": "12.1.0",
+        "@appwrite.io/console": "12.2.0",
         "chalk": "4.1.2",
         "chokidar": "^3.6.0",
         "cli-progress": "^3.12.0",
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@appwrite.io/console": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@appwrite.io/console/-/console-12.1.0.tgz",
-      "integrity": "sha512-pfI4UYCxEo8sGfub6UDDsQZxBu3b38x4d+SIQsZifRvKqCW+F7WRStxSQie6phw5dQaw/5SyEMEGhzURtj2MfQ==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@appwrite.io/console/-/console-12.2.0.tgz",
+      "integrity": "sha512-kv5CS/pWlSkLzG1mPctUr5fMdisZRrkOYStIvAaNPHv+bl/wFCZMMoRoiPGlBpw2NKwTddGFkkQvHq8GbxehNA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "json-bigint": "1.0.0"

--- a/templates/cli/package.json
+++ b/templates/cli/package.json
@@ -48,7 +48,7 @@
     "windows-arm64": "esbuild cli.ts --bundle --loader:.hbs=text --platform=node --target=node18 --format=esm --external:fsevents --external:terminal-image --outfile=dist/bundle-win-arm64.mjs && pkg dist/bundle-win-arm64.mjs --fallback-to-source -t node18-win-arm64 -o build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
-    "@appwrite.io/console": "12.1.0",
+    "@appwrite.io/console": "12.2.0",
     "chalk": "4.1.2",
     "chokidar": "^3.6.0",
     "cli-progress": "^3.12.0",

--- a/templates/cli/package.json.twig
+++ b/templates/cli/package.json.twig
@@ -51,7 +51,7 @@
     "windows-arm64": "esbuild cli.ts --bundle --loader:.hbs=text --platform=node --target=node18 --format=esm --external:fsevents --external:terminal-image --outfile=dist/bundle-win-arm64.mjs && pkg dist/bundle-win-arm64.mjs --fallback-to-source -t node18-win-arm64 -o build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
-    "@appwrite.io/console": "12.1.0",
+    "@appwrite.io/console": "12.2.0",
     "chalk": "4.1.2",
     "chokidar": "^3.6.0",
     "cli-progress": "^3.12.0",


### PR DESCRIPTION
## What

Bumps `@appwrite.io/console` from `12.1.0` to `12.2.0` (latest stable on npm) in the CLI SDK template.

## Why

The CLI SDK release for the upcoming Appwrite Cloud 1.9.x specs relies on the renamed email-policy and proxy-rule endpoints (and other deny-email-policy / `provider-id` / `update-rule-status` surfaces). Those live in `@appwrite.io/console@12.2.0`. Pinning the template ensures the generated `sdk-for-cli` consumes the matching console client.

## Files changed

* `templates/cli/package.json` — dependency pin
* `templates/cli/package.json.twig` — rendered dependency pin
* `templates/cli/bun.lock.twig` — version + sha512 integrity
* `templates/cli/package-lock.json.twig` — version + resolved URL + integrity

## Test plan

- [ ] Existing CI/template render passes
- [ ] After release, regenerate `sdk-for-cli` and confirm `package.json`, `bun.lock`, `package-lock.json` all resolve to `@appwrite.io/console@12.2.0`