### PR TITLE
Pin Go CI to 1.25.11

### DIFF
--- a/.github/workflows/sdk-build-validation.yml
+++ b/.github/workflows/sdk-build-validation.yml
@@ -161,7 +161,7 @@ jobs:
         if: matrix.sdk == 'go' || matrix.sdk == 'dart' || matrix.sdk == 'flutter'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25.10'
+          go-version: '1.25.11'
 
       - name: Install OSV Scanner
         if: matrix.sdk == 'dart' || matrix.sdk == 'flutter'


### PR DESCRIPTION
## What changed

Pinned the Go toolchain used by SDK build validation from `1.25.10` to `1.25.11`.

## Why

The Go validation job for PR #1568 failed in `govulncheck` because Go `1.25.10` contains standard-library vulnerabilities `GO-2026-5039` and `GO-2026-5037`. The audit output reports both are fixed in Go `1.25.11`.

This is a workflow-only fix; generated Go SDK code and templates are unchanged.

## Validation

Generated the Go SDK in a disposable temp checkout and ran the Go validation path with Go `1.25.11` first on `PATH`:

```sh
php example.php go server
go mod tidy || true
go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
govulncheck ./...
go build ./...
go test ./...
```

Results:

- `govulncheck ./...`: `No vulnerabilities found.`
- `go build ./...`: passed
- `go test ./...`: passed
