### PR TITLE
fix(unity): ship SDK as a UPM package with .meta files

### DIFF
--- a/src/SDK/Language.php
+++ b/src/SDK/Language.php
@@ -57,6 +57,20 @@ abstract class Language
     abstract public function getFiles(): array;
 
     /**
+     * Hook invoked once after all files have been generated.
+     *
+     * Languages can override this to run post-processing over the
+     * generated output (e.g. emitting sidecar files that depend on the
+     * full file tree). Default implementation is a no-op.
+     *
+     * @param string $target Absolute path the SDK was generated into.
+     * @return void
+     */
+    public function postGenerate(string $target): void
+    {
+    }
+
+    /**
      * @param array $parameter
      * @return string
      */

--- a/src/SDK/Language/Unity.php
+++ b/src/SDK/Language/Unity.php
@@ -586,6 +586,13 @@ class Unity extends DotNet
             return implode("\n", $lines) . "\n";
         }
 
+        // Plugins/Android/AndroidManifest.xml must import as an Android
+        // plugin so Unity merges it into the build manifest; a plain
+        // DefaultImporter would import it as an inert text asset.
+        if (str_ends_with($relativePath, 'Plugins/Android/AndroidManifest.xml')) {
+            return implode("\n", $this->pluginImporterMeta($guid, 'Android')) . "\n";
+        }
+
         $extension = strtolower(pathinfo($relativePath, PATHINFO_EXTENSION));
 
         $lines = match ($extension) {
@@ -604,40 +611,7 @@ class Unity extends DotNet
             ],
             // WebGL JavaScript plugin: enable on WebGL only so the cookie
             // shim is actually compiled into WebGL builds.
-            'jslib' => [
-                'fileFormatVersion: 2',
-                "guid: {$guid}",
-                'PluginImporter:',
-                '  externalObjects: {}',
-                '  serializedVersion: 2',
-                '  iconMap: {}',
-                '  executionOrder: {}',
-                '  defineConstraints: []',
-                '  isPreloaded: 0',
-                '  isOverridable: 0',
-                '  isExplicitlyReferenced: 0',
-                '  validateReferences: 1',
-                '  platformData:',
-                '  - first:',
-                '      Any:',
-                '    second:',
-                '      enabled: 0',
-                '      settings: {}',
-                '  - first:',
-                '      Editor: Editor',
-                '    second:',
-                '      enabled: 0',
-                '      settings:',
-                '        DefaultValueInitialized: true',
-                '  - first:',
-                '      WebGL: WebGL',
-                '    second:',
-                '      enabled: 1',
-                '      settings: {}',
-                '  userData:',
-                '  assetBundleName:',
-                '  assetBundleVariant:',
-            ],
+            'jslib' => $this->pluginImporterMeta($guid, 'WebGL'),
             default => [
                 'fileFormatVersion: 2',
                 "guid: {$guid}",
@@ -650,5 +624,51 @@ class Unity extends DotNet
         };
 
         return implode("\n", $lines) . "\n";
+    }
+
+    /**
+     * Build PluginImporter meta lines enabling a single target platform
+     * (and the editor stub), with every other platform disabled.
+     *
+     * @param string $guid
+     * @param string $platform Unity platform key (e.g. 'WebGL', 'Android').
+     * @return array<string>
+     */
+    private function pluginImporterMeta(string $guid, string $platform): array
+    {
+        return [
+            'fileFormatVersion: 2',
+            "guid: {$guid}",
+            'PluginImporter:',
+            '  externalObjects: {}',
+            '  serializedVersion: 2',
+            '  iconMap: {}',
+            '  executionOrder: {}',
+            '  defineConstraints: []',
+            '  isPreloaded: 0',
+            '  isOverridable: 0',
+            '  isExplicitlyReferenced: 0',
+            '  validateReferences: 1',
+            '  platformData:',
+            '  - first:',
+            '      Any:',
+            '    second:',
+            '      enabled: 0',
+            '      settings: {}',
+            '  - first:',
+            '      Editor: Editor',
+            '    second:',
+            '      enabled: 0',
+            '      settings:',
+            '        DefaultValueInitialized: true',
+            '  - first:',
+            "      {$platform}: {$platform}",
+            '    second:',
+            '      enabled: 1',
+            '      settings: {}',
+            '  userData:',
+            '  assetBundleName:',
+            '  assetBundleVariant:',
+        ];
     }
 }

