### PR TITLE
Add cover image param and download scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ public function getFiles(): array
     return [
         // ...existing entries...
         [
-            'scope'       => 'default',   // default|service|method|definition|requestModel|enum|copy
+            'scope'       => 'default',   // default|service|method|definition|requestModel|enum|copy|download
             'destination' => 'path/to/output.ext',
             'template'    => 'lang/path/to/template.twig',
         ],
@@ -105,6 +105,7 @@ public function getFiles(): array
 - `requestModel` — generated once per request model
 - `enum` — generated once per enum
 - `copy` — static files copied as-is, no Twig processing
+- `download` — generated once per SDK by downloading the URL in `template` to `destination`
 
 3. Regenerate and verify
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,7 @@ Each file scope determines what template parameters will be available.
 * Service scope - Generate x templates where x is the number of API services, adds service-specific params to the template such as service name and methods.
 * Method scope - Generate x*y templates where x is the number of API services and y is the number of methods, adds service and method-specific params to the template, such as service name, method name, and method params. Used to generate MD files with examples for documenting each method.
 * Copy scope - Static files such as images that will be copied directly and not processed by twig.
+* Download scope - Static remote files where `template` is a URL that will be downloaded directly to `destination`.
 
 **getTypeName**
 This method receives the API param type and should return the equivalent param in the implemented language.
@@ -104,7 +105,7 @@ sdk-generator/blob/master/example.php:
     // NewLang
     $sdk  = new SDK(new NewLang(), new Swagger2($spec));
     $sdk
-        ->setLogo('https://appwrite.io/v1/images/console.png')
+        ->setCoverImage('https://github.com/appwrite/appwrite/raw/main/public/images/github.png')
         ->setLicenseContent('test test test')
         ->setWarning('**WORK IN PROGRESS - NOT READY FOR USAGE**')
     ;

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $lang // Set language or platform specific options
 $sdk  = new SDK($lang, $spec);
 
 $sdk
-    ->setLogo('https://appwrite.io/v1/images/console.png')
+    ->setCoverImage('https://github.com/appwrite/appwrite/raw/main/public/images/github.png')
     ->setLicenseContent('License content here.')
     ->setVersion('v1.1.0')
 ;

--- a/example.php
+++ b/example.php
@@ -49,7 +49,7 @@ try {
             'description' => 'Repo description goes here',
             'shortDescription' => 'Repo short description goes here',
             'url' => 'https://example.com',
-            'logo' => 'https://appwrite.io/images/logos/logo.svg',
+            'coverImage' => 'https://github.com/appwrite/appwrite/raw/main/public/images/github.png',
             'licenseContent' => 'test test test',
             'warning' => '**WORK IN PROGRESS - NOT READY FOR USAGE**',
             'changelog' => '**CHANGELOG**',
@@ -81,7 +81,7 @@ try {
             ->setDescription($config['description'])
             ->setShortDescription($config['shortDescription'])
             ->setURL($config['url'])
-            ->setLogo($config['logo'])
+            ->setCoverImage($config['coverImage'])
             ->setLicenseContent($config['licenseContent'])
             ->setWarning($config['warning'])
             ->setChangelog($config['changelog'])

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -56,6 +56,7 @@ class SDK
         'gitRepo' => '',
         'gitRepoName' => '',
         'gitUserName' => '',
+        'coverImage' => '',
         'logo' => '',
         'url' => '',
         'shareText' => '',
@@ -432,6 +433,18 @@ class SDK
     public function setLogo(string $url): SDK
     {
         $this->setParam('logo', $url);
+        $this->setParam('coverImage', $url);
+
+        return $this;
+    }
+
+    /**
+     * @param string $url
+     * @return $this
+     */
+    public function setCoverImage(string $url): SDK
+    {
+        $this->setParam('coverImage', $url);
 
         return $this;
     }
@@ -1029,7 +1042,7 @@ class SDK
         ];
 
         foreach ($this->language->getFiles() as $file) {
-            if ($file['scope'] != 'copy') {
+            if (!\in_array($file['scope'], ['copy', 'download'], true)) {
                 $template = $this->twig->load($file['template']); /* @var $template TemplateWrapper */
             }
             $destination    = $target . '/' . $file['destination'];
@@ -1045,6 +1058,9 @@ class SDK
                         mkdir(dirname($destination), 0777, true);
                     }
                     copy(realpath(__DIR__ . '/../../templates/' . $file['template']), $destination);
+                    break;
+                case 'download':
+                    $this->download($file['template'], $destination, $params);
                     break;
                 case 'service':
                     foreach ($filteredServices as $key => $service) {
@@ -1442,6 +1458,34 @@ class SDK
                 default:
                     throw new Exception('No minifier found for ' . $ext . ' file');
             }
+        }
+    }
+
+    /**
+     * @param string $url
+     * @param string $destination
+     * @param array $params
+     *
+     * @throws Exception
+     */
+    protected function download(string $url, string $destination, array $params = []): void
+    {
+        $destination = $this->twig->createTemplate($destination)->render($params);
+
+        if (!file_exists(dirname($destination))) {
+            mkdir(dirname($destination), 0777, true);
+        }
+
+        $output = @file_get_contents($url);
+
+        if ($output === false) {
+            throw new Exception('Can\'t download file: ' . $url);
+        }
+
+        $result = file_put_contents($destination, $output);
+
+        if ($result === false) {
+            throw new Exception('Can\'t save file: ' . $destination);
         }
     }
 

--- a/templates/agent-skills/README.md.twig
+++ b/templates/agent-skills/README.md.twig
@@ -16,8 +16,8 @@
 
 {{ sdk.description }}
 
-{% if sdk.logo %}
-![{{ spec.title }}]({{ sdk.logo }})
+{% if sdk.coverImage %}
+![{{ spec.title }}]({{ sdk.coverImage }})
 {% endif %}
 
 {% if sdk.gettingStarted %}

--- a/templates/android/README.md.twig
+++ b/templates/android/README.md.twig
@@ -17,8 +17,8 @@
 
 {{ sdk.description }}
 
-{% if sdk.logo %}
-![{{ spec.title }}]({{ sdk.logo }})
+{% if sdk.coverImage %}
+![{{ spec.title }}]({{ sdk.coverImage }})
 {% endif %}
 
 ## Installation

--- a/templates/cli/README.md.twig
+++ b/templates/cli/README.md.twig
@@ -16,8 +16,8 @@
 
 {{ sdk.description }}
 
-{% if sdk.logo %}
-![{{ spec.title }}]({{ sdk.logo }})
+{% if sdk.coverImage %}
+![{{ spec.title }}]({{ sdk.coverImage }})
 {% endif %}
 
 ## Installation

--- a/templates/dart/README.md.twig
+++ b/templates/dart/README.md.twig
@@ -17,8 +17,8 @@
 
 {{ sdk.description }}
 
-{% if sdk.logo %}
-![{{ spec.title }}]({{ sdk.logo }})
+{% if sdk.coverImage %}
+![{{ spec.title }}]({{ sdk.coverImage }})
 {% endif %}
 
 ## Installation

--- a/templates/deno/README.md.twig
+++ b/templates/deno/README.md.twig
@@ -16,8 +16,8 @@
 
 {{ sdk.description }}
 
-{% if sdk.logo %}
-![{{ spec.title }}]({{ sdk.logo }})
+{% if sdk.coverImage %}
+![{{ spec.title }}]({{ sdk.coverImage }})
 {% endif %}
 
 ## Installation

--- a/templates/dotnet/README.md.twig
+++ b/templates/dotnet/README.md.twig
@@ -16,8 +16,8 @@
 
 {{ sdk.description }}
 
-{% if sdk.logo %}
-![{{ spec.title }}]({{ sdk.logo }})
+{% if sdk.coverImage %}
+![{{ spec.title }}]({{ sdk.coverImage }})
 {% endif %}
 
 ## Installation

--- a/templates/flutter/README.md.twig
+++ b/templates/flutter/README.md.twig
@@ -17,8 +17,8 @@
 
 {{ sdk.description }}
 
-{% if sdk.logo %}
-![{{ spec.title }}]({{ sdk.logo }})
+{% if sdk.coverImage %}
+![{{ spec.title }}]({{ sdk.coverImage }})
 {% endif %}
 
 ## Installation

--- a/templates/go/README.md.twig
+++ b/templates/go/README.md.twig
@@ -16,8 +16,8 @@
 
 {{ sdk.description }}
 
-{% if sdk.logo %}
-![{{ spec.title }}]({{ sdk.logo }})
+{% if sdk.coverImage %}
+![{{ spec.title }}]({{ sdk.coverImage }})
 {% endif %}
 
 ## Installation

--- a/templates/kotlin/README.md.twig
+++ b/templates/kotlin/README.md.twig
@@ -16,8 +16,8 @@
 
 {{ sdk.description }}
 
-{% if sdk.logo %}
-![{{ spec.title }}]({{ sdk.logo }})
+{% if sdk.coverImage %}
+![{{ spec.title }}]({{ sdk.coverImage }})
 {% endif %}
 
 ## Installation

--- a/templates/node/README.md.twig
+++ b/templates/node/README.md.twig
@@ -16,8 +16,8 @@
 
 {{ sdk.description }}
 
-{% if sdk.logo %}
-![{{ spec.title }}]({{ sdk.logo }})
+{% if sdk.coverImage %}
+![{{ spec.title }}]({{ sdk.coverImage }})
 {% endif %}
 
 ## Installation

--- a/templates/php/README.md.twig
+++ b/templates/php/README.md.twig
@@ -16,8 +16,8 @@
 
 {{ sdk.description }}
 
-{% if sdk.logo %}
-![{{ spec.title }}]({{ sdk.logo }})
+{% if sdk.coverImage %}
+![{{ spec.title }}]({{ sdk.coverImage }})
 {% endif %}
 
 ## Installation

--- a/templates/python/README.md.twig
+++ b/templates/python/README.md.twig
@@ -16,8 +16,8 @@
 
 {{ sdk.description }}
 
-{% if sdk.logo %}
-![{{ spec.title }}]({{ sdk.logo }})
+{% if sdk.coverImage %}
+![{{ spec.title }}]({{ sdk.coverImage }})
 {% endif %}
 
 ## Installation

--- a/templates/react-native/README.md.twig
+++ b/templates/react-native/README.md.twig
@@ -16,8 +16,8 @@
 
 {{ sdk.description }}
 
-{% if sdk.logo %}
-![{{ spec.title }}]({{ sdk.logo }})
+{% if sdk.coverImage %}
+![{{ spec.title }}]({{ sdk.coverImage }})
 {% endif %}
 
 ## Installation

--- a/templates/ruby/README.md.twig
+++ b/templates/ruby/README.md.twig
@@ -16,8 +16,8 @@
 
 {{ sdk.description }}
 
-{% if sdk.logo %}
-![{{ spec.title }}]({{ sdk.logo }})
+{% if sdk.coverImage %}
+![{{ spec.title }}]({{ sdk.coverImage }})
 {% endif %}
 
 ## Installation

--- a/templates/rust/README.md.twig
+++ b/templates/rust/README.md.twig
@@ -11,8 +11,8 @@
 
 {{ sdk.description }}
 
-{% if sdk.logo %}
-![{{ spec.title }}]({{ sdk.logo }})
+{% if sdk.coverImage %}
+![{{ spec.title }}]({{ sdk.coverImage }})
 {% endif %}
 
 ## Installation

--- a/templates/swift/README.md.twig
+++ b/templates/swift/README.md.twig
@@ -17,8 +17,8 @@
 
 {{ sdk.description }}
 
-{% if sdk.logo %}
-![{{ spec.title }}]({{ sdk.logo }})
+{% if sdk.coverImage %}
+![{{ spec.title }}]({{ sdk.coverImage }})
 {% endif %}
 
 ## Installation

--- a/templates/web/README.md.twig
+++ b/templates/web/README.md.twig
@@ -16,8 +16,8 @@
 
 {{ sdk.description }}
 
-{% if sdk.logo %}
-![{{ spec.title }}]({{ sdk.logo }})
+{% if sdk.coverImage %}
+![{{ spec.title }}]({{ sdk.coverImage }})
 {% endif %}
 
 ## Installation

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -369,7 +369,7 @@ abstract class Base extends TestCase
             ->setPlatform($this->sdkPlatform)
             ->setDescription('Repo description goes here')
             ->setShortDescription('Repo short description goes here')
-            ->setLogo('https://appwrite.io/v1/images/console.png')
+            ->setCoverImage('https://github.com/appwrite/appwrite/raw/main/public/images/github.png')
             ->setWarning('**WORK IN PROGRESS - THIS IS JUST A TEST SDK**')
             ->setExamples('**EXAMPLES** <HTML>')
             ->setGitUserName('repoowner')


### PR DESCRIPTION
## Summary

- Add `SDK::setCoverImage()` and keep `setLogo()` as a backwards-compatible alias for README cover images.
- Update README templates to use `sdk.coverImage` instead of `sdk.logo`.
- Add a new `download` file scope that downloads the URL from `template` directly to the rendered `destination` path.
- Replace stale Appwrite console image examples with the GitHub cover image URL.

## Testing

- `php -l src/SDK/SDK.php`
- `composer lint-twig`

## Notes

- Full generation was not run because Composer install was interrupted earlier and left `vendor/autoload.php` missing in this worktree.
