### PR TITLE
fix: stop realtime heartbeat from stacking and crashing on closed socket

### DIFF
--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -309,13 +309,15 @@ class Client {
         },
         createHeartbeat: () => {
             if (this.realtime.heartbeat) {
-                clearTimeout(this.realtime.heartbeat);
+                clearInterval(this.realtime.heartbeat);
             }
 
             this.realtime.heartbeat = window?.setInterval(() => {
-                this.realtime.socket?.send(JSONbig.stringify({
-                    type: 'ping'
-                }));
+                if (this.realtime.socket?.readyState === WebSocket.OPEN) {
+                    this.realtime.socket.send(JSONbig.stringify({
+                        type: 'ping'
+                    }));
+                }
             }, 20_000);
         },
         createSocket: () => {

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -504,13 +504,15 @@ class Client {
         },
         createHeartbeat: () => {
             if (this.realtime.heartbeat) {
-                clearTimeout(this.realtime.heartbeat);
+                clearInterval(this.realtime.heartbeat);
             }
 
             this.realtime.heartbeat = window?.setInterval(() => {
-                this.realtime.socket?.send(JSONbig.stringify({
-                    type: 'ping'
-                }));
+                if (this.realtime.socket?.readyState === WebSocket.OPEN) {
+                    this.realtime.socket.send(JSONbig.stringify({
+                        type: 'ping'
+                    }));
+                }
             }, 20_000);
         },
         createSocket: () => {


### PR DESCRIPTION
The realtime client cleared its heartbeat with clearTimeout, but the handle comes from setInterval, so it was never cancelled - a new interval stacked on every reconnect. The interval also called socket.send() with no readyState check, which throws INVALID_STATE_ERROR when the socket is CLOSING/CLOSED during a reconnect (background + network drop + foreground cycle).

Switched to clearInterval and only send the ping when the socket is OPEN, in both the web and react-native client templates.

Reported against the React Native SDK (which is generated from these templates): appwrite/sdk-for-react-native#101