--- a/src/SDK/Language/Unity.php
+++ b/src/SDK/Language/Unity.php
@@ -514,6 +514,8 @@ class Unity extends DotNet
             return;
         }
 
+        $normalizedTarget = rtrim(str_replace('\\', '/', $target), '/');
+
         $iterator = new \RecursiveIteratorIterator(
             new \RecursiveDirectoryIterator($target, \FilesystemIterator::SKIP_DOTS),
             \RecursiveIteratorIterator::SELF_FIRST
@@ -522,7 +524,7 @@ class Unity extends DotNet
         foreach ($iterator as $item) {
             /** @var \SplFileInfo $item */
             $path     = $item->getPathname();
-            $relative = ltrim(str_replace('\\', '/', substr($path, strlen($target))), '/');
+            $relative = ltrim(substr(str_replace('\\', '/', $path), strlen($normalizedTarget)), '/');
 
             if ($relative === '') {
                 continue;
@@ -552,7 +554,9 @@ class Unity extends DotNet
                 continue;
             }
 
-            file_put_contents($meta, $this->getMetaContents($relative, $item->isDir()));
+            if (file_put_contents($meta, $this->getMetaContents($relative, $item->isDir())) === false) {
+                throw new \RuntimeException("Failed to write meta file: {$meta}");
+            }
         }
     }
 

--- a/src/SDK/Language/Unity.php
+++ b/src/SDK/Language/Unity.php
@@ -458,6 +458,8 @@ class Unity extends DotNet
             ],
         ];
 
+        $inTest = isset($GLOBALS['UNITY_TEST_MODE']) && $GLOBALS['UNITY_TEST_MODE'] === true;
+
         foreach ($files as &$file) {
             if (
                 str_starts_with($file['destination'], 'Packages/')
@@ -465,12 +467,16 @@ class Unity extends DotNet
             ) {
                 $file['test'] = true;
             }
+
+            if (!$inTest && str_starts_with($file['destination'], 'Assets/')) {
+                $file['destination'] = substr($file['destination'], \strlen('Assets/'));
+            }
         }
         unset($file);
 
         // Filter out problematic files in test mode
         // Check if we're in test mode by looking for a global variable
