### PR TITLE
Fix CLI signature verification under errexit

### DIFF
--- a/templates/cli/.github/workflows/publish.yml
+++ b/templates/cli/.github/workflows/publish.yml
@@ -99,8 +99,8 @@ jobs:
           verify_signature() {
             local file="$1"
             local output rc
-            output="$(osslsigncode verify -in "$file" 2>&1)"
-            rc=$?
+            rc=0
+            output="$(osslsigncode verify -in "$file" 2>&1)" || rc=$?
             echo "--- $file (osslsigncode exit $rc) ---"
             echo "$output"
 


### PR DESCRIPTION
## Summary
- Fix CLI release signature verification when osslsigncode returns non-zero.
- Capture the verify exit code explicitly so the warning path can run under GitHub Actions bash -e.

## Testing
- `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php cli`
- `composer lint-twig`
- Local bash `-euo pipefail` smoke test for non-zero command substitution handling

## Context
- Failed run: https://github.com/appwrite/sdk-for-cli/actions/runs/25904326290
