### PR TITLE
Fix generated SDK CI failures

### DIFF
--- a/src/SDK/Language/Dart.php
+++ b/src/SDK/Language/Dart.php
@@ -286,6 +286,26 @@ class Dart extends Language
         };
     }
 
+    public function getModelToMapValue(array $property): string
+    {
+        $name = $this->escapeKeyword($property['name'] ?? '');
+        $nullAware = !empty($property['required']) ? '' : '?';
+
+        if (!empty($property['sub_schema'])) {
+            if (($property['type'] ?? '') === self::TYPE_ARRAY) {
+                return "{$name}{$nullAware}.map((p) => p.toMap()).toList()";
+            }
+
+            return "{$name}{$nullAware}.toMap()";
+        }
+
+        if (!empty($property['enum'])) {
+            return "{$name}{$nullAware}.value";
+        }
+
+        return $name;
+    }
+
     /**
      * @return array
      */
@@ -601,6 +621,9 @@ class Dart extends Language
                 $value = ($example !== null && $example !== '') ? $example : $enumValues[0];
                 return 'enums.' . \ucfirst($enumName) . '.' . $resolveKey($value);
             }),
+            new TwigFilter('modelToMapValue', function (array $property) {
+                return $this->getModelToMapValue($property);
+            }, ['is_safe' => ['html']]),
         ];
     }
 }

--- a/src/SDK/Language/Swift.php
+++ b/src/SDK/Language/Swift.php
@@ -536,6 +536,34 @@ class Swift extends Language
         return $output;
     }
 
+    public function getModelToMapValue(array $property): string
+    {
+        $name = $property['name'] ?? '';
+        if (\in_array($name, $this->getKeywords())) {
+            $name = "`{$name}`";
+        }
+        $name = \str_replace('$', '', $name);
+        $nullAware = !empty($property['required']) ? '' : '?';
+
+        if (!empty($property['sub_schema'])) {
+            if (($property['type'] ?? '') === self::TYPE_ARRAY) {
+                return "{$name}{$nullAware}.map { \$0.toMap() }";
+            }
+
+            return "{$name}{$nullAware}.toMap()";
+        }
+
+        if (!empty($property['enum'])) {
+            return "{$name}{$nullAware}.rawValue";
+        }
+
+        if (!empty($property['enumValues'])) {
+            return "{$name}{$nullAware}.map { \$0.rawValue }";
+        }
+
+        return $name;
+    }
+
     public function getFilters(): array
     {
         return [
@@ -623,6 +651,9 @@ class Swift extends Language
                 $value = ($example !== null && $example !== '') ? $example : $enumValues[0];
                 return '.' . $resolveKey($value);
             }),
+            new TwigFilter('modelToMapValue', function (array $property) {
+                return $this->getModelToMapValue($property);
+            }, ['is_safe' => ['html']]),
         ];
     }
 

