### PR TITLE
Fix CLI Cloud region endpoint detection

### DIFF
--- a/templates/cli/lib/config.ts
+++ b/templates/cli/lib/config.ts
@@ -37,7 +37,7 @@ import type {
   Entity,
   GlobalConfigData,
 } from "./types.js";
-import { createSettingsObject } from "./utils.js";
+import { createSettingsObject, isCloudHostname } from "./utils.js";
 import {
   CONFIG_RESOURCE_KEYS,
   EXECUTABLE_NAME,
@@ -106,10 +106,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 export function normalizeCloudConsoleEndpoint(endpoint: string): string {
   try {
     const url = new URL(endpoint);
-    if (
-      url.hostname === "cloud.appwrite.io" ||
-      url.hostname.endsWith(".cloud.appwrite.io")
-    ) {
+    if (isCloudHostname(url.hostname)) {
       return "https://cloud.appwrite.io/v1";
     }
   } catch (_error) {

--- a/templates/cli/lib/utils.ts
+++ b/templates/cli/lib/utils.ts
@@ -361,8 +361,20 @@ const getHomebrewLatestVersion = async (
   }
 };
 
-export const isCloudHostname = (hostname: string): boolean =>
-  hostname === "cloud.appwrite.io" || hostname.endsWith(".cloud.appwrite.io");
+// TODO: Derive this list from the regions in the API spec.
+const CLOUD_REGION_CODES = new Set(["fra", "nyc", "syd", "sfo", "sgp", "tor"]);
+
+export const isCloudHostname = (hostname: string): boolean => {
+  if (hostname === "cloud.appwrite.io") {
+    return true;
+  }
+
+  if (!hostname.endsWith(".cloud.appwrite.io")) {
+    return false;
+  }
+
+  return CLOUD_REGION_CODES.has(hostname.split(".")[0]);
+};
 
 export const getConsoleBaseUrl = (endpoint: string): string => {
   try {


### PR DESCRIPTION
## Summary
- tighten CLI Cloud hostname detection to only normalize the base Cloud host and known regional Cloud prefixes
- preserve non-region Cloud subdomains for account login endpoints
- reuse the same Cloud hostname check when normalizing stored console login endpoints

## Testing
- `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php cli`
- `composer lint-twig`
- Manual staging login check:

```console
$ ./build/appwrite-cli-darwin-arm64 login --new --endpoint "https://stage.cloud.appwrite.io/v1"

⚠️  A newer version is available: 0.0.0 → 21.0.1
💡 Run 'appwrite update' to update to the latest version.

? Enter your email
```
