### PR TITLE
Fix Kotlin CLI integer type generation

### DIFF
--- a/templates/cli/lib/constants.ts.twig
+++ b/templates/cli/lib/constants.ts.twig
@@ -29,27 +29,16 @@ export const DEFAULT_ENDPOINT = '{{ spec.endpoint }}';
 
 // Config resources
 export const CONFIG_RESOURCE_KEYS = [
-{% for service in spec.services %}
-{% if service.name == 'functions' %}
-  "functions",
-{% elseif service.name == 'sites' %}
-  "sites",
-{% elseif service.name == 'databases' %}
   "databases",
-{% elseif service.name == 'tablesDB' %}
-  "tablesDB",
-  "tables",
-{% elseif service.name == 'storage' %}
-  "buckets",
-{% elseif service.name == 'teams' %}
-  "teams",
-{% elseif service.name == 'webhooks' %}
-  "webhooks",
-{% elseif service.name == 'messaging' %}
+  "functions",
   "topics",
   "messages",
-{% endif %}
-{% endfor %}
+  "sites",
+  "buckets",
+  "tablesDB",
+  "tables",
+  "teams",
+  "webhooks",
   "collections",
 ] as const;
 

--- a/templates/cli/lib/type-generation/languages/kotlin.ts
+++ b/templates/cli/lib/type-generation/languages/kotlin.ts
@@ -23,7 +23,7 @@ export class Kotlin extends LanguageMeta {
         }
         break;
       case AttributeType.INTEGER:
-        type = "Int";
+        type = "Long";
         break;
       case AttributeType.FLOAT:
         type = "Float";

--- a/tests/languages/cli/test.js
+++ b/tests/languages/cli/test.js
@@ -1,8 +1,11 @@
 const { execFileSync, execSync } = require("child_process");
 const fs = require("fs");
+const assert = require("node:assert/strict");
 const os = require("os");
 const path = require("path");
 const Client = require("./lib/client.ts").default;
+const { localConfig } = require("./lib/config.ts");
+const { types } = require("./lib/commands/types.ts");
 const { parse } = require("./lib/parser.ts");
 const {
   openRuntimesVersion,
@@ -100,6 +103,28 @@ const captureStdoutSync = (callback) => {
   }
 
   return stripAnsi(output).replace(/\r/g, "");
+};
+
+const muteStdout = async (callback) => {
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  const originalConsoleLog = console.log.bind(console);
+
+  console.log = () => {};
+  process.stdout.write = (_chunk, _encoding, cb) => {
+    const callback = typeof _encoding === "function" ? _encoding : cb;
+    if (typeof callback === "function") {
+      callback();
+    }
+
+    return true;
+  };
+
+  try {
+    return await callback();
+  } finally {
+    console.log = originalConsoleLog;
+    process.stdout.write = originalWrite;
+  }
 };
 
 const withArgv = (args, callback) => {
@@ -616,6 +641,51 @@ void (async () => {
     "bun ./node_modules/typescript/bin/tsc --pretty false --noEmit --strict --exactOptionalPropertyTypes --skipLibCheck --module NodeNext --moduleResolution NodeNext generated/appwrite/types.ts",
     { stdio: "pipe" },
   );
+
+  fs.writeFileSync(
+    path.join(process.cwd(), "appwrite.config.json"),
+    JSON.stringify(
+      {
+        projectId: "console",
+        tables: [
+          {
+            $id: "entitlements",
+            databaseId: "billing",
+            name: "entitlements",
+            rowSecurity: true,
+            columns: [
+              {
+                key: "purchaseTime",
+                type: "integer",
+                required: false,
+                default: null,
+              },
+            ],
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+  localConfig.useCwdConfig();
+  await muteStdout(async () => {
+    await types.parseAsync([
+      "bun",
+      "types",
+      "generated/kotlin",
+      "--language",
+      "kotlin",
+    ]);
+  });
+
+  const kotlinTypes = fs.readFileSync(
+    path.join(process.cwd(), "generated/kotlin/Entitlements.kt"),
+    "utf8",
+  );
+  assert.match(kotlinTypes, /val purchaseTime: Long\?/);
+  assert.doesNotMatch(kotlinTypes, /val purchaseTime: Int\?/);
+
   console.log("CLI_TYPEGEN:passed");
 })().catch((error) => {
   throw error;


### PR DESCRIPTION
## Summary
- Map CLI Kotlin type generation integer attributes to `Long` instead of `Int`, matching Kotlin/Android SDK models.
- Add a CLI type-generation regression that generates Kotlin table row types from an integer column and asserts `Long`, not `Int`.
- Make generated CLI config resource keys stable so `sites` is part of `ConfigResourceKey` even when a test spec omits the Sites service; this keeps copied CLI command files type-checking from the real config schema keys.

## Test plan
- `php example.php cli`
- `vendor/bin/phpunit --filter 'CLIBun10Test|CLIBun11Test|CLIBun13Test' tests/CLIBun10Test.php tests/CLIBun11Test.php tests/CLIBun13Test.php`\n- `/tmp/codex-djlint-sdk-generator/bin/djlint templates/ --lint`\n- `composer lint`\n- `git diff --check`\n\nNote: this repo has `master` as the default branch and no `origin/main`, so the PR targets `master`.