### PR TITLE
Pin workflow actions and npm release age

### DIFF
--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -299,6 +299,11 @@ class CLI extends Node
             ],
             [
                 'scope'         => 'copy',
+                'destination'   => '.npmrc',
+                'template'      => 'cli/.npmrc',
+            ],
+            [
+                'scope'         => 'copy',
                 'destination'   => 'bun-types.d.ts',
                 'template'      => 'cli/bun-types.d.ts',
             ],

--- a/src/SDK/Language/Markdown.php
+++ b/src/SDK/Language/Markdown.php
@@ -66,6 +66,11 @@ class Markdown extends JS
                 'template'    => 'markdown/package.json.twig',
             ],
             [
+                'scope'       => 'copy',
+                'destination' => '.npmrc',
+                'template'    => 'markdown/.npmrc',
+            ],
+            [
                 'scope'       => 'default',
                 'destination' => 'README.md',
                 'template'    => 'markdown/README.md.twig',

--- a/src/SDK/Language/Node.php
+++ b/src/SDK/Language/Node.php
@@ -303,6 +303,11 @@ class Node extends Web
                 'template'      => 'node/.gitignore',
             ],
             [
+                'scope'         => 'copy',
+                'destination'   => '.npmrc',
+                'template'      => 'node/.npmrc',
+            ],
+            [
                 'scope'         => 'default',
                 'destination'   => 'package-lock.json',
                 'template'      => 'node/package-lock.json.twig',

--- a/src/SDK/Language/ReactNative.php
+++ b/src/SDK/Language/ReactNative.php
@@ -141,6 +141,11 @@ class ReactNative extends Web
                 'template'      => 'react-native/.gitignore',
             ],
             [
+                'scope'         => 'copy',
+                'destination'   => '.npmrc',
+                'template'      => 'react-native/.npmrc',
+            ],
+            [
                 'scope'         => 'default',
                 'destination'   => 'package-lock.json',
                 'template'      => 'react-native/package-lock.json.twig',

--- a/src/SDK/Language/Web.php
+++ b/src/SDK/Language/Web.php
@@ -156,6 +156,11 @@ class Web extends JS
                 'template'      => 'web/.gitignore',
             ],
             [
+                'scope'         => 'copy',
+                'destination'   => '.npmrc',
+                'template'      => 'web/.npmrc',
+            ],
+            [
                 'scope'         => 'default',
                 'destination'   => 'package-lock.json',
                 'template'      => 'web/package-lock.json.twig',

--- a/templates/android/.github/workflows/autoclose.yml
+++ b/templates/android/.github/workflows/autoclose.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   auto_close:
     if: github.head_ref != 'dev'
-    uses: appwrite/.github/.github/workflows/autoclose.yml@main
+    uses: appwrite/.github/.github/workflows/autoclose.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main
     secrets:
       GH_AUTO_CLOSE_PR_TOKEN: ${{ secrets.GH_AUTO_CLOSE_PR_TOKEN }}

--- a/templates/android/.github/workflows/publish.yml
+++ b/templates/android/.github/workflows/publish.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: 17

--- a/templates/android/.github/workflows/stale.yml
+++ b/templates/android/.github/workflows/stale.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   stale:
-    uses: appwrite/.github/.github/workflows/stale.yml@main 
+    uses: appwrite/.github/.github/workflows/stale.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main

--- a/templates/apple/.github/workflows/autoclose.yml
+++ b/templates/apple/.github/workflows/autoclose.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   auto_close:
     if: github.head_ref != 'dev'
-    uses: appwrite/.github/.github/workflows/autoclose.yml@main
+    uses: appwrite/.github/.github/workflows/autoclose.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main
     secrets:
       GH_AUTO_CLOSE_PR_TOKEN: ${{ secrets.GH_AUTO_CLOSE_PR_TOKEN }}

--- a/templates/apple/.github/workflows/stale.yml
+++ b/templates/apple/.github/workflows/stale.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   stale:
-    uses: appwrite/.github/.github/workflows/stale.yml@main 
+    uses: appwrite/.github/.github/workflows/stale.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main

--- a/templates/cli/.github/workflows/ci.yml
+++ b/templates/cli/.github/workflows/ci.yml
@@ -25,15 +25,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: ${{ env.CLI_BUN_VERSION }}
 

--- a/templates/cli/.github/workflows/publish.yml
+++ b/templates/cli/.github/workflows/publish.yml
@@ -23,10 +23,10 @@ jobs:
       WINDOWS_SIGNING_POLICY_SLUG: ${{ vars.WINDOWS_SIGNING_POLICY_SLUG || 'release-signing' }}
       WINDOWS_SIGNING_ARTIFACT_CONFIGURATION_SLUG: ${{ vars.WINDOWS_SIGNING_ARTIFACT_CONFIGURATION_SLUG || 'initial' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.GH_TOKEN }}
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: ${{ env.CLI_BUN_VERSION }}
 
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload unsigned Windows binaries
         id: upload-windows-unsigned
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           name: windows-unsigned
           path: |
@@ -116,7 +116,7 @@ jobs:
           exit "$final"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24.14.1'
           registry-url: 'https://registry.npmjs.org'
@@ -136,14 +136,14 @@ jobs:
       - name: Publish
         run: npm publish --provenance --access public --tag ${{ steps.release_tag.outputs.tag }}
 
-      - uses: fnkr/github-action-ghr@v1
+      - uses: fnkr/github-action-ghr@2fcb5ab637a49c14f4b3e7d81d0389d059171d35 # v1
         env:
           GHR_PATH: build/
           GHR_REPLACE: false
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Check out Homebrew tap
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ env.HOMEBREW_TAP_REPO }}
           token: ${{ secrets.HOMEBREW_TAP_GH_TOKEN }}

