### PR TITLE
Clear Composer GitHub auth in CI

### DIFF
--- a/.github/workflows/sdk-build-validation.yml
+++ b/.github/workflows/sdk-build-validation.yml
@@ -87,6 +87,12 @@ jobs:
           php-version: '8.3'
           extensions: curl
 
+      - name: Clear Composer GitHub auth
+        run: |
+          rm -f "$HOME/.composer/auth.json"
+          rm -f "$HOME/.config/composer/auth.json"
+          composer config --global --unset github-oauth.github.com || true
+
       - name: Install Composer Dependencies
         run: composer install
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,12 @@ jobs:
           php-version: ${{ matrix.php-version }}
           extensions: curl
 
+      - name: Clear Composer GitHub auth
+        run: |
+          rm -f "$HOME/.composer/auth.json"
+          rm -f "$HOME/.config/composer/auth.json"
+          composer config --global --unset github-oauth.github.com || true
+
       - name: Before Install
         run: |
           if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
@@ -96,6 +102,12 @@ jobs:
         with:
           php-version: '8.3'
           extensions: curl
+
+      - name: Clear Composer GitHub auth
+        run: |
+          rm -f "$HOME/.composer/auth.json"
+          rm -f "$HOME/.config/composer/auth.json"
+          composer config --global --unset github-oauth.github.com || true
 
       - name: Install
         run: composer install


### PR DESCRIPTION
## Summary

- Remove Composer auth files created by setup-php before running Composer.
- Explicitly unset any global `github-oauth.github.com` value as a fallback.

## Context

A blank control PR (#1534) reproduced the Composer token failure on current `master`, confirming this is a baseline CI issue rather than caused by #1533.

Pinning Composer to 2.8 did not fix it: setup-php still wrote the GitHub Actions `ghs_...` token into Composer auth, and Composer rejected that token before install.

## Testing

- `git diff --check`
