### PR TITLE
Add Accept header from spec produces

### DIFF
--- a/mock-server/app/http.php
+++ b/mock-server/app/http.php
@@ -289,6 +289,7 @@ App::get('/v1/mock/tests/general/headers')
             'x-sdk-platform' => $request->getHeader('x-sdk-platform'),
             'x-sdk-language' => $request->getHeader('x-sdk-language'),
             'x-sdk-version' => $request->getHeader('x-sdk-version'),
+            'accept' => $request->getHeader('accept'),
         ];
         $res = array_map(function ($key, $value) {
             return $key . ': ' . $value;

--- a/src/Spec/Swagger2.php
+++ b/src/Spec/Swagger2.php
@@ -224,6 +224,7 @@ class Swagger2 extends Spec
             'securityHeaders' => $methodSecurityHeaders,
             'securityQueries' => $methodSecurityQueries,
             'consumes' => $method['consumes'] ?? [],
+            'produces' => $method['produces'] ?? [],
             'cookies' => $method['x-appwrite']['cookies'] ?? false,
             'platforms' => $method['x-appwrite']['platforms'] ?? [],
             'consoleOnly' => $method['x-appwrite']['consoleOnly'] ?? false,
@@ -256,6 +257,10 @@ class Swagger2 extends Spec
             foreach ($method['consumes'] as $consume) {
                 $output['headers']['content-type'] = $consume;
             }
+        }
+
+        if (isset($method['produces']) && is_array($method['produces']) && !empty($method['produces'])) {
+            $output['headers']['accept'] = implode(', ', $method['produces']);
         }
 
         $method['parameters'] = (isset($method['parameters']) && is_array($method['parameters'])) ? $method['parameters'] : [];

--- a/templates/cli/base/mock.twig
+++ b/templates/cli/base/mock.twig
@@ -32,7 +32,11 @@ class {{ service.name | caseUcfirst }} {
 {% elseif method.name == 'redirect' %}
     return { result: '{{ method.method | upper }}:/v1{{ method.path }}/done:passed' };
 {% elseif method.name == 'headers' %}
-    return { result: 'x-sdk-name: {{ sdk.name }}; x-sdk-platform: {{ sdk.platform }}; x-sdk-language: {{ language.name | caseLower }}; x-sdk-version: {{ sdk.version }}' };
+    return {
+      result: 'x-sdk-name: {{ sdk.name }}; x-sdk-platform: {{ sdk.platform }}; '
+        + 'x-sdk-language: {{ language.name | caseLower }}; x-sdk-version: {{ sdk.version }}'
+        + '{% for key, header in method.headers %}; {{ key }}: {{ header }}{% endfor %}'
+    };
 {% else %}
     return { result: '{{ method.method | upper }}:/v1{{ method.path }}:passed' };
 {% endif %}

--- a/templates/rust/tests/tests.rs
+++ b/templates/rust/tests/tests.rs
@@ -1,4 +1,13 @@
-use appwrite::{Client, services::*, id::ID, permission::Permission, query::Query, role::Role, input_file::InputFile};
+use appwrite::{
+    Client,
+    id::ID,
+    input_file::InputFile,
+    operator::{self, Condition},
+    permission::Permission,
+    query::Query,
+    role::Role,
+    services::*,
+};
 use serde_json::json;
 use std::path::Path;
 use tokio;
@@ -146,6 +155,9 @@ async fn test_general_service(client: &Client, string_in_array: &[String]) -> Re
 
     // Test Id Helpers
     test_id_helpers();
+
+    // Test Operator Helpers
+    test_operator_helpers();
 
     // Final test
     match general.headers().await {
@@ -296,4 +308,32 @@ fn test_permission_helpers() {
 fn test_id_helpers() {
     println!("{}", ID::unique());
     println!("{}", ID::custom("custom_id"));
+}
+
+fn test_operator_helpers() {
+    println!("{}", operator::increment());
+    println!("{}", operator::increment_with_max(5, 100));
+    println!("{}", operator::decrement());
+    println!("{}", operator::decrement_with_min(3, 0));
+    println!("{}", operator::multiply(2));
+    println!("{}", operator::multiply_with_max(3, 1000));
+    println!("{}", operator::divide(2));
+    println!("{}", operator::divide_with_min(4, 1));
+    println!("{}", operator::modulo(5));
+    println!("{}", operator::power(2));
+    println!("{}", operator::power_with_max(3, 100));
+    println!("{}", operator::array_append(&["item1", "item2"]));
+    println!("{}", operator::array_prepend(&["first", "second"]));
+    println!("{}", operator::array_insert(0, "newItem"));
+    println!("{}", operator::array_remove("oldItem"));
+    println!("{}", operator::array_unique());
+    println!("{}", operator::array_intersect(&["a", "b", "c"]));
+    println!("{}", operator::array_diff(&["x", "y"]));
+    println!("{}", operator::array_filter_with_value(Condition::Equal, "test"));
+    println!("{}", operator::string_concat("suffix"));
+    println!("{}", operator::string_replace("old", "new"));
+    println!("{}", operator::toggle());
+    println!("{}", operator::date_add_days(7));
+    println!("{}", operator::date_sub_days(3));
+    println!("{}", operator::date_set_now());
 }

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -215,7 +215,8 @@ abstract class Base extends TestCase
     ];
 
     protected const CLI_HEADERS_RESPONSES = [
-        'x-sdk-name: cli; x-sdk-platform: server; x-sdk-language: cli; x-sdk-version: 0.0.1',
+        'x-sdk-name: cli; x-sdk-platform: server; x-sdk-language: cli; '
+            . 'x-sdk-version: 0.0.1; accept: application/json, text/plain',
     ];
 
     protected const CLI_FUNCTION_RESPONSES = [
@@ -237,6 +238,8 @@ abstract class Base extends TestCase
         'CLI_LOCAL_FUNCTION_RUNNER_CONFIG:passed',
         'CLI_LOCAL_SOURCE_PREFLIGHT:passed',
     ];
+
+    protected const HEADERS_RESPONSE = '__HEADERS_RESPONSE__';
 
     protected const CLI_RUNTIME_RENDERING_RESPONSES = [
         'CLI_RUNTIME_RENDERING:passed',
@@ -322,6 +325,7 @@ abstract class Base extends TestCase
         '{"method":"dateAddDays","values":[7]}',
         '{"method":"dateSubDays","values":[3]}',
         '{"method":"dateSetNow","values":[]}',
+        self::HEADERS_RESPONSE,
     ];
 
     protected string $class = '';
@@ -434,6 +438,10 @@ abstract class Base extends TestCase
         echo \implode("\n", $output);
 
         foreach ($this->expectedOutput as $index => $expected) {
+            if ($expected === self::HEADERS_RESPONSE) {
+                $expected = $this->getExpectedSdkHeaders() . '; accept: application/json, text/plain';
+            }
+
             // HACK: Swift does not guarantee the order of the JSON parameters
             if (\str_starts_with($expected, '{')) {
                 $this->assertEquals(

--- a/tests/Rust183Test.php
+++ b/tests/Rust183Test.php
@@ -24,5 +24,6 @@ class Rust183Test extends Base
         ...Base::QUERY_HELPER_RESPONSES,
         ...Base::PERMISSION_HELPER_RESPONSES,
         ...Base::ID_HELPER_RESPONSES,
+        ...Base::OPERATOR_HELPER_RESPONSES,
     ];
 }

--- a/tests/languages/react-native/browser.js
+++ b/tests/languages/react-native/browser.js
@@ -363,6 +363,9 @@ import {
     console.log(Operator.dateSubDays(3));
     console.log(Operator.dateSetNow());
 
+    response = await general.headers();
+    console.log(response.result);
+
     window.__APPWRITE_TEST_DONE__ = true;
 })().catch((err) => {
     console.log('TEST RUNNER ERROR: ' + (err && err.message ? err.message : String(err)));

--- a/tests/resources/spec.json
+++ b/tests/resources/spec.json
@@ -1665,7 +1665,10 @@
         "summary": "Get headers",
         "operationId": "generalHeaders",
         "consumes": [],
-        "produces": [],
+        "produces": [
+          "application/json",
+          "text/plain"
+        ],
         "tags": [
           "general"
         ],


### PR DESCRIPTION
## Summary
- Read operation-level Swagger `produces` values in the parser.
- Generate a per-request `accept` header through the existing `method.headers` path.
- Extend the existing mock spec/header endpoint assertions to verify the generated header value.

## Tests
- `php -l tests/Base.php && php -l src/Spec/Swagger2.php && php -l mock-server/app/http.php`
- `vendor/bin/phpcs src/Spec/Swagger2.php tests/Base.php mock-server/app/http.php`
- `composer lint-twig`
- `php example.php` (completed successfully; emitted existing Dart/Flutter Twig array-to-string warnings)
- Parser fixture check: `general.empty` has no `accept`; `general.headers` has `accept: application/json, text/plain`
- `vendor/bin/phpunit tests/PHP83Test.php` was attempted but failed locally because the PHP Docker container could not open the mounted `tests/languages/php/test.php` file, despite the file being visible/readable via `ls` and PHP `file_exists()` inside the same container.