--- a/templates/cli/.npmrc
+++ b/templates/cli/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/templates/cli/bunfig.toml
+++ b/templates/cli/bunfig.toml
@@ -1,2 +1,5 @@
 [loader]
 ".hbs" = "text"
+
+[install]
+minimumReleaseAge = 604800 # 7d

--- a/templates/dart/.github/workflows/autoclose.yml
+++ b/templates/dart/.github/workflows/autoclose.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   auto_close:
     if: github.head_ref != 'dev'
-    uses: appwrite/.github/.github/workflows/autoclose.yml@main
+    uses: appwrite/.github/.github/workflows/autoclose.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main
     secrets:
       GH_AUTO_CLOSE_PR_TOKEN: ${{ secrets.GH_AUTO_CLOSE_PR_TOKEN }}

--- a/templates/dart/.github/workflows/format.yml.twig
+++ b/templates/dart/.github/workflows/format.yml.twig
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
           ref: ${{ '{{'}} github.event.pull_request.head.ref {{ '}}' }}
@@ -30,7 +30,7 @@ jobs:
         run: git config --global --add safe.directory /__w/sdk-for-dart/sdk-for-dart # required to fix dubious ownership
 
       - name: Add & Commit
-        uses: EndBug/add-and-commit@v9.1.4
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         with:
             add: '["lib", "test"]'
     

--- a/templates/dart/.github/workflows/publish.yml.twig
+++ b/templates/dart/.github/workflows/publish.yml.twig
@@ -11,8 +11,8 @@ jobs:
       id-token: write # Required for authentication using OIDC
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dart-lang/setup-dart@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
       - name: Install dependencies
         run: dart pub get
       - name: Publish

--- a/templates/dart/.github/workflows/stale.yml
+++ b/templates/dart/.github/workflows/stale.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   stale:
-    uses: appwrite/.github/.github/workflows/stale.yml@main 
+    uses: appwrite/.github/.github/workflows/stale.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main

