### PR TITLE
[codex] Fix Go array doc examples

### DIFF
--- a/src/SDK/Language/Go.php
+++ b/src/SDK/Language/Go.php
@@ -325,7 +325,7 @@ class Go extends Language
                     $output .= 'map[string]interface{}{}';
                     break;
                 case self::TYPE_ARRAY:
-                    $output .= '[]interface{}{}';
+                    $output .= $this->getTypeName($param) . '{}';
                     break;
                 case self::TYPE_FILE:
                     $output .= 'file.NewInputFile("/path/to/file.png", "file.png")';
@@ -344,7 +344,7 @@ class Go extends Language
                     if (\str_ends_with($example, ']')) {
                         $example = \substr($example, 0, -1);
                     }
-                    $output .= 'interface{}{' . $example . '}';
+                    $output .= $this->getTypeName($param) . '{' . $example . '}';
                     break;
                 case self::TYPE_OBJECT:
                     $output .= ($example === '{}')


### PR DESCRIPTION
## Summary

- Fix Go docs examples for array parameters to use the generated concrete Go type.
- Preserve `[]interface{}{}` for arrays without known item types.

## Why

A Greptile P1 review noted that generated Go docs can emit `[]interface{}{}` for params whose SDK option setter expects a concrete type such as `[]string`, making copied examples fail to compile.

## Validation

- `docker run --rm -v $(pwd):/app -w /app php:8.3-cli php example.php go`
- Direct `Go::getParamExample()` check: array<string> -> `[]string{}`, array<integer> -> `[]int{}`, unknown array -> `[]interface{}{}`
- `composer lint-twig`
