### PR TITLE
fix(cli): quote release tag passed to SignPath

### DIFF
--- a/templates/cli/.github/workflows/publish.yml
+++ b/templates/cli/.github/workflows/publish.yml
@@ -74,7 +74,7 @@ jobs:
           wait-for-completion: true
           output-artifact-directory: build-signed
           parameters: |
-            version: ${{ github.event.release.tag_name }}
+            version: "${{ github.event.release.tag_name }}"
 
       - name: Replace unsigned Windows binaries
         run: |


### PR DESCRIPTION
## Problem

The Windows-signing step on `sdk-for-cli`'s `20.2.0-rc.1` release failed with:

```
Run signpath/github-action-submit-signing-request@b9d91eadd323de506c0c81cf0c7fe7438f3360fd
Submitting the signing request to SignPath GitHub Actions connector...
Error: Invalid parameter value: 20.2.0-rc.1 - SyntaxError: Unexpected non-whitespace character after JSON at position 4 (line 1 column 5). Only valid JSON strings are allowed.
```

SignPath's GitHub Action parses each parameter VALUE as JSON. `20.2.0-rc.1` is not a valid JSON literal (numbers can't have multiple dots; strings must be quoted), so the action errors at position 4 (the second `.` after `20.2`).

Stable tags like `20.1.0` happened to almost parse as JSON numbers, which is why this bug only surfaced once we cut a pre-release tag with a dotted/dashed suffix.

## Fix

Wrap the release tag in double quotes inside `parameters:` so SignPath sees `version: "20.2.0-rc.1"` — a valid JSON string.

```yaml
parameters: |
-  version: ${{ github.event.release.tag_name }}
+  version: "${{ github.event.release.tag_name }}"
```

## Companion PR

A direct hotfix has been applied to `sdk-for-cli` so the existing `20.2.0-rc.1` release can be re-run: appwrite/sdk-for-cli#313.

## Test plan

- [ ] Regenerate `sdk-for-cli` after this merges and confirm the produced `.github/workflows/publish.yml` has the quoted version.
- [ ] Cut another pre-release tag (e.g., `20.2.0-rc.2`) and verify SignPath accepts the parameter.