### PR TITLE
Support ProjectQuery security in generated SDKs

### DIFF
--- a/src/Spec/Swagger2.php
+++ b/src/Spec/Swagger2.php
@@ -161,10 +161,21 @@ class Swagger2 extends Spec
         $methodSecurity = $method['security'][0] ?? [];
 
         foreach ($methodAuth as $i => $node) {
-            $methodAuth[$i] = (array_key_exists($i, $security)) ? $security[$i] : [];
+            $methodAuth[$i] = (array_key_exists($i, $security)) ? [...$security[$i], 'global' => $i !== 'Project'] : [];
         }
         foreach ($methodSecurity as $i => $node) {
-            $methodSecurity[$i] = (array_key_exists($i, $security)) ? $security[$i] : [];
+            $methodSecurity[$i] = (array_key_exists($i, $security)) ? [...$security[$i], 'global' => $i !== 'Project'] : [];
+        }
+
+        $methodSecurityHeaders = [];
+        $methodSecurityQueries = [];
+        foreach ($methodSecurity as $i => $node) {
+            if (($node['in'] ?? '') === 'header' && !($node['global'] ?? false)) {
+                $methodSecurityHeaders[$i] = $node;
+            }
+            if (($node['in'] ?? '') === 'query') {
+                $methodSecurityQueries[$i] = $node;
+            }
         }
 
         $responseModel = '';
@@ -210,7 +221,8 @@ class Swagger2 extends Spec
             'title' => $method['summary'] ?? '',
             'description' => $method['description'] ?? '',
             'auth' => [$methodAuth] ?? [],
-            'security' => [$methodSecurity] ?? [],
+            'securityHeaders' => $methodSecurityHeaders,
+            'securityQueries' => $methodSecurityQueries,
             'consumes' => $method['consumes'] ?? [],
             'cookies' => $method['x-appwrite']['cookies'] ?? false,
             'platforms' => $method['x-appwrite']['platforms'] ?? [],
@@ -584,6 +596,9 @@ class Swagger2 extends Spec
                     'key' => $key,
                     'name' => $definition['name'],
                     'description' => $definition['description'],
+                    // Project is stored on the client, but each method's security decides
+                    // whether it is sent as X-Appwrite-Project or as a ProjectQuery param.
+                    'global' => $key !== 'Project',
                 ];
             } elseif (
                 isset($definition['type']) && $definition['type'] === 'http' &&
@@ -594,6 +609,7 @@ class Swagger2 extends Spec
                     'name' => 'Authorization',
                     'description' => $definition['description'] ?? 'Bearer token authentication',
                     'type' => 'bearer',
+                    'global' => true,
                 ];
             }
         }