--- a/templates/dart/.github/workflows/test.yml
+++ b/templates/dart/.github/workflows/test.yml
@@ -6,8 +6,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dart-lang/setup-dart@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
       - name: Install dependencies
         run: dart pub get
       - name: Analyze

--- a/templates/deno/.github/workflows/autoclose.yml
+++ b/templates/deno/.github/workflows/autoclose.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   auto_close:
     if: github.head_ref != 'dev'
-    uses: appwrite/.github/.github/workflows/autoclose.yml@main
+    uses: appwrite/.github/.github/workflows/autoclose.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main
     secrets:
       GH_AUTO_CLOSE_PR_TOKEN: ${{ secrets.GH_AUTO_CLOSE_PR_TOKEN }}

--- a/templates/deno/.github/workflows/stale.yml
+++ b/templates/deno/.github/workflows/stale.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   stale:
-    uses: appwrite/.github/.github/workflows/stale.yml@main 
+    uses: appwrite/.github/.github/workflows/stale.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main

--- a/templates/dotnet/.github/workflows/autoclose.yml
+++ b/templates/dotnet/.github/workflows/autoclose.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   auto_close:
     if: github.head_ref != 'dev'
-    uses: appwrite/.github/.github/workflows/autoclose.yml@main
+    uses: appwrite/.github/.github/workflows/autoclose.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main
     secrets:
       GH_AUTO_CLOSE_PR_TOKEN: ${{ secrets.GH_AUTO_CLOSE_PR_TOKEN }}

--- a/templates/dotnet/.github/workflows/publish.yml.twig
+++ b/templates/dotnet/.github/workflows/publish.yml.twig
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: '6'
 

--- a/templates/dotnet/.github/workflows/stale.yml
+++ b/templates/dotnet/.github/workflows/stale.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   stale:
-    uses: appwrite/.github/.github/workflows/stale.yml@main 
+    uses: appwrite/.github/.github/workflows/stale.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main

--- a/templates/flutter/.github/workflows/autoclose.yml
+++ b/templates/flutter/.github/workflows/autoclose.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   auto_close:
     if: github.head_ref != 'dev'
-    uses: appwrite/.github/.github/workflows/autoclose.yml@main
+    uses: appwrite/.github/.github/workflows/autoclose.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main
     secrets:
       GH_AUTO_CLOSE_PR_TOKEN: ${{ secrets.GH_AUTO_CLOSE_PR_TOKEN }}

--- a/templates/flutter/.github/workflows/format.yml.twig
+++ b/templates/flutter/.github/workflows/format.yml.twig
@@ -13,13 +13,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
           ref: ${{ '{{'}} github.event.pull_request.head.ref {{ '}}' }}
 
       - name: Install Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: stable
 
@@ -33,7 +33,7 @@ jobs:
         run: git config --global --add safe.directory /__w/sdk-for-flutter/sdk-for-flutter # required to fix dubious ownership
 
       - name: Add & Commit
-        uses: EndBug/add-and-commit@v9.1.4
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         with:
             add: '["lib", "test"]'
     

--- a/templates/flutter/.github/workflows/publish.yml.twig
+++ b/templates/flutter/.github/workflows/publish.yml.twig
@@ -11,13 +11,13 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: stable
       - name: Install dependencies
         run: flutter pub get
-      - uses: dart-lang/setup-dart@v1
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
       - name: Publish
         run: dart pub publish --force

--- a/templates/flutter/.github/workflows/stale.yml
+++ b/templates/flutter/.github/workflows/stale.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   stale:
-    uses: appwrite/.github/.github/workflows/stale.yml@main 
+    uses: appwrite/.github/.github/workflows/stale.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main

--- a/templates/flutter/.github/workflows/test.yml
+++ b/templates/flutter/.github/workflows/test.yml
@@ -6,9 +6,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: stable
       - run: flutter pub get

--- a/templates/go/.github/workflows/autoclose.yml
+++ b/templates/go/.github/workflows/autoclose.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   auto_close:
     if: github.head_ref != 'dev'
