### PR TITLE
Fix enumerable toString on TypeScript responses

### DIFF
--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -531,7 +531,11 @@ class Client {
         }
 
         if (data && typeof data === 'object') {
-            data.toString = () => JSONbig.stringify(data);
+            Object.defineProperty(data, 'toString', {
+                value: () => JSONbig.stringify(data),
+                enumerable: false,
+                configurable: true,
+            });
         }
 
         return data;

--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -533,6 +533,7 @@ class Client {
         if (data && typeof data === 'object') {
             Object.defineProperty(data, 'toString', {
                 value: () => JSONbig.stringify(data),
+                writable: true,
                 enumerable: false,
                 configurable: true,
             });

--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -629,7 +629,11 @@ class Client {
             }
 
             if (data && typeof data === 'object') {
-                data.toString = () => JSONbig.stringify(data);
+                Object.defineProperty(data, 'toString', {
+                    value: () => JSONbig.stringify(data),
+                    enumerable: false,
+                    configurable: true,
+                });
             }
 
             return data;

--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -631,6 +631,7 @@ class Client {
             if (data && typeof data === 'object') {
                 Object.defineProperty(data, 'toString', {
                     value: () => JSONbig.stringify(data),
+                    writable: true,
                     enumerable: false,
                     configurable: true,
                 });

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -988,6 +988,7 @@ class Client {
         if (data && typeof data === 'object') {
             Object.defineProperty(data, 'toString', {
                 value: () => JSONbig.stringify(data),
+                writable: true,
                 enumerable: false,
                 configurable: true,
             });

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -986,7 +986,11 @@ class Client {
         }
 
         if (data && typeof data === 'object') {
-            data.toString = () => JSONbig.stringify(data);
+            Object.defineProperty(data, 'toString', {
+                value: () => JSONbig.stringify(data),
+                enumerable: false,
+                configurable: true,
+            });
         }
 
         return data;


### PR DESCRIPTION
## What

Fixes TypeScript SDK response objects so the generated `toString` helper is attached as a non-enumerable property.

## Why

The previous direct assignment added `toString` as an own enumerable property on returned model objects. Framework serializers and object iteration can observe that extra property and treat the SDK response shape as polluted.

## Changes

- Use `Object.defineProperty` for response `toString` in Web, Node, and React Native client templates.
- Keep `String(model)`, template literal coercion, and manual `model.toString()` behavior intact.
- Avoid exposing `toString` through object spread, iteration, and JSON serialization.

## Testing

- `php example.php web`
- `php example.php node`
- `php example.php cli`
- `php example.php react-native`
- `composer lint-twig`
- `git diff --check`
