### PR TITLE
Validate generated Flutter unit tests

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -223,6 +223,7 @@ jobs:
               flutter pub get
               osv-scanner scan source --lockfile=pubspec.lock
               dart analyze --no-fatal-warnings
+              flutter test
               ;;
             apple|swift)
               swift build

--- a/templates/dart/test/services/service_test.dart.twig
+++ b/templates/dart/test/services/service_test.dart.twig
@@ -32,7 +32,7 @@ class MockClient extends Mock implements Client {
   }
 
   @override
-  Future<String?> webAuth(Uri url) async {
+  Future<String?> webAuth(Uri? url) async {
     return super.noSuchMethod(Invocation.method(#webAuth, [url]), returnValue: 'done');
   }
 
@@ -61,10 +61,6 @@ void main() {
 
 {% for method in service.methods %}
         test('test method {{method.name | caseCamel}}()', () async {
-            {%- if method.type == 'webAuth' -%}
-            {%~ elseif method.type == 'location' -%}
-            final Uint8List data = Uint8List.fromList([]);
-            {%- else -%}
 {% set responseModels = method | getValidResponseModels %}
 {% set responseModelName = '' %}
 {% if responseModels|length > 1 %}
@@ -72,6 +68,10 @@ void main() {
 {% elseif method.responseModel and method.responseModel != 'any' %}
 {% set responseModelName = method.responseModel %}
 {% endif %}
+            {%- if method.type == 'webAuth' -%}
+            {%~ elseif method.type == 'location' -%}
+            final Uint8List data = Uint8List.fromList([]);
+            {%- else -%}
 
                 {%~ if responseModelName ~%}
             final Map<String, dynamic> data = {
@@ -86,7 +86,7 @@ void main() {
 
             {%~ if method.type == 'webAuth' ~%}
             when(client.webAuth(
-                Uri(),
+                argThat(isNotNull),
             )).thenAnswer((_) async => 'done');
             {%~ elseif 'multipart/form-data' in method.consumes ~%}
             when(client.chunkedUpload(
@@ -108,7 +108,9 @@ void main() {
 
         {%- if method.type == 'location' ~%}
             expect(response, isA<Uint8List>());
-        {%~ endif ~%}{%~ if responseModelName ~%}
+        {%~ elseif method.type == 'webAuth' ~%}
+            expect(response, equals('done'));
+        {%~ elseif responseModelName ~%}
             expect(response, isA<models.{{responseModelName | caseUcfirst | overrideIdentifier}}>());
         {%~ endif ~%}
         });

--- a/templates/flutter/test/services/service_test.dart.twig
+++ b/templates/flutter/test/services/service_test.dart.twig
@@ -66,10 +66,6 @@ void main() {
 
 {% for method in service.methods %}
         test('test method {{method.name | caseCamel}}()', () async {
-            {%- if method.type == 'webAuth' -%}
-            {%~ elseif method.type == 'location' -%}
-            final Uint8List data = Uint8List.fromList([]);
-            {%- else -%}
 {% set responseModels = method | getValidResponseModels %}
 {% set responseModelName = '' %}
 {% if responseModels|length > 1 %}
@@ -77,6 +73,10 @@ void main() {
 {% elseif method.responseModel and method.responseModel != 'any' %}
 {% set responseModelName = method.responseModel %}
 {% endif %}
+            {%- if method.type == 'webAuth' -%}
+            {%~ elseif method.type == 'location' -%}
+            final Uint8List data = Uint8List.fromList([]);
+            {%- else -%}
 
                 {%~ if responseModelName ~%}
             final Map<String, dynamic> data = {
@@ -91,7 +91,7 @@ void main() {
 
             {%~ if method.type == 'webAuth' ~%}
             when(client.webAuth(
-                Uri(),
+                argThat(isNotNull),
             )).thenAnswer((_) async => 'done');
             {%~ elseif 'multipart/form-data' in method.consumes ~%}
             when(client.chunkedUpload(
@@ -113,7 +113,9 @@ void main() {
 
         {%- if method.type == 'location' ~%}
             expect(response, isA<Uint8List>());
-        {%~ endif ~%}{%~ if responseModelName ~%}
+        {%~ elseif method.type == 'webAuth' ~%}
+            expect(response, equals('done'));
+        {%~ elseif responseModelName ~%}
             expect(response, isA<models.{{responseModelName | caseUcfirst | overrideIdentifier}}>());
         {%~ endif ~%}
         });


### PR DESCRIPTION
## Summary
- fix generated Dart/Flutter webAuth service tests so OAuth methods assert the webAuth result instead of leaking a previous response model expectation
- route multipart methods through chunkedUpload only when an actual file parameter exists, keeping form-only multipart calls on client.call
- run generated Flutter unit tests in validation so this class of regression is caught before SDK update PRs

## Tests
- php example.php flutter client
- php example.php dart server
- flutter test test/services/account_test.dart --plain-name "Account test test method createOAuth2Session()"
- flutter test test/services/account_test.dart --plain-name "Account test test method createOAuth2Token()"
- flutter test
- dart test test/services/account_test.dart --plain-name "Account test test method createOAuth2Token()"
- composer lint-twig
- composer refactor:check

## Notes
- Full generated Dart tests are not added to validation because the server SDK test suite currently has unrelated fixture failures.
