### PR TITLE
Allow CLI Windows signature warning during publish

### DIFF
--- a/templates/cli/.github/workflows/publish.yml
+++ b/templates/cli/.github/workflows/publish.yml
@@ -105,15 +105,12 @@ jobs:
             echo "$output"
 
             if [ "$rc" -ne 0 ] || ! grep -Fq "Succeeded" <<< "$output"; then
-              echo "::error::$file signature verification failed"
-              return 1
+              echo "::warning::$file signature verification failed; continuing while Windows signing policy is being enabled"
             fi
           }
 
-          final=0
-          verify_signature build/appwrite-cli-win-x64.exe || final=1
-          verify_signature build/appwrite-cli-win-arm64.exe || final=1
-          exit "$final"
+          verify_signature build/appwrite-cli-win-x64.exe
+          verify_signature build/appwrite-cli-win-arm64.exe
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
## Summary

- Downgrades CLI Windows signature verification failures from workflow errors to GitHub warnings.
- Keeps verification output visible while SignPath enables the Windows signing policy.

## Testing

- docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php cli
- composer lint-twig

Related workflow failure: https://github.com/appwrite/sdk-for-cli/actions/runs/25729206774/job/75549778450
