### PR TITLE
Fix CLI upload artifact action pin

### DIFF
--- a/templates/cli/.github/workflows/publish.yml
+++ b/templates/cli/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload unsigned Windows binaries
         id: upload-windows-unsigned
-        uses: actions/upload-artifact@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: windows-unsigned
           path: |


### PR DESCRIPTION
## Summary
- Fix the CLI release workflow upload-artifact action pin.
- Replace the accidental actions/cache v4.2.4 SHA with the actions/upload-artifact v4.6.2 SHA.

## Testing
- `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php cli`
- `composer lint-twig`
