### PR TITLE
Fix Dart row data fallback for flattened fields

### DIFF
--- a/templates/dart/lib/src/models/model.dart.twig
+++ b/templates/dart/lib/src/models/model.dart.twig
@@ -55,7 +55,7 @@ class {{ definition.name | caseUcfirst | overrideIdentifier }} implements Model 
 {% endfor %}
 {% if definition.additionalProperties %}
 {% if definition.properties | length > 0 %}
-            {{ definition.additionalPropertiesKey | default('data') | escapeKeyword }}: Map<String, dynamic>.from(map["{{ definition.additionalPropertiesKey | default('data') | escapeDollarSign }}"] ?? {}),
+            {{ definition.additionalPropertiesKey | default('data') | escapeKeyword }}: Map<String, dynamic>.from(map["{{ definition.additionalPropertiesKey | default('data') | escapeDollarSign }}"] ?? map),
 {% else %}
             {{ definition.additionalPropertiesKey | default('data') | escapeKeyword }}: map["{{ definition.additionalPropertiesKey | default('data') | escapeDollarSign }}"] ?? map,
 {% endif %}

--- a/templates/dart/test/src/models/model_test.dart.twig
+++ b/templates/dart/test/src/models/model_test.dart.twig
@@ -33,5 +33,20 @@ void main() {
       {% endif %}
 {% endfor %}
     });
+{% if definition.additionalProperties and definition.properties | length > 0 %}
+
+    test('fromMap preserves flattened additional properties', () {
+      final result = {{ definition.name | caseUcfirst | overrideIdentifier }}.fromMap({
+{% for property in definition.properties | filter(p => p.required) %}
+        '{{ property.name | escapeDollarSign }}': {% if property.type == 'array' %}[]{% elseif property.type == 'object' %}{}{% elseif property.enum %}'{{ property.enum[0] | escapeDollarSign }}'{% elseif property.type == 'string' %}'{{property['x-example'] | escapeDollarSign}}'{% elseif property.type == 'boolean' %}true{% else %}{{property['x-example']}}{% endif %},
+{% endfor %}
+        'custom': 'value',
+        'nested': {'enabled': true},
+      });
+
+      expect(result.{{ definition.additionalPropertiesKey | default('data') | escapeKeyword }}['custom'], 'value');
+      expect(result.{{ definition.additionalPropertiesKey | default('data') | escapeKeyword }}['nested'], {'enabled': true});
+    });
+{% endif %}
   });
 }

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -202,6 +202,10 @@ abstract class Base extends TestCase
         'custom_id'
     ];
 
+    protected const ROW_DATA_RESPONSES = [
+        '["1.2.4","1.2.5"]',
+    ];
+
     protected const ADDITIONAL_PROPERTIES_RESPONSES = [
         '{"theme":"dark","timezone":"UTC"}',
         '{"$id":"row1","custom":"value","nested":{"enabled":true}}',

--- a/tests/DartBetaTest.php
+++ b/tests/DartBetaTest.php
@@ -31,6 +31,7 @@ class DartBetaTest extends Base
         ...Base::QUERY_HELPER_RESPONSES,
         ...Base::PERMISSION_HELPER_RESPONSES,
         ...Base::ID_HELPER_RESPONSES,
+        ...Base::ROW_DATA_RESPONSES,
         ...Base::OPERATOR_HELPER_RESPONSES
     ];
 }

--- a/tests/DartStableTest.php
+++ b/tests/DartStableTest.php
@@ -31,6 +31,7 @@ class DartStableTest extends Base
         ...Base::QUERY_HELPER_RESPONSES,
         ...Base::PERMISSION_HELPER_RESPONSES,
         ...Base::ID_HELPER_RESPONSES,
+        ...Base::ROW_DATA_RESPONSES,
         ...Base::OPERATOR_HELPER_RESPONSES
     ];
 }

--- a/tests/FlutterBetaTest.php
+++ b/tests/FlutterBetaTest.php
@@ -32,6 +32,7 @@ class FlutterBetaTest extends Base
         ...Base::QUERY_HELPER_RESPONSES,
         ...Base::PERMISSION_HELPER_RESPONSES,
         ...Base::ID_HELPER_RESPONSES,
+        ...Base::ROW_DATA_RESPONSES,
         ...Base::CHANNEL_HELPER_RESPONSES,
         ...Base::OPERATOR_HELPER_RESPONSES
     ];