-    uses: appwrite/.github/.github/workflows/autoclose.yml@main
+    uses: appwrite/.github/.github/workflows/autoclose.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main
     secrets:
       GH_AUTO_CLOSE_PR_TOKEN: ${{ secrets.GH_AUTO_CLOSE_PR_TOKEN }}

--- a/templates/go/.github/workflows/stale.yml
+++ b/templates/go/.github/workflows/stale.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   stale:
-    uses: appwrite/.github/.github/workflows/stale.yml@main 
+    uses: appwrite/.github/.github/workflows/stale.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main

--- a/templates/graphql/.github/workflows/autoclose.yml
+++ b/templates/graphql/.github/workflows/autoclose.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   auto_close:
     if: github.head_ref != 'dev'
-    uses: appwrite/.github/.github/workflows/autoclose.yml@main
+    uses: appwrite/.github/.github/workflows/autoclose.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main
     secrets:
       GH_AUTO_CLOSE_PR_TOKEN: ${{ secrets.GH_AUTO_CLOSE_PR_TOKEN }}

--- a/templates/graphql/.github/workflows/stale.yml
+++ b/templates/graphql/.github/workflows/stale.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   stale:
-    uses: appwrite/.github/.github/workflows/stale.yml@main 
+    uses: appwrite/.github/.github/workflows/stale.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main

--- a/templates/kotlin/.github/workflows/autoclose.yml
+++ b/templates/kotlin/.github/workflows/autoclose.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   auto_close:
     if: github.head_ref != 'dev'
-    uses: appwrite/.github/.github/workflows/autoclose.yml@main
+    uses: appwrite/.github/.github/workflows/autoclose.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main
     secrets:
       GH_AUTO_CLOSE_PR_TOKEN: ${{ secrets.GH_AUTO_CLOSE_PR_TOKEN }}

--- a/templates/kotlin/.github/workflows/publish.yml
+++ b/templates/kotlin/.github/workflows/publish.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
           java-version: 17

--- a/templates/kotlin/.github/workflows/stale.yml
+++ b/templates/kotlin/.github/workflows/stale.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   stale:
-    uses: appwrite/.github/.github/workflows/stale.yml@main 
+    uses: appwrite/.github/.github/workflows/stale.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main

--- a/templates/markdown/.github/workflows/publish.yml
+++ b/templates/markdown/.github/workflows/publish.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Use Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '24.14.1'
         registry-url: 'https://registry.npmjs.org'

--- a/templates/markdown/.npmrc
+++ b/templates/markdown/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/templates/node/.github/workflows/autoclose.yml
+++ b/templates/node/.github/workflows/autoclose.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   auto_close:
     if: github.head_ref != 'dev'
-    uses: appwrite/.github/.github/workflows/autoclose.yml@main
+    uses: appwrite/.github/.github/workflows/autoclose.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main
     secrets:
       GH_AUTO_CLOSE_PR_TOKEN: ${{ secrets.GH_AUTO_CLOSE_PR_TOKEN }}

--- a/templates/node/.github/workflows/publish.yml.twig
+++ b/templates/node/.github/workflows/publish.yml.twig
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Use Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '24.14.1'
         registry-url: 'https://registry.npmjs.org'

--- a/templates/node/.github/workflows/stale.yml
+++ b/templates/node/.github/workflows/stale.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   stale:
-    uses: appwrite/.github/.github/workflows/stale.yml@main 
+    uses: appwrite/.github/.github/workflows/stale.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main

--- a/templates/node/.npmrc
+++ b/templates/node/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/templates/php/.github/workflows/autoclose.yml
+++ b/templates/php/.github/workflows/autoclose.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   auto_close:
     if: github.head_ref != 'dev'
-    uses: appwrite/.github/.github/workflows/autoclose.yml@main
+    uses: appwrite/.github/.github/workflows/autoclose.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main
     secrets:
       GH_AUTO_CLOSE_PR_TOKEN: ${{ secrets.GH_AUTO_CLOSE_PR_TOKEN }}