-        if (isset($GLOBALS['UNITY_TEST_MODE']) && $GLOBALS['UNITY_TEST_MODE'] === true) {
+        if ($inTest) {
             $excludeInTest = [
                 'Assets/Runtime/Utilities/{{ spec.title | caseUcfirst }}Utilities.cs',
                 'Assets/Runtime/{{ spec.title | caseUcfirst }}Config.cs',
@@ -486,5 +492,159 @@ class Unity extends DotNet
         }
 
         return $files;
+    }
+
+    /**
+     * Emit a .meta for every asset that lacks one.
+     *
+     * Immutable UPM packages need committed .meta files (Unity won't generate
+     * them), else assets are ignored. GUIDs are path-derived for stable diffs;
+     * existing metas (asmdef, .dll plugins) are left untouched.
+     *
+     * @param string $target
+     * @return void
+     */
+    public function postGenerate(string $target): void
+    {
+        if (isset($GLOBALS['UNITY_TEST_MODE']) && $GLOBALS['UNITY_TEST_MODE'] === true) {
+            return;
+        }
+
+        if (!is_dir($target)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($target, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::SELF_FIRST
+        );
+
+        foreach ($iterator as $item) {
+            /** @var \SplFileInfo $item */
+            $path     = $item->getPathname();
+            $relative = ltrim(str_replace('\\', '/', substr($path, strlen($target))), '/');
+
+            if ($relative === '') {
+                continue;
+            }
+
+            // Unity ignores hidden entries and anything inside a folder (or
+            // file) suffixed with '~' (e.g. Samples~, Documentation~), so
+            // emitting metas there would be wrong. Skip the whole subtree.
+            $skip = false;
+            foreach (explode('/', $relative) as $segment) {
+                if ($segment === '' || $segment[0] === '.' || str_ends_with($segment, '~')) {
+                    $skip = true;
+                    break;
+                }
+            }
+            if ($skip) {
+                continue;
+            }
+
+            // Never emit a meta for a meta, and never clobber an existing one.
+            if (str_ends_with($path, '.meta')) {
+                continue;
+            }
+
+            $meta = $path . '.meta';
+            if (file_exists($meta)) {
+                continue;
+            }
+
+            file_put_contents($meta, $this->getMetaContents($relative, $item->isDir()));
+        }
+    }
+
+    /**
+     * Build the contents of a .meta file for a given asset.
+     *
+     * @param string $relativePath Package-relative path (forward slashes).
+     * @param bool   $isDir        Whether the asset is a directory.
+     * @return string
+     */
+    private function getMetaContents(string $relativePath, bool $isDir): string
+    {
+        $guid = md5($relativePath);
+
+        if ($isDir) {
+            $lines = [
+                'fileFormatVersion: 2',
+                "guid: {$guid}",
+                'folderAsset: yes',
+                'DefaultImporter:',
+                '  externalObjects: {}',
+                '  userData:',
+                '  assetBundleName:',
+                '  assetBundleVariant:',
+            ];
+
+            return implode("\n", $lines) . "\n";
+        }
+
+        $extension = strtolower(pathinfo($relativePath, PATHINFO_EXTENSION));
+
+        $lines = match ($extension) {
+            'cs' => [
+                'fileFormatVersion: 2',
+                "guid: {$guid}",
+                'MonoImporter:',
+                '  externalObjects: {}',
+                '  serializedVersion: 2',
+                '  defaultReferences: []',
+                '  executionOrder: 0',
+                '  icon: {instanceID: 0}',
+                '  userData:',
+                '  assetBundleName:',
+                '  assetBundleVariant:',
+            ],
+            // WebGL JavaScript plugin: enable on WebGL only so the cookie
+            // shim is actually compiled into WebGL builds.
+            'jslib' => [
+                'fileFormatVersion: 2',
+                "guid: {$guid}",
+                'PluginImporter:',
+                '  externalObjects: {}',
+                '  serializedVersion: 2',
+                '  iconMap: {}',
+                '  executionOrder: {}',
+                '  defineConstraints: []',
+                '  isPreloaded: 0',
+                '  isOverridable: 0',
+                '  isExplicitlyReferenced: 0',
+                '  validateReferences: 1',
+                '  platformData:',
+                '  - first:',
+                '      Any:',
+                '    second:',
+                '      enabled: 0',
+                '      settings: {}',
+                '  - first:',
+                '      Editor: Editor',
+                '    second:',
+                '      enabled: 0',
+                '      settings:',
+                '        DefaultValueInitialized: true',
+                '  - first:',
+                '      WebGL: WebGL',
+                '    second:',
+                '      enabled: 1',
+                '      settings: {}',
+                '  userData:',
+                '  assetBundleName:',
+                '  assetBundleVariant:',
+            ],
+            default => [
+                'fileFormatVersion: 2',
+                "guid: {$guid}",
+                'DefaultImporter:',
+                '  externalObjects: {}',
+                '  userData:',
+                '  assetBundleName:',
+                '  assetBundleVariant:',
+            ],
+        };
+
+        return implode("\n", $lines) . "\n";
     }
 }

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -1145,6 +1145,8 @@ class SDK
                     break;
             }
         }