--- a/src/Spec/Swagger2.php
+++ b/src/Spec/Swagger2.php
@@ -54,7 +54,22 @@ class Swagger2 extends Spec
      */
     public function getEndpointDocs(): string
     {
-        return $this->getAttribute('x-appwrite.endpointDocs', '');
+        $servers = $this->getAttribute('servers', []);
+        if (empty($servers)) {
+            return '';
+        }
+
+        $server = $servers[0];
+        foreach ($servers as $candidate) {
+            if (isset($candidate['url']) && \str_contains($candidate['url'], '{region}')) {
+                $server = $candidate;
+                break;
+            }
+        }
+
+        return \preg_replace_callback('/\{([^}]+)\}/', function (array $matches) {
+            return '<' . \strtoupper($matches[1]) . '>';
+        }, $server['url'] ?? '') ?? '';
     }
 
     /**

--- a/src/Spec/Swagger2.php
+++ b/src/Spec/Swagger2.php
@@ -56,7 +56,12 @@ class Swagger2 extends Spec
     {
         $servers = $this->getAttribute('servers', []);
         if (empty($servers)) {
-            return '';
+            $host = $this->getAttribute('x-host-docs', '');
+            if ($host === '') {
+                return '';
+            }
+
+            return $this->getAttribute('schemes.0', 'https') . '://' . $host . $this->getAttribute('basePath', '');
         }
 
         $server = $servers[0];

--- a/templates/dart/lib/src/models/model.dart.twig
+++ b/templates/dart/lib/src/models/model.dart.twig
@@ -67,7 +67,7 @@ class {{ definition.name | caseUcfirst | overrideIdentifier }} implements Model 
     Map<String, dynamic> toMap() {
         return {
 {% for property in definition.properties %}
-            "{{ property.name | escapeDollarSign }}": {% if property.sub_schema %}{% if property.type == 'array' %}{{property.name | escapeKeyword}}{% if not property.required %}?{% endif %}.map((p) => p.toMap()).toList(){% else %}{{property.name | escapeKeyword}}{% if not property.required %}?{% endif %}.toMap(){% endif %}{% elseif property.enum %}{{property.name | escapeKeyword}}{% if not property.required %}?{% endif %}.value{% else %}{{property.name | escapeKeyword }}{% endif %},
+            "{{ property.name | escapeDollarSign }}": {{ property | modelToMapValue }},
 {% endfor %}
 {% if definition.additionalProperties %}
             "{{ definition.additionalPropertiesKey | default('data') | escapeDollarSign }}": {{ definition.additionalPropertiesKey | default('data') | escapeKeyword }},

--- a/templates/dart/lib/src/models/model.dart.twig
+++ b/templates/dart/lib/src/models/model.dart.twig
@@ -67,7 +67,7 @@ class {{ definition.name | caseUcfirst | overrideIdentifier }} implements Model 
     Map<String, dynamic> toMap() {
         return {
 {% for property in definition.properties %}
-            "{{ property.name | escapeDollarSign }}": {% if property.sub_schema %}{% if property.type == 'array' %}{{property.name | escapeKeyword}}.map((p) => p.toMap()).toList(){% else %}{{property.name | escapeKeyword}}.toMap(){% endif %}{% elseif property.enum %}{{property.name | escapeKeyword}}{% if not property.required %}?{% endif %}.value{% else %}{{property.name | escapeKeyword }}{% endif %},
+            "{{ property.name | escapeDollarSign }}": {% if property.sub_schema %}{% if property.type == 'array' %}{{property.name | escapeKeyword}}{% if not property.required %}?{% endif %}.map((p) => p.toMap()).toList(){% else %}{{property.name | escapeKeyword}}{% if not property.required %}?{% endif %}.toMap(){% endif %}{% elseif property.enum %}{{property.name | escapeKeyword}}{% if not property.required %}?{% endif %}.value{% else %}{{property.name | escapeKeyword }}{% endif %},
 {% endfor %}
 {% if definition.additionalProperties %}
             "{{ definition.additionalPropertiesKey | default('data') | escapeDollarSign }}": {{ definition.additionalPropertiesKey | default('data') | escapeKeyword }},

--- a/templates/go/services/service_test.go.twig
+++ b/templates/go/services/service_test.go.twig
@@ -36,10 +36,10 @@
 {%- else -%}
     {%- if property.type == 'object' -%}
 {}
-    {%- elseif property.type == 'array' -%}
+{%- elseif property.type == 'array' -%}
 []
-    {%- elseif property.type == 'string' -%}
-"{{ (property.example | default('string')) | replace({'"': '\\"', '\\': '\\\\'}) }}"
+{%- elseif property.type == 'string' -%}
+"{{ (property.example | default('string')) | replace({'"': '\\"', '\\': '\\\\', '`': '\\u0060'}) }}"
     {%- elseif property.type == 'boolean' -%}
 true
     {%- elseif property.type == 'integer' -%}
@@ -113,7 +113,7 @@ func Test{{ service.name | caseUcfirst }}(t *testing.T) {
 		mockResponse := `
 {
 {% for property in definition.properties | filter((param) => param.required) %}
-    "{{ property.name | replace({'"': '\\"', '\\': '\\\\'}) }}": {% if discriminatorConditions[property.name] is defined %}"{{ discriminatorConditions[property.name] | replace({'"': '\\"', '\\': '\\\\'}) }}"{% else %}{{ _self.render_json_value(spec.definitions, property, spec, '    ') | trim | raw }}{% endif %}{% if not loop.last %},{% endif %}{{ "\n" -}}
+    "{{ property.name | replace({'"': '\\"', '\\': '\\\\'}) }}": {% if discriminatorConditions[property.name] is defined %}"{{ discriminatorConditions[property.name] | replace({'"': '\\"', '\\': '\\\\', '`': '\\u0060'}) }}"{% else %}{{ _self.render_json_value(spec.definitions, property, spec, '    ') | trim | raw }}{% endif %}{% if not loop.last %},{% endif %}{{ "\n" -}}
 {% endfor %}
 }
 `

--- a/templates/go/services/service_test.go.twig
+++ b/templates/go/services/service_test.go.twig
@@ -29,7 +29,7 @@
     {%- else -%}
 {
 {% for prop in requiredProps %}
-{{ indent }}    "{{ prop.name | replace({'"': '\\"', '\\': '\\\\'}) }}": {{ helper.render_json_value(definitions, prop, spec, indent ~ '    ') | trim | raw }}{% if not loop.last %},{% endif %}{{ "\n" -}}
+{{ indent }}    "{{ prop.name | replace({'"': '\\"', '\\': '\\\\', '`': '\\u0060'}) }}": {{ helper.render_json_value(definitions, prop, spec, indent ~ '    ') | trim | raw }}{% if not loop.last %},{% endif %}{{ "\n" -}}
 {% endfor %}
 {{ indent }}}
     {%- endif -%}
@@ -113,7 +113,7 @@ func Test{{ service.name | caseUcfirst }}(t *testing.T) {
 		mockResponse := `
 {
 {% for property in definition.properties | filter((param) => param.required) %}
-    "{{ property.name | replace({'"': '\\"', '\\': '\\\\'}) }}": {% if discriminatorConditions[property.name] is defined %}"{{ discriminatorConditions[property.name] | replace({'"': '\\"', '\\': '\\\\', '`': '\\u0060'}) }}"{% else %}{{ _self.render_json_value(spec.definitions, property, spec, '    ') | trim | raw }}{% endif %}{% if not loop.last %},{% endif %}{{ "\n" -}}
+    "{{ property.name | replace({'"': '\\"', '\\': '\\\\', '`': '\\u0060'}) }}": {% if discriminatorConditions[property.name] is defined %}"{{ discriminatorConditions[property.name] | replace({'"': '\\"', '\\': '\\\\', '`': '\\u0060'}) }}"{% else %}{{ _self.render_json_value(spec.definitions, property, spec, '    ') | trim | raw }}{% endif %}{% if not loop.last %},{% endif %}{{ "\n" -}}
 {% endfor %}
 }
 `

--- a/templates/php/composer.json.twig
+++ b/templates/php/composer.json.twig
@@ -28,5 +28,10 @@
         "phpunit/phpunit": "^10",
         "mockery/mockery": "1.6.12"
     },
+    "config": {
+        "audit": {
+            "abandoned": "ignore"
+        }
+    },
     "minimum-stability": "dev"
 }

--- a/templates/php/composer.json.twig
+++ b/templates/php/composer.json.twig
@@ -25,13 +25,9 @@
 
     },
     "require-dev": {
-        "phpunit/phpunit": "^10",
+        "phpunit/phpunit": "^12",
         "mockery/mockery": "1.6.12"
     },
-    "config": {
-        "audit": {
-            "abandoned": "ignore"
-        }
-    },
+    "prefer-stable": true,
     "minimum-stability": "dev"
 }

--- a/templates/php/phpunit.xml.twig
+++ b/templates/php/phpunit.xml.twig
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd"
     bootstrap="vendor/autoload.php"
     cacheDirectory=".phpunit.cache"
     colors="true"

--- a/templates/php/tests/QueryTest.php.twig
+++ b/templates/php/tests/QueryTest.php.twig
@@ -22,9 +22,9 @@ final class QueryTest extends TestCase {
      */
     private $tests;
 
