### PR TITLE
Fix JS upload worker shutdown

### DIFF
--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -360,13 +360,19 @@ class Client {
             const queue = [...chunks];
             const workers: Promise<void>[] = [];
             const workerCount = Math.min(CONCURRENCY, queue.length);
+            let failed = false;
 
             for (let i = 0; i < workerCount; i++) {
                 workers.push(
                     (async () => {
-                        while (queue.length > 0) {
+                        while (!failed && queue.length > 0) {
                             const chunk = queue.shift()!;
-                            await uploadChunk(chunk);
+                            try {
+                                await uploadChunk(chunk);
+                            } catch (error) {
+                                failed = true;
+                                throw error;
+                            }
                         }
                     })()
                 );
@@ -466,13 +472,19 @@ class Client {
         const queue = [...chunks];
         const workers: Promise<void>[] = [];
         const workerCount = Math.min(CONCURRENCY, queue.length);
+        let failed = false;
 
         for (let i = 0; i < workerCount; i++) {
             workers.push(
                 (async () => {
-                    while (queue.length > 0) {
+                    while (!failed && queue.length > 0) {
                         const chunk = queue.shift()!;
-                        await uploadChunk(chunk);
+                        try {
+                            await uploadChunk(chunk);
+                        } catch (error) {
+                            failed = true;
+                            throw error;
+                        }
                     }
                 })()
             );

--- a/templates/react-native/src/services/template.ts.twig
+++ b/templates/react-native/src/services/template.ts.twig
@@ -289,13 +289,19 @@ export class {{ service.name | caseUcfirst }} extends Service {
         const queue = [...chunks];
         const workers: Promise<void>[] = [];
         const workerCount = Math.min(CONCURRENCY, queue.length);
+        let failed = false;
 
         for (let i = 0; i < workerCount; i++) {
             workers.push(
                 (async () => {
-                    while (queue.length > 0) {
+                    while (!failed && queue.length > 0) {
                         const chunk = queue.shift()!;
-                        await uploadChunk(chunk);
+                        try {
+                            await uploadChunk(chunk);
+                        } catch (error) {
+                            failed = true;
+                            throw error;
+                        }
                     }
                 })()
             );

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -907,8 +907,13 @@ class Client {
             let nextChunk = 0;
             let inFlight = 0;
             let completed = 0;
+            let rejected = false;
 
             const uploadNext = () => {
+                if (rejected) {
+                    return;
+                }
+
                 if (completed === chunks.length) {
                     resolve();
                     return;
@@ -924,7 +929,10 @@ class Client {
                             completed++;
                             uploadNext();
                         })
-                        .catch(reject);
+                        .catch((error) => {
+                            rejected = true;
+                            reject(error);
+                        });
                 }
             };
 


### PR DESCRIPTION
## What
- Stop Node and React Native upload worker loops from dispatching new chunks after a chunk upload fails
- Stop Web/Console upload scheduling after the first rejected chunk

## Why
Greptile flagged that concurrent workers could keep draining queued chunks after the caller had already received a failure, causing extra background requests and possible progress callbacks after rejection.

## Verification
- composer lint-twig
- git diff --check
- composer test tests/Node18Test.php
- composer test tests/WebChromiumTest.php
- composer test tests/ReactNativeTest.php
- composer test tests/CLIBun13Test.php