### PR TITLE
Fix CLI organization config compatibility

### DIFF
--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -417,6 +417,11 @@ class CLI extends Node
             ],
             [
                 'scope'         => 'copy',
+                'destination'   => 'lib/config-filters.ts',
+                'template'      => 'cli/lib/config-filters.ts',
+            ],
+            [
+                'scope'         => 'copy',
                 'destination'   => 'lib/completions.ts',
                 'template'      => 'cli/lib/completions.ts',
             ],

--- a/templates/cli/lib/commands/config.ts
+++ b/templates/cli/lib/commands/config.ts
@@ -484,6 +484,7 @@ const ConfigIncludesSchema = z
 
 const ConfigSchema = z
   .object({
+    organizationId: z.string().optional(),
     projectId: z.string(),
     projectName: z.string().optional(),
     endpoint: z.string().optional(),

--- a/templates/cli/lib/commands/generate.ts
+++ b/templates/cli/lib/commands/generate.ts
@@ -94,6 +94,7 @@ const generateAction = async (
   }
 
   const config: ConfigType = {
+    organizationId: project.organizationId,
     projectId: project.projectId,
     projectName: project.projectName,
     endpoint:

--- a/templates/cli/lib/commands/generic.ts
+++ b/templates/cli/lib/commands/generic.ts
@@ -82,7 +82,7 @@ const getCurrentAccount = async (): Promise<Models.User | null> => {
     globalConfig.setEndpoint(endpoint);
   }
 
-  const client = await sdkForConsole(false);
+  const client = await sdkForConsole({ requiresAuth: false });
   const accountClient = new Account(client);
 
   try {
@@ -308,7 +308,7 @@ export const loginCommand = async ({
       normalizeCloudConsoleEndpoint(globalConfig.getEndpoint()),
     );
 
-    const client = await sdkForConsole(false);
+    const client = await sdkForConsole({ requiresAuth: false });
     const accountClient = new Account(client);
     const legacyClient = createLegacyConsoleClient(
       globalConfig.getEndpoint() || DEFAULT_ENDPOINT,
@@ -348,7 +348,7 @@ export const loginCommand = async ({
   // Use legacy client for login to extract cookies from response
   const legacyClient = createLegacyConsoleClient(configEndpoint);
 
-  const client = await sdkForConsole(false);
+  const client = await sdkForConsole({ requiresAuth: false });
   let accountClient = new Account(client);
 
   let account;

--- a/templates/cli/lib/commands/init.ts
+++ b/templates/cli/lib/commands/init.ts
@@ -103,17 +103,17 @@ interface InitProjectStepOptions {
   autoPulled: boolean;
 }
 
-const extractSelectionId = (value: string): string => {
-  const match = value.match(/\(([^()]+)\)$/);
-  return match ? match[1] : value;
-};
-
 const getExistingProjectSummary = async (
+  organizationId: string,
   projectId: string,
 ): Promise<ExistingProjectSummary> => {
-  const organizationService = await getOrganizationService();
+  const client = await sdkForConsole({
+    requiresAuth: true,
+    organizationId,
+  });
+  const organizationService = await getOrganizationService(client);
   const project = await organizationService.getProject({
-    projectId: extractSelectionId(projectId),
+    projectId,
   });
 
   return {
@@ -314,9 +314,6 @@ const initProject = async ({
       log("No changes made. Existing project configuration was kept.");
       return;
     }
-    if (typeof answers.organization === "string") {
-      answers.organization = extractSelectionId(answers.organization);
-    }
   } else {
     const selectedOrganization =
       organizationId ??
@@ -326,16 +323,17 @@ const initProject = async ({
     const selectedProjectId =
       projectId ?? (await inquirer.prompt([questionsInitProject[4]])).id;
 
-    const normalizedOrganization = extractSelectionId(selectedOrganization);
-
     answers = {
       start: "existing",
       project: selectedProjectId,
-      organization: normalizedOrganization,
+      organization: selectedOrganization,
     };
 
     try {
-      answers.project = await getExistingProjectSummary(selectedProjectId);
+      answers.project = await getExistingProjectSummary(
+        selectedOrganization,
+        selectedProjectId,
+      );
     } catch (e) {
       if (e instanceof AppwriteException && e.code === 404) {
         answers = {
@@ -351,7 +349,10 @@ const initProject = async ({
   }
 
   if (answers.start === "existing" && typeof answers.project === "string") {
-    answers.project = await getExistingProjectSummary(answers.project);
+    answers.project = await getExistingProjectSummary(
+      answers.organization,
+      answers.project,
+    );
   }
 
   localConfig.clear(); // Clear the config to avoid any conflicts
@@ -376,10 +377,10 @@ const initProject = async ({
         break;
     }
 
-    // The Organization SDK has no per-request orgId param; the server resolves
-    // the target organization from the X-Appwrite-Organization header.
-    const consoleClient = await sdkForConsole();
-    consoleClient.headers["X-Appwrite-Organization"] = answers.organization;
+    const consoleClient = await sdkForConsole({
+      requiresAuth: true,
+      organizationId: answers.organization,
+    });
     const organizationService = await getOrganizationService(consoleClient);
     const response = await organizationService.createProject({
       projectId: projectIdToCreate,
@@ -388,6 +389,7 @@ const initProject = async ({
     });
 
     localConfig.setProject(response["$id"], response.name ?? "");
+    localConfig.setOrganizationId(answers.organization);
     if (answers.region) {
       localConfig.setEndpoint(
         `https://${answers.region}.${url.host}${url.pathname}`,
@@ -409,6 +411,7 @@ const initProject = async ({
     }
 
     localConfig.setProject(selectedProject.$id, selectedProject.name ?? "");
+    localConfig.setOrganizationId(answers.organization);
 
     if (isCloud() && selectedProject.region) {
       localConfig.setEndpoint(

--- a/templates/cli/lib/commands/pull.ts
+++ b/templates/cli/lib/commands/pull.ts
@@ -21,6 +21,7 @@ import {
 import { getFunctionsService, getSitesService } from "../services.js";
 import { sdkForProject, sdkForConsole } from "../sdks.js";
 import { localConfig } from "../config.js";
+import { applyConfigFilters } from "../config-filters.js";
 import { paginate } from "../paginate.js";
 import {
   questionsPullFunctions,
@@ -105,7 +106,9 @@ async function createPullInstance(
 ): Promise<Pull> {
   const { silent = false, requiresConsoleAuth = false, resource } = options;
   const projectClient = await sdkForProject();
-  const consoleClient = await sdkForConsole(requiresConsoleAuth);
+  const consoleClient = await sdkForConsole({
+    requiresAuth: requiresConsoleAuth,
+  });
 
   const pullInstance = new Pull(projectClient, consoleClient, silent);
   pullInstance.setConfigDirectoryPath(
@@ -185,7 +188,10 @@ export class Pull {
 
     try {
       if (shouldPullAll || options.settings) {
-        const settings = await this.pullSettings(config.projectId);
+        const settings = await this.pullSettings(
+          config.organizationId,
+          config.projectId,
+        );
         updatedConfig.settings = settings.settings;
         updatedConfig.projectName = settings.projectName;
       }
@@ -255,9 +261,19 @@ export class Pull {
   /**
    * Pull project settings
    */
-  public async pullSettings(projectId: string): Promise<PullSettingsResult> {
+  public async pullSettings(
+    organizationId: string | undefined,
+    projectId: string,
+  ): Promise<PullSettingsResult> {
     this.log("Pulling project settings ...");
 
+    await applyConfigFilters({
+      config: {
+        organizationId,
+        projectId,
+      },
+      consoleClient: this.consoleClient,
+    });
     const organizationService = new Organization(this.consoleClient);
     const projectService = new Project(this.projectClient);
     const project = await organizationService.getProject({
@@ -838,8 +854,12 @@ const pullSettings = async (): Promise<void> => {
   const pullInstance = await createPullInstance({
     requiresConsoleAuth: true,
   });
-  const projectId = localConfig.getProject().projectId;
-  const settings = await pullInstance.pullSettings(projectId);
+  const project = localConfig.getProject();
+  const projectId = project.projectId;
+  const settings = await pullInstance.pullSettings(
+    project.organizationId,
+    projectId,
+  );
 
   localConfig.setProject(projectId, settings.projectName, settings.project);
 };

--- a/templates/cli/lib/commands/push.ts
+++ b/templates/cli/lib/commands/push.ts
@@ -20,6 +20,7 @@ import {
   KeysCollection,
   KeysTable,
 } from "../config.js";
+import { applyConfigFilters } from "../config-filters.js";
 import {
   ConfigSchema,
   type SettingsType,
@@ -767,6 +768,7 @@ export class Push {
         try {
           this.log("Pushing settings ...");
           await this.pushSettings({
+            organizationId: config.organizationId,
             projectId: config.projectId,
             projectName: config.projectName,
             settings: config.settings,
@@ -985,9 +987,14 @@ export class Push {
 
   public async pushSettings(config: {
     projectId: string;
+    organizationId?: string;
     projectName?: string;
     settings?: SettingsType;
   }): Promise<void> {
+    await applyConfigFilters({
+      config,
+      consoleClient: this.consoleClient,
+    });
     const organizationService = await getOrganizationService(
       this.consoleClient,
     );
@@ -2405,10 +2412,11 @@ export class Push {
         )
       ) {
         try {
-          const consoleClient = await sdkForConsole(
-            true,
-            localConfig.getEndpoint() || globalConfig.getEndpoint(),
-          );
+          const consoleClient = await sdkForConsole({
+            requiresAuth: true,
+            endpointOverride:
+              localConfig.getEndpoint() || globalConfig.getEndpoint(),
+          });
           sitePreviewRenderer = {
             consoleClient,
             storageService: await getStorageService(consoleClient),
@@ -2827,7 +2835,9 @@ async function createPushInstance(
 ): Promise<Push> {
   const { silent, requiresConsoleAuth } = options;
   const projectClient = await sdkForProject();
-  const consoleClient = await sdkForConsole(requiresConsoleAuth);
+  const consoleClient = await sdkForConsole({
+    requiresAuth: requiresConsoleAuth,
+  });
 
   return new Push(projectClient, consoleClient, silent);
 }
@@ -2895,6 +2905,7 @@ const pushResources = async ({
     });
     const project = localConfig.getProject();
     const config: ConfigType = {
+      organizationId: project.organizationId,
       projectId: project.projectId ?? "",
       projectName: project.projectName,
       settings: project.projectSettings,
@@ -2961,10 +2972,20 @@ const pushResources = async ({
 const pushSettings = async (): Promise<void> => {
   checkDeployConditions(localConfig);
 
+  let resolvedOrganizationId: string | undefined;
+
   try {
-    const organizationService = await getOrganizationService();
+    const project = localConfig.getProject();
+    const consoleClient = await sdkForConsole({ requiresAuth: true });
+    await applyConfigFilters({
+      config: project,
+      consoleClient,
+    });
+    resolvedOrganizationId =
+      consoleClient.headers["X-Appwrite-Organization"];
+    const organizationService = await getOrganizationService(consoleClient);
     const projectService = await getProjectService();
-    const projectId = localConfig.getProject().projectId;
+    const projectId = project.projectId;
     const response = await organizationService.getProject({
       projectId,
     });
@@ -3020,6 +3041,7 @@ const pushSettings = async (): Promise<void> => {
 
     await pushInstance.pushSettings({
       projectId: config.projectId,
+      organizationId: config.organizationId ?? resolvedOrganizationId,
       projectName: config.projectName,
       settings: config.projectSettings,
     });

--- a/templates/cli/lib/config-filters.ts
+++ b/templates/cli/lib/config-filters.ts
@@ -1,0 +1,77 @@
+import { Client } from "@appwrite.io/console";
+import { warn } from "./parser.js";
+
+type ConfigFilterContext = {
+  config: {
+    organizationId?: string;
+    projectId?: string;
+  };
+  consoleClient: Client;
+};
+
+type ConfigFilter = {
+  id: string;
+  matches(context: ConfigFilterContext): boolean;
+  apply(context: ConfigFilterContext): Promise<void>;
+};
+
+const warned = new Set<string>();
+
+const configFilters: ConfigFilter[] = [
+  {
+    id: "organization-id-header",
+    matches({ config, consoleClient }) {
+      return (
+        !consoleClient.headers["X-Appwrite-Organization"] &&
+        (!!config.organizationId || !!config.projectId)
+      );
+    },
+    async apply({ config, consoleClient }) {
+      let organizationId = config.organizationId;
+
+      if (!organizationId) {
+        if (!config.projectId) {
+          throw new Error(
+            "Project configuration not found. Please run 'appwrite init project' to initialize your project first.",
+          );
+        }
+
+        const project = await consoleClient.call(
+          "get",
+          new URL(
+            `${consoleClient.config.endpoint}/projects/${encodeURIComponent(config.projectId)}`,
+          ),
+          {},
+          {},
+        );
+
+        organizationId = project.teamId;
+
+        if (!organizationId || typeof organizationId !== "string") {
+          throw new Error(
+            "Unable to resolve organization for this project. Please run 'appwrite init project' to relink this project.",
+          );
+        }
+
+        if (!warned.has(this.id)) {
+          warned.add(this.id);
+          warn(
+            "Your appwrite.config.json is missing organizationId. The CLI resolved it for this command without changing your config. Run 'appwrite init project' to relink and persist it.",
+          );
+        }
+      }
+
+      consoleClient.headers["X-Appwrite-Organization"] = organizationId;
+    },
+  },
+];
+
+export const applyConfigFilters = async (
+  context: ConfigFilterContext,
+): Promise<void> => {
+  for (const filter of configFilters) {
+    if (filter.matches(context)) {
+      await filter.apply(context);
+    }
+  }
+};

--- a/templates/cli/lib/config.ts
+++ b/templates/cli/lib/config.ts
@@ -81,6 +81,7 @@ const KeyIndexes = getSchemaKeys(IndexSchema);
 const KeyIndexesColumns = getSchemaKeys(IndexTableSchema);
 
 const CONFIG_KEY_ORDER = [
+  "organizationId",
   "projectId",
   "projectName",
   "endpoint",
@@ -1156,6 +1157,7 @@ class Local extends Config<ConfigType> {
   }
 
   getProject(): {
+    organizationId?: string;
     projectId?: string;
     projectName?: string;
     projectSettings?: SettingsType;
@@ -1165,6 +1167,7 @@ class Local extends Config<ConfigType> {
     }
 
     return {
+      organizationId: this.get("organizationId"),
       projectId: this.get("projectId"),
       projectName: this.get("projectName"),
       projectSettings: this.get("settings"),
@@ -1187,6 +1190,10 @@ class Local extends Config<ConfigType> {
     }
 
     this.set("settings", createSettingsObject(project));
+  }
+
+  setOrganizationId(organizationId: string): void {
+    this.set("organizationId", organizationId);
   }
 }
 

--- a/templates/cli/lib/questions.ts
+++ b/templates/cli/lib/questions.ts
@@ -94,11 +94,6 @@ const validateSitePath = (value: unknown): boolean | string => {
 const buildSelectionLabel = (name: string, id: string): string =>
   `${name} (${id})`;
 
-const extractSelectionId = (value: string): string => {
-  const match = value.match(/\(([^()]+)\)$/);
-  return match ? match[1] : value;
-};
-
 const getInitProjectOverrideMessage = (): string => {
   const projectName = localConfig.getProject().projectName;
 
@@ -244,7 +239,7 @@ export const questionsInitProject: Question[] = [
     name: "organization",
     message: "Choose your organization:",
     choices: async () => {
-      const client = await sdkForConsole(true);
+      const client = await sdkForConsole({ requiresAuth: true });
       const { teams } = isCloud()
         ? await paginate(
             async (args) =>
@@ -269,7 +264,7 @@ export const questionsInitProject: Question[] = [
         const label = buildSelectionLabel(team.name, team["$id"]);
         return {
           name: label,
-          value: label,
+          value: team["$id"],
         };
       });
 
@@ -304,21 +299,25 @@ export const questionsInitProject: Question[] = [
     name: "project",
     message: "Choose your project:",
     choices: async (answers: Answers) => {
+      const client = await sdkForConsole({
+        requiresAuth: true,
+        organizationId: answers.organization,
+      });
       const queries = [
         JSON.stringify({
           method: "equal",
           attribute: "teamId",
-          values: [extractSelectionId(answers.organization)],
+          values: [answers.organization],
         }),
         JSON.stringify({ method: "orderDesc", attribute: "$id" }),
       ];
 
       const { projects } = await paginate(
         async (args) =>
-          (await getOrganizationService()).listProjects({
+          (await getOrganizationService(args.sdk as Client)).listProjects({
             queries: args.queries as string[],
           }),
-        { parseOutput: false },
+        { parseOutput: false, sdk: client },
         100,
         "projects",
         queries,
@@ -328,7 +327,7 @@ export const questionsInitProject: Question[] = [
         const label = buildSelectionLabel(project.name, project["$id"]);
         return {
           name: label,
-          value: label,
+          value: project["$id"],
         };
       });
 
@@ -345,7 +344,7 @@ export const questionsInitProject: Question[] = [
     name: "region",
     message: `Select your ${SDK_TITLE} Cloud region`,
     choices: async () => {
-      const client = await sdkForConsole(true);
+      const client = await sdkForConsole({ requiresAuth: true });
       const endpoint = globalConfig.getEndpoint() || DEFAULT_ENDPOINT;
       const response = (await client.call(
         "GET",
@@ -1200,7 +1199,7 @@ export const questionsListFactors: Question[] = [
     message:
       "Your account is protected by multi-factor authentication. Please choose one for verification.",
     choices: async () => {
-      const client = await sdkForConsole(false);
+      const client = await sdkForConsole({ requiresAuth: false });
       const accountClient = new Account(client);
       const factors = await accountClient.listMfaFactors();
 

--- a/templates/cli/lib/sdks.ts
+++ b/templates/cli/lib/sdks.ts
@@ -8,10 +8,15 @@ import {
   SDK_VERSION,
 } from "./constants.js";
 
-export const sdkForConsole = async (
-  requiresAuth: boolean = true,
-  endpointOverride?: string,
-): Promise<Client> => {
+export const sdkForConsole = async ({
+  requiresAuth = true,
+  endpointOverride,
+  organizationId,
+}: {
+  requiresAuth?: boolean;
+  endpointOverride?: string;
+  organizationId?: string;
+} = {}): Promise<Client> => {
   const client = new Client();
   const endpoint =
     endpointOverride || globalConfig.getEndpoint() || DEFAULT_ENDPOINT;
@@ -39,6 +44,10 @@ export const sdkForConsole = async (
     .setCookie(cookie)
     .setSelfSigned(selfSigned)
     .setLocale("en-US");
+
+  if (organizationId) {
+    client.headers["X-Appwrite-Organization"] = organizationId;
+  }
 
   return client;
 };


### PR DESCRIPTION
## Summary
- Store `organizationId` in new CLI project configs and keep it ordered before `projectId`.
- Add a runtime config filter that resolves missing `organizationId` from the project for backwards-compatible existing configs, warning without modifying the config file.
- Route organization-scoped console requests through `sdkForConsole({ organizationId })` and remove selection-label parsing.

## Type of Change
- Bug fix

## Tests
- `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php cli`
- `composer lint-twig`
- `npm run build:types` in `examples/cli`
- `npm run mac-arm64` in `examples/cli`
- Runtime old-config filter check resolves `X-Appwrite-Organization` from `projectId` and only emits a warning.
