### PR TITLE
Support security-backed path parameters

### DIFF
--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -612,8 +612,19 @@ class SDK
                 continue;
             }
 
+            $key = $enumKeys[$index] ?? $value;
+            $normalizedKey = \strtoupper((string) \preg_replace('/[^a-zA-Z0-9]/', '', (string) $key));
+            $existingKeys = \array_map(
+                fn($existingKey) => \strtoupper((string) \preg_replace('/[^a-zA-Z0-9]/', '', (string) $existingKey)),
+                $list[$enumName]['keys']
+            );
+
+            if (\in_array($normalizedKey, $existingKeys, true)) {
+                continue;
+            }
+
             $list[$enumName]['enum'][] = $value;
-            $list[$enumName]['keys'][] = $enumKeys[$index] ?? $value;
+            $list[$enumName]['keys'][] = $key;
         }
     }
 

--- a/src/Spec/Swagger2.php
+++ b/src/Spec/Swagger2.php
@@ -144,7 +144,16 @@ class Swagger2 extends Spec
 
         $methodSecurityHeaders = [];
         $methodSecurityQueries = [];
+        $methodSecurityPathParams = [];
         foreach ($methodSecurity as $i => $node) {
+            if (($node['x-appwrite']['location'] ?? '') === 'path') {
+                $methodSecurityPathParams[$node['x-appwrite']['param'] ?? $node['name'] ?? (string) $i] = [
+                    'key' => (string) $i,
+                    'config' => $node['x-appwrite']['config'] ?? $node['name'] ?? '',
+                ];
+                continue;
+            }
+
             if (($node['in'] ?? '') === 'header' && !($node['global'] ?? false)) {
                 $methodSecurityHeaders[$i] = $node;
             }
@@ -198,6 +207,7 @@ class Swagger2 extends Spec
             'auth' => [$methodAuth] ?? [],
             'securityHeaders' => $methodSecurityHeaders,
             'securityQueries' => $methodSecurityQueries,
+            'securityPathParams' => $methodSecurityPathParams,
             'consumes' => $method['consumes'] ?? [],
             'produces' => $method['produces'] ?? [],
             'cookies' => $method['x-appwrite']['cookies'] ?? false,
@@ -277,6 +287,15 @@ class Swagger2 extends Spec
                     $output['parameters']['header'][] = $param;
                     break;
                 case 'path':
+                    if (isset($methodSecurityPathParams[$param['name']])) {
+                        $param['source'] = 'security';
+                        $param['security'] = $methodSecurityPathParams[$param['name']]['key'];
+                        $param['config'] = $methodSecurityPathParams[$param['name']]['config'];
+                        $output['parameters']['path'][] = $param;
+
+                        continue 2;
+                    }
+
                     $output['parameters']['path'][] = $param;
                     break;
                 case 'query':
@@ -568,7 +587,7 @@ class Swagger2 extends Spec
                     'name' => $definition['name'],
                     'description' => $definition['description'],
                     // Project is stored on the client, but each method's security decides
-                    // whether it is sent as X-Appwrite-Project or as a ProjectQuery param.
+                    // whether it is sent as X-Appwrite-Project or injected into the path.
                     'global' => $key !== 'Project',
                 ];
             } elseif (

--- a/templates/android/library/src/main/java/io/package/services/Service.kt.twig
+++ b/templates/android/library/src/main/java/io/package/services/Service.kt.twig
@@ -69,7 +69,7 @@ class {{ service.name | caseUcfirst }}(client: Client) : Service(client) {
     ){% if method.type != "webAuth" %}: {{ method | returnType(spec, sdk.namespace | caseDot) | raw }}{% endif %} {
         val apiPath = "{{ method.path }}"
         {%~ for parameter in method.parameters.path %}
-            .replace("{{ '{' ~ parameter.name ~ '}' }}", {{ parameter.name | caseCamel }}{% if parameter.enumValues is not empty %}.value{% endif %})
+            .replace("{{ '{' ~ parameter.name ~ '}' }}", {% if parameter.source|default('') == 'security' %}client.config["{{ parameter.config | caseCamel }}"].orEmpty(){% else %}{{ parameter.name | caseCamel }}{% if parameter.enumValues is not empty %}.value{% endif %}{% endif %})
         {%~ endfor %}
             {%~ for security in method.securityQueries %}
             + "{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=${java.net.URLEncoder.encode(client.config["{{ security.name | caseCamel }}"].orEmpty(), "UTF-8")}"

--- a/templates/android/library/src/main/java/io/package/services/Service.kt.twig
+++ b/templates/android/library/src/main/java/io/package/services/Service.kt.twig
@@ -67,13 +67,14 @@ class {{ service.name | caseUcfirst }}(client: Client) : Service(client) {
         onProgress: ((UploadProgress) -> Unit)? = null
         {%~ endif %}
     ){% if method.type != "webAuth" %}: {{ method | returnType(spec, sdk.namespace | caseDot) | raw }}{% endif %} {
-        val apiPath = "{{ method.path }}"
+        val apiPath = ("{{ method.path }}"
         {%~ for parameter in method.parameters.path %}
             .replace("{{ '{' ~ parameter.name ~ '}' }}", {% if parameter.source|default('') == 'security' %}client.config["{{ parameter.config | caseCamel }}"].orEmpty(){% else %}{{ parameter.name | caseCamel }}{% if parameter.enumValues is not empty %}.value{% endif %}{% endif %})
         {%~ endfor %}
             {%~ for security in method.securityQueries %}
-            + "{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=${java.net.URLEncoder.encode(client.config["{{ security.name | caseCamel }}"].orEmpty(), "UTF-8")}"
+            + "{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=${java.net.URLEncoder.encode(client.config[\"{{ security.name | caseCamel }}\"].orEmpty(), \"UTF-8\")}"
             {%~ endfor %}
+        )
 
         val apiParams = mutableMapOf<String, Any?>(
         {%~ for parameter in method.parameters.query | merge(method.parameters.body) %}

--- a/templates/android/library/src/main/java/io/package/services/Service.kt.twig
+++ b/templates/android/library/src/main/java/io/package/services/Service.kt.twig
@@ -72,7 +72,7 @@ class {{ service.name | caseUcfirst }}(client: Client) : Service(client) {
             .replace("{{ '{' ~ parameter.name ~ '}' }}", {% if parameter.source|default('') == 'security' %}client.config["{{ parameter.config | caseCamel }}"].orEmpty(){% else %}{{ parameter.name | caseCamel }}{% if parameter.enumValues is not empty %}.value{% endif %}{% endif %})
         {%~ endfor %}
             {%~ for security in method.securityQueries %}
-            + "{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=${java.net.URLEncoder.encode(client.config[\"{{ security.name | caseCamel }}\"].orEmpty(), \"UTF-8\")}"
+            + "{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=${java.net.URLEncoder.encode(client.config.get("{{ security.name | caseCamel }}").orEmpty(), "UTF-8")}"
             {%~ endfor %}
         )
 

--- a/templates/dart/lib/services/service.dart.twig
+++ b/templates/dart/lib/services/service.dart.twig
@@ -27,7 +27,7 @@ class {{ service.name | caseUcfirst }} extends Service {
     {% if method.type == 'location' %}Future<Uint8List>{% else %}{% set responseModels = method | getValidResponseModels %}{% if responseModels|length > 1 %}Future<models.Model>{% elseif method.responseModel and method.responseModel != 'any' %}Future<models.{{method.responseModel | caseUcfirst | overrideIdentifier}}>{% else %}Future{% endif %}{% endif %} {{ method.name | caseCamel | overrideIdentifier }}({{ _self.method_parameters(method.parameters.all, method.consumes) }}) async {
         final String apiPath = '{{ method.path }}'
             {%- for parameter in method.parameters.path -%}
-            .replaceAll('{{ '{' }}{{ parameter.name }}{{ '}' }}', {{ parameter.name | caseCamel | overrideIdentifier }}{% if parameter.enumValues | length > 0  %}.value{% endif %})
+            .replaceAll('{{ '{' }}{{ parameter.name }}{{ '}' }}', {% if parameter.source|default('') == 'security' %}client.config['{{ parameter.config | caseLower }}'] ?? ''{% else %}{{ parameter.name | caseCamel | overrideIdentifier }}{% if parameter.enumValues | length > 0  %}.value{% endif %}{% endif %})
             {%- endfor -%}
             {%- for security in method.securityQueries -%}
             + '{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=${Uri.encodeComponent(client.config['{{ security.name | caseCamel }}'] ?? '')}'

--- a/templates/deno/src/services/service.ts.twig
+++ b/templates/deno/src/services/service.ts.twig
@@ -89,7 +89,7 @@ export class {{ service.name | caseUcfirst }} extends Service {
 
 {% endif %}
 {% endfor %}
-        let apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replace('{{ '{' }}{{ parameter.name }}{{ '}' }}', {{ parameter.name | caseCamel | escapeKeyword }}){% endfor %};
+        let apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replace('{{ '{' }}{{ parameter.name }}{{ '}' }}', {% if parameter.source|default('') == 'security' %}this.client.config['{{ parameter.config | caseLower }}']{% else %}{{ parameter.name | caseCamel | escapeKeyword }}{% endif %}){% endfor %};
         {%~ for security in method.securityQueries %}
         apiPath += `{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=${encodeURIComponent(this.client.config['{{ security.name | caseLower }}'])}`;
         {%~ endfor %}

--- a/templates/dotnet/base/params.twig
+++ b/templates/dotnet/base/params.twig
@@ -1,6 +1,6 @@
 {% import 'dotnet/base/utils.twig' as utils %}
             {%~ for parameter in method.parameters.path %}
-                .Replace("{{ '{' ~ parameter.name ~ '}' }}", {{ parameter.name | caseCamel | escapeKeyword }}{% if parameter.enumValues is not empty %}.Value{% endif %}){% if loop.last %};{% endif %}
+                .Replace("{{ '{' ~ parameter.name ~ '}' }}", {% if parameter.source|default('') == 'security' %}_client.GetConfig("{{ parameter.config | caseCamel }}"){% else %}{{ parameter.name | caseCamel | escapeKeyword }}{% if parameter.enumValues is not empty %}.Value{% endif %}{% endif %}){% if loop.last %};{% endif %}
 
             {%~ endfor %}
             {%~ for security in method.securityQueries %}

--- a/templates/flutter/lib/services/service.dart.twig
+++ b/templates/flutter/lib/services/service.dart.twig
@@ -28,7 +28,7 @@ class {{ service.name | caseUcfirst }} extends Service {
   {% if method.type == 'webAuth' %}Future{% elseif method.type == 'location' %}Future<Uint8List>{% else %}{% set responseModels = method | getValidResponseModels %}{% if responseModels|length > 1 %}Future<models.Model>{% elseif method.responseModel and method.responseModel != 'any' %}Future<models.{{method.responseModel | caseUcfirst | overrideIdentifier}}>{% else %}Future{% endif %}{% endif %} {{ method.name | caseCamel | overrideIdentifier }}({{ _self.method_parameters(method.parameters.all, method.consumes) }}) async {
     final String apiPath = '{{ method.path }}'
         {%- for parameter in method.parameters.path -%}
-        .replaceAll('{{ '{' }}{{ parameter.name }}{{ '}' }}', {{ parameter.name | caseCamel | overrideIdentifier }}{% if parameter.enumValues | length > 0  %}.value{% endif %})
+        .replaceAll('{{ '{' }}{{ parameter.name }}{{ '}' }}', {% if parameter.source|default('') == 'security' %}client.config['{{ parameter.config | caseLower }}'] ?? ''{% else %}{{ parameter.name | caseCamel | overrideIdentifier }}{% if parameter.enumValues | length > 0  %}.value{% endif %}{% endif %})
         {%- endfor -%}
         {%- for security in method.securityQueries -%}
         + '{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=${Uri.encodeComponent(client.config['{{ security.name | caseCamel }}'] ?? '')}'

--- a/templates/go/models/model_test.go.twig
+++ b/templates/go/models/model_test.go.twig
@@ -14,13 +14,13 @@
         {%- elseif property.type == 'array' -%}
             {{ (property | typeName) }}{
                 {%- if property.items.type == 'string' -%}
-                    "{{ property.items.example | default('test') | replace({'"': '\\"', '\\': '\\\\'}) }}"
+                    "{{ property.items.example | default('test') | replace({'\\': '\\\\', '"': '\\"'}) | raw }}"
                 {%- elseif property.items.type == 'integer' -%}
                     1
                 {%- endif -%}
             }
         {%- elseif property.type == 'string' -%}
-            "{{ (property.example | default('string')) | replace({'"': '\\"', '\\': '\\\\'}) }}"
+            "{{ (property.example | default('string')) | replace({'\\': '\\\\', '"': '\\"'}) | raw }}"
         {%- elseif property.type == 'boolean' -%}
             true
         {%- elseif property.type == 'integer' -%}

--- a/templates/go/services/service.go.twig
+++ b/templates/go/services/service.go.twig
@@ -125,7 +125,7 @@ func (srv *{{ service.name | caseUcfirst }}) With{{ method.name | caseUcfirst }}
 {% set returnType = method | returnType(spec, spec.title | caseLower) %}
 func (srv *{{ service.name | caseUcfirst }}) {{ method.name | caseUcfirst }}({{ params }})({% if returnType == 'models.Model' %}{{ returnType }}{% else %}*{{ returnType }}{% endif %}, error) {
 {% if method.parameters.path|length > 0 %}
-	r := strings.NewReplacer({% for parameter in method.parameters.path %}"{{ '{' }}{{ parameter.name }}{{ '}' }}", {{ parameter.name | caseUcfirst }}{% if not loop.last %}, {% endif %}{% endfor %})
+	r := strings.NewReplacer({% for parameter in method.parameters.path %}"{{ '{' }}{{ parameter.name }}{{ '}' }}", {% if parameter.source|default('') == 'security' %}srv.client.Config["{{ parameter.config | caseLower }}"]{% else %}{{ parameter.name | caseUcfirst }}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %})
 	path := r.Replace("{{ method.path }}")
 {% else %}
 	path := "{{ method.path }}"
@@ -157,7 +157,7 @@ func (srv *{{ service.name | caseUcfirst }}) {{ method.name | caseUcfirst }}({{ 
 {% endif %}
 func (srv *{{ service.name | caseUcfirst }}) {{ method.name | caseUcfirst }}URL({{ params }}) (*string, error) {
 {% if method.parameters.path|length > 0 %}
-	r := strings.NewReplacer({% for parameter in method.parameters.path %}"{{ '{' }}{{ parameter.name }}{{ '}' }}", {{ parameter.name | caseUcfirst }}{% if not loop.last %}, {% endif %}{% endfor %})
+	r := strings.NewReplacer({% for parameter in method.parameters.path %}"{{ '{' }}{{ parameter.name }}{{ '}' }}", {% if parameter.source|default('') == 'security' %}srv.client.Config["{{ parameter.config | caseLower }}"]{% else %}{{ parameter.name | caseUcfirst }}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %})
 	path := r.Replace("{{ method.path }}")
 {% else %}
 	path := "{{ method.path }}"

--- a/templates/go/services/service_test.go.twig
+++ b/templates/go/services/service_test.go.twig
@@ -22,14 +22,14 @@
 [
 {{ childIndent }}{
 {% for prop in requiredProps %}
-{{ childIndent }}    "{{ prop.name | replace({'"': '\\"', '\\': '\\\\'}) }}": {{ helper.render_json_value(definitions, prop, spec, childIndent ~ '    ') | trim | raw }}{% if not loop.last %},{% endif %}{{ "\n" -}}
+{{ childIndent }}    "{{ prop.name | replace({'\\': '\\\\', '"': '\\"'}) | raw }}": {{ helper.render_json_value(definitions, prop, spec, childIndent ~ '    ') | trim | raw }}{% if not loop.last %},{% endif %}{{ "\n" -}}
 {% endfor %}
 {{ childIndent }}}
 {{ indent }}]
     {%- else -%}
 {
 {% for prop in requiredProps %}
-{{ indent }}    "{{ prop.name | replace({'"': '\\"', '\\': '\\\\', '`': '\\u0060'}) }}": {{ helper.render_json_value(definitions, prop, spec, indent ~ '    ') | trim | raw }}{% if not loop.last %},{% endif %}{{ "\n" -}}
+{{ indent }}    "{{ prop.name | replace({'\\': '\\\\', '"': '\\"', '`': '\\u0060'}) | raw }}": {{ helper.render_json_value(definitions, prop, spec, indent ~ '    ') | trim | raw }}{% if not loop.last %},{% endif %}{{ "\n" -}}
 {% endfor %}
 {{ indent }}}
     {%- endif -%}
@@ -39,7 +39,7 @@
 {%- elseif property.type == 'array' -%}
 []
 {%- elseif property.type == 'string' -%}
-"{{ (property.example | default('string')) | replace({'"': '\\"', '\\': '\\\\', '`': '\\u0060'}) }}"
+"{{ (property.example | default('string')) | replace({'\\': '\\\\', '"': '\\"', '`': '\\u0060'}) | raw }}"
     {%- elseif property.type == 'boolean' -%}
 true
     {%- elseif property.type == 'integer' -%}
@@ -113,7 +113,7 @@ func Test{{ service.name | caseUcfirst }}(t *testing.T) {
 		mockResponse := `
 {
 {% for property in definition.properties | filter((param) => param.required) %}
-    "{{ property.name | replace({'"': '\\"', '\\': '\\\\', '`': '\\u0060'}) }}": {% if discriminatorConditions[property.name] is defined %}"{{ discriminatorConditions[property.name] | replace({'"': '\\"', '\\': '\\\\', '`': '\\u0060'}) }}"{% else %}{{ _self.render_json_value(spec.definitions, property, spec, '    ') | trim | raw }}{% endif %}{% if not loop.last %},{% endif %}{{ "\n" -}}
+    "{{ property.name | replace({'\\': '\\\\', '"': '\\"', '`': '\\u0060'}) | raw }}": {% if discriminatorConditions[property.name] is defined %}"{{ discriminatorConditions[property.name] | replace({'\\': '\\\\', '"': '\\"', '`': '\\u0060'}) | raw }}"{% else %}{{ _self.render_json_value(spec.definitions, property, spec, '    ') | trim | raw }}{% endif %}{% if not loop.last %},{% endif %}{{ "\n" -}}
 {% endfor %}
 }
 `
@@ -177,7 +177,7 @@ func Test{{ service.name | caseUcfirst }}(t *testing.T) {
 {% elseif parameter.type == 'boolean' %}
 {% set val = 'true' %}
 {% elseif parameter.type == 'string' %}
-{% set val = '"' ~ (parameter.example | replace({'"': '\\"', '\\': '\\\\'})) ~ '"' %}
+{% set val = '"' ~ (parameter.example | replace({'\\': '\\\\', '"': '\\"'}) | raw) ~ '"' %}
 {% elseif parameter.type == 'integer' %}
 {% set val = '1' %}
 {% elseif parameter.type == 'number' %}

--- a/templates/kotlin/src/main/kotlin/io/appwrite/services/ServiceTemplate.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/services/ServiceTemplate.kt.twig
@@ -57,13 +57,14 @@ class {{ service.name | caseUcfirst }}(client: Client) : Service(client) {
         onProgress: ((UploadProgress) -> Unit)? = null
         {%~ endif %}
     ): {{ method | returnType(spec, sdk.namespace | caseDot) | raw }} {
-        val apiPath = "{{ method.path }}"
+        val apiPath = ("{{ method.path }}"
         {%~ for parameter in method.parameters.path %}
             .replace("{{ '{' ~ parameter.name ~ '}' }}", {% if parameter.source|default('') == 'security' %}client.config["{{ parameter.config | caseCamel }}"].orEmpty(){% else %}{{ parameter.name | caseCamel }}{% if parameter.enumValues is not empty %}.value{% endif %}{% endif %})
         {%~ endfor %}
             {%~ for security in method.securityQueries %}
-            + "{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=${java.net.URLEncoder.encode(client.config["{{ security.name | caseCamel }}"].orEmpty(), "UTF-8")}"
+            + "{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=${java.net.URLEncoder.encode(client.config[\"{{ security.name | caseCamel }}\"].orEmpty(), \"UTF-8\")}"
             {%~ endfor %}
+        )
 
         val apiParams = mutableMapOf<String, Any?>(
         {%~ for parameter in method.parameters.query | merge(method.parameters.body) %}

--- a/templates/kotlin/src/main/kotlin/io/appwrite/services/ServiceTemplate.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/services/ServiceTemplate.kt.twig
@@ -62,7 +62,7 @@ class {{ service.name | caseUcfirst }}(client: Client) : Service(client) {
             .replace("{{ '{' ~ parameter.name ~ '}' }}", {% if parameter.source|default('') == 'security' %}client.config["{{ parameter.config | caseCamel }}"].orEmpty(){% else %}{{ parameter.name | caseCamel }}{% if parameter.enumValues is not empty %}.value{% endif %}{% endif %})
         {%~ endfor %}
             {%~ for security in method.securityQueries %}
-            + "{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=${java.net.URLEncoder.encode(client.config[\"{{ security.name | caseCamel }}\"].orEmpty(), \"UTF-8\")}"
+            + "{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=${java.net.URLEncoder.encode(client.config.get("{{ security.name | caseCamel }}").orEmpty(), "UTF-8")}"
             {%~ endfor %}
         )
 

--- a/templates/kotlin/src/main/kotlin/io/appwrite/services/ServiceTemplate.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/services/ServiceTemplate.kt.twig
@@ -59,7 +59,7 @@ class {{ service.name | caseUcfirst }}(client: Client) : Service(client) {
     ): {{ method | returnType(spec, sdk.namespace | caseDot) | raw }} {
         val apiPath = "{{ method.path }}"
         {%~ for parameter in method.parameters.path %}
-            .replace("{{ '{' ~ parameter.name ~ '}' }}", {{ parameter.name | caseCamel }}{% if parameter.enumValues is not empty %}.value{% endif %})
+            .replace("{{ '{' ~ parameter.name ~ '}' }}", {% if parameter.source|default('') == 'security' %}client.config["{{ parameter.config | caseCamel }}"].orEmpty(){% else %}{{ parameter.name | caseCamel }}{% if parameter.enumValues is not empty %}.value{% endif %}{% endif %})
         {%~ endfor %}
             {%~ for security in method.securityQueries %}
             + "{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=${java.net.URLEncoder.encode(client.config["{{ security.name | caseCamel }}"].orEmpty(), "UTF-8")}"

--- a/templates/node/src/services/template.ts.twig
+++ b/templates/node/src/services/template.ts.twig
@@ -109,7 +109,7 @@ export class {{ service.name | caseUcfirst }} {
         {%~ endif %}
         {%~ endfor %}
 
-        const apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replace('{{ '{' }}{{ parameter.name }}{{ '}' }}', {{ parameter.name | caseCamel | escapeKeyword }}){% endfor %};
+        const apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replace('{{ '{' }}{{ parameter.name }}{{ '}' }}', {% if parameter.source|default('') == 'security' %}this.client.config.{{ parameter.config | caseLower }}{% else %}{{ parameter.name | caseCamel | escapeKeyword }}{% endif %}){% endfor %};
         const payload: Payload = {};
         {%~ for parameter in method.parameters.query %}
         if (typeof {{ parameter.name | caseCamel | escapeKeyword }} !== 'undefined') {

--- a/templates/php/src/Services/Service.php.twig
+++ b/templates/php/src/Services/Service.php.twig
@@ -69,7 +69,7 @@ class {{ service.name | caseUcfirst }} extends Service
     {
         $apiPath = str_replace(
             [{% for parameter in method.parameters.path %}'{{ '{' }}{{ parameter.name }}{{ '}' }}'{% if not loop.last %}, {% endif %}{% endfor %}],
-            [{% for parameter in method.parameters.path %}${{ parameter.name | caseCamel | escapeKeyword }}{% if not loop.last %}, {% endif %}{% endfor %}],
+            [{% for parameter in method.parameters.path %}{% if parameter.source|default('') == 'security' %}$this->client->getConfig('{{ parameter.config | caseLower }}'){% else %}${{ parameter.name | caseCamel | escapeKeyword }}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}],
             '{{ method.path }}'
         );
         {%~ for security in method.securityQueries %}

--- a/templates/python/base/params.twig
+++ b/templates/python/base/params.twig
@@ -8,7 +8,7 @@
 {% endif %}
 {% endfor %}
 {% for parameter in method.parameters.path %}
-        api_path = api_path.replace('{{ '{' }}{{ parameter.name }}{{ '}' }}', str(self._normalize_value({{ parameter.name | escapeKeyword | caseSnake }})))
+        api_path = api_path.replace('{{ '{' }}{{ parameter.name }}{{ '}' }}', str(self._normalize_value({% if parameter.source|default('') == 'security' %}self.client.get_config('{{ parameter.config | caseLower }}'){% else %}{{ parameter.name | escapeKeyword | caseSnake }}{% endif %})))
 {% endfor %}
 
 {% for parameter in method.parameters.query %}

--- a/templates/react-native/src/services/template.ts.twig
+++ b/templates/react-native/src/services/template.ts.twig
@@ -110,7 +110,7 @@ export class {{ service.name | caseUcfirst }} extends Service {
 
 {% endif %}
 {% endfor %}
-        const apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replace('{{ '{' }}{{ parameter.name }}{{ '}' }}', {{ parameter.name | caseCamel | escapeKeyword }}){% endfor %};
+        const apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replace('{{ '{' }}{{ parameter.name }}{{ '}' }}', {% if parameter.source|default('') == 'security' %}this.client.config.{{ parameter.config | caseLower }}{% else %}{{ parameter.name | caseCamel | escapeKeyword }}{% endif %}){% endfor %};
         const payload: Payload = {};
 
 {% for parameter in method.parameters.query %}
@@ -360,7 +360,7 @@ export class {{ service.name | caseUcfirst }} extends Service {
     {%~ endif %}
     */
     {{ method.name | caseCamel }}URL({% for parameter in method.parameters.all %}{{ parameter.name | caseCamel | escapeKeyword }}{% if not parameter.required or parameter.nullable %}?{% endif %}: {{ parameter | getPropertyType(method) | raw }}{% if not loop.last %}, {% endif %}{% endfor %}{% if 'multipart/form-data' in method.consumes %}, onProgress = (progress: UploadProgress) => void{% endif %}): URL {
-        const apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replace('{{ '{' }}{{ parameter.name }}{{ '}' }}', {{ parameter.name | caseCamel | escapeKeyword }}){% endfor %};
+        const apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replace('{{ '{' }}{{ parameter.name }}{{ '}' }}', {% if parameter.source|default('') == 'security' %}this.client.config.{{ parameter.config | caseLower }}{% else %}{{ parameter.name | caseCamel | escapeKeyword }}{% endif %}){% endfor %};
         const payload: Payload = {};
 
 {% for parameter in method.parameters.query %}

--- a/templates/ruby/base/params.twig
+++ b/templates/ruby/base/params.twig
@@ -1,6 +1,6 @@
             api_path = '{{ method.path }}'
 {% for parameter in method.parameters.path %}
-                .gsub('{{ '{' }}{{ parameter.name }}{{ '}' }}', {{ parameter.name | caseSnake | escapeKeyword }})
+                .gsub('{{ '{' }}{{ parameter.name }}{{ '}' }}', {% if parameter.source|default('') == 'security' %}@client.get_config('{{ parameter.config | caseLower }}'){% else %}{{ parameter.name | caseSnake | escapeKeyword }}{% endif %})
 {% endfor %}
             {%~ for security in method.securityQueries %}
             api_path += '{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=' + URI.encode_www_form_component(@client.get_config('{{ security.name | caseLower }}'))

--- a/templates/rust/src/services/service.rs.twig
+++ b/templates/rust/src/services/service.rs.twig
@@ -136,7 +136,7 @@ impl {{ service.name | caseUcfirst }} {
 {% endfor %}
 {% endif %}
 
-        let path = "{{ method.path }}".to_string(){% for parameter in method.parameters.path %}.replace("{{ '{' }}{{ parameter.name }}{{ '}' }}", &{{ parameter | paramValue(parameter.name | caseSnake | overrideIdentifier) }}.to_string()){% endfor %};
+        let path = "{{ method.path }}".to_string(){% for parameter in method.parameters.path %}.replace("{{ '{' }}{{ parameter.name }}{{ '}' }}", &{% if parameter.source|default('') == 'security' %}self.client.get_headers().get("x-appwrite-{{ parameter.config | caseLower }}").cloned().unwrap_or_default(){% else %}{{ parameter | paramValue(parameter.name | caseSnake | overrideIdentifier) }}.to_string(){% endif %}){% endfor %};
 
 {% set hasFileParam = false %}
 {% set fileParamName = '' %}

--- a/templates/swift/base/params.twig
+++ b/templates/swift/base/params.twig
@@ -1,6 +1,6 @@
         let apiPath: String = "{{ method.path }}"
         {%~ for parameter in method.parameters.path %}
-            .replacingOccurrences(of: "{{ '{' }}{{ parameter.name }}{{ '}' }}", with: {{ parameter.name | caseCamel | escapeSwiftKeyword }}{% if parameter.enumValues is not empty %}.rawValue{% endif %})
+            .replacingOccurrences(of: "{{ '{' }}{{ parameter.name }}{{ '}' }}", with: {% if parameter.source|default('') == 'security' %}client.config["{{ parameter.config | caseCamel }}"] ?? ""{% else %}{{ parameter.name | caseCamel | escapeSwiftKeyword }}{% if parameter.enumValues is not empty %}.rawValue{% endif %}{% endif %})
         {%~ endfor %}
         {%~ for security in method.securityQueries %}
             + "{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=\(client.config["{{ security.name | caseCamel }}"]?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")"

--- a/templates/web/src/services/template.ts.twig
+++ b/templates/web/src/services/template.ts.twig
@@ -106,7 +106,7 @@ export class {{ service.name | caseUcfirst }} {
         {%~ endif %}
         {%~ endfor %}
 
-        const apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replace('{{ '{' }}{{ parameter.name }}{{ '}' }}', {{ parameter.name | caseCamel | escapeKeyword }}){% endfor %};
+        const apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replace('{{ '{' }}{{ parameter.name }}{{ '}' }}', {% if parameter.source|default('') == 'security' %}this.client.config.{{ parameter.config | caseLower }}{% else %}{{ parameter.name | caseCamel | escapeKeyword }}{% endif %}){% endfor %};
         const payload: Payload = {};
         {%~ for parameter in method.parameters.query %}
         if (typeof {{ parameter.name | caseCamel | escapeKeyword }} !== 'undefined') {


### PR DESCRIPTION
## What does this PR do?

Adds support for security-backed path parameters in Swagger 2 specs. When a security definition carries `x-appwrite.location: path`, the matching path parameter remains available for URL replacement but is excluded from generated SDK method signatures.

This lets Appwrite specs express paths like `/oauth2/{project_id}/approve` while SDK methods source `project_id` from the client project config instead of requiring a method argument.

Updated service templates across SDK languages to replace security-sourced path params from the client config/header state.

## Test Plan

- `php -l src/Spec/Swagger2.php`
- `rg -n "ProjectQuery" src templates tests` returned no matches
- Verified through the Cloud repo generation flow that Web and Node OAuth2 services generate `/oauth2/{project_id}/...` paths using the configured project and do not add `?project=` for approve/authorize/reject.

## Related PRs

- appwrite/appwrite#12554
