### PR TITLE
Simplify CLI config path assignment

### DIFF
--- a/templates/cli/lib/config.ts
+++ b/templates/cli/lib/config.ts
@@ -498,7 +498,7 @@ function whitelistKeys<T = any>(
 }
 
 class Config<T extends ConfigData = ConfigData> {
-  readonly path: string;
+  path: string;
   protected data: T;
 
   constructor(path: string, autoRead = true) {
@@ -507,10 +507,6 @@ class Config<T extends ConfigData = ConfigData> {
     if (autoRead) {
       this.read();
     }
-  }
-
-  protected usePath(path: string): void {
-    (this as { path: string }).path = path;
   }
 
   read(): void {
@@ -655,7 +651,7 @@ class Local extends Config<ConfigType> {
       Local.findConfigFileInCwd(legacyPath) ||
       _path.join(process.cwd(), path);
 
-    this.usePath(absolutePath);
+    this.path = absolutePath;
     this.configDirectoryPath = _path.dirname(absolutePath);
     this.rootData = {};
     this.includePaths = {};


### PR DESCRIPTION
## What

Simplifies CLI config path reassignment by making `Config.path` mutable and assigning it directly in `Local.useCwdConfig()`.

## Why

Addresses review feedback from https://github.com/appwrite/sdk-generator/pull/1530#discussion_r3237643428 by removing the `usePath()` helper and its type cast workaround.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Documentation

## Testing

- [x] Regenerated CLI SDK: `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php cli`
- [x] Linted Twig templates: `composer lint-twig`
