### PR TITLE
Fix CLI init project config resolution

### DIFF
--- a/templates/cli/lib/commands/init.ts
+++ b/templates/cli/lib/commands/init.ts
@@ -277,6 +277,13 @@ const initProject = async ({
   projectName,
 }: InitProjectOptions = {}): Promise<void> => {
   try {
+    localConfig.useCwdConfig();
+  } catch (e) {
+    error(e instanceof Error ? e.message : String(e));
+    process.exit(1);
+  }
+
+  try {
     if (globalConfig.getEndpoint() === "" || globalConfig.getCookie() === "") {
       throw new Error(
         `Missing endpoint or cookie configuration. Please run '${EXECUTABLE_NAME} login' first.`,

--- a/templates/cli/lib/config.ts
+++ b/templates/cli/lib/config.ts
@@ -509,6 +509,10 @@ class Config<T extends ConfigData = ConfigData> {
     }
   }
 
+  protected usePath(path: string): void {
+    (this as { path: string }).path = path;
+  }
+
   read(): void {
     try {
       const file = fs.readFileSync(this.path).toString();
@@ -642,6 +646,23 @@ class Local extends Config<ConfigType> {
     this.read();
   }
 
+  useCwdConfig(
+    path: string = Local.CONFIG_FILE_PATH,
+    legacyPath: string = Local.CONFIG_FILE_PATH_LEGACY,
+  ): void {
+    const absolutePath =
+      Local.findConfigFileInCwd(path) ||
+      Local.findConfigFileInCwd(legacyPath) ||
+      _path.join(process.cwd(), path);
+
+    this.usePath(absolutePath);
+    this.configDirectoryPath = _path.dirname(absolutePath);
+    this.rootData = {};
+    this.includePaths = {};
+    this.includePathHints = {};
+    this.read();
+  }
+
   read(): void {
     if (!fs.existsSync(this.path)) {
       this.rootData = {};
@@ -700,9 +721,14 @@ class Local extends Config<ConfigType> {
 
   static findConfigFile(filename: string): string | null {
     let currentPath = process.cwd();
+    const homeDir = os.homedir();
 
     while (true) {
-      const filePath = `${currentPath}/${filename}`;
+      if (currentPath === homeDir && process.cwd() !== homeDir) {
+        break;
+      }
+
+      const filePath = _path.join(currentPath, filename);
 
       if (fs.existsSync(filePath)) {
         return filePath;
@@ -716,6 +742,12 @@ class Local extends Config<ConfigType> {
     }
 
     return null;
+  }
+
+  static findConfigFileInCwd(filename: string): string | null {
+    const filePath = _path.join(process.cwd(), filename);
+
+    return fs.existsSync(filePath) ? filePath : null;
   }
 
   getDirname(): string {


### PR DESCRIPTION
## What

Fixes CLI local config resolution so `appwrite init project` links the current directory instead of reusing and overwriting an ancestor config.

## Why

`init project` is a creation/linking command for the directory where it is run. It should not treat an ancestor `appwrite.config.json` as the current directory's link target. At the same time, existing operational commands should keep working from project subdirectories.

## How

- Adds `Local.useCwdConfig()` to retarget the shared `localConfig` singleton to only `./appwrite.config.json` or local legacy `./appwrite.json`.
- Calls `useCwdConfig()` at the start of `initProject()` before prompts inspect existing project state.
- Keeps ancestor lookup for other commands, but stops traversal before `$HOME` unless the command is run directly in `$HOME`, preventing stale home-dir configs from hijacking unrelated projects.

## Testing

- `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php cli`
- `composer lint-twig`
- `git diff --check`
- `npm ci && npm run build:types` in `examples/cli`