--- a/tests/FlutterStableTest.php
+++ b/tests/FlutterStableTest.php
@@ -32,6 +32,7 @@ class FlutterStableTest extends Base
         ...Base::QUERY_HELPER_RESPONSES,
         ...Base::PERMISSION_HELPER_RESPONSES,
         ...Base::ID_HELPER_RESPONSES,
+        ...Base::ROW_DATA_RESPONSES,
         ...Base::CHANNEL_HELPER_RESPONSES,
         ...Base::OPERATOR_HELPER_RESPONSES
     ];

--- a/tests/languages/dart/tests.dart
+++ b/tests/languages/dart/tests.dart
@@ -236,6 +236,18 @@ void main() async {
   print(ID.unique());
   print(ID.custom('custom_id'));
 
+  final row = Row.fromMap({
+    'supported_versions': ['1.2.4', '1.2.5'],
+    '\$id': 'row_id',
+    '\$sequence': '1',
+    '\$tableId': 'table_id',
+    '\$databaseId': 'database_id',
+    '\$createdAt': '2026-01-01T00:00:00.000+00:00',
+    '\$updatedAt': '2026-01-01T00:00:00.000+00:00',
+    '\$permissions': [],
+  });
+  print(jsonEncode(row.data['supported_versions']));
+
   // Operator helper tests
   print(Operator.increment(1));
   print(Operator.increment(5, 100));

--- a/tests/languages/flutter/tests.dart
+++ b/tests/languages/flutter/tests.dart
@@ -365,6 +365,18 @@ void main() async {
   print(ID.unique());
   print(ID.custom('custom_id'));
 
+  final row = Row.fromMap({
+    'supported_versions': ['1.2.4', '1.2.5'],
+    '\$id': 'row_id',
+    '\$sequence': '1',
+    '\$tableId': 'table_id',
+    '\$databaseId': 'database_id',
+    '\$createdAt': '2026-01-01T00:00:00.000+00:00',
+    '\$updatedAt': '2026-01-01T00:00:00.000+00:00',
+    '\$permissions': [],
+  });
+  print(jsonEncode(row.data['supported_versions']));
+
   // Channel helper tests
   print(Channel.database('db1').collection('col1').document().toString());
   print(Channel.database('db1').collection('col1').document('doc1').toString());

--- a/tests/resources/spec.json
+++ b/tests/resources/spec.json
@@ -2527,6 +2527,59 @@
       "type": "object",
       "additionalProperties": true
     },
+    "row": {
+      "description": "Row",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "$id": {
+          "type": "string",
+          "description": "Row ID.",
+          "x-example": "row1"
+        },
+        "$sequence": {
+          "type": "string",
+          "description": "Row sequence.",
+          "x-example": "1"
+        },
+        "$tableId": {
+          "type": "string",
+          "description": "Table ID.",
+          "x-example": "table1"
+        },
+        "$databaseId": {
+          "type": "string",
+          "description": "Database ID.",
+          "x-example": "database1"
+        },
+        "$createdAt": {
+          "type": "string",
+          "description": "Creation time.",
+          "x-example": "2026-01-01T00:00:00.000+00:00"
+        },
+        "$updatedAt": {
+          "type": "string",
+          "description": "Update time.",
+          "x-example": "2026-01-01T00:00:00.000+00:00"
+        },
+        "$permissions": {
+          "type": "array",
+          "description": "Permissions.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "$id",
+        "$sequence",
+        "$tableId",
+        "$databaseId",
+        "$createdAt",
+        "$updatedAt",
+        "$permissions"
+      ]
+    },
     "error": {
       "description": "Error",
       "type": "object",


### PR DESCRIPTION
## Summary

- restore the Dart/Flutter model fallback so additionalProperties models with fixed fields use the whole response map when the `data` key is absent
- add a Row fixture to the generator test spec and smoke coverage for Dart + Flutter flattened TablesDB row payloads
- add generated model-test coverage for flattened additional properties

Fixes #1561.

## Verification

- `git diff --check`
- `Get-Content -Raw tests\resources\spec.json | ConvertFrom-Json`
- `uvx djlint templates\dart\lib\src\models\model.dart.twig templates\dart\test\src\models\model_test.dart.twig --lint`

I could not run the full PHP generator / Dart / Flutter test commands locally because this Windows environment does not have PHP, Docker, or Dart installed. The patch is limited to the shared Dart model template and the existing generator smoke-test fixtures.

Implemented with Codex assistance; I reviewed the issue, the recent template regression commit, and the final diff manually.