--- a/templates/android/library/src/main/java/io/package/Client.kt.twig
+++ b/templates/android/library/src/main/java/io/package/Client.kt.twig
@@ -120,7 +120,9 @@ class Client @JvmOverloads constructor(
      */
     fun set{{header.key | caseUcfirst}}(value: String): Client {
         config["{{ header.key | caseCamel }}"] = value
+        {%~ if header.global %}
         addHeader("{{ header.name | caseLower }}", value)
+        {%~ endif %}
         return this
     }
 

--- a/templates/android/library/src/main/java/io/package/Client.kt.twig
+++ b/templates/android/library/src/main/java/io/package/Client.kt.twig
@@ -258,7 +258,10 @@ class Client @JvmOverloads constructor(
     suspend fun ping(): String {
         val apiPath = "/ping"
         val apiParams = mutableMapOf<String, Any?>()
-        val apiHeaders = mutableMapOf("content-type" to "application/json")
+        val apiHeaders = mutableMapOf(
+            "content-type" to "application/json",
+            "X-Appwrite-Project" to config["project"].orEmpty(),
+        )
 
         return call(
             "GET",

--- a/templates/android/library/src/main/java/io/package/services/Service.kt.twig
+++ b/templates/android/library/src/main/java/io/package/services/Service.kt.twig
@@ -71,6 +71,9 @@ class {{ service.name | caseUcfirst }}(client: Client) : Service(client) {
         {%~ for parameter in method.parameters.path %}
             .replace("{{ '{' ~ parameter.name ~ '}' }}", {{ parameter.name | caseCamel }}{% if parameter.enumValues is not empty %}.value{% endif %})
         {%~ endfor %}
+            {%~ for security in method.securityQueries %}
+            + "?{{ security.name }}=${java.net.URLEncoder.encode(client.config["{{ security.name | caseCamel }}"].orEmpty(), "UTF-8")}"
+            {%~ endfor %}
 
         val apiParams = mutableMapOf<String, Any?>(
         {%~ for parameter in method.parameters.query | merge(method.parameters.body) %}
@@ -140,6 +143,9 @@ class {{ service.name | caseUcfirst }}(client: Client) : Service(client) {
         )
         {%~ else %}
         val apiHeaders = mutableMapOf<String, String>(
+        {%~ for key, security in method.securityHeaders %}
+            "{{ security.name }}" to client.config["{{ key | caseCamel }}"].orEmpty(),
+        {%~ endfor %}
         {%~ for key, header in method.headers %}
             "{{ key }}" to "{{ header }}",
         {%~ endfor %}

--- a/templates/android/library/src/main/java/io/package/services/Service.kt.twig
+++ b/templates/android/library/src/main/java/io/package/services/Service.kt.twig
@@ -72,7 +72,7 @@ class {{ service.name | caseUcfirst }}(client: Client) : Service(client) {
             .replace("{{ '{' ~ parameter.name ~ '}' }}", {{ parameter.name | caseCamel }}{% if parameter.enumValues is not empty %}.value{% endif %})
         {%~ endfor %}
             {%~ for security in method.securityQueries %}
-            + "?{{ security.name }}=${java.net.URLEncoder.encode(client.config["{{ security.name | caseCamel }}"].orEmpty(), "UTF-8")}"
+            + "{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=${java.net.URLEncoder.encode(client.config["{{ security.name | caseCamel }}"].orEmpty(), "UTF-8")}"
             {%~ endfor %}
 
         val apiParams = mutableMapOf<String, Any?>(

--- a/templates/apple/Sources/Client.swift.twig
+++ b/templates/apple/Sources/Client.swift.twig
@@ -115,7 +115,9 @@ open class Client {
     ///
     open func set{{ header.key | caseUcfirst }}(_ value: String) -> Client {
         config["{{ header.key | caseLower }}"] = value
+        {%~ if header.global %}
         _ = addHeader(key: "{{header.name}}", value: value)
+        {%~ endif %}
         return self
     }
 
@@ -305,7 +307,7 @@ open class Client {
         let validParams = params.filter { $0.value != nil }
 
         let queryParameters = method == "GET" && !validParams.isEmpty
-            ? "?" + parametersToQueryString(params: validParams)
+            ? (path.contains("?") ? "&" : "?") + parametersToQueryString(params: validParams)
             : ""
 
         var request = HTTPClientRequest(url: endPoint + path + queryParameters)

--- a/templates/apple/Sources/Client.swift.twig
+++ b/templates/apple/Sources/Client.swift.twig
@@ -276,7 +276,8 @@ open class Client {
        let apiPath: String = "/ping"
 
        let apiHeaders: [String: String] = [
-           "content-type": "application/json"
+           "content-type": "application/json",
+           "X-Appwrite-Project": config["project"] ?? ""
        ]
 
        return try await call(

--- a/templates/apple/Sources/Services/Service.swift.twig
+++ b/templates/apple/Sources/Services/Service.swift.twig
@@ -52,12 +52,16 @@ open class {{ service.name | caseUcfirst | overrideIdentifier }}: Service {
         {%~ elseif method.type == 'location' %}
         {{~ include('swift/base/requests/location.twig')}}
         {%~ else %}
-        {%~ if method.headers | length <= 0 %}
+        {%~ if method.headers | length <= 0 and method.securityHeaders | length <= 0 %}
         let apiHeaders: [String: String] = [:]
         {%~ else %}
         {% if 'multipart/form-data' in method.consumes -%} var
         {%- else -%} let
         {%- endif %} apiHeaders: [String: String] = [
+        {%~ for key, security in method.securityHeaders %}
+            "{{ security.name }}": client.config["{{ key | caseCamel }}"] ?? ""{% if not loop.last or method.headers | length > 0 %},{% endif %}
+
+        {%~ endfor %}
         {%~ for key, header in method.headers %}
             "{{ key }}": "{{ header }}"{% if not loop.last %},{% endif %}
 

--- a/templates/dart/base/requests/api.twig
+++ b/templates/dart/base/requests/api.twig
@@ -5,6 +5,9 @@
     };
 
     final Map<String, String> apiHeaders = {
+      {%~ for key, security in method.securityHeaders %}
+      '{{ security.name }}': client.config['{{ key | caseCamel }}'] ?? '',
+      {%~ endfor %}
       {{ utils.map_headers(method.headers) }}
     };
 

--- a/templates/dart/base/requests/file.twig
+++ b/templates/dart/base/requests/file.twig
@@ -5,6 +5,9 @@
     };
 
     final Map<String, String> apiHeaders = {
+      {%~ for key, security in method.securityHeaders %}
+      '{{ security.name }}': client.config['{{ key | caseCamel }}'] ?? '',
+      {%~ endfor %}
       {{ utils.map_headers(method.headers) }}
     };
 

--- a/templates/dart/lib/services/service.dart.twig
+++ b/templates/dart/lib/services/service.dart.twig
@@ -25,7 +25,14 @@ class {{ service.name | caseUcfirst }} extends Service {
 {%~ endif %}
 {%~ endif %}
     {% if method.type == 'location' %}Future<Uint8List>{% else %}{% set responseModels = method | getValidResponseModels %}{% if responseModels|length > 1 %}Future<models.Model>{% elseif method.responseModel and method.responseModel != 'any' %}Future<models.{{method.responseModel | caseUcfirst | overrideIdentifier}}>{% else %}Future{% endif %}{% endif %} {{ method.name | caseCamel | overrideIdentifier }}({{ _self.method_parameters(method.parameters.all, method.consumes) }}) async {
-        final String apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replaceAll('{{ '{' }}{{ parameter.name }}{{ '}' }}', {{ parameter.name | caseCamel | overrideIdentifier }}{% if parameter.enumValues | length > 0  %}.value{% endif %}){% endfor %};
+        final String apiPath = '{{ method.path }}'
+            {%- for parameter in method.parameters.path -%}
+            .replaceAll('{{ '{' }}{{ parameter.name }}{{ '}' }}', {{ parameter.name | caseCamel | overrideIdentifier }}{% if parameter.enumValues | length > 0  %}.value{% endif %})
+            {%- endfor -%}
+            {%- for security in method.securityQueries -%}
+            + '?{{ security.name }}=${Uri.encodeComponent(client.config['{{ security.name | caseCamel }}'] ?? '')}'
+            {%- endfor -%}
+            ;
 
 {% if 'multipart/form-data' in method.consumes %}
 {{ include('dart/base/requests/file.twig') }}

--- a/templates/dart/lib/services/service.dart.twig
+++ b/templates/dart/lib/services/service.dart.twig
@@ -30,7 +30,7 @@ class {{ service.name | caseUcfirst }} extends Service {
             .replaceAll('{{ '{' }}{{ parameter.name }}{{ '}' }}', {{ parameter.name | caseCamel | overrideIdentifier }}{% if parameter.enumValues | length > 0  %}.value{% endif %})
             {%- endfor -%}
             {%- for security in method.securityQueries -%}
-            + '?{{ security.name }}=${Uri.encodeComponent(client.config['{{ security.name | caseCamel }}'] ?? '')}'
+            + '{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=${Uri.encodeComponent(client.config['{{ security.name | caseCamel }}'] ?? '')}'
             {%- endfor -%}
             ;
 

--- a/templates/dart/lib/src/client_base.dart.twig
+++ b/templates/dart/lib/src/client_base.dart.twig
@@ -29,6 +29,9 @@ abstract class ClientBase implements Client {
     final response = await call(
       HttpMethod.get,
       path: apiPath,
+      headers: {
+        'X-Appwrite-Project': config['project'] ?? '',
+      },
       responseType: ResponseType.plain,
     );
     return response.data;

--- a/templates/dart/lib/src/client_browser.dart.twig
+++ b/templates/dart/lib/src/client_browser.dart.twig
@@ -53,9 +53,11 @@ class ClientBrowser extends ClientBase with ClientMixin {
     /// {{header.description}}
 {% endif %}
     @override
-    ClientBrowser set{{header.key | caseUcfirst}}(value) {
+  ClientBrowser set{{header.key | caseUcfirst}}(value) {
         config['{{ header.key | caseCamel }}'] = value;
-        addHeader('{{header.name}}', value);
+        {%~ if header.global %}
+        addHeader('{{ header.name }}', value);
+        {%~ endif %}
         return this;
     }
 {% endfor %}

--- a/templates/dart/lib/src/client_io.dart.twig
+++ b/templates/dart/lib/src/client_io.dart.twig
@@ -63,9 +63,11 @@ class ClientIO extends ClientBase with ClientMixin {
      /// {{header.description}}
 {% endif %}
     @override
-    ClientIO set{{header.key | caseUcfirst}}(value) {
+  ClientIO set{{header.key | caseUcfirst}}(value) {
         config['{{ header.key | caseCamel }}'] = value;
-        addHeader('{{header.name}}', value);
+        {%~ if header.global %}
+        addHeader('{{ header.name }}', value);
+        {%~ endif %}
         return this;
     }
 {% endfor %}

--- a/templates/dart/lib/src/client_mixin.dart.twig
+++ b/templates/dart/lib/src/client_mixin.dart.twig
@@ -63,7 +63,7 @@ mixin ClientMixin {
           path: uri.path,
           host: uri.host,
           scheme: uri.scheme,
-          queryParameters: params,
+          queryParameters: {...uri.queryParameters, ...params},
           port: uri.port);
       request = http.Request(method.name(), uri);
     } else {

--- a/templates/deno/src/client.ts.twig
+++ b/templates/deno/src/client.ts.twig
@@ -9,6 +9,11 @@ export class Client {
     static DENO_READ_CHUNK_SIZE = 16384; // 16kb; refference: https://github.com/denoland/deno/discussions/9906
     
     endpoint: string = '{{spec.endpoint}}';
+    config: Payload = {
+{% for header in spec.global.headers %}
+        '{{ header.key | caseLower }}': '',
+{% endfor %}
+    };
     headers: Payload = {
         'content-type': '',
         'user-agent' : `{{spec.title | caseUcfirst}}{{ language.name | caseUcfirst }}SDK/{{ sdk.version }} (${Deno.build.os}; ${Deno.build.arch})`,
@@ -34,7 +39,10 @@ export class Client {
      * @return self
      */
     set{{header.key | caseUcfirst}}(value: string): this {
-        this.addHeader('{{header.name}}', value);
+        {%~ if header.global %}
+        this.addHeader('{{ header.name }}', value);
+        {%~ endif %}
+        this.config['{{ header.key | caseLower }}'] = value;
 
         return this;
     }
@@ -79,7 +87,9 @@ export class Client {
         let body: string | FormData | undefined = undefined;
 
         if (method.toUpperCase() === "GET") {
-            url.search = new URLSearchParams(Client.flatten(params)).toString();
+            for (const [key, value] of Object.entries(Client.flatten(params))) {
+                url.searchParams.append(key, value);
+            }
         } else if (headers["content-type"]?.toLowerCase().startsWith("multipart/form-data")) {
             delete headers["content-type"];
             const formData = new FormData();

--- a/templates/deno/src/services/service.ts.twig
+++ b/templates/deno/src/services/service.ts.twig
@@ -91,7 +91,7 @@ export class {{ service.name | caseUcfirst }} extends Service {
 {% endfor %}
         let apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replace('{{ '{' }}{{ parameter.name }}{{ '}' }}', {{ parameter.name | caseCamel | escapeKeyword }}){% endfor %};
         {%~ for security in method.securityQueries %}
-        apiPath += `?{{ security.name }}=${encodeURIComponent(this.client.config['{{ security.name | caseLower }}'])}`;
+        apiPath += `{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=${encodeURIComponent(this.client.config['{{ security.name | caseLower }}'])}`;
         {%~ endfor %}
         const payload: Payload = {};
 

--- a/templates/deno/src/services/service.ts.twig
+++ b/templates/deno/src/services/service.ts.twig
@@ -89,7 +89,10 @@ export class {{ service.name | caseUcfirst }} extends Service {
 
 {% endif %}
 {% endfor %}
-        const apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replace('{{ '{' }}{{ parameter.name }}{{ '}' }}', {{ parameter.name | caseCamel | escapeKeyword }}){% endfor %};
+        let apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replace('{{ '{' }}{{ parameter.name }}{{ '}' }}', {{ parameter.name | caseCamel | escapeKeyword }}){% endfor %};
+        {%~ for security in method.securityQueries %}
+        apiPath += `?{{ security.name }}=${encodeURIComponent(this.client.config['{{ security.name | caseLower }}'])}`;
+        {%~ endfor %}
         const payload: Payload = {};
 
 {% for parameter in method.parameters.query %}
@@ -110,6 +113,9 @@ export class {{ service.name | caseUcfirst }} extends Service {
         const size = {{ parameter.name | caseCamel | escapeKeyword }}.size;
 
         const apiHeaders: { [header: string]: string } = {
+        {%~ for key, security in method.securityHeaders %}
+            '{{ security.name }}': this.client.config['{{ key | caseLower }}'],
+        {%~ endfor %}
 {% for parameter in method.parameters.header %}
             '{{ parameter.name }}': ${{ parameter.name | caseCamel | escapeKeyword }},
 {% endfor %}

--- a/templates/dotnet/Package/Client.cs.twig
+++ b/templates/dotnet/Package/Client.cs.twig
@@ -20,6 +20,11 @@ namespace {{ spec.title | caseUcfirst }}
         public string Endpoint => _endpoint;
         public Dictionary<string, string> Config => _config;
 
+        public string GetConfig(string key)
+        {
+            return _config.TryGetValue(key, out var value) ? value : "";
+        }
+
         private HttpClient _http;
         private HttpClient _httpForRedirect;
         private readonly Dictionary<string, string> _headers;

--- a/templates/dotnet/Package/Client.cs.twig
+++ b/templates/dotnet/Package/Client.cs.twig
@@ -119,8 +119,10 @@ namespace {{ spec.title | caseUcfirst }}
         /// <summary>{{header.description}}</summary>
         {%~ endif %}
         public Client Set{{header.key | caseUcfirst}}(string value) {
-            _config.Add("{{ header.key | caseCamel }}", value);
+            _config["{{ header.key | caseCamel }}"] = value;
+            {%~ if header.global %}
             AddHeader("{{header.name}}", value);
+            {%~ endif %}
 
             return this;
         }
@@ -146,8 +148,8 @@ namespace {{ spec.title | caseUcfirst }}
         {
             var methodGet = "GET".Equals(method, StringComparison.OrdinalIgnoreCase);
 
-            var queryString = methodGet ?
-                "?" + parameters.ToQueryString() :
+            var queryString = methodGet && parameters.Count > 0 ?
+                (path.Contains("?") ? "&" : "?") + parameters.ToQueryString() :
                 string.Empty;
 
             var request = new HttpRequestMessage(

--- a/templates/dotnet/base/params.twig
+++ b/templates/dotnet/base/params.twig
@@ -3,6 +3,10 @@
                 .Replace("{{ '{' ~ parameter.name ~ '}' }}", {{ parameter.name | caseCamel | escapeKeyword }}{% if parameter.enumValues is not empty %}.Value{% endif %}){% if loop.last %};{% endif %}
 
             {%~ endfor %}
+            {%~ for security in method.securityQueries %}
+            apiPath += "?{{ security.name }}=" + Uri.EscapeDataString(_client.Config.GetValueOrDefault("{{ security.name | caseCamel }}", ""));
+
+            {%~ endfor %}
 
             var apiParameters = new Dictionary<string, object?>()
             {
@@ -14,6 +18,10 @@
 
             var apiHeaders = new Dictionary<string, string>()
             {
+                {%~ for key, security in method.securityHeaders %}
+                { "{{ security.name }}", _client.Config.GetValueOrDefault("{{ key | caseCamel }}", "") }{% if not loop.last or method.headers | length > 0 %},{% endif %}
+
+                {%~ endfor %}
                 {%~ for key, header in method.headers %}
                 { "{{ key }}", "{{ header }}" }{% if not loop.last %},{% endif %}
 

--- a/templates/dotnet/base/params.twig
+++ b/templates/dotnet/base/params.twig
@@ -4,7 +4,7 @@
 
             {%~ endfor %}
             {%~ for security in method.securityQueries %}
-            apiPath += "{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=" + Uri.EscapeDataString(_client.Config.GetValueOrDefault("{{ security.name | caseCamel }}", ""));
+            apiPath += "{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=" + Uri.EscapeDataString(_client.GetConfig("{{ security.name | caseCamel }}"));
 
             {%~ endfor %}
 
@@ -19,7 +19,7 @@
             var apiHeaders = new Dictionary<string, string>()
             {
                 {%~ for key, security in method.securityHeaders %}
-                { "{{ security.name }}", _client.Config.GetValueOrDefault("{{ key | caseCamel }}", "") }{% if not loop.last or method.headers | length > 0 %},{% endif %}
+                { "{{ security.name }}", _client.GetConfig("{{ key | caseCamel }}") }{% if not loop.last or method.headers | length > 0 %},{% endif %}
 
                 {%~ endfor %}
                 {%~ for key, header in method.headers %}

--- a/templates/dotnet/base/params.twig
+++ b/templates/dotnet/base/params.twig
@@ -4,7 +4,7 @@
 
             {%~ endfor %}
             {%~ for security in method.securityQueries %}
-            apiPath += "?{{ security.name }}=" + Uri.EscapeDataString(_client.Config.GetValueOrDefault("{{ security.name | caseCamel }}", ""));
+            apiPath += "{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=" + Uri.EscapeDataString(_client.Config.GetValueOrDefault("{{ security.name | caseCamel }}", ""));
 
             {%~ endfor %}
 

--- a/templates/flutter/base/requests/api.twig
+++ b/templates/flutter/base/requests/api.twig
@@ -5,6 +5,9 @@
         };
 
         final Map<String, String> apiHeaders = {
+            {%~ for key, security in method.securityHeaders %}
+            '{{ security.name }}': client.config['{{ key | caseCamel }}'] ?? '',
+            {%~ endfor %}
             {{~ utils.map_headers(method.headers) }}
         };
 

--- a/templates/flutter/base/requests/file.twig
+++ b/templates/flutter/base/requests/file.twig
@@ -5,6 +5,9 @@
         };
 
         final Map<String, String> apiHeaders = {
+            {%~ for key, security in method.securityHeaders %}
+            '{{ security.name }}': client.config['{{ key | caseCamel }}'] ?? '',
+            {%~ endfor %}
             {{~ utils.map_headers(method.headers) }}
         };
 

--- a/templates/flutter/lib/services/service.dart.twig
+++ b/templates/flutter/lib/services/service.dart.twig
@@ -26,7 +26,14 @@ class {{ service.name | caseUcfirst }} extends Service {
 {%~ endif %}
 {%~ endif %}
   {% if method.type == 'webAuth' %}Future{% elseif method.type == 'location' %}Future<Uint8List>{% else %}{% set responseModels = method | getValidResponseModels %}{% if responseModels|length > 1 %}Future<models.Model>{% elseif method.responseModel and method.responseModel != 'any' %}Future<models.{{method.responseModel | caseUcfirst | overrideIdentifier}}>{% else %}Future{% endif %}{% endif %} {{ method.name | caseCamel | overrideIdentifier }}({{ _self.method_parameters(method.parameters.all, method.consumes) }}) async {
-    {% if method.parameters.path | length > 0 %}final{% else %}const{% endif %} String apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replaceAll('{{ '{' }}{{ parameter.name }}{{ '}' }}', {{ parameter.name | caseCamel | overrideIdentifier }}{% if parameter.enumValues | length > 0  %}.value{% endif %}){% endfor %};
+    final String apiPath = '{{ method.path }}'
+        {%- for parameter in method.parameters.path -%}
+        .replaceAll('{{ '{' }}{{ parameter.name }}{{ '}' }}', {{ parameter.name | caseCamel | overrideIdentifier }}{% if parameter.enumValues | length > 0  %}.value{% endif %})
+        {%- endfor -%}
+        {%- for security in method.securityQueries -%}
+        + '?{{ security.name }}=${Uri.encodeComponent(client.config['{{ security.name | caseCamel }}'] ?? '')}'
+        {%- endfor -%}
+        ;
 
 {% if 'multipart/form-data' in method.consumes %}
 {{ include('flutter/base/requests/file.twig') }}

--- a/templates/flutter/lib/services/service.dart.twig
+++ b/templates/flutter/lib/services/service.dart.twig
@@ -31,7 +31,7 @@ class {{ service.name | caseUcfirst }} extends Service {
         .replaceAll('{{ '{' }}{{ parameter.name }}{{ '}' }}', {{ parameter.name | caseCamel | overrideIdentifier }}{% if parameter.enumValues | length > 0  %}.value{% endif %})
         {%- endfor -%}
         {%- for security in method.securityQueries -%}
-        + '?{{ security.name }}=${Uri.encodeComponent(client.config['{{ security.name | caseCamel }}'] ?? '')}'
+        + '{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=${Uri.encodeComponent(client.config['{{ security.name | caseCamel }}'] ?? '')}'
         {%- endfor -%}
         ;
 

--- a/templates/flutter/lib/src/client_base.dart.twig
+++ b/templates/flutter/lib/src/client_base.dart.twig
@@ -32,6 +32,9 @@ abstract class ClientBase implements Client {
     final response = await call(
       HttpMethod.get,
       path: apiPath,
+      headers: {
+        'X-Appwrite-Project': config['project'] ?? '',
+      },
       responseType: ResponseType.plain,
     );
     return response.data;

--- a/templates/flutter/lib/src/client_browser.dart.twig
+++ b/templates/flutter/lib/src/client_browser.dart.twig
@@ -65,7 +65,9 @@ class ClientBrowser extends ClientBase with ClientMixin {
   @override
   ClientBrowser set{{header.key | caseUcfirst}}(value) {
     config['{{ header.key | caseCamel }}'] = value;
-    addHeader('{{header.name}}', value);
+    {%~ if header.global %}
+    addHeader('{{ header.name }}', value);
+    {%~ endif %}
     return this;
   }
 {% endfor %}

--- a/templates/flutter/lib/src/client_io.dart.twig
+++ b/templates/flutter/lib/src/client_io.dart.twig
@@ -91,7 +91,9 @@ class ClientIO extends ClientBase with ClientMixin {
   @override
   ClientIO set{{header.key | caseUcfirst}}(value) {
     config['{{ header.key | caseCamel }}'] = value;
-    addHeader('{{header.name}}', value);
+    {%~ if header.global %}
+    addHeader('{{ header.name }}', value);
+    {%~ endif %}
     return this;
   }
 {% endfor %}

--- a/templates/flutter/lib/src/client_mixin.dart.twig
+++ b/templates/flutter/lib/src/client_mixin.dart.twig
@@ -63,7 +63,7 @@ mixin ClientMixin {
         path: uri.path,
         host: uri.host,
         scheme: uri.scheme,
-        queryParameters: params,
+        queryParameters: {...uri.queryParameters, ...params},
         port: uri.port,
       );
       request = http.Request(method.name(), uri);

--- a/templates/go/appwrite.go.twig
+++ b/templates/go/appwrite.go.twig
@@ -67,7 +67,10 @@ func WithChunkSize(size int64) client.ClientOption {
 {% endif %}
 func With{{header.key | caseUcfirst}}(value string) client.ClientOption {
 	return func(clt *client.Client) error {
+		clt.Config["{{ header.key | caseLower }}"] = value
+		{%~ if header.global %}
 		clt.Headers["{{header.name}}"] = value
+		{%~ endif %}
 		return nil
 	}
 }

--- a/templates/go/base/params.twig
+++ b/templates/go/base/params.twig
@@ -15,6 +15,9 @@
 {% endif %}
 {% endfor %}
 	headers := map[string]interface{}{
+{%~ for key, security in method.securityHeaders %}
+		"{{ security.name }}": srv.client.Config["{{ key | caseLower }}"],
+{%~ endfor %}
 {% for key, header in method.headers %}
 		"{{ key }}": "{{ header }}",
 {% endfor %}

--- a/templates/go/client.go.twig
+++ b/templates/go/client.go.twig
@@ -64,6 +64,7 @@ func (ce *{{ spec.title | caseUcfirst }}Error) GetResponse() string {
 type Client struct {
 	Client     *http.Client
 	Headers    map[string]string
+	Config     map[string]string
 	Endpoint   string
 	Timeout    time.Duration
 	SelfSigned bool
@@ -92,6 +93,7 @@ func New(optionalSetters ...ClientOption) Client {
 		Client:    httpClient,
 		Timeout:   defaultTimeout,
 		Headers:   headers,
+		Config:    map[string]string{},
 		ChunkSize: defaultChunkSize,
 	}
 

--- a/templates/go/services/service.go.twig
+++ b/templates/go/services/service.go.twig
@@ -2,7 +2,7 @@
 {%- set requireFilesPkg = false -%}
 {%- set requireUrlPkg = false -%}
 {%- for method in service.methods -%}
-{%- if method.type == 'location' -%}
+{%- if method.type == 'location' or method.securityQueries | length > 0 -%}
 {%- set requireUrlPkg = true -%}
 {%- endif -%}
 {%- endfor -%}
@@ -130,6 +130,9 @@ func (srv *{{ service.name | caseUcfirst }}) {{ method.name | caseUcfirst }}({{ 
 {% else %}
 	path := "{{ method.path }}"
 {% endif %}
+{%~ for security in method.securityQueries %}
+	path += "?{{ security.name }}=" + url.QueryEscape(srv.client.Config["{{ security.name | caseLower }}"])
+{%~ endfor %}
 {{include('go/base/params.twig')}}
 {% if 'multipart/form-data' in method.consumes %}
 {{ include('go/base/requests/file.twig') }}

--- a/templates/go/services/service.go.twig
+++ b/templates/go/services/service.go.twig
@@ -131,7 +131,7 @@ func (srv *{{ service.name | caseUcfirst }}) {{ method.name | caseUcfirst }}({{ 
 	path := "{{ method.path }}"
 {% endif %}
 {%~ for security in method.securityQueries %}
-	path += "?{{ security.name }}=" + url.QueryEscape(srv.client.Config["{{ security.name | caseLower }}"])
+	path += "{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=" + url.QueryEscape(srv.client.Config["{{ security.name | caseLower }}"])
 {%~ endfor %}
 {{include('go/base/params.twig')}}
 {% if 'multipart/form-data' in method.consumes %}

--- a/templates/graphql/docs/example.md.twig
+++ b/templates/graphql/docs/example.md.twig
@@ -20,7 +20,7 @@
 {% for key,header in method.headers %}
 {% if header == 'multipart/form-data' %}
 {% set boundary = 'cec8e8123c05ba25' %}
-{{ method.method | caseUpper }} {{spec.basePath}}{{ method.path }} HTTP/1.1
+{{ method.method | caseUpper }} {{spec.basePath}}{{ method.path }}{% for security in method.securityQueries %}{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}={{ security['x-appwrite']['demo'] | raw }}{% endfor %} HTTP/1.1
 Host: {{ spec.host }}
 {% for key, header in method.headers %}
 {{ key | caseUcwords }}: {{ header }}{% if header == 'multipart/form-data' %}; boundary="{{boundary}}"{% endif ~%}
@@ -28,10 +28,8 @@ Host: {{ spec.host }}
 {% for key,header in spec.global.defaultHeaders %}
 {{ key }}: {{ header }}
 {% endfor %}
-{% for node in method.security %}
-{% for key,header in node | keys %}
-{{ node[header]['name'] }}: {{ node[header]['x-appwrite']['demo'] | raw }}
-{% endfor %}
+{% for security in method.securityHeaders %}
+{{ security.name }}: {{ security['x-appwrite']['demo'] | raw }}
 {% endfor %}
 Content-Length: *Length of your entity body in bytes*
 

--- a/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
@@ -95,7 +95,9 @@ class Client @JvmOverloads constructor(
      */
     fun set{{header.key | caseUcfirst}}(value: String): Client {
         config["{{ header.key | caseCamel }}"] = value
+        {%~ if header.global %}
         addHeader("{{ header.name | caseLower }}", value)
+        {%~ endif %}
         return this
     }
 

--- a/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
@@ -199,7 +199,10 @@ class Client @JvmOverloads constructor(
     suspend fun ping(): String {
         val apiPath = "/ping"
         val apiParams = mutableMapOf<String, Any?>()
-        val apiHeaders = mutableMapOf("content-type" to "application/json")
+        val apiHeaders = mutableMapOf(
+            "content-type" to "application/json",
+            "X-Appwrite-Project" to config["project"].orEmpty(),
+        )
 
         return call(
             "GET",

--- a/templates/kotlin/src/main/kotlin/io/appwrite/services/ServiceTemplate.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/services/ServiceTemplate.kt.twig
@@ -61,6 +61,9 @@ class {{ service.name | caseUcfirst }}(client: Client) : Service(client) {
         {%~ for parameter in method.parameters.path %}
             .replace("{{ '{' ~ parameter.name ~ '}' }}", {{ parameter.name | caseCamel }}{% if parameter.enumValues is not empty %}.value{% endif %})
         {%~ endfor %}
+            {%~ for security in method.securityQueries %}
+            + "?{{ security.name }}=${java.net.URLEncoder.encode(client.config["{{ security.name | caseCamel }}"].orEmpty(), "UTF-8")}"
+            {%~ endfor %}
 
         val apiParams = mutableMapOf<String, Any?>(
         {%~ for parameter in method.parameters.query | merge(method.parameters.body) %}
@@ -68,6 +71,9 @@ class {{ service.name | caseUcfirst }}(client: Client) : Service(client) {
         {%~ endfor %}
         )
         val apiHeaders = mutableMapOf<String, String>(
+        {%~ for key, security in method.securityHeaders %}
+            "{{ security.name }}" to client.config["{{ key | caseCamel }}"].orEmpty(),
+        {%~ endfor %}
         {%~ for key, header in method.headers %}
             "{{ key }}" to "{{ header }}",
         {%~ endfor %}

--- a/templates/kotlin/src/main/kotlin/io/appwrite/services/ServiceTemplate.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/services/ServiceTemplate.kt.twig
@@ -62,7 +62,7 @@ class {{ service.name | caseUcfirst }}(client: Client) : Service(client) {
             .replace("{{ '{' ~ parameter.name ~ '}' }}", {{ parameter.name | caseCamel }}{% if parameter.enumValues is not empty %}.value{% endif %})
         {%~ endfor %}
             {%~ for security in method.securityQueries %}
-            + "?{{ security.name }}=${java.net.URLEncoder.encode(client.config["{{ security.name | caseCamel }}"].orEmpty(), "UTF-8")}"
+            + "{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=${java.net.URLEncoder.encode(client.config["{{ security.name | caseCamel }}"].orEmpty(), "UTF-8")}"
             {%~ endfor %}
 
         val apiParams = mutableMapOf<String, Any?>(

--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -206,7 +206,9 @@ class Client {
      * @return {this}
      */
     set{{header.key | caseUcfirst}}(value: string): this {
-        this.headers['{{header.name}}'] = value;
+        {%~ if header.global %}
+        this.headers['{{ header.name }}'] = value;
+        {%~ endif %}
         this.config.{{ header.key | caseLower }} = value;
         return this;
     }

--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -506,7 +506,9 @@ class Client {
     }
 
     async ping(): Promise<unknown> {
-        return this.call('GET', new URL(this.config.endpoint + '/ping'));
+        return this.call('GET', new URL(this.config.endpoint + '/ping'), {
+            'X-Appwrite-Project': this.config.project,
+        });
     }
 
     async redirect(method: string, url: URL, headers: Headers = {}, params: Payload = {}): Promise<string> {

--- a/templates/node/src/services/template.ts.twig
+++ b/templates/node/src/services/template.ts.twig
@@ -122,8 +122,14 @@ export class {{ service.name | caseUcfirst }} {
         }
         {%~ endfor %}
         const uri = new URL(this.client.config.endpoint + apiPath);
+        {%~ for security in method.securityQueries %}
+        uri.searchParams.append('{{ security.name }}', this.client.config.{{ security.name | caseLower }});
+        {%~ endfor %}
 
         const apiHeaders: { [header: string]: string } = {
+            {%~ for key, security in method.securityHeaders %}
+            '{{ security.name }}': this.client.config.{{ key | caseLower }},
+            {%~ endfor %}
             {%~ for parameter in method.parameters.header %}
             '{{ parameter.name | caseCamel | escapeKeyword }}': this.client.${{ parameter.name | caseCamel | escapeKeyword }},
             {%~ endfor %}

--- a/templates/php/base/params.twig
+++ b/templates/php/base/params.twig
@@ -13,6 +13,9 @@
 {% endif %}
 
         $apiHeaders = [];
+        {%~ for key, security in method.securityHeaders %}
+        $apiHeaders['{{ security.name }}'] = $this->client->getConfig('{{ key | caseLower }}');
+        {%~ endfor %}
         {%~ for parameter in method.parameters.header %}
         $apiHeaders['{{ parameter.name }}'] = ${{ parameter.name | caseCamel | escapeKeyword }};
         {%~ endfor %}

--- a/templates/php/base/requests/file.twig
+++ b/templates/php/base/requests/file.twig
@@ -94,7 +94,12 @@
 {% endif %}
 {% endfor %}
 
-        $apiHeaders = ['content-type' => 'multipart/form-data'];
+        $apiHeaders = [
+            'content-type' => 'multipart/form-data',
+        {%~ for key, security in method.securityHeaders %}
+            '{{ security.name }}' => $this->client->getConfig('{{ key | caseLower }}'),
+        {%~ endfor %}
+        ];
         $handle = null;
 
         if(!empty(${{parameter.name}}->getPath())) {

--- a/templates/php/src/Client.php.twig
+++ b/templates/php/src/Client.php.twig
@@ -51,6 +51,13 @@ class Client
         'x-sdk-version'=> '{{ sdk.version }}',
     ];
 
+    /**
+     * Auth/config values used by generated service methods.
+     *
+     * @var array
+     */
+    protected array $config = [];
+
 {% if spec.global.headers | hasBearerAuth %}
     /**
      * API key for JWT generation
@@ -117,13 +124,21 @@ class Client
         $this->authorization = null;
         $this->authorizationExpiresAt = null;
 {% else %}
+        {%~ if header.global %}
         $this->addHeader('{{header.name}}', $value);
+        {%~ endif %}
+        $this->config['{{ header.key | caseLower }}'] = $value;
 {% endif %}
 
         return $this;
     }
 
 {% endfor %}
+
+    public function getConfig(string $key): string
+    {
+        return $this->config[$key] ?? '';
+    }
 
     /***
      * @param bool $status
@@ -242,7 +257,8 @@ class Client
         }
 {% endif %}
         $headers = array_merge($this->headers, $headers);
-        $ch = curl_init($this->endpoint . $path . (($method == self::METHOD_GET && !empty($params)) ? '?' . http_build_query($params) : ''));
+        $querySeparator = str_contains($path, '?') ? '&' : '?';
+        $ch = curl_init($this->endpoint . $path . (($method == self::METHOD_GET && !empty($params)) ? $querySeparator . http_build_query($params) : ''));
         $responseHeaders = [];
 
         switch ($headers['content-type']) {

--- a/templates/php/src/Services/Service.php.twig
+++ b/templates/php/src/Services/Service.php.twig
@@ -72,6 +72,9 @@ class {{ service.name | caseUcfirst }} extends Service
             [{% for parameter in method.parameters.path %}${{ parameter.name | caseCamel | escapeKeyword }}{% if not loop.last %}, {% endif %}{% endfor %}],
             '{{ method.path }}'
         );
+        {%~ for security in method.securityQueries %}
+        $apiPath .= '?{{ security.name }}=' . urlencode($this->client->getConfig('{{ security.name | caseLower }}'));
+        {%~ endfor %}
 
         {{~ include('php/base/params.twig') -}}
         {%~ if 'multipart/form-data' in method.consumes %}

--- a/templates/php/src/Services/Service.php.twig
+++ b/templates/php/src/Services/Service.php.twig
@@ -73,7 +73,7 @@ class {{ service.name | caseUcfirst }} extends Service
             '{{ method.path }}'
         );
         {%~ for security in method.securityQueries %}
-        $apiPath .= '?{{ security.name }}=' . urlencode($this->client->getConfig('{{ security.name | caseLower }}'));
+        $apiPath .= '{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=' . urlencode($this->client->getConfig('{{ security.name | caseLower }}'));
         {%~ endfor %}
 
         {{~ include('php/base/params.twig') -}}

--- a/templates/php/tests/Services/ServiceTest.php.twig
+++ b/templates/php/tests/Services/ServiceTest.php.twig
@@ -98,6 +98,9 @@ final class {{ service.name | caseUcfirst }}Test extends TestCase
         $this->client
             ->allows()->call(Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any(){% if method.type == 'webAuth' %}, Mockery::any(){% endif %})
             ->andReturn($data);
+        $this->client
+            ->allows()->getConfig(Mockery::any())
+            ->andReturn('');
 
 {% if requiredParameters | length > 0 %}
         $response = $this->{{ service.name | caseCamel }}->{{ method.name | caseCamel }}(

--- a/templates/python/base/requests/api.twig
+++ b/templates/python/base/requests/api.twig
@@ -1,4 +1,7 @@
         response = self.client.call('{{ method.method | caseLower }}', api_path, {
+{%~ for key, security in method.securityHeaders %}
+            '{{ security.name }}': self.client.get_config('{{ key | caseLower }}'),
+{%~ endfor %}
 {% for parameter in method.parameters.header %}
             '{{ parameter.name }}': self._normalize_value({{ parameter.name | escapeKeyword | caseSnake }}),
 {% endfor %}

--- a/templates/python/base/requests/file.twig
+++ b/templates/python/base/requests/file.twig
@@ -13,6 +13,9 @@
 {% endfor %}
 
         response = self.client.chunked_upload(api_path, {
+{%~ for key, security in method.securityHeaders %}
+            '{{ security.name }}': self.client.get_config('{{ key | caseLower }}'),
+{%~ endfor %}
 {% for parameter in method.parameters.header %}
             '{{ parameter.name }}': self._normalize_value({{ parameter.name | escapeKeyword | caseSnake }}),
 {% endfor %}

--- a/templates/python/package/client.py.twig
+++ b/templates/python/package/client.py.twig
@@ -26,6 +26,7 @@ class Client:
             '{{key}}' : '{{header}}',
 {% endfor %}
         }
+        self._config = {}
 
     def set_self_signed(self, status=True):
         self._self_signed = status
@@ -44,6 +45,9 @@ class Client:
 
     def get_headers(self):
         return dict(self._global_headers)
+
+    def get_config(self, key):
+        return self._config.get(key, '')
 {% for header in spec.global.headers %}
 
     def set_{{header.key | caseSnake}}(self, value):
@@ -51,7 +55,10 @@ class Client:
         """{{header.description}}"""
 
 {% endif %}
+        {%~ if header.global %}
         self._global_headers['{{header.name|lower}}'] = value
+        {%~ endif %}
+        self._config['{{ header.key | caseLower }}'] = value
         return self
 {% endfor %}
 

--- a/templates/python/package/services/service.py.twig
+++ b/templates/python/package/services/service.py.twig
@@ -162,6 +162,9 @@ Dict[str, Any]
         """
 
         api_path = '{{ method.path }}'
+        {%~ for security in method.securityQueries %}
+        api_path += '?{{ security.name }}=' + self.client._normalize_value(self.client.get_config('{{ security.name | caseLower }}'))
+        {%~ endfor %}
 {{ include('python/base/params.twig') }}
 {% if 'multipart/form-data' in method.consumes %}
 {{ include('python/base/requests/file.twig') }}

--- a/templates/python/package/services/service.py.twig
+++ b/templates/python/package/services/service.py.twig
@@ -163,7 +163,7 @@ Dict[str, Any]
 
         api_path = '{{ method.path }}'
         {%~ for security in method.securityQueries %}
-        api_path += '?{{ security.name }}=' + self.client._normalize_value(self.client.get_config('{{ security.name | caseLower }}'))
+        api_path += '{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=' + self.client._normalize_value(self.client.get_config('{{ security.name | caseLower }}'))
         {%~ endfor %}
 {{ include('python/base/params.twig') }}
 {% if 'multipart/form-data' in method.consumes %}

--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -266,7 +266,9 @@ class Client {
      * @return {this}
      */
     set{{header.key | caseUcfirst}}(value: string): this {
-        this.headers['{{header.name}}'] = value;
+        {%~ if header.global %}
+        this.headers['{{ header.name }}'] = value;
+        {%~ endif %}
         this.config.{{ header.key | caseLower }} = value;
         return this;
     }

--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -546,7 +546,9 @@ class Client {
     }
 
     async ping(): Promise<unknown> {
-        return this.call('GET', new URL(this.config.endpoint + '/ping'));
+        return this.call('GET', new URL(this.config.endpoint + '/ping'), {
+            'X-Appwrite-Project': this.config.project,
+        });
     }
 
     async call(method: string, url: URL, headers: Headers = {}, params: Payload = {}, responseType = 'json'): Promise<any> {

--- a/templates/react-native/src/services/template.ts.twig
+++ b/templates/react-native/src/services/template.ts.twig
@@ -126,6 +126,9 @@ export class {{ service.name | caseUcfirst }} extends Service {
 
 {% endfor %}
         const uri = new URL(this.client.config.endpoint + apiPath);
+        {%~ for security in method.securityQueries %}
+        uri.searchParams.append('{{ security.name }}', this.client.config.{{ security.name | caseLower }});
+        {%~ endfor %}
 {% if method.type == 'location' or method.type == 'webAuth' %}
 {% if method.auth|length > 0 %}
 {% for node in method.auth %}
@@ -151,6 +154,9 @@ export class {{ service.name | caseUcfirst }} extends Service {
 
         if (size <= Service.CHUNK_SIZE) {
             return this.client.call('{{ method.method | caseLower }}', uri, {
+            {%~ for key, security in method.securityHeaders %}
+                '{{ security.name }}': this.client.config.{{ key | caseLower }},
+            {%~ endfor %}
 {% for parameter in method.parameters.header %}
                 '{{ parameter.name | caseCamel | escapeKeyword }}': this.client.${{ parameter.name | caseCamel | escapeKeyword }},
 {% endfor %}
@@ -161,6 +167,9 @@ export class {{ service.name | caseUcfirst }} extends Service {
         }
 
         const apiHeaders: { [header: string]: string } = {
+        {%~ for key, security in method.securityHeaders %}
+            '{{ security.name }}': this.client.config.{{ key | caseLower }},
+        {%~ endfor %}
 {% for parameter in method.parameters.header %}
             '{{ parameter.name | caseCamel | escapeKeyword }}': this.client.${{ parameter.name | caseCamel | escapeKeyword }},
 {% endfor %}
@@ -318,6 +327,9 @@ export class {{ service.name | caseUcfirst }} extends Service {
 {% endfor %}
 {% else %}
         return this.client.call('{{ method.method | caseLower }}', uri, {
+        {%~ for key, security in method.securityHeaders %}
+            '{{ security.name }}': this.client.config.{{ key | caseLower }},
+        {%~ endfor %}
 {% for parameter in method.parameters.header %}
             '{{ parameter.name | caseCamel | escapeKeyword }}': this.client.${{ parameter.name | caseCamel | escapeKeyword }},
 {% endfor %}
@@ -364,6 +376,9 @@ export class {{ service.name | caseUcfirst }} extends Service {
 
 {% endfor %}
         const uri = new URL(this.client.config.endpoint + apiPath);
+        {%~ for security in method.securityQueries %}
+        uri.searchParams.append('{{ security.name }}', this.client.config.{{ security.name | caseLower }});
+        {%~ endfor %}
 {% for node in method.auth %}
 {% for key,header in node|keys %}
         payload['{{header|caseLower}}'] = this.client.config.{{header|caseLower}};

--- a/templates/rest/docs/example.md.twig
+++ b/templates/rest/docs/example.md.twig
@@ -1,6 +1,6 @@
 ```http
 {% set boundary = 'cec8e8123c05ba25' %}
-{{ method.method | caseUpper }} {{spec.basePath}}{{ method.path }} HTTP/1.1
+{{ method.method | caseUpper }} {{spec.basePath}}{{ method.path }}{% for security in method.securityQueries %}{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}={{ security['x-appwrite']['demo'] | raw }}{% endfor %} HTTP/1.1
 Host: {{ spec.host }}
 {% for key, header in method.headers %}
 {{ key | caseUcwords }}: {{ header }}{% if header == 'multipart/form-data' %}; boundary="{{boundary}}"{% endif ~%}
@@ -8,10 +8,8 @@ Host: {{ spec.host }}
 {% for key,header in spec.global.defaultHeaders %}
 {{ key }}: {{ header }}
 {% endfor %}
-{% for node in method.security %}
-{% for key,header in node | keys %}
-{{ node[header]['name'] }}: {{ node[header]['x-appwrite']['demo'] | raw }}
-{% endfor %}
+{% for security in method.securityHeaders %}
+{{ security.name }}: {{ security['x-appwrite']['demo'] | raw }}
 {% endfor %}
 {% for key, header in method.headers %}
 {% if header == 'application/json' %}

--- a/templates/ruby/base/params.twig
+++ b/templates/ruby/base/params.twig
@@ -2,6 +2,9 @@
 {% for parameter in method.parameters.path %}
                 .gsub('{{ '{' }}{{ parameter.name }}{{ '}' }}', {{ parameter.name | caseSnake | escapeKeyword }})
 {% endfor %}
+            {%~ for security in method.securityQueries %}
+            api_path += '?{{ security.name }}=' + URI.encode_www_form_component(@client.get_config('{{ security.name | caseLower }}'))
+            {%~ endfor %}
 
 {% for parameter in method.parameters.all %}
 {% if parameter.required %}
@@ -18,6 +21,9 @@
             }
             
             api_headers = {
+            {%~ for key, security in method.securityHeaders %}
+                "{{ security.name }}": @client.get_config('{{ key | caseLower }}'),
+            {%~ endfor %}
 {% for parameter in method.parameters.header %}
                 "{{ parameter.name }}": {{ parameter.name | caseCamel | escapeKeyword }},
 {% endfor %}

--- a/templates/ruby/base/params.twig
+++ b/templates/ruby/base/params.twig
@@ -3,7 +3,7 @@
                 .gsub('{{ '{' }}{{ parameter.name }}{{ '}' }}', {{ parameter.name | caseSnake | escapeKeyword }})
 {% endfor %}
             {%~ for security in method.securityQueries %}
-            api_path += '?{{ security.name }}=' + URI.encode_www_form_component(@client.get_config('{{ security.name | caseLower }}'))
+            api_path += '{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=' + URI.encode_www_form_component(@client.get_config('{{ security.name | caseLower }}'))
             {%~ endfor %}
 
 {% for parameter in method.parameters.all %}

--- a/templates/ruby/lib/container/client.rb.twig
+++ b/templates/ruby/lib/container/client.rb.twig
@@ -23,6 +23,7 @@ module {{ spec.title | caseUcfirst }}
 
             }
             @endpoint = '{{spec.endpoint}}'
+            @config = {}
         end
 
 {% for header in spec.global.headers %}
@@ -36,12 +37,19 @@ module {{ spec.title | caseUcfirst }}
         #
         # @return [self]
         def set_{{header.key | caseSnake}}(value)
+            {%~ if header.global %}
             add_header('{{header.name | caseLower}}', value)
+            {%~ endif %}
+            @config['{{ header.key | caseLower }}'] = value
 
             self
         end
 
 {% endfor %}
+        def get_config(key)
+            @config[key] || ''
+        end
+
         # Set endpoint.
         #
         # @param [String] endpoint The endpoint to set
@@ -103,7 +111,8 @@ module {{ spec.title | caseUcfirst }}
             params: {},
             response_type: nil
         )
-            uri = URI.parse(@endpoint + path + ((method == "GET" && params.length) ? '?' + encode(params) : ''))
+            separator = path.include?('?') ? '&' : '?'
+            uri = URI.parse(@endpoint + path + ((method == "GET" && params.length) ? separator + encode(params) : ''))
 
             fetch(method, uri, headers, params, response_type)
         end

--- a/templates/swift/Sources/Client.swift.twig
+++ b/templates/swift/Sources/Client.swift.twig
@@ -108,7 +108,9 @@ open class Client {
     ///
     open func set{{ header.key | caseUcfirst }}(_ value: String) -> Client {
         config["{{ header.key | caseLower }}"] = value
+        {%~ if header.global %}
         _ = addHeader(key: "{{header.name}}", value: value)
+        {%~ endif %}
         return self
     }
 
@@ -316,7 +318,7 @@ open class Client {
         let validParams = params.filter { $0.value != nil }
 
         let queryParameters = method == "GET" && !validParams.isEmpty
-            ? "?" + parametersToQueryString(params: validParams)
+            ? (path.contains("?") ? "&" : "?") + parametersToQueryString(params: validParams)
             : ""
 
         var request = HTTPClientRequest(url: endPoint + path + queryParameters)

--- a/templates/swift/Sources/Client.swift.twig
+++ b/templates/swift/Sources/Client.swift.twig
@@ -215,7 +215,8 @@ open class Client {
        let apiPath: String = "/ping"
 
        let apiHeaders: [String: String] = [
-           "content-type": "application/json"
+           "content-type": "application/json",
+           "X-Appwrite-Project": config["project"] ?? ""
        ]
 
        return try await call(

--- a/templates/swift/Sources/Services/Service.swift.twig
+++ b/templates/swift/Sources/Services/Service.swift.twig
@@ -44,12 +44,16 @@ open class {{ service.name | caseUcfirst | overrideIdentifier }}: Service {
         {%~ endif %}
     ) async throws -> {{ method | returnType(spec) | raw }} {
         {{~ include('swift/base/params.twig') }}
-        {%~ if method.headers | length <= 0 %}
+        {%~ if method.headers | length <= 0 and method.securityHeaders | length <= 0 %}
         let apiHeaders: [String: String] = [:]
         {%~ else %}
         {% if 'multipart/form-data' in method.consumes -%} var
         {%- else -%} let
         {%- endif %} apiHeaders: [String: String] = [
+        {%~ for key, security in method.securityHeaders %}
+            "{{ security.name }}": client.config["{{ key | caseCamel }}"] ?? ""{% if not loop.last or method.headers | length > 0 %},{% endif %}
+
+        {%~ endfor %}
         {%~ for key, header in method.headers %}
             "{{ key }}": "{{ header }}"{% if not loop.last %},{% endif %}
 

--- a/templates/swift/base/params.twig
+++ b/templates/swift/base/params.twig
@@ -3,7 +3,7 @@
             .replacingOccurrences(of: "{{ '{' }}{{ parameter.name }}{{ '}' }}", with: {{ parameter.name | caseCamel | escapeSwiftKeyword }}{% if parameter.enumValues is not empty %}.rawValue{% endif %})
         {%~ endfor %}
         {%~ for security in method.securityQueries %}
-            + "?{{ security.name }}=\(client.config["{{ security.name | caseCamel }}"]?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")"
+            + "{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=\(client.config["{{ security.name | caseCamel }}"]?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")"
         {%~ endfor %}
 
         {%~ if method.parameters.query | merge(method.parameters.body) | length <= 0 %}

--- a/templates/swift/base/params.twig
+++ b/templates/swift/base/params.twig
@@ -2,6 +2,9 @@
         {%~ for parameter in method.parameters.path %}
             .replacingOccurrences(of: "{{ '{' }}{{ parameter.name }}{{ '}' }}", with: {{ parameter.name | caseCamel | escapeSwiftKeyword }}{% if parameter.enumValues is not empty %}.rawValue{% endif %})
         {%~ endfor %}
+        {%~ for security in method.securityQueries %}
+            + "?{{ security.name }}=\(client.config["{{ security.name | caseCamel }}"]?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")"
+        {%~ endfor %}
 
         {%~ if method.parameters.query | merge(method.parameters.body) | length <= 0 %}
         let apiParams: [String: Any] = [:]

--- a/templates/unity/Assets/Runtime/Core/Client.cs.twig
+++ b/templates/unity/Assets/Runtime/Core/Client.cs.twig
@@ -181,7 +181,7 @@ namespace {{ spec.title | caseUcfirst }}
             bool selfSigned)
         {
             client.ConfigureEndpoint(endpoint);
-            client.SetHeader("project", "X-{{ spec.title | caseUcfirst }}-Project", projectId);
+            client._config["project"] = projectId;
             client._config["endpointRealtime"] = string.IsNullOrEmpty(endpointRealtime)
                 ? ToRealtimeEndpoint(endpoint)
                 : ValidateRealtimeEndpoint(endpointRealtime);
@@ -370,7 +370,9 @@ namespace {{ spec.title | caseUcfirst }}
             Dictionary<string, object?> parameters)
         {
             var methodGet = "GET".Equals(method, StringComparison.OrdinalIgnoreCase);
-            var queryString = methodGet ? "?" + parameters.ToQueryString() : string.Empty;
+            var queryString = methodGet && parameters.Count > 0
+                ? (path.Contains("?") ? "&" : "?") + parameters.ToQueryString()
+                : string.Empty;
             var url = _endpoint + path + queryString;
             
             var isMultipart = headers.TryGetValue("Content-Type", out var contentType) && 

--- a/templates/unity/Assets/Runtime/Core/Client.cs.twig
+++ b/templates/unity/Assets/Runtime/Core/Client.cs.twig
@@ -226,7 +226,8 @@ namespace {{ spec.title | caseUcfirst }}
         {
             var headers = new Dictionary<string, string>
             {
-                ["content-type"] = "application/json"
+                ["content-type"] = "application/json",
+                ["X-Appwrite-Project"] = _config.GetValueOrDefault("project", "")
             };
 
             var parameters = new Dictionary<string, object?>();

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -949,7 +949,9 @@ class Client {
     }
 
     async ping(): Promise<unknown> {
-        return this.call('GET', new URL(this.config.endpoint + '/ping'));
+        return this.call('GET', new URL(this.config.endpoint + '/ping'), {
+            'X-Appwrite-Project': this.config.project,
+        });
     }
 
     async call(method: string, url: URL, headers: Headers = {}, params: Payload = {}, responseType = 'json'): Promise<any> {

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -465,7 +465,9 @@ class Client {
      * @return {this}
      */
     set{{header.key | caseUcfirst}}(value: string): this {
-        this.headers['{{header.name}}'] = value;
+        {%~ if header.global %}
+        this.headers['{{ header.name }}'] = value;
+        {%~ endif %}
         this.config.{{ header.key | caseLower }} = value;
         return this;
     }

--- a/templates/web/src/services/template.ts.twig
+++ b/templates/web/src/services/template.ts.twig
@@ -119,8 +119,14 @@ export class {{ service.name | caseUcfirst }} {
         }
         {%~ endfor %}
         const uri = new URL(this.client.config.endpoint + apiPath);
+        {%~ for security in method.securityQueries %}
+        uri.searchParams.append('{{ security.name }}', this.client.config.{{ security.name | caseLower }});
+        {%~ endfor %}
 
         const apiHeaders: { [header: string]: string } = {
+            {%~ for key, security in method.securityHeaders %}
+            '{{ security.name }}': this.client.config.{{ key | caseLower }},
+            {%~ endfor %}
             {%~ for parameter in method.parameters.header %}
             '{{ parameter.name | caseCamel | escapeKeyword }}': this.client.${{ parameter.name | caseCamel | escapeKeyword }},
             {%~ endfor %}

--- a/tests/Unity2021Test.php
+++ b/tests/Unity2021Test.php
@@ -63,11 +63,6 @@ CMD;
 
     public function testHTTPSuccess(): void
     {
-        $license = \getenv('UNITY_LICENSE');
-        if ($license === false || \trim($license) === '') {
-            $this->markTestSkipped('UNITY_LICENSE is required to run Unity SDK tests.');
-        }
-
         // Set Unity test mode to exclude problematic files
         $GLOBALS['UNITY_TEST_MODE'] = true;
 

--- a/tests/Unity2021Test.php
+++ b/tests/Unity2021Test.php
@@ -63,6 +63,11 @@ CMD;
 
     public function testHTTPSuccess(): void
     {
+        $license = \getenv('UNITY_LICENSE');
+        if ($license === false || \trim($license) === '') {
+            $this->markTestSkipped('UNITY_LICENSE is required to run Unity SDK tests.');
+        }
+
         // Set Unity test mode to exclude problematic files
         $GLOBALS['UNITY_TEST_MODE'] = true;
 


### PR DESCRIPTION
## What changed

This updates the SDK generator to support security schemes that should be sent as URL query parameters, specifically the new `ProjectQuery` scheme used by OAuth approve/authorize/reject methods.

The parser now resolves method security into two flattened method-level collections:

- `method.securityHeaders` for method-scoped security headers such as `Project`
- `method.securityQueries` for method-scoped security query params such as `ProjectQuery`

The old parsed `method.security` output has been removed from template context so SDK templates no longer need nested security-node loops or scheme-specific checks.

## Why

OAuth methods can require the project ID in the request URL rather than as `X-Appwrite-Project`. Previously SDKs treated project as a global header through `setProject`, which meant these methods could not follow specs that declare only `ProjectQuery` security.

With this change:

- `setProject` stores the project ID in client config
- methods declaring `Project` send `X-Appwrite-Project`
- methods declaring `ProjectQuery` append `project=...` to the request URL
- if a future method declares both schemes, both transports are generated from the spec

## SDK/template impact

Updated request generation templates across the supported clients to use the flattened security fields:

- Web, Node, React Native, Deno
- PHP, Python, Ruby
- Dart, Flutter
- Go
- Swift, Apple
- Kotlin, Android
- .NET, Unity

Client setters now keep project in config without registering it as a global header. Other global headers keep the existing behavior.

Request clients that append GET params were also adjusted where needed so existing URL query strings are preserved instead of overwritten.

## Docs impact

REST and GraphQL HTTP example templates now render security according to transport:

- query security appears in the request URL, e.g. `?project=<YOUR_PROJECT_ID>`
- header security appears as an HTTP header, e.g. `X-Appwrite-Project: <YOUR_PROJECT_ID>`

Generated REST OAuth examples now show project in the URL instead of as a fake `project:` header.

## Validation

- Ran `composer lint-twig`
  - `565` Twig files linted
  - `0` errors
- Regenerated affected SDK examples from the saved client spec:
  - web, node, php, python, ruby, dart, flutter, react-native, go, swift, apple, dotnet, android, kotlin, unity
  - REST, GraphQL, Markdown docs
- Verified generated OAuth methods append `project` as a query parameter.
- Verified normal secured methods still send `X-Appwrite-Project`.
- Verified no remaining `method.security` references in `src` or `templates`.

## Notes

`global` is internal generator metadata. `Project` is marked non-global because the project ID is stored on the client, but each method's security declaration decides whether it is sent as `X-Appwrite-Project` or as a `ProjectQuery` URL parameter.
