### PR TITLE
Support platform-filtered merged specs

### DIFF
--- a/example.php
+++ b/example.php
@@ -42,6 +42,10 @@ try {
         return $result;
     }
 
+    function isValidSpec($spec): bool {
+        return is_string($spec) && is_array(json_decode($spec, true));
+    }
+
     function configureSDK($sdk, $overrides = []) {
         $defaults = [
             'name' => 'NAME',
@@ -113,16 +117,32 @@ try {
         $platform = 'console';
         // $platform = 'client';
         // $platform = 'server';
+        // $platform = 'client-server';
     }
 
     $version = '1.9.x';
     $speclessSDKs = ['agent-skills', 'cursor-plugin', 'claude-plugin', 'codex-plugin'];
     $needsSpec = !$requestedSdk || !in_array($requestedSdk, $speclessSDKs);
 
-    if ($needsSpec) {
-        $spec = getSSLPage("https://raw.githubusercontent.com/appwrite/specs/main/specs/{$version}/swagger2-{$version}-{$platform}.json");
+    $specTargetPlatforms = match ($platform) {
+        'client' => ['client'],
+        'server' => ['server'],
+        'client-server' => ['client', 'server'],
+        default => [],
+    };
 
-        if(empty($spec)) {
+    if ($needsSpec) {
+        $specFile = empty($specTargetPlatforms)
+            ? "swagger2-{$version}-{$platform}.json"
+            : "swagger2-{$version}.json";
+        $spec = getSSLPage("https://raw.githubusercontent.com/appwrite/specs/main/specs/{$version}/{$specFile}");
+
+        if (!isValidSpec($spec) && count($specTargetPlatforms) === 1) {
+            $fallbackSpecFile = "swagger2-{$version}-{$platform}.json";
+            $spec = getSSLPage("https://raw.githubusercontent.com/appwrite/specs/main/specs/{$version}/{$fallbackSpecFile}");
+        }
+
+        if(!isValidSpec($spec)) {
             throw new Exception('Failed to fetch spec from Appwrite server');
         }
     }
@@ -137,21 +157,21 @@ try {
         $php
             ->setComposerVendor('appwrite')
             ->setComposerPackage('appwrite');
-        $sdk  = new SDK($php, new Swagger2($spec));
+        $sdk  = new SDK($php, new Swagger2($spec, $specTargetPlatforms));
         configureSDK($sdk);
         $sdk->generate(__DIR__ . '/examples/php');
     }
 
     // Web
     if (!$requestedSdk || $requestedSdk === 'web') {
-        $sdk  = new SDK(new Web(), new Swagger2($spec));
+        $sdk  = new SDK(new Web(), new Swagger2($spec, $specTargetPlatforms));
         configureSDK($sdk, ['platform' => $platform]);
         $sdk->generate(__DIR__ . '/examples/web');
     }
 
     // Node
     if (!$requestedSdk || $requestedSdk === 'node') {
-        $sdk  = new SDK(new Node(), new Swagger2($spec));
+        $sdk  = new SDK(new Node(), new Swagger2($spec, $specTargetPlatforms));
         configureSDK($sdk);
         $sdk->generate(__DIR__ . '/examples/node');
     }
@@ -178,7 +198,7 @@ try {
   \_/ \_/ .__/| .__/ \_/\_/ |_|  |_|\__\___| \____/\____/\____/
         |_|   |_|                                                ");
 
-        $sdk  = new SDK($language, new Swagger2($spec));
+        $sdk  = new SDK($language, new Swagger2($spec, $specTargetPlatforms));
         $sdk->setTest(false);
         configureSDK($sdk, [
             'exclude' => [
@@ -194,14 +214,14 @@ try {
 
     // Ruby
     if (!$requestedSdk || $requestedSdk === 'ruby') {
-        $sdk  = new SDK(new Ruby(), new Swagger2($spec));
+        $sdk  = new SDK(new Ruby(), new Swagger2($spec, $specTargetPlatforms));
         configureSDK($sdk);
         $sdk->generate(__DIR__ . '/examples/ruby');
     }
 
     // Python
     if (!$requestedSdk || $requestedSdk === 'python') {
-        $sdk  = new SDK(new Python(), new Swagger2($spec));
+        $sdk  = new SDK(new Python(), new Swagger2($spec, $specTargetPlatforms));
         configureSDK($sdk);
         $sdk->generate(__DIR__ . '/examples/python');
     }
@@ -210,7 +230,7 @@ try {
     if (!$requestedSdk || $requestedSdk === 'dart') {
         $dart = new Dart();
         $dart->setPackageName('dart_appwrite');
-        $sdk  = new SDK($dart, new Swagger2($spec));
+        $sdk  = new SDK($dart, new Swagger2($spec, $specTargetPlatforms));
         configureSDK($sdk);
         $sdk->generate(__DIR__ . '/examples/dart');
     }
@@ -219,7 +239,7 @@ try {
     if (!$requestedSdk || $requestedSdk === 'flutter') {
         $flutter = new Flutter();
         $flutter->setPackageName('appwrite');
-        $sdk  = new SDK($flutter, new Swagger2($spec));
+        $sdk  = new SDK($flutter, new Swagger2($spec, $specTargetPlatforms));
         configureSDK($sdk);
         $sdk->generate(__DIR__ . '/examples/flutter');
     }
@@ -228,49 +248,49 @@ try {
     if (!$requestedSdk || $requestedSdk === 'react-native') {
         $reactNative = new ReactNative();
         $reactNative->setNPMPackage('react-native-appwrite');
-        $sdk  = new SDK($reactNative, new Swagger2($spec));
+        $sdk  = new SDK($reactNative, new Swagger2($spec, $specTargetPlatforms));
         configureSDK($sdk);
         $sdk->generate(__DIR__ . '/examples/react-native');
     }
 
     // GO
     if (!$requestedSdk || $requestedSdk === 'go') {
-        $sdk  = new SDK(new Go(), new Swagger2($spec));
+        $sdk  = new SDK(new Go(), new Swagger2($spec, $specTargetPlatforms));
         configureSDK($sdk);
         $sdk->generate(__DIR__ . '/examples/go');
     }
 
     // Swift
     if (!$requestedSdk || $requestedSdk === 'swift') {
-        $sdk  = new SDK(new Swift(), new Swagger2($spec));
+        $sdk  = new SDK(new Swift(), new Swagger2($spec, $specTargetPlatforms));
         configureSDK($sdk);
         $sdk->generate(__DIR__ . '/examples/swift');
     }
 
     // Apple
     if (!$requestedSdk || $requestedSdk === 'apple') {
-        $sdk  = new SDK(new Apple(), new Swagger2($spec));
+        $sdk  = new SDK(new Apple(), new Swagger2($spec, $specTargetPlatforms));
         configureSDK($sdk);
         $sdk->generate(__DIR__ . '/examples/apple');
     }
 
     // DotNet
     if (!$requestedSdk || $requestedSdk === 'dotnet') {
-        $sdk  = new SDK(new DotNet(), new Swagger2($spec));
+        $sdk  = new SDK(new DotNet(), new Swagger2($spec, $specTargetPlatforms));
         configureSDK($sdk);
         $sdk->generate(__DIR__ . '/examples/dotnet');
     }
 
     // REST
     if (!$requestedSdk || $requestedSdk === 'rest') {
-        $sdk  = new SDK(new REST(), new Swagger2($spec));
+        $sdk  = new SDK(new REST(), new Swagger2($spec, $specTargetPlatforms));
         configureSDK($sdk);
         $sdk->generate(__DIR__ . '/examples/REST');
     }
 
     // Android
     if (!$requestedSdk || $requestedSdk === 'android') {
-        $sdk = new SDK(new Android(), new Swagger2($spec));
+        $sdk = new SDK(new Android(), new Swagger2($spec, $specTargetPlatforms));
         configureSDK($sdk, [
             'namespace' => 'io.appwrite',
         ]);
@@ -279,7 +299,7 @@ try {
 
     // Kotlin
     if (!$requestedSdk || $requestedSdk === 'kotlin') {
-        $sdk = new SDK(new Kotlin(), new Swagger2($spec));
+        $sdk = new SDK(new Kotlin(), new Swagger2($spec, $specTargetPlatforms));
         configureSDK($sdk, [
             'namespace' => 'io.appwrite',
         ]);
@@ -288,7 +308,7 @@ try {
 
     // GraphQL
     if (!$requestedSdk || $requestedSdk === 'graphql') {
-        $sdk = new SDK(new GraphQL(), new Swagger2($spec));
+        $sdk = new SDK(new GraphQL(), new Swagger2($spec, $specTargetPlatforms));
         configureSDK($sdk);
         $sdk->generate(__DIR__ . '/examples/graphql');
     }
@@ -297,7 +317,7 @@ try {
     if (!$requestedSdk || $requestedSdk === 'markdown') {
         $markdown = new Markdown();
         $markdown->setNPMPackage('@appwrite.io/docs');
-        $sdk = new SDK($markdown, new Swagger2($spec));
+        $sdk = new SDK($markdown, new Swagger2($spec, $specTargetPlatforms));
         configureSDK($sdk);
         $sdk->generate(__DIR__ . '/examples/markdown');
     }
@@ -355,7 +375,7 @@ try {
 
     // Rust
     if (!$requestedSdk || $requestedSdk === 'rust') {
-        $sdk = new SDK(new Rust(), new Swagger2($spec));
+        $sdk = new SDK(new Rust(), new Swagger2($spec, $specTargetPlatforms));
         configureSDK($sdk);
         $sdk->generate(__DIR__ . '/examples/rust');
     }

--- a/src/Spec/Spec.php
+++ b/src/Spec/Spec.php
@@ -7,6 +7,10 @@ use ArrayObject;
 
 abstract class Spec extends ArrayObject
 {
+    /**
+     * @var array<string>
+     */
+    protected array $targetPlatforms = [];
     private const SET_TYPE_ASSIGN   = 'assign';
     private const SET_TYPE_PREPEND  = 'prepend';
     private const SET_TYPE_APPEND   = 'append';
@@ -16,8 +20,9 @@ abstract class Spec extends ArrayObject
      * @param string $input
      * @throws Exception
      */
-    public function __construct($input)
+    public function __construct($input, array $targetPlatforms = [])
     {
+        $this->targetPlatforms = $targetPlatforms;
         if (\filter_var($input, FILTER_VALIDATE_URL)) {
             $data = \file_get_contents($input, false, \stream_context_create([
                 'ssl' => [
@@ -100,6 +105,25 @@ abstract class Spec extends ArrayObject
     public function getServices(): array
     {
         return [];
+    }
+
+    /**
+     * @param array<string> $platforms
+     * @return $this
+     */
+    public function setTargetPlatforms(array $platforms): static
+    {
+        $this->targetPlatforms = \array_values(\array_unique($platforms));
+
+        return $this;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getTargetPlatforms(): array
+    {
+        return $this->targetPlatforms;
     }
 
     public function getMethods($service): array

--- a/src/Spec/Swagger2.php
+++ b/src/Spec/Swagger2.php
@@ -102,6 +102,60 @@ class Swagger2 extends Spec
     /**
      * @return array
      */
+    protected function supportsTargetPlatforms(array $method): bool
+    {
+        if (empty($this->targetPlatforms)) {
+            return true;
+        }
+
+        $platforms = $method['x-appwrite']['platforms'] ?? [];
+
+        if (empty($platforms)) {
+            return true;
+        }
+
+        return !empty(\array_intersect($this->targetPlatforms, $platforms));
+    }
+
+    protected function supportsAdditionalTargetPlatforms(array $additionalMethod): bool
+    {
+        if (empty($this->targetPlatforms)) {
+            return true;
+        }
+
+        $platforms = $additionalMethod['platforms'] ?? [];
+
+        if (empty($platforms)) {
+            return true;
+        }
+
+        return !empty(\array_intersect($this->targetPlatforms, $platforms));
+    }
+
+    protected function resolvePlatformSecurity(array $method): array
+    {
+        $platformSecurity = $method['x-appwrite']['platformSecurity'] ?? [];
+
+        if (empty($platformSecurity)) {
+            return $method['x-appwrite']['auth'] ?? [];
+        }
+
+        $platforms = $this->targetPlatforms ?: ($method['x-appwrite']['platforms'] ?? \array_keys($platformSecurity));
+        $auth = [];
+
+        foreach ($platforms as $platform) {
+            foreach ($platformSecurity[$platform] ?? [] as $security) {
+                foreach ($security as $key => $value) {
+                    $auth[$key] = $value;
+                }
+            }
+        }
+
+        return $auth;
+    }
+
+
+
     public function getServices(): array
     {
         $list = [];
@@ -111,6 +165,10 @@ class Swagger2 extends Spec
 
         foreach ($paths as $path) {
             foreach ($path as $method) {
+                if (!\is_array($method) || !$this->supportsTargetPlatforms($method)) {
+                    continue;
+                }
+
                 if (isset($method['tags'])) {
                     foreach ($method['tags'] as $tag) {
                         if (!array_key_exists($tag, $list)) {
@@ -139,7 +197,7 @@ class Swagger2 extends Spec
     protected function parseMethod(string $methodName, string $pathName, array $method): array
     {
         $security = $this->getAttribute('securityDefinitions', []);
-        $methodAuth = $method['x-appwrite']['auth'] ?? [];
+        $methodAuth = $this->resolvePlatformSecurity($method);
         $methodSecurity = $method['security'][0] ?? [];
 
         foreach ($methodAuth as $i => $node) {
@@ -420,11 +478,19 @@ class Swagger2 extends Spec
 
         foreach ($paths as $pathName => $path) {
             foreach ($path as $methodName => $method) {
+                if (!\is_array($method) || !$this->supportsTargetPlatforms($method)) {
+                    continue;
+                }
+
                 $isCurrentService = isset($method['tags']) && is_array($method['tags']) && in_array($service, $method['tags']);
 
                 if (!$isCurrentService) {
                     if (!empty($method['x-appwrite']['methods'] ?? [])) {
                         foreach ($method['x-appwrite']['methods'] as $additionalMethod) {
+                            if (!$this->supportsAdditionalTargetPlatforms($additionalMethod)) {
+                                continue;
+                            }
+
                             // has multiple namespaced methods!
                             $targetNamespace = $additionalMethod['namespace'] ?? null;
 
@@ -442,6 +508,10 @@ class Swagger2 extends Spec
                 }
 
                 foreach ($method['x-appwrite']['methods'] as $additionalMethod) {
+                    if (!$this->supportsAdditionalTargetPlatforms($additionalMethod)) {
+                        continue;
+                    }
+
                     $targetNamespace = $this->getTargetNamespace($additionalMethod, $service);
 
                     if ($targetNamespace === $service) {
@@ -466,6 +536,14 @@ class Swagger2 extends Spec
         $duplicatedMethod = $method;
         $duplicatedMethod['x-appwrite']['method'] = $additionalMethod['name'];
         $duplicatedMethod['x-appwrite']['auth'] = $additionalMethod['auth'] ?? [];
+
+        if (isset($additionalMethod['platforms'])) {
+            $duplicatedMethod['x-appwrite']['platforms'] = $additionalMethod['platforms'];
+        }
+
+        if (isset($additionalMethod['platformSecurity'])) {
+            $duplicatedMethod['x-appwrite']['platformSecurity'] = $additionalMethod['platformSecurity'];
+        }
 
         if (isset($additionalMethod['deprecated'])) {
             $duplicatedMethod['deprecated'] = $additionalMethod['deprecated'];


### PR DESCRIPTION
## Summary
- allow specs to declare target platforms for filtering
- resolve x-appwrite.platformSecurity into generator auth metadata
- use the merged client+server spec for client, server, and client-server example generation

## Tests
- php -l example.php src/Spec/Spec.php src/Spec/Swagger2.php
- parsed merged spec for client, server, and client-server target platforms