### PR TITLE
fix: update flutter_web_auth_2 to 5.0.2 for macOS SPM support

### DIFF
--- a/templates/flutter/pubspec.yaml.twig
+++ b/templates/flutter/pubspec.yaml.twig
@@ -20,7 +20,7 @@ dependencies:
     sdk: flutter
   cookie_jar: ^4.0.8
   device_info_plus: '>=11.5.0 <13.0.0'
-  flutter_web_auth_2: ^5.0.0
+  flutter_web_auth_2: ^5.0.2
   http: '>=0.13.6 <2.0.0'
   package_info_plus: '>=8.0.2 <10.0.0'
   path_provider: ^2.1.4


### PR DESCRIPTION
## What does this PR do?

Updates `flutter_web_auth_2` from `^5.0.0` to `^5.0.2` to resolve macOS Swift Package Manager compatibility warnings introduced by transitive dependencies.

Previously, Flutter emitted the following warning during macOS builds:

```txt
The following plugins do not support Swift Package Manager for macos:
- window_to_front
- desktop_webview_window
```

These plugins are used transitively by `flutter_web_auth_2`.
Version `5.0.2` includes updated dependency support for Swift Package Manager compatibility on macOS.

This PR only updates the dependency version and does not introduce any application logic changes.

## Test Plan

* Updated `flutter_web_auth_2` dependency to `^5.0.2`
* Ran:

```bash
flutter pub get
flutter pub deps --style=tree
flutter build macos
```

* Verified that dependency resolution succeeds correctly
* Verified that the previous macOS Swift Package Manager warnings are resolved
* Confirmed no breaking changes in existing authentication flows

## Related PRs and Issues

This PR is related to Flutter macOS Swift Package Manager support warnings caused by transitive dependencies:

* `window_to_front`
* `desktop_webview_window`

No related Appwrite issue was found.

### Have you read the Contributing Guidelines on issues?

Yes.
