### PR TITLE
Fix JS language override property fatal

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\CodeQuality\Rector\Catch_\ThrowWithPreviousExceptionRector;
 use Rector\Config\RectorConfig;
 use Rector\Php84\Rector\MethodCall\NewMethodCallWithoutParenthesesRector;
+use Rector\Php85\Rector\Property\AddOverrideAttributeToOverriddenPropertiesRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 
@@ -30,6 +31,7 @@ return RectorConfig::configure()
     ])
     ->withSkip([
         ThrowWithPreviousExceptionRector::class,
+        AddOverrideAttributeToOverriddenPropertiesRector::class,
         DisallowedEmptyRuleFixerRector::class,
         NewMethodCallWithoutParenthesesRector::class => [
             __DIR__ . '/tests/languages/php/test.php',

--- a/src/SDK/Language/JS.php
+++ b/src/SDK/Language/JS.php
@@ -8,7 +8,6 @@ use Twig\TwigFilter;
 
 abstract class JS extends Language
 {
-    #[Override]
     protected $params = [
         'npmPackage' => 'packageName',
         'bowerPackage' => 'packageName',


### PR DESCRIPTION
## What

- Remove the invalid `#[Override]` attribute from `JS::$params`, which PHP rejects because `Override` only targets methods in the runtime used by CI.
- Skip Rector’s `AddOverrideAttributeToOverriddenPropertiesRector` rule so `composer refactor:check` does not reintroduce the fatal attribute.

## Why

Web SDK generation with `VERSION="1.9.x"` failed during class loading before generation could start:

```
Attribute "Override" cannot target property (allowed targets: method)
```

## Test Plan

- `php -l src/SDK/Language/JS.php`
- `php -l rector.php`
- `composer refactor:check`
- `composer lint-twig`
- `VERSION="1.9.x" php example.php web`
