### PR TITLE
Scope React Native brace-expansion override

### DIFF
--- a/templates/react-native/package-lock.json.twig
+++ b/templates/react-native/package-lock.json.twig
@@ -3380,6 +3380,7 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "18 || 20 || >=22"
       }
@@ -3494,6 +3495,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
       "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -3815,6 +3817,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/connect": {
       "version": "3.7.0",
@@ -6834,6 +6843,24 @@
         "path-is-inside": "1.0.2",
         "path-to-regexp": "3.3.0",
         "range-parser": "1.2.0"
+      }
+    },
+    "node_modules/serve-handler/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/serve-handler/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/serve-handler/node_modules/bytes": {

--- a/templates/react-native/package.json.twig
+++ b/templates/react-native/package.json.twig
@@ -49,12 +49,14 @@
     "expo": "*"
   },
   "overrides": {
-    "glob": "^13.0.0",
+    "glob": {
+      ".": "^13.0.0",
+      "brace-expansion": "^5.0.6"
+    },
     "rimraf": "^6.0.0",
     "@xmldom/xmldom": "^0.9.10",
     "uuid": "^14.0.0",
     "postcss": "^8.5.12",
-    "ws": "^8.20.1",
-    "brace-expansion": "^5.0.6"
+    "ws": "^8.20.1"
   }
 }


### PR DESCRIPTION
## What
- Scope the React Native brace-expansion override to glob instead of applying it globally
- Regenerate the React Native package lock template
- Preserve serve-handler's nested CommonJS-compatible brace-expansion@1.1.14

## Testing
- python3 -m json.tool templates/react-native/package.json.twig
- python3 -m json.tool templates/react-native/package-lock.json.twig
- composer lint-twig
- docker run --rm -v <repo>:/app -w /app php:8.3-cli php example.php react-native