### PR TITLE
Suppress JS upload updates after failures

### DIFF
--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -315,6 +315,7 @@ class Client {
             let uploadedBytes = firstChunkEnd;
             let lastResponse = response;
             let finalResponse = null;
+            let failed = false;
 
             const isUploadComplete = (chunkResponse: any) => {
                 const chunksUploaded = chunkResponse?.chunksUploaded;
@@ -334,6 +335,10 @@ class Client {
                 chunkPayload[fileParam] = new File([chunkBlob], file.filename);
 
                 const chunkResponse = await this.call(method, url, chunkHeaders, chunkPayload);
+
+                if (failed) {
+                    return chunkResponse;
+                }
                 
                 completedCount++;
                 uploadedBytes += (chunk.end - chunk.start);
@@ -360,7 +365,6 @@ class Client {
             const queue = [...chunks];
             const workers: Promise<void>[] = [];
             const workerCount = Math.min(CONCURRENCY, queue.length);
-            let failed = false;
 
             for (let i = 0; i < workerCount; i++) {
                 workers.push(
@@ -427,6 +431,7 @@ class Client {
         let uploadedBytes = firstChunkEnd;
         let lastResponse = response;
         let finalResponse = null;
+        let failed = false;
 
         const isUploadComplete = (chunkResponse: any) => {
             const chunksUploaded = chunkResponse?.chunksUploaded;
@@ -446,6 +451,10 @@ class Client {
             chunkPayload[fileParam] = new File([chunkBlob], file.name);
 
             const chunkResponse = await this.call(method, url, chunkHeaders, chunkPayload);
+
+            if (failed) {
+                return chunkResponse;
+            }
             
             completedCount++;
             uploadedBytes += (chunk.end - chunk.start);
@@ -472,7 +481,6 @@ class Client {
         const queue = [...chunks];
         const workers: Promise<void>[] = [];
         const workerCount = Math.min(CONCURRENCY, queue.length);
-        let failed = false;
 
         for (let i = 0; i < workerCount; i++) {
             workers.push(
@@ -495,7 +503,7 @@ class Client {
         return finalResponse ?? lastResponse;
     }
 
-    async ping(): Promise<any> {
+    async ping(): Promise<unknown> {
         return this.call('GET', new URL(this.config.endpoint + '/ping'));
     }
 

--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -543,7 +543,7 @@ class Client {
         }
     }
 
-    async ping(): Promise<any> {
+    async ping(): Promise<unknown> {
         return this.call('GET', new URL(this.config.endpoint + '/ping'));
     }
 

--- a/templates/react-native/src/services/template.ts.twig
+++ b/templates/react-native/src/services/template.ts.twig
@@ -233,6 +233,7 @@ export class {{ service.name | caseUcfirst }} extends Service {
         let completedCount = startChunkIndex;
         let uploadedBytes = offset;
         let finalResponse = null;
+        let failed = false;
 
         const isUploadComplete = (chunkResponse: any) => {
             const chunksUploaded = chunkResponse?.chunksUploaded;
@@ -264,6 +265,10 @@ export class {{ service.name | caseUcfirst }} extends Service {
 
             const chunkResponse = await this.client.call('{{ method.method | caseLower }}', uri, chunkHeaders, chunkPayload);
 
+            if (failed) {
+                return chunkResponse;
+            }
+
             completedCount++;
             uploadedBytes += (chunk.end - chunk.start);
 
@@ -289,7 +294,6 @@ export class {{ service.name | caseUcfirst }} extends Service {
         const queue = [...chunks];
         const workers: Promise<void>[] = [];
         const workerCount = Math.min(CONCURRENCY, queue.length);
-        let failed = false;
 
         for (let i = 0; i < workerCount; i++) {
             workers.push(

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -862,6 +862,7 @@ class Client {
         let uploadedBytes = firstChunkEnd;
         let lastResponse = response;
         let finalResponse = null;
+        let rejected = false;
 
         const isUploadComplete = (chunkResponse: any) => {
             const chunksUploaded = chunkResponse?.chunksUploaded;
@@ -881,6 +882,10 @@ class Client {
             chunkPayload[fileParam] = new File([chunkBlob], file.name);
 
             const chunkResponse = await this.call(method, url, chunkHeaders, chunkPayload);
+
+            if (rejected) {
+                return chunkResponse;
+            }
             
             completedCount++;
             uploadedBytes += (chunk.end - chunk.start);
@@ -907,7 +912,6 @@ class Client {
             let nextChunk = 0;
             let inFlight = 0;
             let completed = 0;
-            let rejected = false;
 
             const uploadNext = () => {
                 if (rejected) {
@@ -942,7 +946,7 @@ class Client {
         return finalResponse ?? lastResponse;
     }
 
-    async ping(): Promise<any> {
+    async ping(): Promise<unknown> {
         return this.call('GET', new URL(this.config.endpoint + '/ping'));
     }
 


### PR DESCRIPTION
## What
- Stop in-flight JS upload workers from mutating shared upload state or firing progress callbacks after another chunk has already failed
- Tighten generated TypeScript ping return types from Promise<any> to Promise<unknown>
- Applies to Node, Web/Console, and React Native templates

## Why
Greptile flagged remaining low-confidence cases in downstream Node and Console SDK PRs: after the first chunk failure, already in-flight chunks could still complete their post-await code path and emit progress updates after the caller had observed a rejection.

## Verification
- composer lint-twig
- git diff --check
- composer test tests/Node18Test.php
- composer test tests/WebChromiumTest.php
- composer test tests/ReactNativeTest.php
- composer test tests/CLIBun13Test.php