--- a/templates/php/.github/workflows/stale.yml
+++ b/templates/php/.github/workflows/stale.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   stale:
-    uses: appwrite/.github/.github/workflows/stale.yml@main 
+    uses: appwrite/.github/.github/workflows/stale.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main

--- a/templates/python/.github/workflows/autoclose.yml
+++ b/templates/python/.github/workflows/autoclose.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   auto_close:
     if: github.head_ref != 'dev'
-    uses: appwrite/.github/.github/workflows/autoclose.yml@main
+    uses: appwrite/.github/.github/workflows/autoclose.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main
     secrets:
       GH_AUTO_CLOSE_PR_TOKEN: ${{ secrets.GH_AUTO_CLOSE_PR_TOKEN }}

--- a/templates/python/.github/workflows/publish.yml.twig
+++ b/templates/python/.github/workflows/publish.yml.twig
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.9'
 

--- a/templates/python/.github/workflows/stale.yml
+++ b/templates/python/.github/workflows/stale.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   stale:
-    uses: appwrite/.github/.github/workflows/stale.yml@main 
+    uses: appwrite/.github/.github/workflows/stale.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main

--- a/templates/react-native/.github/workflows/autoclose.yml
+++ b/templates/react-native/.github/workflows/autoclose.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   auto_close:
     if: github.head_ref != 'dev'
-    uses: appwrite/.github/.github/workflows/autoclose.yml@main
+    uses: appwrite/.github/.github/workflows/autoclose.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main
     secrets:
       GH_AUTO_CLOSE_PR_TOKEN: ${{ secrets.GH_AUTO_CLOSE_PR_TOKEN }}

--- a/templates/react-native/.github/workflows/publish.yml.twig
+++ b/templates/react-native/.github/workflows/publish.yml.twig
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Use Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '24.14.1'
         registry-url: 'https://registry.npmjs.org'

--- a/templates/react-native/.github/workflows/stale.yml
+++ b/templates/react-native/.github/workflows/stale.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   stale:
-    uses: appwrite/.github/.github/workflows/stale.yml@main 
+    uses: appwrite/.github/.github/workflows/stale.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main

--- a/templates/react-native/.npmrc
+++ b/templates/react-native/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/templates/rest/.github/workflows/autoclose.yml
+++ b/templates/rest/.github/workflows/autoclose.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   auto_close:
     if: github.head_ref != 'dev'
-    uses: appwrite/.github/.github/workflows/autoclose.yml@main
+    uses: appwrite/.github/.github/workflows/autoclose.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main
     secrets:
       GH_AUTO_CLOSE_PR_TOKEN: ${{ secrets.GH_AUTO_CLOSE_PR_TOKEN }}

--- a/templates/rest/.github/workflows/stale.yml
+++ b/templates/rest/.github/workflows/stale.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   stale:
-    uses: appwrite/.github/.github/workflows/stale.yml@main 
+    uses: appwrite/.github/.github/workflows/stale.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main

--- a/templates/ruby/.github/workflows/autoclose.yml
+++ b/templates/ruby/.github/workflows/autoclose.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   auto_close:
     if: github.head_ref != 'dev'
-    uses: appwrite/.github/.github/workflows/autoclose.yml@main
+    uses: appwrite/.github/.github/workflows/autoclose.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main
     secrets:
       GH_AUTO_CLOSE_PR_TOKEN: ${{ secrets.GH_AUTO_CLOSE_PR_TOKEN }}

--- a/templates/ruby/.github/workflows/publish.yml.twig
+++ b/templates/ruby/.github/workflows/publish.yml.twig
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           ruby-version: 2.7
           bundler-cache: true

--- a/templates/ruby/.github/workflows/stale.yml
+++ b/templates/ruby/.github/workflows/stale.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   stale:
-    uses: appwrite/.github/.github/workflows/stale.yml@main 
+    uses: appwrite/.github/.github/workflows/stale.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main

