### PR TITLE
Keep logo and cover image setters separate

### DIFF
--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -433,7 +433,6 @@ class SDK
     public function setLogo(string $url): SDK
     {
         $this->setParam('logo', $url);
-        $this->setParam('coverImage', $url);
 
         return $this;
     }


### PR DESCRIPTION
## Summary

- Keep `SDK::setLogo()` scoped to the legacy `logo` parameter only.
- Leave `SDK::setCoverImage()` as the separate setter for README cover images.

## Testing

- `php -l src/SDK/SDK.php`
- `composer lint-twig`
