### PR TITLE
fix(cli): surface osslsigncode output when verify fails

### DIFF
--- a/templates/cli/.github/workflows/publish.yml
+++ b/templates/cli/.github/workflows/publish.yml
@@ -94,23 +94,26 @@ jobs:
 
       - name: Verify Windows signatures
         run: |
-          set -euo pipefail
+          set -uo pipefail
 
           verify_signature() {
             local file="$1"
-            local output
-
+            local output rc
             output="$(osslsigncode verify -in "$file" 2>&1)"
+            rc=$?
+            echo "--- $file (osslsigncode exit $rc) ---"
             echo "$output"
 
-            if ! grep -Fq "Succeeded" <<< "$output"; then
-              echo "$file signature verification failed"
-              exit 1
+            if [ "$rc" -ne 0 ] || ! grep -Fq "Succeeded" <<< "$output"; then
+              echo "::error::$file signature verification failed"
+              return 1
             fi
           }
 
-          verify_signature build/appwrite-cli-win-x64.exe
-          verify_signature build/appwrite-cli-win-arm64.exe
+          final=0
+          verify_signature build/appwrite-cli-win-x64.exe || final=1
+          verify_signature build/appwrite-cli-win-arm64.exe || final=1
+          exit "$final"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Problem

On the latest \`sdk-for-cli\` \`20.2.0-rc.1\` rerun, SignPath returned _\"The signing request was successfully processed\"_ — so the binaries _are_ signed — but the next step \`Verify Windows signatures\` fails with no diagnostic. Step log goes from \`set -uo pipefail\` setup to \`Process completed with exit code 1\` in ~0.3s, which is too short for osslsigncode to have run on two ~30MB binaries.

## Root cause

The current verify script uses \`set -euo pipefail\` and assigns \`osslsigncode\` output to a variable in a single line:

\`\`\`bash
output=\"\$(osslsigncode verify -in \"\$file\" 2>&1)\"
echo \"\$output\"
\`\`\`

Under \`set -e\`, when osslsigncode exits non-zero (e.g. CA chain not trusted by the GitHub runner — likely the case while on a test signing policy), the assignment line itself fails, the function aborts, and \`echo \"\$output\"\` never runs. The captured diagnostic is lost.

## Fix

- Drop \`set -e\` for this block (errors are handled explicitly).
- Capture osslsigncode's exit code separately and echo the output before deciding pass/fail.
- Aggregate per-file results so both binaries are reported.
- Emit \`::error::\` annotations for Actions UI visibility.

## Companion PR

A direct hotfix has been opened against \`appwrite/sdk-for-cli\` so the existing \`20.2.0-rc.1\` release can be reverified after merge: appwrite/sdk-for-cli#314.

## Test plan

- [ ] Once merged, the next CLI regeneration carries the diagnostic verify step.
- [ ] On any subsequent SignPath-policy iteration we can see the real osslsigncode reason for failure instead of a bare exit 1.