+
+        $this->language->postGenerate($target);
     }
 
     /**

--- a/templates/unity/README.md.twig
+++ b/templates/unity/README.md.twig
@@ -30,10 +30,12 @@
 3. Enter the following URL:
 
 ```sh
-https://github.com/{{ sdk.gitUserName|url_encode }}/{{ sdk.gitRepoName|url_encode }}.git
+https://github.com/{{ sdk.gitUserName|url_encode }}/{{ sdk.gitRepoName|url_encode }}.git#{{ sdk.version }}
 ```
 
 4. Click **Add**.
+
+The `#{{ sdk.version }}` suffix pins the package to a specific release. Change it to any released tag, or omit `#{{ sdk.version }}` to track the latest commit on the default branch.
 
 ### Manual Installation
 

--- a/templates/unity/README.md.twig
+++ b/templates/unity/README.md.twig
@@ -30,7 +30,7 @@
 3. Enter the following URL:
 
 ```sh
-https://github.com/{{ sdk.gitUserName|url_encode }}/{{ sdk.gitRepoName|url_encode }}.git?path=Assets
+https://github.com/{{ sdk.gitUserName|url_encode }}/{{ sdk.gitRepoName|url_encode }}.git
 ```
 
 4. Click **Add**.

--- a/templates/unity/package.json.twig
+++ b/templates/unity/package.json.twig
@@ -5,6 +5,11 @@
   "description": "{{spec.description}}",
   "unity": "2021.3",
   "documentationUrl": "{{ sdk.url }}",
+  "author": {
+    "name": "{{ spec.contactName }}",
+    "email": "{{ spec.contactEmail }}",
+    "url": "{{ spec.contactURL }}"
+  },
   "keywords": [
     "{{spec.title | caseLower}}",
     "backend",


### PR DESCRIPTION
## Problem

The Unity SDK installs via UPM but is completely non-functional: every asset is ignored with

> Asset Packages/io.appwrite.unity/… has no meta file, but it's in an immutable folder. The asset will be ignored.

Two root causes:

1. **Missing `.meta` files.** A UPM package consumed via git URL is **immutable**, and Unity does **not** generate `.meta` files for immutable packages — they must already exist in the repo. The generator only emitted metas for the `.asmdef` and bundled `.dll` files (8 of ~70 assets), so every `.cs` file, every folder, `package.json`, etc. was ignored.
2. **Project layout, not package layout.** `package.json` shipped under `Assets/`, forcing the awkward `?path=Assets` install URL.

This was never caught because the Unity PlayMode test generates a **mutable** project (under `Assets/`), where Unity auto-generates metas — so the test environment structurally can't reproduce the immutable-package failure.

## Fix

- Add a generic `postGenerate(string $target)` hook on `Language` (no-op) invoked after generation in `SDK::generate()`.
- `Unity::postGenerate()` sweeps the generated package and writes a deterministic `.meta` for every file/folder missing one:
  - GUIDs derived from the package-relative path → stable across regenerations (clean diffs).
  - Correct importer per type (`MonoImporter` for `.cs`, `folderAsset` for dirs, WebGL-enabled `PluginImporter` for `.jslib`, `DefaultImporter` otherwise).
  - Skips `~` folders (`Samples~`, `docs~`) and existing metas (asmdef/dll GUIDs + import settings preserved).
- Ship the package at the **repo root** in publish mode (strip the `Assets/` prefix) so it installs from the bare git URL. **Test mode keeps the `Assets/` project layout**, so the PlayMode test is unchanged.
- Drop `?path=Assets` from the README install instructions.

## Verification

Local generation was checked against every invariant Unity enforces at import (25/25):

- All importable files **and** folders have a sibling `.meta` (72/72).
- GUIDs valid 32-hex and globally unique; every `.meta` is valid YAML with `fileFormatVersion: 2`.
- Importer type correct per asset; `WebGLCookies.jslib` enabled on WebGL.
- Hand-authored asmdef/dll metas preserved byte-for-byte.
- Fully deterministic across regenerations.
- Test-mode output byte-for-byte unchanged (Assets/ layout + ProjectSettings/Packages intact, sweep skipped).
- PHP and Go generation unaffected by the new hook.

## Follow-ups (outside this repo)

- The publish pipeline copies `Assets/` today — it must copy the **repo root** for the new layout to reach the published `sdk-for-unity` repo.
- `appwrite/sdk-for-unity` needs regeneration + republish; the currently-published package stays broken until then.