--- a/templates/rust/.github/workflows/autoclose.yml
+++ b/templates/rust/.github/workflows/autoclose.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   auto_close:
     if: github.head_ref != 'dev'
-    uses: appwrite/.github/.github/workflows/autoclose.yml@main
+    uses: appwrite/.github/.github/workflows/autoclose.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main
     secrets:
       GH_AUTO_CLOSE_PR_TOKEN: ${{ secrets.GH_AUTO_CLOSE_PR_TOKEN }}

--- a/templates/rust/.github/workflows/publish.yml.twig
+++ b/templates/rust/.github/workflows/publish.yml.twig
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@1.83.0
+        uses: dtolnay/rust-toolchain@bd41891a8e7f4b8649f6d684415e1a6155fe4e22 # 1.83.0
 
       - name: Run tests
         run: cargo test --all-features

--- a/templates/rust/.github/workflows/stale.yml
+++ b/templates/rust/.github/workflows/stale.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   stale:
-    uses: appwrite/.github/.github/workflows/stale.yml@main
+    uses: appwrite/.github/.github/workflows/stale.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main

--- a/templates/swift/.github/workflows/autoclose.yml
+++ b/templates/swift/.github/workflows/autoclose.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   auto_close:
     if: github.head_ref != 'dev'
-    uses: appwrite/.github/.github/workflows/autoclose.yml@main
+    uses: appwrite/.github/.github/workflows/autoclose.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main
     secrets:
       GH_AUTO_CLOSE_PR_TOKEN: ${{ secrets.GH_AUTO_CLOSE_PR_TOKEN }}

--- a/templates/swift/.github/workflows/publish.yml
+++ b/templates/swift/.github/workflows/publish.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Setup Swift
-        uses: fwal/setup-swift@v1
+        uses: fwal/setup-swift@cdbe0f7f4c77929b6580e71983e8606e55ffe7e4 # v1
         with:
           swift-version: "5.4"
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install cocoapods
         run: gem install cocoapods

--- a/templates/swift/.github/workflows/stale.yml
+++ b/templates/swift/.github/workflows/stale.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   stale:
-    uses: appwrite/.github/.github/workflows/stale.yml@main 
+    uses: appwrite/.github/.github/workflows/stale.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main

--- a/templates/web/.github/workflows/autoclose.yml
+++ b/templates/web/.github/workflows/autoclose.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   auto_close:
     if: github.head_ref != 'dev'
-    uses: appwrite/.github/.github/workflows/autoclose.yml@main
+    uses: appwrite/.github/.github/workflows/autoclose.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main
     secrets:
       GH_AUTO_CLOSE_PR_TOKEN: ${{ secrets.GH_AUTO_CLOSE_PR_TOKEN }}

--- a/templates/web/.github/workflows/publish.yml.twig
+++ b/templates/web/.github/workflows/publish.yml.twig
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Use Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '24.14.1'
         registry-url: 'https://registry.npmjs.org'

--- a/templates/web/.github/workflows/stale.yml
+++ b/templates/web/.github/workflows/stale.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   stale:
-    uses: appwrite/.github/.github/workflows/stale.yml@main 
+    uses: appwrite/.github/.github/workflows/stale.yml@dd94e24bffbb6941e79ce3a26c01db22a774b1a1 # main

--- a/templates/web/.npmrc
+++ b/templates/web/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7


### PR DESCRIPTION
## Summary

- Add generated `.npmrc` files with `min-release-age=7` for TypeScript/npm-based SDK packages.
- Set CLI Bun installs to `minimumReleaseAge = 604800 # 7d`.
- Pin generated SDK GitHub workflow action refs to immutable commit SHAs, reusing the existing pinned versions already used by this repo where available.

## Testing

- `php example.php`
- `composer lint-twig`
- `git diff --cached --check`
- Verified no unpinned workflow action refs remain outside vendored `templates/cli/node_modules` workflows.
