### PR TITLE
Fix concurrent upload review issues

### DIFF
--- a/mock-server/app/http.php
+++ b/mock-server/app/http.php
@@ -784,18 +784,34 @@ App::shutdown()
         $result = [];
         $route  = $utopia->getRoute();
         $path   = APP_STORAGE_CACHE . '/tests.json';
-        $tests  = (\file_exists($path)) ? \json_decode(\file_get_contents($path), true) : [];
+        $handle = \fopen($path, 'c+');
 
-        if (!\is_array($tests)) {
-            throw new Exception(Exception::GENERAL_MOCK, 'Failed to read results', 500);
+        if ($handle === false || !\flock($handle, LOCK_EX)) {
+            throw new Exception(Exception::GENERAL_MOCK, 'Failed to lock results', 500);
         }
 
-        $result[$route->getMethod() . ':' . $route->getPath()] = true;
+        try {
+            $contents = \stream_get_contents($handle);
+            $tests = ($contents !== false && $contents !== '') ? \json_decode($contents, true) : [];
 
-        $tests = \array_merge($tests, $result);
+            if (!\is_array($tests)) {
+                throw new Exception(Exception::GENERAL_MOCK, 'Failed to read results', 500);
+            }
 
-        if (!\file_put_contents($path, \json_encode($tests), LOCK_EX)) {
-            throw new Exception(Exception::GENERAL_MOCK, 'Failed to save results', 500);
+            $result[$route->getMethod() . ':' . $route->getPath()] = true;
+            $tests = \array_merge($tests, $result);
+
+            \ftruncate($handle, 0);
+            \rewind($handle);
+
+            if (!\fwrite($handle, \json_encode($tests))) {
+                throw new Exception(Exception::GENERAL_MOCK, 'Failed to save results', 500);
+            }
+
+            \fflush($handle);
+        } finally {
+            \flock($handle, LOCK_UN);
+            \fclose($handle);
         }
 
         $response->json(['result' => $route->getMethod() . ':' . $route->getPath() . ':passed']);

--- a/mock-server/app/http.php
+++ b/mock-server/app/http.php
@@ -786,11 +786,15 @@ App::shutdown()
         $path   = APP_STORAGE_CACHE . '/tests.json';
         $handle = \fopen($path, 'c+');
 
-        if ($handle === false || !\flock($handle, LOCK_EX)) {
+        if ($handle === false) {
             throw new Exception(Exception::GENERAL_MOCK, 'Failed to lock results', 500);
         }
 
         try {
+            if (!\flock($handle, LOCK_EX)) {
+                throw new Exception(Exception::GENERAL_MOCK, 'Failed to lock results', 500);
+            }
+
             $contents = \stream_get_contents($handle);
             $tests = ($contents !== false && $contents !== '') ? \json_decode($contents, true) : [];
 

--- a/templates/android/library/src/main/java/io/package/Client.kt.twig
+++ b/templates/android/library/src/main/java/io/package/Client.kt.twig
@@ -452,6 +452,12 @@ class Client @JvmOverloads constructor(
 
         val totalChunks = (size + CHUNK_SIZE - 1) / CHUNK_SIZE
 
+        fun isUploadComplete(chunkResult: Map<*, *>): Boolean {
+            val chunksUploaded = chunkResult["chunksUploaded"]?.toString()?.toLongOrNull() ?: return false
+            val chunksTotal = chunkResult["chunksTotal"]?.toString()?.toLongOrNull() ?: totalChunks
+            return chunksUploaded >= chunksTotal
+        }
+
         suspend fun uploadChunk(index: Int, start: Long, end: Long, includeUploadId: Boolean): Map<*, *> {
             val chunkParams = params.toMutableMap()
             val chunkHeaders = headers.toMutableMap()
@@ -509,7 +515,8 @@ class Client @JvmOverloads constructor(
             val nextChunk = AtomicInteger(0)
             val completedChunks = AtomicInteger((offset / CHUNK_SIZE).toInt())
             val uploadedBytes = AtomicLong(offset.coerceAtMost(size))
-            val resultRef = AtomicReference(result)
+            val completedResultRef = AtomicReference<Map<*, *>?>(null)
+            val lastResultRef = AtomicReference(result)
             val progressLock = Any()
 
             coroutineScope {
@@ -527,7 +534,10 @@ class Client @JvmOverloads constructor(
                             val chunksUploaded = completedChunks.incrementAndGet()
                             val sizeUploaded = uploadedBytes.addAndGet(end - start)
 
-                            resultRef.set(chunkResult)
+                            lastResultRef.set(chunkResult)
+                            if (isUploadComplete(chunkResult)) {
+                                completedResultRef.set(chunkResult)
+                            }
 
                             synchronized(progressLock) {
                                 onProgress?.invoke(
@@ -544,7 +554,7 @@ class Client @JvmOverloads constructor(
                     }
                 }.awaitAll()
             }
-            result = resultRef.get()
+            result = completedResultRef.get() ?: lastResultRef.get()
         }
 
         return converter(result as Map<String, Any>)

--- a/templates/android/library/src/main/java/io/package/Client.kt.twig
+++ b/templates/android/library/src/main/java/io/package/Client.kt.twig
@@ -35,6 +35,7 @@ import java.security.SecureRandom
 import java.security.cert.X509Certificate
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLSocketFactory
 import javax.net.ssl.TrustManager
@@ -451,12 +452,6 @@ class Client @JvmOverloads constructor(
 
         val totalChunks = (size + CHUNK_SIZE - 1) / CHUNK_SIZE
 
-        fun isUploadComplete(chunkResult: Map<*, *>): Boolean {
-            val chunksUploaded = chunkResult["chunksUploaded"]?.toString()?.toLongOrNull() ?: return false
-            val chunksTotal = chunkResult["chunksTotal"]?.toString()?.toLongOrNull() ?: totalChunks
-            return chunksUploaded >= chunksTotal
-        }
-
         suspend fun uploadChunk(index: Int, start: Long, end: Long, includeUploadId: Boolean): Map<*, *> {
             val chunkParams = params.toMutableMap()
             val chunkHeaders = headers.toMutableMap()
@@ -480,7 +475,7 @@ class Client @JvmOverloads constructor(
                 responseType = Map::class.java
             )
 
-            if (index == 0 || uploadId == null) {
+            if (index == 0) {
                 uploadId = chunkResult["\$id"].toString()
             }
 
@@ -514,6 +509,8 @@ class Client @JvmOverloads constructor(
             val nextChunk = AtomicInteger(0)
             val completedChunks = AtomicInteger((offset / CHUNK_SIZE).toInt())
             val uploadedBytes = AtomicLong(offset.coerceAtMost(size))
+            val resultRef = AtomicReference(result)
+            val progressLock = Any()
 
             coroutineScope {
                 List(MAX_CONCURRENT_UPLOADS.coerceAtMost(chunks.size)) {
@@ -530,23 +527,24 @@ class Client @JvmOverloads constructor(
                             val chunksUploaded = completedChunks.incrementAndGet()
                             val sizeUploaded = uploadedBytes.addAndGet(end - start)
 
-                            if (isUploadComplete(chunkResult)) {
-                                result = chunkResult
-                            }
+                            resultRef.set(chunkResult)
 
-                            onProgress?.invoke(
-                                UploadProgress(
-                                    id = uploadId ?: chunkResult["\$id"].toString(),
-                                    progress = sizeUploaded.coerceAtMost(size).toDouble() / size * 100,
-                                    sizeUploaded = sizeUploaded.coerceAtMost(size),
-                                    chunksTotal = chunkResult["chunksTotal"].toString().toInt(),
-                                    chunksUploaded = chunksUploaded,
+                            synchronized(progressLock) {
+                                onProgress?.invoke(
+                                    UploadProgress(
+                                        id = uploadId ?: chunkResult["\$id"].toString(),
+                                        progress = sizeUploaded.coerceAtMost(size).toDouble() / size * 100,
+                                        sizeUploaded = sizeUploaded.coerceAtMost(size),
+                                        chunksTotal = chunkResult["chunksTotal"].toString().toInt(),
+                                        chunksUploaded = chunksUploaded,
+                                    )
                                 )
-                            )
+                            }
                         }
                     }
                 }.awaitAll()
             }
+            result = resultRef.get()
         }
 
         return converter(result as Map<String, Any>)

--- a/templates/apple/Sources/Client.swift.twig
+++ b/templates/apple/Sources/Client.swift.twig
@@ -466,8 +466,19 @@ open class Client {
         var nextChunk = offset / Client.chunkSize
         var completedChunks = nextChunk
         var uploadedBytes = min(offset, size)
+        var completedResponse: [String: Any]? = nil
+        var lastChunkResponse: [String: Any]? = nil
         let baseParams = params
         let baseHeaders = headers
+
+        func isUploadComplete(_ response: [String: Any]) -> Bool {
+            guard let chunksUploaded = response["chunksUploaded"] as? Int else {
+                return false
+            }
+
+            let chunksTotal = response["chunksTotal"] as? Int ?? totalChunks
+            return chunksUploaded >= chunksTotal
+        }
 
         func uploadChunk(index: Int, uploadId: String?) async throws -> (Int, Int, [String: Any]) {
             let chunkOffset = index * Client.chunkSize
@@ -527,7 +538,10 @@ open class Client {
                 inFlight -= 1
                 completedChunks += 1
                 uploadedBytes += chunk.1
-                result = chunk.2
+                lastChunkResponse = chunk.2
+                if isUploadComplete(chunk.2) {
+                    completedResponse = chunk.2
+                }
 
                 onProgress?(UploadProgress(
                     id: uploadId ?? "",
@@ -546,6 +560,8 @@ open class Client {
                 }
             }
         }
+
+        result = completedResponse ?? lastChunkResponse ?? result
 
         return try converter!(result)
     }

--- a/templates/apple/Sources/Client.swift.twig
+++ b/templates/apple/Sources/Client.swift.twig
@@ -16,6 +16,7 @@ open class Client {
 
     // MARK: Properties
     public static var chunkSize = 5 * 1024 * 1024 // 5MB
+    public static var maxConcurrentUploads = 8
 
     open var endPoint = "{{spec.endpoint}}"
 
@@ -468,19 +469,12 @@ open class Client {
         let baseParams = params
         let baseHeaders = headers
 
-        func isUploadComplete(_ response: [String: Any]) -> Bool {
-            guard let chunksUploaded = response["chunksUploaded"] as? Int else {
-                return false
-            }
-
-            let chunksTotal = response["chunksTotal"] as? Int ?? totalChunks
-            return chunksUploaded >= chunksTotal
-        }
-
         func uploadChunk(index: Int, uploadId: String?) async throws -> (Int, Int, [String: Any]) {
             let chunkOffset = index * Client.chunkSize
             let chunkLength = min(Client.chunkSize, size - chunkOffset)
-            let slice = (input.data as! ByteBuffer).getSlice(at: chunkOffset, length: chunkLength)!
+            guard let slice = (input.data as! ByteBuffer).getSlice(at: chunkOffset, length: chunkLength) else {
+                throw {{ spec.title | caseUcfirst }}Error(message: "Failed to read upload chunk")
+            }
             var chunkParams = baseParams
             var chunkHeaders = baseHeaders
             chunkParams[paramName] = InputFile.fromBuffer(slice, filename: input.filename, mimeType: input.mimeType)
@@ -516,7 +510,7 @@ open class Client {
             ))
         }
 
-        let maxConcurrency = 8
+        let maxConcurrency = Client.maxConcurrentUploads
 
         try await withThrowingTaskGroup(of: (Int, Int, [String: Any]).self) { group in
             var inFlight = 0
@@ -533,9 +527,7 @@ open class Client {
                 inFlight -= 1
                 completedChunks += 1
                 uploadedBytes += chunk.1
-                if isUploadComplete(chunk.2) {
-                    result = chunk.2
-                }
+                result = chunk.2
 
                 onProgress?(UploadProgress(
                     id: uploadId ?? "",

--- a/templates/dart/lib/src/client_browser.dart.twig
+++ b/templates/dart/lib/src/client_browser.dart.twig
@@ -173,6 +173,13 @@ class ClientBrowser extends ClientBase with ClientMixin {
     var completedChunks = firstIndex + 1;
     var uploadedBytes = firstEnd;
     var lastResponse = res;
+    Response? finalResponse;
+
+    bool isUploadComplete(Response response) {
+      final chunksUploaded = response.data['chunksUploaded'];
+      final chunksTotal = response.data['chunksTotal'] ?? totalChunks;
+      return chunksUploaded is num && chunksTotal is num && chunksUploaded >= chunksTotal;
+    }
 
     final progress = UploadProgress(
       $id: uploadId ?? '',
@@ -206,6 +213,9 @@ class ClientBrowser extends ClientBase with ClientMixin {
         completedChunks++;
         uploadedBytes += chunk['end']! - chunk['start']!;
         lastResponse = chunkResponse;
+        if (isUploadComplete(chunkResponse)) {
+          finalResponse = chunkResponse;
+        }
 
         final progress = UploadProgress(
           $id: uploadId ?? '',
@@ -221,7 +231,7 @@ class ClientBrowser extends ClientBase with ClientMixin {
     final concurrency = min(8, chunks.length);
     await Future.wait(List.generate(concurrency, (_) => uploadNext()));
 
-    return lastResponse;
+    return finalResponse ?? lastResponse;
   }
 
   @override

--- a/templates/dart/lib/src/client_browser.dart.twig
+++ b/templates/dart/lib/src/client_browser.dart.twig
@@ -174,12 +174,6 @@ class ClientBrowser extends ClientBase with ClientMixin {
     var uploadedBytes = firstEnd;
     var lastResponse = res;
 
-    bool isUploadComplete(Response response) {
-      final chunksUploaded = response.data['chunksUploaded'];
-      final chunksTotal = response.data['chunksTotal'] ?? totalChunks;
-      return chunksUploaded is num && chunksTotal is num && chunksUploaded >= chunksTotal;
-    }
-
     final progress = UploadProgress(
       $id: uploadId ?? '',
       progress: min(uploadedBytes, size) / size * 100,
@@ -211,9 +205,7 @@ class ClientBrowser extends ClientBase with ClientMixin {
         );
         completedChunks++;
         uploadedBytes += chunk['end']! - chunk['start']!;
-        if (isUploadComplete(chunkResponse)) {
-          lastResponse = chunkResponse;
-        }
+        lastResponse = chunkResponse;
 
         final progress = UploadProgress(
           $id: uploadId ?? '',

--- a/templates/dart/lib/src/client_io.dart.twig
+++ b/templates/dart/lib/src/client_io.dart.twig
@@ -210,6 +210,13 @@ class ClientIO extends ClientBase with ClientMixin {
     var completedChunks = firstIndex + 1;
     var uploadedBytes = firstEnd;
     var lastResponse = res;
+    Response? finalResponse;
+
+    bool isUploadComplete(Response response) {
+      final chunksUploaded = response.data['chunksUploaded'];
+      final chunksTotal = response.data['chunksTotal'] ?? totalChunks;
+      return chunksUploaded is num && chunksTotal is num && chunksUploaded >= chunksTotal;
+    }
 
     final progress = UploadProgress(
       $id: uploadId ?? '',
@@ -246,6 +253,9 @@ class ClientIO extends ClientBase with ClientMixin {
           completedChunks++;
           uploadedBytes += chunk['end']! - chunk['start']!;
           lastResponse = chunkResponse;
+          if (isUploadComplete(chunkResponse)) {
+            finalResponse = chunkResponse;
+          }
 
           final progress = UploadProgress(
             $id: uploadId ?? '',
@@ -264,7 +274,7 @@ class ClientIO extends ClientBase with ClientMixin {
     final concurrency = min(8, chunks.length);
     await Future.wait(List.generate(concurrency, (_) => uploadNext()));
 
-    return lastResponse;
+    return finalResponse ?? lastResponse;
   }
 
   @override

--- a/templates/dart/lib/src/client_io.dart.twig
+++ b/templates/dart/lib/src/client_io.dart.twig
@@ -164,17 +164,23 @@ class ClientIO extends ClientBase with ClientMixin {
 
     final totalChunks = (size / chunkSize).ceil();
 
-    Future<Response> uploadChunk(int index, int start, int end, String? id) async {
+    Future<Response> uploadChunk(int index, int start, int end, String? id,
+        [RandomAccessFile? raf]) async {
       List<int> chunk = [];
       if (file.bytes != null) {
         chunk = file.bytes!.getRange(start, end).toList();
       } else {
-        final raf = await iofile!.open(mode: FileMode.read);
-        try {
+        if (raf != null) {
           await raf.setPosition(start);
           chunk = await raf.read(end - start);
-        } finally {
-          await raf.close();
+        } else {
+          final chunkFile = await iofile!.open(mode: FileMode.read);
+          try {
+            await chunkFile.setPosition(start);
+            chunk = await chunkFile.read(end - start);
+          } finally {
+            await chunkFile.close();
+          }
         }
       }
 
@@ -205,12 +211,6 @@ class ClientIO extends ClientBase with ClientMixin {
     var uploadedBytes = firstEnd;
     var lastResponse = res;
 
-    bool isUploadComplete(Response response) {
-      final chunksUploaded = response.data['chunksUploaded'];
-      final chunksTotal = response.data['chunksTotal'] ?? totalChunks;
-      return chunksUploaded is num && chunksTotal is num && chunksUploaded >= chunksTotal;
-    }
-
     final progress = UploadProgress(
       $id: uploadId ?? '',
       progress: min(uploadedBytes, size) / size * 100,
@@ -232,28 +232,32 @@ class ClientIO extends ClientBase with ClientMixin {
 
     var nextChunk = 0;
     Future<void> uploadNext() async {
-      while (nextChunk < chunks.length) {
-        final chunk = chunks[nextChunk++];
-        final chunkResponse = await uploadChunk(
-          chunk['index']!,
-          chunk['start']!,
-          chunk['end']!,
-          uploadId,
-        );
-        completedChunks++;
-        uploadedBytes += chunk['end']! - chunk['start']!;
-        if (isUploadComplete(chunkResponse)) {
+      final raf = file.bytes == null ? await iofile!.open(mode: FileMode.read) : null;
+      try {
+        while (nextChunk < chunks.length) {
+          final chunk = chunks[nextChunk++];
+          final chunkResponse = await uploadChunk(
+            chunk['index']!,
+            chunk['start']!,
+            chunk['end']!,
+            uploadId,
+            raf,
+          );
+          completedChunks++;
+          uploadedBytes += chunk['end']! - chunk['start']!;
           lastResponse = chunkResponse;
-        }
 
-        final progress = UploadProgress(
-          $id: uploadId ?? '',
-          progress: min(uploadedBytes, size) / size * 100,
-          sizeUploaded: min(uploadedBytes, size),
-          chunksTotal: totalChunks,
-          chunksUploaded: completedChunks,
-        );
-        onProgress?.call(progress);
+          final progress = UploadProgress(
+            $id: uploadId ?? '',
+            progress: min(uploadedBytes, size) / size * 100,
+            sizeUploaded: min(uploadedBytes, size),
+            chunksTotal: totalChunks,
+            chunksUploaded: completedChunks,
+          );
+          onProgress?.call(progress);
+        }
+      } finally {
+        await raf?.close();
       }
     }
 

--- a/templates/deno/src/services/service.ts.twig
+++ b/templates/deno/src/services/service.ts.twig
@@ -239,12 +239,6 @@ export class {{ service.name | caseUcfirst }} extends Service {
         let nextChunk = 1;
         let lastResponse = response;
 
-        const isUploadComplete = (chunkResponse: any) => {
-            const chunksUploaded = chunkResponse?.chunksUploaded;
-            const chunksTotal = chunkResponse?.chunksTotal ?? totalChunks;
-            return typeof chunksUploaded === 'number' && typeof chunksTotal === 'number' && chunksUploaded >= chunksTotal;
-        };
-
         const uploadNext = async () => {
             while (nextChunk < chunks.length) {
                 const chunk = chunks[nextChunk++];
@@ -252,9 +246,7 @@ export class {{ service.name | caseUcfirst }} extends Service {
                 completedCount++;
                 uploadedBytes += chunk.end - chunk.start;
 
-                if (isUploadComplete(chunkResponse)) {
-                    lastResponse = chunkResponse;
-                }
+                lastResponse = chunkResponse;
 
                 if (onProgress !== null) {
                     onProgress({

--- a/templates/deno/src/services/service.ts.twig
+++ b/templates/deno/src/services/service.ts.twig
@@ -238,6 +238,13 @@ export class {{ service.name | caseUcfirst }} extends Service {
         const CONCURRENCY = 8;
         let nextChunk = 1;
         let lastResponse = response;
+        let finalResponse = null;
+
+        const isUploadComplete = (chunkResponse: any) => {
+            const chunksUploaded = chunkResponse?.chunksUploaded;
+            const chunksTotal = chunkResponse?.chunksTotal ?? totalChunks;
+            return typeof chunksUploaded === 'number' && typeof chunksTotal === 'number' && chunksUploaded >= chunksTotal;
+        };
 
         const uploadNext = async () => {
             while (nextChunk < chunks.length) {
@@ -247,6 +254,9 @@ export class {{ service.name | caseUcfirst }} extends Service {
                 uploadedBytes += chunk.end - chunk.start;
 
                 lastResponse = chunkResponse;
+                if (isUploadComplete(chunkResponse)) {
+                    finalResponse = chunkResponse;
+                }
 
                 if (onProgress !== null) {
                     onProgress({
@@ -262,7 +272,7 @@ export class {{ service.name | caseUcfirst }} extends Service {
 
         await Promise.all(Array.from({ length: Math.min(CONCURRENCY, chunks.length - 1) }, uploadNext));
 
-        response = lastResponse;
+        response = finalResponse ?? lastResponse;
 
         return response;
 {% endif %}

--- a/templates/dotnet/Package/Client.cs.twig
+++ b/templates/dotnet/Package/Client.cs.twig
@@ -384,7 +384,6 @@ namespace {{ spec.title | caseUcfirst }}
             {
                 case "path":
                     var info = new FileInfo(input.Path);
-                    input.Data = info.OpenRead();
                     size = info.Length;
                     break;
                 case "stream":
@@ -410,6 +409,8 @@ namespace {{ spec.title | caseUcfirst }}
                 switch(input.SourceType)
                 {
                     case "path":
+                        buffer = await System.IO.File.ReadAllBytesAsync(input.Path);
+                        break;
                     case "stream":
                         var dataStream = input.Data as Stream;
                         if (dataStream == null)
@@ -541,7 +542,7 @@ namespace {{ spec.title | caseUcfirst }}
                     chunkParameters
                 );
 
-                if (index == 0 || string.IsNullOrEmpty(uploadId))
+                if (index == 0)
                 {
                     uploadId = chunkResult.ContainsKey("$id")
                         ? chunkResult["$id"]?.ToString() ?? string.Empty
@@ -590,21 +591,6 @@ namespace {{ spec.title | caseUcfirst }}
                 var uploadedBytes = offset;
                 var resultLock = new object();
 
-                bool IsUploadComplete(Dictionary<string, object?> chunkResult)
-                {
-                    if (!chunkResult.TryGetValue("chunksUploaded", out var chunksUploadedValue) || chunksUploadedValue == null)
-                    {
-                        return false;
-                    }
-
-                    var chunksUploaded = Convert.ToInt64(chunksUploadedValue);
-                    var chunksTotal = chunkResult.TryGetValue("chunksTotal", out var chunksTotalValue) && chunksTotalValue != null
-                        ? Convert.ToInt64(chunksTotalValue)
-                        : totalChunks;
-
-                    return chunksUploaded >= chunksTotal;
-                }
-
                 var workers = Enumerable.Range(0, Math.Min(MaxConcurrentUploads, chunks.Count))
                     .Select(async _ =>
                     {
@@ -617,12 +603,9 @@ namespace {{ spec.title | caseUcfirst }}
                             var chunk = chunks[chunkIndex];
                             var chunkResult = await UploadChunkAsync(chunk.Index, chunk.Start, chunk.End, true);
 
-                            if (IsUploadComplete(chunkResult))
+                            lock (resultLock)
                             {
-                                lock (resultLock)
-                                {
-                                    result = chunkResult;
-                                }
+                                result = chunkResult;
                             }
 
                             var chunksUploaded = Interlocked.Increment(ref completedChunks);

--- a/templates/dotnet/Package/Client.cs.twig
+++ b/templates/dotnet/Package/Client.cs.twig
@@ -409,7 +409,7 @@ namespace {{ spec.title | caseUcfirst }}
                 switch(input.SourceType)
                 {
                     case "path":
-                        buffer = await System.IO.File.ReadAllBytesAsync(input.Path);
+                        buffer = System.IO.File.ReadAllBytes(input.Path);
                         break;
                     case "stream":
                         var dataStream = input.Data as Stream;
@@ -590,6 +590,23 @@ namespace {{ spec.title | caseUcfirst }}
                 var completedChunks = (long)(offset / ChunkSize);
                 var uploadedBytes = offset;
                 var resultLock = new object();
+                var lastResult = result;
+                Dictionary<string, object?>? completedResult = null;
+
+                bool IsUploadComplete(Dictionary<string, object?> chunkResult)
+                {
+                    if (!chunkResult.TryGetValue("chunksUploaded", out var chunksUploadedValue) || chunksUploadedValue == null)
+                    {
+                        return false;
+                    }
+
+                    var chunksUploaded = Convert.ToInt64(chunksUploadedValue);
+                    var chunksTotal = chunkResult.TryGetValue("chunksTotal", out var chunksTotalValue) && chunksTotalValue != null
+                        ? Convert.ToInt64(chunksTotalValue)
+                        : totalChunks;
+
+                    return chunksUploaded >= chunksTotal;
+                }
 
                 var workers = Enumerable.Range(0, Math.Min(MaxConcurrentUploads, chunks.Count))
                     .Select(async _ =>
@@ -605,7 +622,11 @@ namespace {{ spec.title | caseUcfirst }}
 
                             lock (resultLock)
                             {
-                                result = chunkResult;
+                                lastResult = chunkResult;
+                                if (IsUploadComplete(chunkResult))
+                                {
+                                    completedResult = chunkResult;
+                                }
                             }
 
                             var chunksUploaded = Interlocked.Increment(ref completedChunks);
@@ -625,6 +646,7 @@ namespace {{ spec.title | caseUcfirst }}
                     });
 
                 await Task.WhenAll(workers);
+                result = completedResult ?? lastResult;
             }
 
             // Convert to non-nullable dictionary for converter

--- a/templates/flutter/lib/src/client_browser.dart.twig
+++ b/templates/flutter/lib/src/client_browser.dart.twig
@@ -205,12 +205,6 @@ class ClientBrowser extends ClientBase with ClientMixin {
     var uploadedBytes = firstEnd;
     var lastResponse = res;
 
-    bool isUploadComplete(Response response) {
-      final chunksUploaded = response.data['chunksUploaded'];
-      final chunksTotal = response.data['chunksTotal'] ?? totalChunks;
-      return chunksUploaded is num && chunksTotal is num && chunksUploaded >= chunksTotal;
-    }
-
     final progress = UploadProgress(
       $id: uploadId ?? '',
       progress: min(uploadedBytes, size) / size * 100,
@@ -242,9 +236,7 @@ class ClientBrowser extends ClientBase with ClientMixin {
         );
         completedChunks++;
         uploadedBytes += chunk['end']! - chunk['start']!;
-        if (isUploadComplete(chunkResponse)) {
-          lastResponse = chunkResponse;
-        }
+        lastResponse = chunkResponse;
 
         final progress = UploadProgress(
           $id: uploadId ?? '',

--- a/templates/flutter/lib/src/client_browser.dart.twig
+++ b/templates/flutter/lib/src/client_browser.dart.twig
@@ -204,6 +204,13 @@ class ClientBrowser extends ClientBase with ClientMixin {
     var completedChunks = firstIndex + 1;
     var uploadedBytes = firstEnd;
     var lastResponse = res;
+    Response? finalResponse;
+
+    bool isUploadComplete(Response response) {
+      final chunksUploaded = response.data['chunksUploaded'];
+      final chunksTotal = response.data['chunksTotal'] ?? totalChunks;
+      return chunksUploaded is num && chunksTotal is num && chunksUploaded >= chunksTotal;
+    }
 
     final progress = UploadProgress(
       $id: uploadId ?? '',
@@ -237,6 +244,9 @@ class ClientBrowser extends ClientBase with ClientMixin {
         completedChunks++;
         uploadedBytes += chunk['end']! - chunk['start']!;
         lastResponse = chunkResponse;
+        if (isUploadComplete(chunkResponse)) {
+          finalResponse = chunkResponse;
+        }
 
         final progress = UploadProgress(
           $id: uploadId ?? '',
@@ -252,7 +262,7 @@ class ClientBrowser extends ClientBase with ClientMixin {
     final concurrency = min(8, chunks.length);
     await Future.wait(List.generate(concurrency, (_) => uploadNext()));
 
-    return lastResponse;
+    return finalResponse ?? lastResponse;
   }
 
   @override

--- a/templates/flutter/lib/src/client_io.dart.twig
+++ b/templates/flutter/lib/src/client_io.dart.twig
@@ -292,17 +292,23 @@ class ClientIO extends ClientBase with ClientMixin {
 
     final totalChunks = (size / chunkSize).ceil();
 
-    Future<Response> uploadChunk(int index, int start, int end, String? id) async {
+    Future<Response> uploadChunk(int index, int start, int end, String? id,
+        [RandomAccessFile? raf]) async {
       List<int> chunk = [];
       if (file.bytes != null) {
         chunk = file.bytes!.getRange(start, end).toList();
       } else {
-        final raf = await iofile!.open(mode: FileMode.read);
-        try {
+        if (raf != null) {
           await raf.setPosition(start);
           chunk = await raf.read(end - start);
-        } finally {
-          await raf.close();
+        } else {
+          final chunkFile = await iofile!.open(mode: FileMode.read);
+          try {
+            await chunkFile.setPosition(start);
+            chunk = await chunkFile.read(end - start);
+          } finally {
+            await chunkFile.close();
+          }
         }
       }
 
@@ -336,12 +342,6 @@ class ClientIO extends ClientBase with ClientMixin {
     var uploadedBytes = firstEnd;
     var lastResponse = res;
 
-    bool isUploadComplete(Response response) {
-      final chunksUploaded = response.data['chunksUploaded'];
-      final chunksTotal = response.data['chunksTotal'] ?? totalChunks;
-      return chunksUploaded is num && chunksTotal is num && chunksUploaded >= chunksTotal;
-    }
-
     final progress = UploadProgress(
       $id: uploadId ?? '',
       progress: min(uploadedBytes, size) / size * 100,
@@ -363,28 +363,32 @@ class ClientIO extends ClientBase with ClientMixin {
 
     var nextChunk = 0;
     Future<void> uploadNext() async {
-      while (nextChunk < chunks.length) {
-        final chunk = chunks[nextChunk++];
-        final chunkResponse = await uploadChunk(
-          chunk['index']!,
-          chunk['start']!,
-          chunk['end']!,
-          uploadId,
-        );
-        completedChunks++;
-        uploadedBytes += chunk['end']! - chunk['start']!;
-        if (isUploadComplete(chunkResponse)) {
+      final raf = file.bytes == null ? await iofile!.open(mode: FileMode.read) : null;
+      try {
+        while (nextChunk < chunks.length) {
+          final chunk = chunks[nextChunk++];
+          final chunkResponse = await uploadChunk(
+            chunk['index']!,
+            chunk['start']!,
+            chunk['end']!,
+            uploadId,
+            raf,
+          );
+          completedChunks++;
+          uploadedBytes += chunk['end']! - chunk['start']!;
           lastResponse = chunkResponse;
-        }
 
-        final progress = UploadProgress(
-          $id: uploadId ?? '',
-          progress: min(uploadedBytes, size) / size * 100,
-          sizeUploaded: min(uploadedBytes, size),
-          chunksTotal: totalChunks,
-          chunksUploaded: completedChunks,
-        );
-        onProgress?.call(progress);
+          final progress = UploadProgress(
+            $id: uploadId ?? '',
+            progress: min(uploadedBytes, size) / size * 100,
+            sizeUploaded: min(uploadedBytes, size),
+            chunksTotal: totalChunks,
+            chunksUploaded: completedChunks,
+          );
+          onProgress?.call(progress);
+        }
+      } finally {
+        await raf?.close();
       }
     }
 

--- a/templates/flutter/lib/src/client_io.dart.twig
+++ b/templates/flutter/lib/src/client_io.dart.twig
@@ -341,6 +341,13 @@ class ClientIO extends ClientBase with ClientMixin {
     var completedChunks = firstIndex + 1;
     var uploadedBytes = firstEnd;
     var lastResponse = res;
+    Response? finalResponse;
+
+    bool isUploadComplete(Response response) {
+      final chunksUploaded = response.data['chunksUploaded'];
+      final chunksTotal = response.data['chunksTotal'] ?? totalChunks;
+      return chunksUploaded is num && chunksTotal is num && chunksUploaded >= chunksTotal;
+    }
 
     final progress = UploadProgress(
       $id: uploadId ?? '',
@@ -377,6 +384,9 @@ class ClientIO extends ClientBase with ClientMixin {
           completedChunks++;
           uploadedBytes += chunk['end']! - chunk['start']!;
           lastResponse = chunkResponse;
+          if (isUploadComplete(chunkResponse)) {
+            finalResponse = chunkResponse;
+          }
 
           final progress = UploadProgress(
             $id: uploadId ?? '',
@@ -395,7 +405,7 @@ class ClientIO extends ClientBase with ClientMixin {
     final concurrency = min(8, chunks.length);
     await Future.wait(List.generate(concurrency, (_) => uploadNext()));
 
-    return lastResponse;
+    return finalResponse ?? lastResponse;
   }
 
   bool get _customSchemeAllowed => Platform.isWindows || Platform.isLinux;

--- a/templates/go/client.go.twig
+++ b/templates/go/client.go.twig
@@ -247,6 +247,33 @@ func (client *Client) FileUpload(url string, headers map[string]interface{}, par
 		return ""
 	}
 
+	isUploadComplete := func(resp *ClientResponse) bool {
+		if resp == nil || !strings.HasPrefix(resp.Type, "application/json") {
+			return false
+		}
+
+		var parsed map[string]interface{}
+		if resStr, ok := resp.Result.(string); ok {
+			_ = json.Unmarshal([]byte(resStr), &parsed)
+		} else {
+			parsed, _ = resp.Result.(map[string]interface{})
+		}
+		if parsed == nil || parsed["chunksUploaded"] == nil {
+			return false
+		}
+
+		chunksUploaded, ok := parsed["chunksUploaded"].(float64)
+		if !ok {
+			return false
+		}
+		chunksTotal := float64(numChunks)
+		if value, ok := parsed["chunksTotal"].(float64); ok {
+			chunksTotal = value
+		}
+
+		return chunksUploaded >= chunksTotal
+	}
+
 	uploadChunk := func(i int64, id string) (*ClientResponse, error) {
 		chunkSize := client.ChunkSize
 		offset := i * client.ChunkSize
@@ -335,13 +362,22 @@ func (client *Client) FileUpload(url string, headers map[string]interface{}, par
 		}
 	}()
 
+	var lastResult *ClientResponse
+	completeFound := false
 	for i := int64(0); i < remainingChunks; i++ {
 		chunk := <-results
 		if chunk.err != nil {
 			close(done)
 			return nil, chunk.err
 		}
-		result = chunk.resp
+		lastResult = chunk.resp
+		if isUploadComplete(chunk.resp) {
+			result = chunk.resp
+			completeFound = true
+		}
+	}
+	if !completeFound && lastResult != nil {
+		result = lastResult
 	}
 	return result, nil
 }

--- a/templates/go/client.go.twig
+++ b/templates/go/client.go.twig
@@ -239,40 +239,12 @@ func (client *Client) FileUpload(url string, headers map[string]interface{}, par
 	parseUploadId := func(resp *ClientResponse) string {
 		var parsed map[string]interface{}
 		if resp != nil && strings.HasPrefix(resp.Type, "application/json") {
-			err = json.Unmarshal([]byte(resp.Result.(string)), &parsed)
-			if err == nil {
+			if unmarshalErr := json.Unmarshal([]byte(resp.Result.(string)), &parsed); unmarshalErr == nil {
 				id, _ := parsed["$id"].(string)
 				return id
 			}
 		}
 		return ""
-	}
-
-	isUploadComplete := func(resp *ClientResponse) bool {
-		if resp == nil || !strings.HasPrefix(resp.Type, "application/json") {
-			return false
-		}
-
-		var parsed map[string]interface{}
-		if resStr, ok := resp.Result.(string); ok {
-			_ = json.Unmarshal([]byte(resStr), &parsed)
-		} else {
-			parsed, _ = resp.Result.(map[string]interface{})
-		}
-		if parsed == nil || parsed["chunksUploaded"] == nil {
-			return false
-		}
-
-		chunksUploaded, ok := parsed["chunksUploaded"].(float64)
-		if !ok {
-			return false
-		}
-		chunksTotal := float64(numChunks)
-		if value, ok := parsed["chunksTotal"].(float64); ok {
-			chunksTotal = value
-		}
-
-		return chunksUploaded >= chunksTotal
 	}
 
 	uploadChunk := func(i int64, id string) (*ClientResponse, error) {
@@ -333,38 +305,43 @@ func (client *Client) FileUpload(url string, headers map[string]interface{}, par
 
 	jobs := make(chan int64)
 	results := make(chan chunkResult, int(remainingChunks))
+	done := make(chan struct{})
 
 	for worker := int64(0); worker < concurrency; worker++ {
 		go func() {
-			for i := range jobs {
-				resp, err := uploadChunk(i, uploadId)
-				results <- chunkResult{index: i, resp: resp, err: err}
+			for {
+				select {
+				case <-done:
+					return
+				case i, ok := <-jobs:
+					if !ok {
+						return
+					}
+					resp, err := uploadChunk(i, uploadId)
+					results <- chunkResult{index: i, resp: resp, err: err}
+				}
 			}
 		}()
 	}
 
 	go func() {
+		defer close(jobs)
 		for i := currentChunk; i < numChunks; i++ {
-			jobs <- i
+			select {
+			case <-done:
+				return
+			case jobs <- i:
+			}
 		}
-		close(jobs)
 	}()
 
-	var firstErr error
 	for i := int64(0); i < remainingChunks; i++ {
 		chunk := <-results
 		if chunk.err != nil {
-			if firstErr == nil {
-				firstErr = chunk.err
-			}
-			continue
+			close(done)
+			return nil, chunk.err
 		}
-		if isUploadComplete(chunk.resp) {
-			result = chunk.resp
-		}
-	}
-	if firstErr != nil {
-		return nil, firstErr
+		result = chunk.resp
 	}
 	return result, nil
 }

--- a/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
@@ -433,6 +433,12 @@ class Client @JvmOverloads constructor(
 
         val totalChunks = (size + CHUNK_SIZE - 1) / CHUNK_SIZE
 
+        fun isUploadComplete(chunkResult: Map<*, *>): Boolean {
+            val chunksUploaded = chunkResult["chunksUploaded"]?.toString()?.toLongOrNull() ?: return false
+            val chunksTotal = chunkResult["chunksTotal"]?.toString()?.toLongOrNull() ?: totalChunks
+            return chunksUploaded >= chunksTotal
+        }
+
         suspend fun uploadChunk(index: Int, start: Long, end: Long, includeUploadId: Boolean): Map<*, *> {
             val chunkParams = params.toMutableMap()
             val chunkHeaders = headers.toMutableMap()
@@ -490,7 +496,8 @@ class Client @JvmOverloads constructor(
             val nextChunk = AtomicInteger(0)
             val completedChunks = AtomicInteger((offset / CHUNK_SIZE).toInt())
             val uploadedBytes = AtomicLong(offset.coerceAtMost(size))
-            val resultRef = AtomicReference(result)
+            val completedResultRef = AtomicReference<Map<*, *>?>(null)
+            val lastResultRef = AtomicReference(result)
             val progressLock = Any()
 
             coroutineScope {
@@ -508,7 +515,10 @@ class Client @JvmOverloads constructor(
                             val chunksUploaded = completedChunks.incrementAndGet()
                             val sizeUploaded = uploadedBytes.addAndGet(end - start)
 
-                            resultRef.set(chunkResult)
+                            lastResultRef.set(chunkResult)
+                            if (isUploadComplete(chunkResult)) {
+                                completedResultRef.set(chunkResult)
+                            }
 
                             synchronized(progressLock) {
                                 onProgress?.invoke(
@@ -525,7 +535,7 @@ class Client @JvmOverloads constructor(
                     }
                 }.awaitAll()
             }
-            result = resultRef.get()
+            result = completedResultRef.get() ?: lastResultRef.get()
         }
 
         return converter(result as Map<String, Any>)

--- a/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
@@ -29,6 +29,7 @@ import java.security.SecureRandom
 import java.security.cert.X509Certificate
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 import javax.net.ssl.HostnameVerifier
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLSocketFactory
@@ -432,12 +433,6 @@ class Client @JvmOverloads constructor(
 
         val totalChunks = (size + CHUNK_SIZE - 1) / CHUNK_SIZE
 
-        fun isUploadComplete(chunkResult: Map<*, *>): Boolean {
-            val chunksUploaded = chunkResult["chunksUploaded"]?.toString()?.toLongOrNull() ?: return false
-            val chunksTotal = chunkResult["chunksTotal"]?.toString()?.toLongOrNull() ?: totalChunks
-            return chunksUploaded >= chunksTotal
-        }
-
         suspend fun uploadChunk(index: Int, start: Long, end: Long, includeUploadId: Boolean): Map<*, *> {
             val chunkParams = params.toMutableMap()
             val chunkHeaders = headers.toMutableMap()
@@ -461,7 +456,7 @@ class Client @JvmOverloads constructor(
                 responseType = Map::class.java
             )
 
-            if (index == 0 || uploadId == null) {
+            if (index == 0) {
                 uploadId = chunkResult["\$id"].toString()
             }
 
@@ -495,6 +490,8 @@ class Client @JvmOverloads constructor(
             val nextChunk = AtomicInteger(0)
             val completedChunks = AtomicInteger((offset / CHUNK_SIZE).toInt())
             val uploadedBytes = AtomicLong(offset.coerceAtMost(size))
+            val resultRef = AtomicReference(result)
+            val progressLock = Any()
 
             coroutineScope {
                 List(MAX_CONCURRENT_UPLOADS.coerceAtMost(chunks.size)) {
@@ -511,23 +508,24 @@ class Client @JvmOverloads constructor(
                             val chunksUploaded = completedChunks.incrementAndGet()
                             val sizeUploaded = uploadedBytes.addAndGet(end - start)
 
-                            if (isUploadComplete(chunkResult)) {
-                                result = chunkResult
-                            }
+                            resultRef.set(chunkResult)
 
-                            onProgress?.invoke(
-                                UploadProgress(
-                                    id = uploadId ?: chunkResult["\$id"].toString(),
-                                    progress = sizeUploaded.coerceAtMost(size).toDouble() / size * 100,
-                                    sizeUploaded = sizeUploaded.coerceAtMost(size),
-                                    chunksTotal = chunkResult["chunksTotal"].toString().toInt(),
-                                    chunksUploaded = chunksUploaded,
+                            synchronized(progressLock) {
+                                onProgress?.invoke(
+                                    UploadProgress(
+                                        id = uploadId ?: chunkResult["\$id"].toString(),
+                                        progress = sizeUploaded.coerceAtMost(size).toDouble() / size * 100,
+                                        sizeUploaded = sizeUploaded.coerceAtMost(size),
+                                        chunksTotal = chunkResult["chunksTotal"].toString().toInt(),
+                                        chunksUploaded = chunksUploaded,
+                                    )
                                 )
-                            )
+                            }
                         }
                     }
                 }.awaitAll()
             }
+            result = resultRef.get()
         }
 
         return converter(result as Map<String, Any>)

--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -302,11 +302,11 @@ class Client {
             }
 
             // Prepare remaining chunks
-            const chunks: { index: number; start: number; end: number }[] = [];
+            const chunks: { start: number; end: number }[] = [];
             for (let i = 1; i < totalChunks; i++) {
                 const start = i * Client.CHUNK_SIZE;
                 const end = Math.min(start + Client.CHUNK_SIZE, size);
-                chunks.push({ index: i, start, end });
+                chunks.push({ start, end });
             }
 
             // Upload remaining chunks with max concurrency of 8
@@ -314,12 +314,6 @@ class Client {
             let completedCount = 1;
             let uploadedBytes = firstChunkEnd;
             let lastResponse = response;
-
-            const isUploadComplete = (chunkResponse: any) => {
-                const chunksUploaded = chunkResponse?.chunksUploaded;
-                const chunksTotal = chunkResponse?.chunksTotal ?? totalChunks;
-                return typeof chunksUploaded === 'number' && typeof chunksTotal === 'number' && chunksUploaded >= chunksTotal;
-            };
 
             const uploadChunk = async (chunk: typeof chunks[0]) => {
                 const chunkHeaders = { ...headers };
@@ -337,9 +331,7 @@ class Client {
                 completedCount++;
                 uploadedBytes += (chunk.end - chunk.start);
                 
-                if (isUploadComplete(chunkResponse)) {
-                    lastResponse = chunkResponse;
-                }
+                lastResponse = chunkResponse;
 
                 if (onProgress && typeof onProgress === 'function') {
                     onProgress({
@@ -406,11 +398,11 @@ class Client {
         }
 
         // Prepare remaining chunks
-        const chunks: { index: number; start: number; end: number }[] = [];
+        const chunks: { start: number; end: number }[] = [];
         for (let i = 1; i < totalChunks; i++) {
             const start = i * Client.CHUNK_SIZE;
             const end = Math.min(start + Client.CHUNK_SIZE, file.size);
-            chunks.push({ index: i, start, end });
+            chunks.push({ start, end });
         }
 
         // Upload remaining chunks with max concurrency of 8
@@ -418,12 +410,6 @@ class Client {
         let completedCount = 1;
         let uploadedBytes = firstChunkEnd;
         let lastResponse = response;
-
-        const isUploadComplete = (chunkResponse: any) => {
-            const chunksUploaded = chunkResponse?.chunksUploaded;
-            const chunksTotal = chunkResponse?.chunksTotal ?? totalChunks;
-            return typeof chunksUploaded === 'number' && typeof chunksTotal === 'number' && chunksUploaded >= chunksTotal;
-        };
 
         const uploadChunk = async (chunk: typeof chunks[0]) => {
             const chunkHeaders = { ...headers };
@@ -441,9 +427,7 @@ class Client {
             completedCount++;
             uploadedBytes += (chunk.end - chunk.start);
             
-            if (isUploadComplete(chunkResponse)) {
-                lastResponse = chunkResponse;
-            }
+            lastResponse = chunkResponse;
 
             if (onProgress && typeof onProgress === 'function') {
                 onProgress({
@@ -479,7 +463,7 @@ class Client {
         return lastResponse;
     }
 
-    async ping(): Promise<string> {
+    async ping(): Promise<any> {
         return this.call('GET', new URL(this.config.endpoint + '/ping'));
     }
 

--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -314,6 +314,13 @@ class Client {
             let completedCount = 1;
             let uploadedBytes = firstChunkEnd;
             let lastResponse = response;
+            let finalResponse = null;
+
+            const isUploadComplete = (chunkResponse: any) => {
+                const chunksUploaded = chunkResponse?.chunksUploaded;
+                const chunksTotal = chunkResponse?.chunksTotal ?? totalChunks;
+                return typeof chunksUploaded === 'number' && typeof chunksTotal === 'number' && chunksUploaded >= chunksTotal;
+            };
 
             const uploadChunk = async (chunk: typeof chunks[0]) => {
                 const chunkHeaders = { ...headers };
@@ -332,6 +339,9 @@ class Client {
                 uploadedBytes += (chunk.end - chunk.start);
                 
                 lastResponse = chunkResponse;
+                if (isUploadComplete(chunkResponse)) {
+                    finalResponse = chunkResponse;
+                }
 
                 if (onProgress && typeof onProgress === 'function') {
                     onProgress({
@@ -364,7 +374,7 @@ class Client {
 
             await Promise.all(workers);
 
-            return lastResponse;
+            return finalResponse ?? lastResponse;
         }
 
         if (file.size <= Client.CHUNK_SIZE) {
@@ -410,6 +420,13 @@ class Client {
         let completedCount = 1;
         let uploadedBytes = firstChunkEnd;
         let lastResponse = response;
+        let finalResponse = null;
+
+        const isUploadComplete = (chunkResponse: any) => {
+            const chunksUploaded = chunkResponse?.chunksUploaded;
+            const chunksTotal = chunkResponse?.chunksTotal ?? totalChunks;
+            return typeof chunksUploaded === 'number' && typeof chunksTotal === 'number' && chunksUploaded >= chunksTotal;
+        };
 
         const uploadChunk = async (chunk: typeof chunks[0]) => {
             const chunkHeaders = { ...headers };
@@ -428,6 +445,9 @@ class Client {
             uploadedBytes += (chunk.end - chunk.start);
             
             lastResponse = chunkResponse;
+            if (isUploadComplete(chunkResponse)) {
+                finalResponse = chunkResponse;
+            }
 
             if (onProgress && typeof onProgress === 'function') {
                 onProgress({
@@ -460,7 +480,7 @@ class Client {
 
         await Promise.all(workers);
 
-        return lastResponse;
+        return finalResponse ?? lastResponse;
     }
 
     async ping(): Promise<any> {

--- a/templates/php/base/requests/file.twig
+++ b/templates/php/base/requests/file.twig
@@ -140,6 +140,14 @@
             return $this->client->call(Client::METHOD_POST, $apiPath, $chunkHeaders, $chunkParams);
         };
 
+        $isUploadComplete = function($chunkResponse) use ($totalChunks): bool {
+            if(!is_array($chunkResponse) || !isset($chunkResponse['chunksUploaded'])) {
+                return false;
+            }
+
+            return (int) $chunkResponse['chunksUploaded'] >= (int) ($chunkResponse['chunksTotal'] ?? $totalChunks);
+        };
+
         if (!empty($chunks)) {
             $response = $uploadChunk($chunks[0], $uploadId);
             if(empty($uploadId)) {
@@ -170,6 +178,8 @@
             }, $this->client, Client::class);
             [$endpoint, $globalHeaders, $selfSigned, $timeout, $connectTimeout] = $clientConfig();
             $responseHeaders = [];
+            $lastResponse = $response;
+            $completedResponse = null;
 
             $makeHandle = function(array $chunk) use ($readChunk, $apiPath, $apiHeaders, $apiParams, $mimeType, $postedName, $size, $uploadId, $endpoint, $globalHeaders, $selfSigned, $timeout, $connectTimeout, $flattenParams, &$responseHeaders) {
                 $chunkParams = $apiParams;
@@ -258,7 +268,10 @@
 
                         $completedCount++;
                         $uploadedSize += $handleInfo['chunk']['end'] - $handleInfo['chunk']['start'];
-                        $response = $chunkResponse;
+                        $lastResponse = $chunkResponse;
+                        if($isUploadComplete($chunkResponse)) {
+                            $completedResponse = $chunkResponse;
+                        }
                         if($onProgress !== null) {
                             $onProgress([
                                 '$id' => $uploadId,
@@ -277,6 +290,7 @@
                     curl_multi_close($multiHandle);
                 }
             }
+            $response = $completedResponse ?? $lastResponse;
 
         }
         if(!empty($handle)) {

--- a/templates/php/base/requests/file.twig
+++ b/templates/php/base/requests/file.twig
@@ -140,14 +140,6 @@
             return $this->client->call(Client::METHOD_POST, $apiPath, $chunkHeaders, $chunkParams);
         };
 
-        $isUploadComplete = function($chunkResponse) use ($totalChunks): bool {
-            if(!is_array($chunkResponse) || !isset($chunkResponse['chunksUploaded'])) {
-                return false;
-            }
-
-            return (int) $chunkResponse['chunksUploaded'] >= (int) ($chunkResponse['chunksTotal'] ?? $totalChunks);
-        };
-
         if (!empty($chunks)) {
             $response = $uploadChunk($chunks[0], $uploadId);
             if(empty($uploadId)) {
@@ -236,52 +228,54 @@
                     curl_multi_add_handle($multiHandle, $ch);
                 }
 
-                do {
-                    $status = curl_multi_exec($multiHandle, $active);
-                    if ($active) {
-                        curl_multi_select($multiHandle);
-                    }
-                } while ($active && $status == CURLM_OK);
+                try {
+                    do {
+                        $status = curl_multi_exec($multiHandle, $active);
+                        if ($active) {
+                            curl_multi_select($multiHandle);
+                        }
+                    } while ($active && ($status == CURLM_OK || $status == CURLM_CALL_MULTI_PERFORM));
 
-                foreach ($handles as $handleInfo) {
-                    $ch = $handleInfo['handle'];
-                    $body = curl_multi_getcontent($ch);
-                    $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-                    $contentType = $responseHeaders[spl_object_id($ch)]['content-type'] ?? '';
+                    foreach ($handles as $handleInfo) {
+                        $ch = $handleInfo['handle'];
+                        $body = curl_multi_getcontent($ch);
+                        $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+                        $contentType = $responseHeaders[spl_object_id($ch)]['content-type'] ?? '';
 
-                    if (curl_errno($ch)) {
-                        throw new {{ spec.namespace | split('\\') | last | caseUcfirst}}Exception(curl_error($ch), $statusCode, '', $body);
-                    }
-
-                    $chunkResponse = str_starts_with($contentType, 'application/json') ? json_decode($body, true) : $body;
-
-                    if($statusCode >= 400) {
-                        if(is_array($chunkResponse)) {
-                            throw new {{ spec.namespace | split('\\') | last | caseUcfirst}}Exception($chunkResponse['message'], $statusCode, $chunkResponse['type'] ?? '', json_encode($chunkResponse));
+                        if (curl_errno($ch)) {
+                            throw new {{ spec.namespace | split('\\') | last | caseUcfirst}}Exception(curl_error($ch), $statusCode, '', $body);
                         }
 
-                        throw new {{ spec.namespace | split('\\') | last | caseUcfirst}}Exception($chunkResponse, $statusCode, '', $chunkResponse);
-                    }
+                        $chunkResponse = str_starts_with($contentType, 'application/json') ? json_decode($body, true) : $body;
 
-                    $completedCount++;
-                    $uploadedSize += $handleInfo['chunk']['end'] - $handleInfo['chunk']['start'];
-                    if($isUploadComplete($chunkResponse)) {
+                        if($statusCode >= 400) {
+                            if(is_array($chunkResponse)) {
+                                throw new {{ spec.namespace | split('\\') | last | caseUcfirst}}Exception($chunkResponse['message'], $statusCode, $chunkResponse['type'] ?? '', json_encode($chunkResponse));
+                            }
+
+                            throw new {{ spec.namespace | split('\\') | last | caseUcfirst}}Exception($chunkResponse, $statusCode, '', $chunkResponse);
+                        }
+
+                        $completedCount++;
+                        $uploadedSize += $handleInfo['chunk']['end'] - $handleInfo['chunk']['start'];
                         $response = $chunkResponse;
+                        if($onProgress !== null) {
+                            $onProgress([
+                                '$id' => $uploadId,
+                                'progress' => $uploadedSize / $size * 100,
+                                'sizeUploaded' => $uploadedSize,
+                                'chunksTotal' => $totalChunks,
+                                'chunksUploaded' => $completedCount,
+                            ]);
+                        }
                     }
-                    if($onProgress !== null) {
-                        $onProgress([
-                            '$id' => $uploadId,
-                            'progress' => $uploadedSize / $size * 100,
-                            'sizeUploaded' => $uploadedSize,
-                            'chunksTotal' => $totalChunks,
-                            'chunksUploaded' => $completedCount,
-                        ]);
+                } finally {
+                    foreach ($handles as $handleInfo) {
+                        curl_multi_remove_handle($multiHandle, $handleInfo['handle']);
+                        curl_close($handleInfo['handle']);
                     }
-
-                    curl_multi_remove_handle($multiHandle, $ch);
+                    curl_multi_close($multiHandle);
                 }
-
-                curl_multi_close($multiHandle);
             }
 
         }

--- a/templates/python/package/client.py.twig
+++ b/templates/python/package/client.py.twig
@@ -193,6 +193,14 @@ class Client:
         uploaded_size = chunks[0]['start']
         progress_lock = Lock()
         last_result = None
+        final_result = None
+
+        def is_upload_complete(chunk_result):
+            chunks_uploaded = chunk_result.get('chunksUploaded')
+            if chunks_uploaded is None:
+                return False
+            chunks_total = chunk_result.get('chunksTotal', total_chunks)
+            return int(chunks_uploaded) >= int(chunks_total)
 
         def upload_chunk(chunk, current_upload_id):
             chunk_input = InputFile.from_bytes(
@@ -231,12 +239,14 @@ class Client:
             })
 
         def upload_remaining_chunk(chunk):
-            nonlocal completed_count, uploaded_size, last_result
+            nonlocal completed_count, uploaded_size, last_result, final_result
             chunk_result = upload_chunk(chunk, upload_id_header)
             with progress_lock:
                 completed_count = completed_count + 1
                 uploaded_size = uploaded_size + (chunk['end'] - chunk['start'])
                 last_result = chunk_result
+                if is_upload_complete(chunk_result):
+                    final_result = chunk_result
                 if on_progress is not None:
                     on_progress({
                         "$id": upload_id_header,
@@ -251,7 +261,7 @@ class Client:
             for future in as_completed(futures):
                 future.result()
 
-        return last_result
+        return final_result or last_result
 
     def flatten(self, data, prefix='', stringify=False):
         output = {}

--- a/templates/python/package/client.py.twig
+++ b/templates/python/package/client.py.twig
@@ -136,14 +136,15 @@ class Client:
 
         if input_file.source_type == 'path':
             size = os.stat(input_file.path).st_size
-            input = open(input_file.path, 'rb')
+            input = None
         elif input_file.source_type == 'bytes':
             size = len(input_file.data)
             input = input_file.data
 
         if size < self._chunk_size:
             if input_file.source_type == 'path':
-                input_file.data = input.read()
+                with open(input_file.path, 'rb') as input:
+                    input_file.data = input.read()
 
             params[param_name] = input_file
             return self.call(
@@ -164,8 +165,6 @@ class Client:
 
         if counter > 0:
             offset = counter * self._chunk_size
-            if input_file.source_type == 'path':
-                input.seek(offset)
 
         total_chunks = (size + self._chunk_size - 1) // self._chunk_size
         chunks = []
@@ -194,13 +193,6 @@ class Client:
         uploaded_size = chunks[0]['start']
         progress_lock = Lock()
         last_result = None
-
-        def is_upload_complete(chunk_result):
-            chunks_uploaded = chunk_result.get('chunksUploaded')
-            if chunks_uploaded is None:
-                return False
-            chunks_total = chunk_result.get('chunksTotal', total_chunks)
-            return int(chunks_uploaded) >= int(chunks_total)
 
         def upload_chunk(chunk, current_upload_id):
             chunk_input = InputFile.from_bytes(
@@ -231,7 +223,7 @@ class Client:
 
         if on_progress is not None:
             on_progress({
-                "$id": result["$id"],
+                "$id": result.get("$id"),
                 "progress": uploaded_size / size * 100,
                 "sizeUploaded": uploaded_size,
                 "chunksTotal": total_chunks,
@@ -244,8 +236,7 @@ class Client:
             with progress_lock:
                 completed_count = completed_count + 1
                 uploaded_size = uploaded_size + (chunk['end'] - chunk['start'])
-                if is_upload_complete(chunk_result):
-                    last_result = chunk_result
+                last_result = chunk_result
                 if on_progress is not None:
                     on_progress({
                         "$id": upload_id_header,

--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -543,7 +543,7 @@ class Client {
         }
     }
 
-    async ping(): Promise<string> {
+    async ping(): Promise<any> {
         return this.call('GET', new URL(this.config.endpoint + '/ping'));
     }
 

--- a/templates/react-native/src/services/template.ts.twig
+++ b/templates/react-native/src/services/template.ts.twig
@@ -233,12 +233,6 @@ export class {{ service.name | caseUcfirst }} extends Service {
         let completedCount = startChunkIndex;
         let uploadedBytes = offset;
 
-        const isUploadComplete = (chunkResponse: any) => {
-            const chunksUploaded = chunkResponse?.chunksUploaded;
-            const chunksTotal = chunkResponse?.chunksTotal ?? totalChunks;
-            return typeof chunksUploaded === 'number' && typeof chunksTotal === 'number' && chunksUploaded >= chunksTotal;
-        };
-
         const uploadChunk = async (chunk: typeof chunks[0]) => {
             const chunkHeaders = { ...apiHeaders };
             if (uploadId) {
@@ -266,9 +260,7 @@ export class {{ service.name | caseUcfirst }} extends Service {
             completedCount++;
             uploadedBytes += (chunk.end - chunk.start);
 
-            if (isUploadComplete(chunkResponse)) {
-                response = chunkResponse;
-            }
+            response = chunkResponse;
 
             if (onProgress) {
                 onProgress({

--- a/templates/react-native/src/services/template.ts.twig
+++ b/templates/react-native/src/services/template.ts.twig
@@ -232,6 +232,13 @@ export class {{ service.name | caseUcfirst }} extends Service {
         const CONCURRENCY = 8;
         let completedCount = startChunkIndex;
         let uploadedBytes = offset;
+        let finalResponse = null;
+
+        const isUploadComplete = (chunkResponse: any) => {
+            const chunksUploaded = chunkResponse?.chunksUploaded;
+            const chunksTotal = chunkResponse?.chunksTotal ?? totalChunks;
+            return typeof chunksUploaded === 'number' && typeof chunksTotal === 'number' && chunksUploaded >= chunksTotal;
+        };
 
         const uploadChunk = async (chunk: typeof chunks[0]) => {
             const chunkHeaders = { ...apiHeaders };
@@ -261,6 +268,9 @@ export class {{ service.name | caseUcfirst }} extends Service {
             uploadedBytes += (chunk.end - chunk.start);
 
             response = chunkResponse;
+            if (isUploadComplete(chunkResponse)) {
+                finalResponse = chunkResponse;
+            }
 
             if (onProgress) {
                 onProgress({
@@ -293,7 +303,7 @@ export class {{ service.name | caseUcfirst }} extends Service {
 
         await Promise.all(workers);
 
-        return response;
+        return finalResponse ?? response;
 {% endif %}
 {% endfor %}
 {% else %}

--- a/templates/ruby/lib/container/client.rb.twig
+++ b/templates/ruby/lib/container/client.rb.twig
@@ -206,6 +206,14 @@ module {{ spec.title | caseUcfirst }}
             completed_count = chunks.first[:index] + 1
             uploaded_size = chunks.first[:ending]
 
+            upload_complete = lambda do |chunk_result|
+                chunks_uploaded = chunk_result['chunksUploaded']
+                return false if chunks_uploaded.nil?
+
+                chunks_total = chunk_result['chunksTotal'] || total_chunks
+                chunks_uploaded.to_i >= chunks_total.to_i
+            end
+
             on_progress.call({
                 id: result['$id'],
                 progress: uploaded_size.to_f/size.to_f * 100.0,
@@ -218,6 +226,8 @@ module {{ spec.title | caseUcfirst }}
             queue = Queue.new
             chunks.drop(1).each { |chunk| queue << chunk }
             first_error = nil
+            last_result = result
+            completed_result = nil
 
             workers = [8, queue.size].min.times.map do
                 Thread.new do
@@ -240,7 +250,8 @@ module {{ spec.title | caseUcfirst }}
                         mutex.synchronize do
                             completed_count += 1
                             uploaded_size += chunk[:ending] - chunk[:start]
-                            result = chunk_result
+                            last_result = chunk_result
+                            completed_result = chunk_result if upload_complete.call(chunk_result)
                             on_progress.call({
                                 id: upload_id,
                                 progress: uploaded_size.to_f/size.to_f * 100.0,
@@ -255,6 +266,8 @@ module {{ spec.title | caseUcfirst }}
 
             workers.each(&:join)
             raise first_error if first_error
+
+            result = completed_result || last_result
 
             return result unless response_type.respond_to?("from")
 

--- a/templates/ruby/lib/container/client.rb.twig
+++ b/templates/ruby/lib/container/client.rb.twig
@@ -206,14 +206,6 @@ module {{ spec.title | caseUcfirst }}
             completed_count = chunks.first[:index] + 1
             uploaded_size = chunks.first[:ending]
 
-            upload_complete = lambda do |chunk_result|
-                chunks_uploaded = chunk_result['chunksUploaded']
-                return false if chunks_uploaded.nil?
-
-                chunks_total = chunk_result['chunksTotal'] || total_chunks
-                chunks_uploaded.to_i >= chunks_total.to_i
-            end
-
             on_progress.call({
                 id: result['$id'],
                 progress: uploaded_size.to_f/size.to_f * 100.0,
@@ -225,18 +217,30 @@ module {{ spec.title | caseUcfirst }}
             mutex = Mutex.new
             queue = Queue.new
             chunks.drop(1).each { |chunk| queue << chunk }
+            first_error = nil
 
             workers = [8, queue.size].min.times.map do
                 Thread.new do
                     loop do
-                        chunk = queue.pop(true) rescue nil
+                        break if mutex.synchronize { !first_error.nil? }
+
+                        chunk = begin
+                            queue.pop(true)
+                        rescue ThreadError
+                            nil
+                        end
                         break unless chunk
 
-                        chunk_result = upload_chunk.call(chunk, upload_id)
+                        begin
+                            chunk_result = upload_chunk.call(chunk, upload_id)
+                        rescue => error
+                            mutex.synchronize { first_error ||= error }
+                            break
+                        end
                         mutex.synchronize do
                             completed_count += 1
                             uploaded_size += chunk[:ending] - chunk[:start]
-                            result = chunk_result if upload_complete.call(chunk_result)
+                            result = chunk_result
                             on_progress.call({
                                 id: upload_id,
                                 progress: uploaded_size.to_f/size.to_f * 100.0,
@@ -249,7 +253,8 @@ module {{ spec.title | caseUcfirst }}
                 end
             end
 
-            workers.each(&:value)
+            workers.each(&:join)
+            raise first_error if first_error
 
             return result unless response_type.respond_to?("from")
 

--- a/templates/rust/src/client.rs.twig
+++ b/templates/rust/src/client.rs.twig
@@ -46,6 +46,7 @@ impl UploadProgress {
 pub struct UploadOptions<F> {
     pub upload_id: Option<String>,
     pub on_progress: Option<F>,
+    pub max_concurrency: Option<usize>,
 }
 
 impl<F> Default for UploadOptions<F> {
@@ -53,6 +54,7 @@ impl<F> Default for UploadOptions<F> {
         Self {
             upload_id: None,
             on_progress: None,
+            max_concurrency: None,
         }
     }
 }
@@ -617,6 +619,7 @@ impl Client {
             UploadOptions {
                 upload_id,
                 on_progress: None::<fn(UploadProgress)>,
+                max_concurrency: None,
             },
         )
         .await
@@ -755,18 +758,6 @@ impl Client {
         let mut uploaded_chunks = start_chunk;
         let mut uploaded_bytes = (start_chunk * chunk_size as u64).min(file_size);
 
-        let is_upload_complete = |response: &Value| -> bool {
-            let Some(chunks_uploaded) = response.get("chunksUploaded").and_then(|v| v.as_u64()) else {
-                return false;
-            };
-            let chunks_total = response
-                .get("chunksTotal")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(total_chunks);
-
-            chunks_uploaded >= chunks_total
-        };
-
         if next_chunk == 0 {
             let result = self.upload_file_chunk(
                 path,
@@ -800,7 +791,7 @@ impl Client {
             next_chunk = 1;
         }
 
-        let max_concurrency = 8usize;
+        let max_concurrency = options.max_concurrency.unwrap_or(8).max(1);
         let mut tasks = JoinSet::new();
 
         while tasks.len() < max_concurrency && next_chunk < total_chunks {
@@ -835,9 +826,7 @@ impl Client {
             let (chunk_index, result) = joined
                 .map_err(|e| {{ spec.title | caseUcfirst }}Error::new(0, format!("Chunk upload task failed: {}", e), None, String::new()))??;
 
-            if is_upload_complete(&result) {
-                last_response = Some(result.clone());
-            }
+            last_response = Some(result.clone());
 
             uploaded_chunks += 1;
             let chunk_start = chunk_index * chunk_size as u64;

--- a/templates/rust/src/client.rs.twig
+++ b/templates/rust/src/client.rs.twig
@@ -757,6 +757,19 @@ impl Client {
         let mut next_chunk = start_chunk;
         let mut uploaded_chunks = start_chunk;
         let mut uploaded_bytes = (start_chunk * chunk_size as u64).min(file_size);
+        let mut completed_response = None;
+
+        let is_upload_complete = |response: &Value| -> bool {
+            let Some(chunks_uploaded) = response.get("chunksUploaded").and_then(|v| v.as_u64()) else {
+                return false;
+            };
+            let chunks_total = response
+                .get("chunksTotal")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(total_chunks);
+
+            chunks_uploaded >= chunks_total
+        };
 
         if next_chunk == 0 {
             let result = self.upload_file_chunk(
@@ -778,6 +791,9 @@ impl Client {
             uploaded_chunks = 1;
             uploaded_bytes = (chunk_size as u64).min(file_size);
             last_response = Some(result.clone());
+            if is_upload_complete(&result) {
+                completed_response = Some(result.clone());
+            }
 
             if let Some(ref callback) = options.on_progress {
                 callback(UploadProgress {
@@ -827,6 +843,9 @@ impl Client {
                 .map_err(|e| {{ spec.title | caseUcfirst }}Error::new(0, format!("Chunk upload task failed: {}", e), None, String::new()))??;
 
             last_response = Some(result.clone());
+            if is_upload_complete(&result) {
+                completed_response = Some(result.clone());
+            }
 
             uploaded_chunks += 1;
             let chunk_start = chunk_index * chunk_size as u64;
@@ -871,7 +890,8 @@ impl Client {
             }
         }
 
-        last_response
+        completed_response
+            .or(last_response)
             .ok_or_else(|| {{ spec.title | caseUcfirst }}Error::new(0, "No chunks uploaded", None, String::new()))
             .and_then(|v| serde_json::from_value(v).map_err(Into::into))
     }

--- a/templates/swift/Sources/Client.swift.twig
+++ b/templates/swift/Sources/Client.swift.twig
@@ -468,8 +468,19 @@ open class Client {
         var nextChunk = offset / Client.chunkSize
         var completedChunks = nextChunk
         var uploadedBytes = min(offset, size)
+        var completedResponse: [String: Any]? = nil
+        var lastChunkResponse: [String: Any]? = nil
         let baseParams = params
         let baseHeaders = headers
+
+        func isUploadComplete(_ response: [String: Any]) -> Bool {
+            guard let chunksUploaded = response["chunksUploaded"] as? Int else {
+                return false
+            }
+
+            let chunksTotal = response["chunksTotal"] as? Int ?? totalChunks
+            return chunksUploaded >= chunksTotal
+        }
 
         func uploadChunk(index: Int, uploadId: String?) async throws -> (Int, Int, [String: Any]) {
             let chunkOffset = index * Client.chunkSize
@@ -529,7 +540,10 @@ open class Client {
                 inFlight -= 1
                 completedChunks += 1
                 uploadedBytes += chunk.1
-                result = chunk.2
+                lastChunkResponse = chunk.2
+                if isUploadComplete(chunk.2) {
+                    completedResponse = chunk.2
+                }
 
                 onProgress?(UploadProgress(
                     id: uploadId ?? "",
@@ -548,6 +562,8 @@ open class Client {
                 }
             }
         }
+
+        result = completedResponse ?? lastChunkResponse ?? result
 
         return try converter!(result)
     }

--- a/templates/swift/Sources/Client.swift.twig
+++ b/templates/swift/Sources/Client.swift.twig
@@ -16,6 +16,7 @@ open class Client {
 
     // MARK: Properties
     public static var chunkSize = 5 * 1024 * 1024 // 5MB
+    public static var maxConcurrentUploads = 8
 
     open var endPoint = "{{spec.endpoint}}"
 
@@ -470,19 +471,12 @@ open class Client {
         let baseParams = params
         let baseHeaders = headers
 
-        func isUploadComplete(_ response: [String: Any]) -> Bool {
-            guard let chunksUploaded = response["chunksUploaded"] as? Int else {
-                return false
-            }
-
-            let chunksTotal = response["chunksTotal"] as? Int ?? totalChunks
-            return chunksUploaded >= chunksTotal
-        }
-
         func uploadChunk(index: Int, uploadId: String?) async throws -> (Int, Int, [String: Any]) {
             let chunkOffset = index * Client.chunkSize
             let chunkLength = min(Client.chunkSize, size - chunkOffset)
-            let slice = (input.data as! ByteBuffer).getSlice(at: chunkOffset, length: chunkLength)!
+            guard let slice = (input.data as! ByteBuffer).getSlice(at: chunkOffset, length: chunkLength) else {
+                throw {{ spec.title | caseUcfirst }}Error(message: "Failed to read upload chunk")
+            }
             var chunkParams = baseParams
             var chunkHeaders = baseHeaders
             chunkParams[paramName] = InputFile.fromBuffer(slice, filename: input.filename, mimeType: input.mimeType)
@@ -518,7 +512,7 @@ open class Client {
             ))
         }
 
-        let maxConcurrency = 8
+        let maxConcurrency = Client.maxConcurrentUploads
 
         try await withThrowingTaskGroup(of: (Int, Int, [String: Any]).self) { group in
             var inFlight = 0
@@ -535,9 +529,7 @@ open class Client {
                 inFlight -= 1
                 completedChunks += 1
                 uploadedBytes += chunk.1
-                if isUploadComplete(chunk.2) {
-                    result = chunk.2
-                }
+                result = chunk.2
 
                 onProgress?(UploadProgress(
                     id: uploadId ?? "",

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -861,6 +861,13 @@ class Client {
         let completedCount = 1;
         let uploadedBytes = firstChunkEnd;
         let lastResponse = response;
+        let finalResponse = null;
+
+        const isUploadComplete = (chunkResponse: any) => {
+            const chunksUploaded = chunkResponse?.chunksUploaded;
+            const chunksTotal = chunkResponse?.chunksTotal ?? totalChunks;
+            return typeof chunksUploaded === 'number' && typeof chunksTotal === 'number' && chunksUploaded >= chunksTotal;
+        };
 
         const uploadChunk = async (chunk: typeof chunks[0]) => {
             const chunkHeaders = { ...headers };
@@ -879,6 +886,9 @@ class Client {
             uploadedBytes += (chunk.end - chunk.start);
             
             lastResponse = chunkResponse;
+            if (isUploadComplete(chunkResponse)) {
+                finalResponse = chunkResponse;
+            }
 
             if (onProgress && typeof onProgress === 'function') {
                 onProgress({
@@ -921,7 +931,7 @@ class Client {
             uploadNext();
         });
 
-        return lastResponse;
+        return finalResponse ?? lastResponse;
     }
 
     async ping(): Promise<any> {

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -849,11 +849,11 @@ class Client {
         }
 
         // Prepare remaining chunks
-        const chunks: { index: number; start: number; end: number }[] = [];
+        const chunks: { start: number; end: number }[] = [];
         for (let i = 1; i < totalChunks; i++) {
             const start = i * Client.CHUNK_SIZE;
             const end = Math.min(start + Client.CHUNK_SIZE, file.size);
-            chunks.push({ index: i, start, end });
+            chunks.push({ start, end });
         }
 
         // Upload remaining chunks with max concurrency of 8
@@ -861,12 +861,6 @@ class Client {
         let completedCount = 1;
         let uploadedBytes = firstChunkEnd;
         let lastResponse = response;
-
-        const isUploadComplete = (chunkResponse: any) => {
-            const chunksUploaded = chunkResponse?.chunksUploaded;
-            const chunksTotal = chunkResponse?.chunksTotal ?? totalChunks;
-            return typeof chunksUploaded === 'number' && typeof chunksTotal === 'number' && chunksUploaded >= chunksTotal;
-        };
 
         const uploadChunk = async (chunk: typeof chunks[0]) => {
             const chunkHeaders = { ...headers };
@@ -884,9 +878,7 @@ class Client {
             completedCount++;
             uploadedBytes += (chunk.end - chunk.start);
             
-            if (isUploadComplete(chunkResponse)) {
-                lastResponse = chunkResponse;
-            }
+            lastResponse = chunkResponse;
 
             if (onProgress && typeof onProgress === 'function') {
                 onProgress({
@@ -932,7 +924,7 @@ class Client {
         return lastResponse;
     }
 
-    async ping(): Promise<string> {
+    async ping(): Promise<any> {
         return this.call('GET', new URL(this.config.endpoint + '/ping'));
     }
 


### PR DESCRIPTION
## What
- Track the latest successful chunk response across SDK upload templates instead of relying on completion markers only
- Fix PHP curl_multi handling and ensure cURL handles are cleaned up on exceptions
- Remove unsafe concurrent uploadId/result writes in JVM/.NET paths and serialize progress callback invocation for JVM SDKs
- Fix path file handle leaks in Python/.NET and reduce Dart/Flutter RandomAccessFile churn by opening one handle per worker
- Stop Go/Ruby workers earlier on upload failures and clean up minor review issues
- Adjust TS client ping return typing where non-JSON responses are wrapped\n\n

## Verification
- Regenerated affected SDKs with example.php
- composer lint-twig
- git diff --check