### PR TITLE
fix(spec): resolve nested model references emitted as allOf and property-level x-oneOf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           Ruby31,
           Rust183,
           AppleSwift60,
+          Swagger2Spec,
           Swift60,
           Unity2021,
           WebChromium,

--- a/src/Spec/Swagger2.php
+++ b/src/Spec/Swagger2.php
@@ -636,6 +636,14 @@ class Swagger2 extends Spec
                         $model['properties'][$name]['sub_schema'] = str_replace('#/definitions/', '', $def['$ref']);
                     }
 
+                    foreach ($def['allOf'] ?? [] as $nested) {
+                        //nested model reference merged with sibling keywords
+                        if (isset($nested['$ref'])) {
+                            $model['properties'][$name]['sub_schema'] = str_replace('#/definitions/', '', $nested['$ref']);
+                            break;
+                        }
+                    }
+
                     if (isset($def['items']['$ref'])) {
                         //nested model
                         $model['properties'][$name]['sub_schema'] = str_replace('#/definitions/', '', $def['items']['$ref']);
@@ -649,6 +657,16 @@ class Swagger2 extends Spec
                     if (isset($def['items']['x-oneOf'])) {
                         //nested model
                         $model['properties'][$name]['sub_schemas'] = \array_map(fn(array $schema): string|array => str_replace('#/definitions/', '', $schema['$ref']), $def['items']['x-oneOf']);
+                    }
+
+                    if (isset($def['x-anyOf'])) {
+                        //nested model union on an object property
+                        $model['properties'][$name]['sub_schemas'] = \array_map(fn(array $schema): string|array => str_replace('#/definitions/', '', $schema['$ref']), $def['x-anyOf']);
+                    }
+
+                    if (isset($def['x-oneOf'])) {
+                        //nested model union on an object property
+                        $model['properties'][$name]['sub_schemas'] = \array_map(fn(array $schema): string|array => str_replace('#/definitions/', '', $schema['$ref']), $def['x-oneOf']);
                     }
 
                     if (isset($def['enum'])) {
@@ -697,6 +715,13 @@ class Swagger2 extends Spec
                         $model['properties'][$name]['sub_schema'] = str_replace('#/definitions/', '', $def['$ref']);
                     }
 
+                    foreach ($def['allOf'] ?? [] as $nested) {
+                        if (isset($nested['$ref'])) {
+                            $model['properties'][$name]['sub_schema'] = str_replace('#/definitions/', '', $nested['$ref']);
+                            break;
+                        }
+                    }
+
                     if (isset($def['items']['$ref'])) {
                         $model['properties'][$name]['sub_schema'] = str_replace('#/definitions/', '', $def['items']['$ref']);
                     }
@@ -707,6 +732,14 @@ class Swagger2 extends Spec
 
                     if (isset($def['items']['x-oneOf'])) {
                         $model['properties'][$name]['sub_schemas'] = \array_map(fn(array $schema): string|array => str_replace('#/definitions/', '', $schema['$ref']), $def['items']['x-oneOf']);
+                    }
+
+                    if (isset($def['x-anyOf'])) {
+                        $model['properties'][$name]['sub_schemas'] = \array_map(fn(array $schema): string|array => str_replace('#/definitions/', '', $schema['$ref']), $def['x-anyOf']);
+                    }
+
+                    if (isset($def['x-oneOf'])) {
+                        $model['properties'][$name]['sub_schemas'] = \array_map(fn(array $schema): string|array => str_replace('#/definitions/', '', $schema['$ref']), $def['x-oneOf']);
                     }
 
                     if (isset($def['enum'])) {

--- a/tests/Swagger2SpecTest.php
+++ b/tests/Swagger2SpecTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Appwrite\Spec\Swagger2;
+use PHPUnit\Framework\TestCase;
+
+final class Swagger2SpecTest extends TestCase
+{
+    private Swagger2 $spec;
+
+    protected function setUp(): void
+    {
+        $this->spec = new Swagger2(\json_encode([
+            'definitions' => [
+                'user' => [
+                    'description' => 'User',
+                    'type' => 'object',
+                    'properties' => [
+                        'prefs' => [
+                            'type' => 'object',
+                            'description' => 'User preferences as a key-value object',
+                            'x-example' => null,
+                            'allOf' => [
+                                ['$ref' => '#/definitions/preferences'],
+                            ],
+                        ],
+                        'legacyPrefs' => [
+                            'type' => 'object',
+                            'description' => 'User preferences as a key-value object',
+                            'x-example' => null,
+                            'items' => [
+                                '$ref' => '#/definitions/preferences',
+                            ],
+                        ],
+                        'hashOptions' => [
+                            'type' => 'object',
+                            'description' => 'Password hashing algorithm options.',
+                            'x-example' => null,
+                            'x-oneOf' => [
+                                ['$ref' => '#/definitions/algoArgon2'],
+                                ['$ref' => '#/definitions/algoScrypt'],
+                            ],
+                        ],
+                        'legacyHashOptions' => [
+                            'type' => 'object',
+                            'description' => 'Password hashing algorithm options.',
+                            'x-example' => null,
+                            'items' => [
+                                'x-oneOf' => [
+                                    ['$ref' => '#/definitions/algoArgon2'],
+                                    ['$ref' => '#/definitions/algoScrypt'],
+                                ],
+                            ],
+                        ],
+                        'targets' => [
+                            'type' => 'array',
+                            'description' => 'User targets.',
+                            'x-example' => null,
+                            'items' => [
+                                '$ref' => '#/definitions/target',
+                            ],
+                        ],
+                        'attributes' => [
+                            'type' => 'array',
+                            'description' => 'Mixed attributes.',
+                            'x-example' => null,
+                            'items' => [
+                                'x-anyOf' => [
+                                    ['$ref' => '#/definitions/attributeString'],
+                                    ['$ref' => '#/definitions/attributeInteger'],
+                                ],
+                            ],
+                        ],
+                        'name' => [
+                            'type' => 'string',
+                            'description' => 'User name.',
+                            'x-example' => 'John Doe',
+                        ],
+                    ],
+                ],
+                'createUser' => [
+                    'description' => 'Create user request',
+                    'type' => 'object',
+                    'x-request-model' => true,
+                    'properties' => [
+                        'prefs' => [
+                            'type' => 'object',
+                            'description' => 'User preferences as a key-value object',
+                            'x-example' => null,
+                            'allOf' => [
+                                ['$ref' => '#/definitions/preferences'],
+                            ],
+                        ],
+                        'hashOptions' => [
+                            'type' => 'object',
+                            'description' => 'Password hashing algorithm options.',
+                            'x-example' => null,
+                            'x-oneOf' => [
+                                ['$ref' => '#/definitions/algoArgon2'],
+                                ['$ref' => '#/definitions/algoScrypt'],
+                            ],
+                        ],
+                    ],
+                ],
+                'preferences' => ['type' => 'object', 'properties' => []],
+                'algoArgon2' => ['type' => 'object', 'properties' => []],
+                'algoScrypt' => ['type' => 'object', 'properties' => []],
+                'target' => ['type' => 'object', 'properties' => []],
+                'attributeString' => ['type' => 'object', 'properties' => []],
+                'attributeInteger' => ['type' => 'object', 'properties' => []],
+            ],
+        ]));
+    }
+
+    public function testObjectPropertyWithAllOfReferenceResolvesSubSchema(): void
+    {
+        $properties = $this->spec->getDefinitions()['user']['properties'];
+
+        $this->assertSame('preferences', $properties['prefs']['sub_schema']);
+        $this->assertSame('object', $properties['prefs']['type']);
+    }
+
+    public function testObjectPropertyWithLegacyItemsReferenceResolvesSubSchema(): void
+    {
+        $properties = $this->spec->getDefinitions()['user']['properties'];
+
+        $this->assertSame('preferences', $properties['legacyPrefs']['sub_schema']);
+    }
+
+    public function testObjectPropertyWithOneOfUnionResolvesSubSchemas(): void
+    {
+        $properties = $this->spec->getDefinitions()['user']['properties'];
+
+        $this->assertSame(['algoArgon2', 'algoScrypt'], $properties['hashOptions']['sub_schemas']);
+    }
+
+    public function testObjectPropertyWithLegacyItemsOneOfUnionResolvesSubSchemas(): void
+    {
+        $properties = $this->spec->getDefinitions()['user']['properties'];
+
+        $this->assertSame(['algoArgon2', 'algoScrypt'], $properties['legacyHashOptions']['sub_schemas']);
+    }
+
+    public function testArrayPropertyWithItemsReferenceResolvesSubSchema(): void
+    {
+        $properties = $this->spec->getDefinitions()['user']['properties'];
+
+        $this->assertSame('target', $properties['targets']['sub_schema']);
+        $this->assertSame('array', $properties['targets']['type']);
+    }
+
+    public function testArrayPropertyWithItemsAnyOfUnionResolvesSubSchemas(): void
+    {
+        $properties = $this->spec->getDefinitions()['user']['properties'];
+
+        $this->assertSame(['attributeString', 'attributeInteger'], $properties['attributes']['sub_schemas']);
+    }
+
+    public function testScalarPropertyHasNoSubSchema(): void
+    {
+        $properties = $this->spec->getDefinitions()['user']['properties'];
+
+        $this->assertArrayNotHasKey('sub_schema', $properties['name']);
+        $this->assertArrayNotHasKey('sub_schemas', $properties['name']);
+    }
+
+    public function testRequestModelPropertiesResolveSubSchemas(): void
+    {
+        $properties = $this->spec->getRequestModels()['createUser']['properties'];
+
+        $this->assertSame('preferences', $properties['prefs']['sub_schema']);
+        $this->assertSame(['algoArgon2', 'algoScrypt'], $properties['hashOptions']['sub_schemas']);
+    }
+
+    public function testRequestModelsAreExcludedFromDefinitions(): void
+    {
+        $this->assertArrayNotHasKey('createUser', $this->spec->getDefinitions());
+    }
+}


### PR DESCRIPTION
## What

[appwrite/appwrite#12553](https://github.com/appwrite/appwrite/pull/12553) fixed the spec formatters so object-typed model properties no longer carry an array-only `items` keyword (DAT-1552 — 38 occurrences in the 1.9.x console spec: `user.prefs`, `subscriber.target`, `billingPlan.usage`, `specification.pricing`, ...). The regenerated Swagger2 specs now emit:

- single nested model references as `allOf: [{$ref}]` (instead of `items: {$ref}`)
- multi-type unions as property-level `x-oneOf` (instead of `items: {x-oneOf}`)

The Swagger2 spec parser here only resolved `sub_schema` from `items.$ref` and `sub_schemas` from `items.x-anyOf` / `items.x-oneOf`, so SDK generation from a regenerated spec **silently** loses every object-typed nested model. Generation still completes — which is why the change looked safe — but the output regresses.

Generating the Kotlin console SDK from a post-#12553-shaped spec without this fix:

```kotlin
// before (broken parse)
@SerializedName("prefs")
val prefs: Any,
...
prefs = map["prefs"] as Any,
```

```kotlin
// after (this PR)
@SerializedName("prefs")
val prefs: Preferences<T>,
...
prefs = Preferences.from(map = map["prefs"] as Map<String, Any>, nestedType),
```

Worse, `sub_schema` also drives model reachability in `SDK::getFilteredModelData()`, so models referenced only through object-typed properties were dropped from the SDK entirely — 12 model classes vanished from the Kotlin console SDK (`AlgoArgon2`, `AlgoBcrypt`, `AlgoMd5`, `AlgoPhpass`, `AlgoScrypt`, `AlgoScryptModified`, `AlgoSha`, `BillingLimits`, `BillingPlanAddon`, `BillingPlanAddonDetails`, `AdditionalResource`, `UsageBillingPlan`).

## How

`src/Spec/Swagger2.php` (`getDefinitions()` and `getRequestModels()`):

- resolve `sub_schema` from the first `$ref` inside `allOf`
- resolve `sub_schemas` from property-level `x-anyOf` / `x-oneOf`
- keep the legacy `items.*` shapes for backwards compatibility with already-published specs

## Verification

- New `tests/Swagger2SpecTest.php` covers both new shapes, both legacy shapes, array properties, scalar properties, and request models (fails on master, passes with the fix). Added a `Swagger2Spec` entry to the CI matrix so it runs in CI.
- Generated the Kotlin console SDK from the cloud console spec in both shapes: with this fix, the old-shape and new-shape specs produce **byte-identical** SDK output (220 model classes); without it, the new-shape spec produces 208 model classes and untyped properties.
- `composer lint`, `composer refactor:check`, `composer test tests/Swagger2SpecTest.php` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