-    function __construct(string $name)
+    protected function setUp(): void
     {
-        parent::__construct($name);
+        parent::setUp();
         $this->tests = array(
             new BasicFilterQueryTest('with a string', 's', '["s"]'),
             new BasicFilterQueryTest('with a integer', 1, '[1]'),

--- a/templates/python/test/services/test_service.py.twig
+++ b/templates/python/test/services/test_service.py.twig
@@ -35,8 +35,8 @@ class {{ service.name | caseUcfirst }}ServiceTest(unittest.TestCase):
         )
 
         {%~ if method.type != 'webAuth' and method.responseModel and method.responseModel != 'any' %}
-        {%~ if method.responseModel == 'row' or method.responseModel == 'document' or method.responseModel == 'preferences' %}
-        data['data'] = {}
+        {%~ if spec.definitions[method.responseModel].additionalProperties %}
+        data['{{ spec.definitions[method.responseModel].additionalPropertiesKey | default('data') }}'] = {}
         {%~ endif  %}
         self.assertEqual(response.to_dict(), data)
         {%~ else %}

--- a/templates/swift/Sources/Models/Model.swift.twig
+++ b/templates/swift/Sources/Models/Model.swift.twig
@@ -94,7 +94,7 @@ open class {{ definition | modelType(spec) | raw }}: Codable {
     public func toMap() -> [String: Any] {
         return [
             {%~ for property in definition.properties %}
-            "{{ property.name }}": {% if property.sub_schema %}{% if property.type == 'array' %}{{property.name | escapeSwiftKeyword | removeDollarSign}}.map { $0.toMap() }{% else %}{{property.name | escapeSwiftKeyword | removeDollarSign}}.toMap(){% endif %}{% elseif property.enum %}{{property.name | escapeSwiftKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.rawValue{% elseif property.enumValues %}{{property.name | escapeSwiftKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.map { $0.rawValue }{% else %}{{property.name | escapeSwiftKeyword | removeDollarSign}}{% endif %} as Any{% if not loop.last or (loop.last and definition.additionalProperties) %},{% endif %}
+            "{{ property.name }}": {% if property.sub_schema %}{% if property.type == 'array' %}{{property.name | escapeSwiftKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.map { $0.toMap() }{% else %}{{property.name | escapeSwiftKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.toMap(){% endif %}{% elseif property.enum %}{{property.name | escapeSwiftKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.rawValue{% elseif property.enumValues %}{{property.name | escapeSwiftKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.map { $0.rawValue }{% else %}{{property.name | escapeSwiftKeyword | removeDollarSign}}{% endif %} as Any{% if not loop.last or (loop.last and definition.additionalProperties) %},{% endif %}
 
             {%~ endfor %}
             {%~ if definition.additionalProperties %}

--- a/templates/swift/Sources/Models/Model.swift.twig
+++ b/templates/swift/Sources/Models/Model.swift.twig
@@ -94,7 +94,7 @@ open class {{ definition | modelType(spec) | raw }}: Codable {
     public func toMap() -> [String: Any] {
         return [
             {%~ for property in definition.properties %}
-            "{{ property.name }}": {% if property.sub_schema %}{% if property.type == 'array' %}{{property.name | escapeSwiftKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.map { $0.toMap() }{% else %}{{property.name | escapeSwiftKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.toMap(){% endif %}{% elseif property.enum %}{{property.name | escapeSwiftKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.rawValue{% elseif property.enumValues %}{{property.name | escapeSwiftKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.map { $0.rawValue }{% else %}{{property.name | escapeSwiftKeyword | removeDollarSign}}{% endif %} as Any{% if not loop.last or (loop.last and definition.additionalProperties) %},{% endif %}
+            "{{ property.name }}": {{ property | modelToMapValue }} as Any{% if not loop.last or (loop.last and definition.additionalProperties) %},{% endif %}
 
             {%~ endfor %}
             {%~ if definition.additionalProperties %}


### PR DESCRIPTION
## What

- Fix generated PHP Composer audit config for abandoned dependencies.
- Fix Python generated service tests for response models with custom additional-properties keys, including Presence metadata.
- Escape backticks in generated Go raw-string mock JSON as JSON unicode escapes.
- Make Dart and Swift model `toMap()` handle optional nested models/arrays without force-unwrapping.

CLI is intentionally excluded from this PR.

## Testing

- Regenerated `php`, `python`, `go`, `dart`, and `swift` SDK examples with `php example.php <sdk> server`.
- `composer lint-twig`
- `git diff --check`
- `composer install --no-interaction` and `composer audit` in `examples/php`
- `python -m compileall appwrite/` and `python -m unittest` in `examples/python` using an isolated Python 3.12 venv
- `go test ./...` in `examples/go`
- `dart pub get` and `dart analyze --no-fatal-warnings` in `examples/dart`
- `swift build` in `examples/swift`
