### PR TITLE
[codex] Fix CLI organization auth and pull settings

### DIFF
--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -1412,6 +1412,7 @@ class SDK
         $consoleOnlyServices = [
             'account',
             'locale',
+            'organization',
             'organizations',
             'projects',
         ];

--- a/templates/cli/lib/commands/pull.ts
+++ b/templates/cli/lib/commands/pull.ts
@@ -861,7 +861,10 @@ const pullSettings = async (): Promise<void> => {
     projectId,
   );
 
-  localConfig.setProject(projectId, settings.projectName, settings.project);
+  localConfig.setProject(projectId, settings.projectName);
+  if (settings.settings) {
+    localConfig.set("settings", settings.settings);
+  }
 };
 
 const pullFunctions = async ({


### PR DESCRIPTION
## What changed

- Treat the generated CLI `organization` service as console-only so it uses `sdkForConsole()` instead of `sdkForProject()`.
- Preserve the full pulled settings object after standalone `appwrite pull settings`, including auth security settings.

## Why

These changes address the P1 review findings from `appwrite/sdk-for-cli#323` at the sdk-generator source. The CLI SDK is generated from this repo, so the fixes need to live in the generator template/classification instead of only in the generated SDK repo.

## Validation

- `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php cli`
- `composer lint-twig`
- `vendor/bin/phpunit tests/CLIBun13Test.php`
