### PR TITLE
Fix Composer auth token in CI

### DIFF
--- a/.github/workflows/sdk-build-validation.yml
+++ b/.github/workflows/sdk-build-validation.yml
@@ -88,7 +88,9 @@ jobs:
           extensions: curl
 
       - name: Install Composer Dependencies
-        run: composer install
+        run: |
+          rm -f ~/.composer/auth.json ~/.config/composer/auth.json
+          composer install
 
       - name: Generate SDK for ${{ matrix.sdk }}
         run: php example.php ${{ matrix.sdk }} ${{ matrix.platform }}
@@ -236,6 +238,7 @@ jobs:
               ./gradlew build
               ;;
             php)
+              rm -f ~/.composer/auth.json ~/.config/composer/auth.json
               composer install
               composer audit
               composer test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,6 +73,7 @@ jobs:
       - name: Install
         run: |
           docker --version
+          rm -f ~/.composer/auth.json ~/.config/composer/auth.json
           composer install
 
       - name: Lint
@@ -98,7 +99,9 @@ jobs:
           extensions: curl
 
       - name: Install
-        run: composer install
+        run: |
+          rm -f ~/.composer/auth.json ~/.config/composer/auth.json
+          composer install
 
       - name: Lint
         run: composer lint


### PR DESCRIPTION
## Summary
- clear setup-php's generated Composer GitHub OAuth token before composer install
- apply the workaround to CI Workflow and SDK build validation composer installs

## Verification
- git diff --check