### PR TITLE
[codex] Add CLI --filter query flag

### DIFF
--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -246,7 +246,7 @@ class CLI extends Node
             $builderParams[] = 'queries';
 
             if ($hasFilteringQueries) {
-                array_push($builderParams, 'where', 'sortAsc', 'sortDesc', 'cursorAfter', 'cursorBefore');
+                array_push($builderParams, 'filter', 'where', 'sortAsc', 'sortDesc', 'cursorAfter', 'cursorBefore');
             }
 
             if ($hasPaginationQueries) {
@@ -263,9 +263,9 @@ class CLI extends Node
         } elseif ($hasSelectionOnlyQueries) {
             $rawDescriptionPrefix = 'Raw Appwrite JSON query strings (legacy). Use this for advanced queries or automation; for selecting returned attributes prefer --select. When mixed, raw --queries are sent before generated flag queries.';
         } elseif ($hasSelectQueries) {
-            $rawDescriptionPrefix = 'Raw Appwrite JSON query strings (legacy). Use this for advanced queries or automation; for common filtering, sorting, pagination, and selection prefer --where, --sort-asc, --sort-desc, --limit, --offset, and --select. When mixed, raw --queries are sent before generated flag queries.';
+            $rawDescriptionPrefix = 'Raw Appwrite JSON query strings (legacy). Use this for advanced queries or automation; for common filtering, sorting, pagination, and selection prefer --filter, --sort-asc, --sort-desc, --limit, --offset, and --select. When mixed, raw --queries are sent before generated flag queries.';
         } else {
-            $rawDescriptionPrefix = 'Raw Appwrite JSON query strings (legacy). Use this for advanced queries or automation; for common filtering, sorting, and pagination prefer --where, --sort-asc, --sort-desc, --limit, and --offset. When mixed, raw --queries are sent before generated flag queries.';
+            $rawDescriptionPrefix = 'Raw Appwrite JSON query strings (legacy). Use this for advanced queries or automation; for common filtering, sorting, and pagination prefer --filter, --sort-asc, --sort-desc, --limit, and --offset. When mixed, raw --queries are sent before generated flag queries.';
         }
 
         return [

--- a/templates/cli/lib/commands/services/services.ts.twig
+++ b/templates/cli/lib/commands/services/services.ts.twig
@@ -30,7 +30,8 @@ import { resolveFileParam } from "../utils/deployment.js";
 import {
   buildQueries,
   collectQueryValue,
-  parseWhereQuery,
+  parseDeprecatedWhereQuery,
+  parseFilterQuery,
 } from "../utils/query.js";
 {% endif %}
 {% if service.isConsoleOnly %}
@@ -116,7 +117,8 @@ const {{ commandVar }} = {{ service.name | caseCamel }}
 {% endfor %}
 {% if query.hasQueries %}
 {% if query.hasFiltering %}
-  .option(`--where <expression>`, `Filter using a simple comparison expression. Repeat for multiple filters. Supports field=value, field!=value, field>value, field>=value, field<value, and field<=value.`, (value: string, previous: string[] | undefined) => collectQueryValue(parseWhereQuery(value), previous))
+  .option(`--filter <expression>`, `Filter using a simple comparison expression. Repeat for multiple filters. Supports field=value, field!=value, field>value, field>=value, field<value, and field<=value.`, (value: string, previous: string[] | undefined) => collectQueryValue(parseFilterQuery(value), previous))
+  .option(`--where <expression>`, `Deprecated. Use --filter instead. Filter using a simple comparison expression. Repeat for multiple filters.`, (value: string, previous: string[] | undefined) => collectQueryValue(parseDeprecatedWhereQuery(value), previous))
   .option(`--sort-asc <attribute>`, `Sort results by an attribute in ascending order. Repeat for multiple sort fields.`, (value: string, previous: string[] | undefined) => collectQueryValue(value, previous))
   .option(`--sort-desc <attribute>`, `Sort results by an attribute in descending order. Repeat for multiple sort fields.`, (value: string, previous: string[] | undefined) => collectQueryValue(value, previous))
 {% endif %}

--- a/templates/cli/lib/commands/utils/query.ts
+++ b/templates/cli/lib/commands/utils/query.ts
@@ -12,6 +12,7 @@ export type CliQueryOptions = {
   sortAsc?: string[];
   sortDesc?: string[];
   select?: string[];
+  filter?: string[];
   where?: string[];
 };
 
@@ -106,7 +107,7 @@ const parseQueryValue = (value: string): QueryValues => {
   return normalized;
 };
 
-const whereOperators: Array<[RegExp, string]> = [
+const filterOperators: Array<[RegExp, string]> = [
   [/^(.+?)\s*!=\s*(.*)$/, "notEqual"],
   [/^(.+?)\s*>=\s*(.*)$/, "greaterThanEqual"],
   [/^(.+?)\s*<=\s*(.*)$/, "lessThanEqual"],
@@ -120,8 +121,10 @@ export const collectQueryValue = <T>(value: T, previous: T[] = []): T[] => [
   value,
 ];
 
-export const parseWhereQuery = (expression: string): string => {
-  for (const [pattern, method] of whereOperators) {
+let hasWarnedDeprecatedWhere = false;
+
+export const parseFilterQuery = (expression: string): string => {
+  for (const [pattern, method] of filterOperators) {
     const match = expression.match(pattern);
 
     if (!match) {
@@ -131,7 +134,7 @@ export const parseWhereQuery = (expression: string): string => {
     const attribute = match[1].trim();
     if (attribute === "") {
       throw new InvalidArgumentError(
-        "Where filters must include an attribute before the operator.",
+        "Filters must include an attribute before the operator.",
       );
     }
 
@@ -139,8 +142,19 @@ export const parseWhereQuery = (expression: string): string => {
   }
 
   throw new InvalidArgumentError(
-    "Where filters must use one of: field=value, field!=value, field>value, field>=value, field<value, field<=value.",
+    "Filters must use one of: field=value, field!=value, field>value, field>=value, field<value, field<=value.",
   );
+};
+
+export const parseWhereQuery = parseFilterQuery;
+
+export const parseDeprecatedWhereQuery = (expression: string): string => {
+  if (!hasWarnedDeprecatedWhere) {
+    console.warn("Warning: --where is deprecated. Use --filter instead.");
+    hasWarnedDeprecatedWhere = true;
+  }
+
+  return parseFilterQuery(expression);
 };
 
 export const buildQueries = ({
@@ -152,12 +166,19 @@ export const buildQueries = ({
   sortAsc,
   sortDesc,
   select,
+  filter,
   where,
 }: CliQueryOptions): string[] | undefined => {
   const builtQueries = [...(queries ?? [])];
 
+  if (filter) {
+    // parseFilterQuery returns fully serialized Appwrite query JSON strings.
+    builtQueries.push(...filter);
+  }
+
   if (where) {
-    // parseWhereQuery returns fully serialized Appwrite query JSON strings.
+    // Deprecated --where values are appended after --filter values so the
+    // preferred flag takes precedence when both aliases are mixed.
     builtQueries.push(...where);
   }
 

--- a/templates/cli/lib/parser.ts
+++ b/templates/cli/lib/parser.ts
@@ -659,7 +659,7 @@ const printQueryErrorHint = (err: Error): void => {
   }
 
   hint(
-    `For common list filters, use flags like --limit 25, --sort-desc '$createdAt', or --where 'status=active'. Raw --queries values must be Appwrite JSON query strings, for example: ${EXECUTABLE_NAME} tables-db list-rows --queries '{"method":"limit","values":[25]}'`,
+    `For common list filters, use flags like --limit 25, --sort-desc '$createdAt', or --filter 'status=active'. Raw --queries values must be Appwrite JSON query strings, for example: ${EXECUTABLE_NAME} tables-db list-rows --queries '{"method":"limit","values":[25]}'`,
   );
 };
 

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -246,6 +246,7 @@ abstract class Base extends TestCase
         '"{\"method\":\"orderDesc\",\"attribute\":\"rawName\"}",' .
         '"{\"method\":\"equal\",\"attribute\":\"published\",\"values\":[true]}",' .
         '"{\"method\":\"greaterThanEqual\",\"attribute\":\"score\",\"values\":[10]}",' .
+        '"{\"method\":\"equal\",\"attribute\":\"legacy\",\"values\":[true]}",' .
         '"{\"method\":\"equal\",\"attribute\":\"status\",\"values\":[\"draft\",\"published\"]}",' .
         '"{\"method\":\"orderAsc\",\"attribute\":\"title\"}",' .
         '"{\"method\":\"orderDesc\",\"attribute\":\"$createdAt\"}",' .

--- a/tests/languages/cli/test.js
+++ b/tests/languages/cli/test.js
@@ -494,10 +494,12 @@ output = execFileSync(
     "list-rows",
     "--queries",
     '{"method":"orderDesc","attribute":"rawName"}',
-    "--where",
+    "--filter",
     "published=true",
-    "--where",
+    "--filter",
     "score>=10",
+    "--where",
+    "legacy=true",
     "--where",
     'status=["draft","published"]',
     "--sort-asc",
@@ -524,10 +526,10 @@ console.log(extractFirstValue(output));
 try {
   execFileSync(
     "bun",
-    ["./dist/cli.cjs", "general", "list-rows", "--where", "count>1e999"],
+    ["./dist/cli.cjs", "general", "list-rows", "--filter", "count>1e999"],
     { stdio: "pipe" },
   );
-  throw new Error("Expected non-finite numeric where values to be rejected.");
+  throw new Error("Expected non-finite numeric filter values to be rejected.");
 } catch (error) {
   if (!String(error.stderr ?? error.message).includes("finite numbers")) {
     throw error;
@@ -537,12 +539,29 @@ try {
 try {
   execFileSync(
     "bun",
-    ["./dist/cli.cjs", "general", "list-rows", "--where", "count=[1e999]"],
+    ["./dist/cli.cjs", "general", "list-rows", "--filter", "count=[1e999]"],
     { stdio: "pipe" },
   );
-  throw new Error("Expected non-finite array where values to be rejected.");
+  throw new Error("Expected non-finite array filter values to be rejected.");
 } catch (error) {
   if (!String(error.stderr ?? error.message).includes("finite numbers")) {
+    throw error;
+  }
+}
+
+try {
+  execFileSync(
+    "bun",
+    ["./dist/cli.cjs", "general", "list-rows", "--where", "count>1e999"],
+    { stdio: "pipe" },
+  );
+  throw new Error("Expected deprecated where values to be rejected.");
+} catch (error) {
+  const stderr = String(error.stderr ?? error.message);
+  if (
+    !stderr.includes("--where is deprecated") ||
+    !stderr.includes("finite numbers")
+  ) {
     throw error;
   }
 }


### PR DESCRIPTION
## What changed

Adds `--filter` as the preferred simple query-builder flag for CLI list/query methods while keeping `--where` available as a deprecated alias.

- Generated CLI commands now emit `--filter <expression>` before `--where <expression>`.
- `--queries` help text and query-error hints now recommend `--filter`.
- Shared query parsing was renamed around filter terminology while preserving `parseWhereQuery` as an exported alias.
- CLI regression coverage now exercises both new `--filter` and legacy `--where` flags in the same request.

## Validation

- `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php cli`
- `composer lint-twig`
- `vendor/bin/phpunit tests/CLIBun13Test.php`
- `docker run --rm -v $(pwd):/app -w /app/tests/sdks/cli oven/bun:1.3 ./dist/cli.cjs general list-rows --help | rg -- '--filter|--where|--queries'`

Note: the existing test harness logs an ignored `bun run build:types` failure. Running it directly shows pre-existing `sites` type errors in `lib/commands/init.ts`, `pull.ts`, and `push.ts`; the focused PHPUnit CLI test still passes.