### PR TITLE
Use endpointDocs metadata from specs

### DIFF
--- a/src/Spec/Swagger2.php
+++ b/src/Spec/Swagger2.php
@@ -54,9 +54,7 @@ class Swagger2 extends Spec
      */
     public function getEndpointDocs(): string
     {
-        return $this->getAttribute('schemes.0', 'https') .
-        '://' . $this->getAttribute('x-host-docs', 'example.com') .
-        $this->getAttribute('basePath', '');
+        return $this->getAttribute('x-appwrite.endpointDocs', '');
     }
 
     /**


### PR DESCRIPTION
## Summary
- read endpoint docs URL from x-appwrite.endpointDocs
- remove legacy endpointDocs fallback now that generated specs always include endpointDocs metadata

## Testing
- php -l src/Spec/Swagger2.php
- verified getEndpointDocs returns x-appwrite.endpointDocs