### PR TITLE
Fix generated docs example closing fences

### DIFF
--- a/templates/dotnet/docs/example.md.twig
+++ b/templates/dotnet/docs/example.md.twig
@@ -26,5 +26,7 @@ Client client = new Client()
     {{ parameter.name }}: {% if parameter.enumValues | length > 0%}{{ parameter | enumExample }}{% else %}{{ parameter | paramExample }}{% endif %}{% if not loop.last %},{% endif %}{% if not parameter.required %} // optional{% endif %}
     {%~ endfor %}
 
-{% if method.parameters.all | length > 0 %});{% endif %}
+{% if method.parameters.all | length > 0 %}
+);
+{% endif %}
 ```

--- a/templates/php/docs/example.md.twig
+++ b/templates/php/docs/example.md.twig
@@ -37,6 +37,8 @@ $result = ${{ service.name | caseCamel }}->{{ method.name | caseCamel }}({% if m
     {%~ for parameter in method.parameters.all %}
     {{ parameter.name | caseCamel }}: {% if parameter.enumValues | length > 0%}{{ parameter | enumExample }}{% else%}{{ parameter | paramExample }}{% endif %}{% if not loop.last %},{% endif %}{% if not parameter.required %} // optional{% endif %}
 
-    {%~ endfor -%}
-{% if method.parameters.all | length > 0 %});{% endif %}
+    {%~ endfor %}
+{% if method.parameters.all | length > 0 %}
+);
+{% endif %}
 ```


### PR DESCRIPTION
## What

This keeps generated PHP and .NET example code fences on their own line after multi-parameter calls.

The current generated docs can produce lines like:

```text
);```
```

which makes the closing Markdown fence part of the code sample instead of ending the block cleanly.

## Why

The reported .NET issue comes from generated examples in `appwrite/specs`, and those examples are produced from these `sdk-generator` docs templates. While checking the generated source, I found the same fence pattern in the PHP examples too, so this adjusts both matching templates.

Refs appwrite/appwrite#12333.

## Verification

- `uvx djlint templates/dotnet/docs/example.md.twig templates/php/docs/example.md.twig --lint`
- Not run: full SDK regeneration/tests. This local machine does not have PHP, Composer, or Docker available.

This was implemented with Codex assistance and manually reviewed before opening the PR.