### PR TITLE
Generate client methods from specs

### DIFF
--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -447,7 +447,41 @@ class SDK
 
     protected function getFilteredMethods(array $methods, string $serviceName = ''): array
     {
-        return \array_values(\array_filter($methods, fn (array $method): bool => !$this->isMethodExcluded($method, $serviceName)));
+        return \array_values(\array_filter(
+            $methods,
+            function (array $method) use ($serviceName): bool {
+                $method['service'] = $serviceName;
+
+                return !$this->isClientMethod($method) && !$this->isMethodExcluded($method, $serviceName);
+            }
+        ));
+    }
+
+    protected function isClientMethod(array $method): bool
+    {
+        return match (($method['service'] ?? '') . '.' . ($method['name'] ?? '')) {
+            'ping.get' => true,
+            default => false,
+        };
+    }
+
+    protected function getClientMethods(): array
+    {
+        $clientMethods = [];
+
+        foreach (array_keys($this->spec->getServices()) as $serviceName) {
+            foreach ($this->spec->getMethods($serviceName) as $method) {
+                $method['service'] = $serviceName;
+
+                if (!$this->isClientMethod($method)) {
+                    continue;
+                }
+
+                $clientMethods[$serviceName][$method['name']] = $method;
+            }
+        }
+
+        return $clientMethods;
     }
 
     protected function getFilteredDefinitions(): array
@@ -783,6 +817,7 @@ class SDK
                 'contactURL' => $this->spec->getContactURL(),
                 'contactEmail' => $this->spec->getContactEmail(),
                 'services' => $filteredServices,
+                'clientMethods' => $this->getClientMethods(),
                 'requestEnums' => $filteredRequestEnums,
                 'requestModelEnums' => $filteredRequestModelEnums,
                 'responseEnums' => $filteredResponseEnums,

--- a/templates/android/library/src/main/java/io/package/Client.kt.twig
+++ b/templates/android/library/src/main/java/io/package/Client.kt.twig
@@ -250,27 +250,35 @@ class Client @JvmOverloads constructor(
      */
     fun getHttpClient(): OkHttpClient = http
 
+    {%~ for clientMethodName, clientMethods in spec.clientMethods %}
+    {%~ for clientMethod in clientMethods %}
     /**
-     * Sends a "ping" request to Appwrite to verify connectivity.
+     * {{ clientMethod.description | replace({'\n': '\n     * '}) | raw }}
      *
      * @return String
      */
-    suspend fun ping(): String {
-        val apiPath = "/ping"
+    suspend fun {{ clientMethodName | caseCamel }}(): String {
+        val apiPath = "{{ clientMethod.path }}"
         val apiParams = mutableMapOf<String, Any?>()
         val apiHeaders = mutableMapOf(
-            "content-type" to "application/json",
-            "X-Appwrite-Project" to config["project"].orEmpty(),
+            {%~ for key, security in clientMethod.securityHeaders %}
+            "{{ security.name }}" to config["{{ key | caseLower }}"].orEmpty(),
+            {%~ endfor %}
+            {%~ for key, header in clientMethod.headers %}
+            "{{ key }}" to "{{ header }}",
+            {%~ endfor %}
         )
 
         return call(
-            "GET",
+            "{{ clientMethod.method | caseUpper }}",
             apiPath,
             apiHeaders,
             apiParams,
             responseType = String::class.java
         )
     }
+    {%~ endfor %}
+    {%~ endfor %}
 
     /**
      * Send the HTTP request

--- a/templates/apple/Sources/Client.swift.twig
+++ b/templates/apple/Sources/Client.swift.twig
@@ -266,26 +266,34 @@ open class Client {
        )?.replacingOccurrences(of: "+", with: "%2B") ?? "" // since urlHostAllowed doesn't include +
    }
 
+    {%~ for clientMethodName, clientMethods in spec.clientMethods %}
+    {%~ for clientMethod in clientMethods %}
     ///
-    /// Sends a "ping" request to Appwrite to verify connectivity.
+    /// {{ clientMethod.description | replace({'\n': '\n    /// '}) | raw }}
     ///
     /// @return String
     /// @throws Exception
     ///
-   open func ping() async throws -> String {
-       let apiPath: String = "/ping"
+   open func {{ clientMethodName | caseCamel }}() async throws -> String {
+       let apiPath: String = "{{ clientMethod.path }}"
 
        let apiHeaders: [String: String] = [
-           "content-type": "application/json",
-           "X-Appwrite-Project": config["project"] ?? ""
+           {%~ for key, security in clientMethod.securityHeaders %}
+           "{{ security.name }}": config["{{ key | caseLower }}"] ?? "",
+           {%~ endfor %}
+           {%~ for key, header in clientMethod.headers %}
+           "{{ key }}": "{{ header }}",
+           {%~ endfor %}
        ]
 
        return try await call(
-           method: "GET",
+           method: "{{ clientMethod.method | caseUpper }}",
            path: apiPath,
            headers: apiHeaders
        )
     }
+    {%~ endfor %}
+    {%~ endfor %}
 
     ///
     /// Make an API call

--- a/templates/dart/lib/src/client.dart.twig
+++ b/templates/dart/lib/src/client.dart.twig
@@ -51,8 +51,13 @@ abstract class Client {
   /// Get the current request headers.
   Map<String, String> getHeaders();
 
-  /// Sends a "ping" request to Appwrite to verify connectivity.
-  Future<String> ping();
+{% for clientMethodName, clientMethods in spec.clientMethods %}
+{% for clientMethod in clientMethods %}
+  /// {{ clientMethod.description | replace({'\n': '\n  /// '}) | raw }}
+  Future<String> {{ clientMethodName | caseCamel }}();
+
+{% endfor %}
+{% endfor %}
 
   /// Upload a file in chunks.
   Future<Response> chunkedUpload({

--- a/templates/dart/lib/src/client_base.dart.twig
+++ b/templates/dart/lib/src/client_base.dart.twig
@@ -23,19 +23,28 @@ abstract class ClientBase implements Client {
   @override
   Map<String, String> getHeaders();
 
+{% for clientMethodName, clientMethods in spec.clientMethods %}
+{% for clientMethod in clientMethods %}
   @override
-  Future<String> ping() async {
-    final String apiPath = '/ping';
+  Future<String> {{ clientMethodName | caseCamel }}() async {
+    final String apiPath = '{{ clientMethod.path }}';
     final response = await call(
-      HttpMethod.get,
+      HttpMethod.{{ clientMethod.method | caseLower }},
       path: apiPath,
       headers: {
-        'X-Appwrite-Project': config['project'] ?? '',
+        {%~ for key, security in clientMethod.securityHeaders %}
+        '{{ security.name }}': config['{{ key | caseLower }}'] ?? '',
+        {%~ endfor %}
+        {%~ for key, header in clientMethod.headers %}
+        '{{ key }}': '{{ header }}',
+        {%~ endfor %}
       },
       responseType: ResponseType.plain,
     );
     return response.data;
   }
+{% endfor %}
+{% endfor %}
 
   @override
   Future<Response> call(

--- a/templates/flutter/lib/src/client.dart.twig
+++ b/templates/flutter/lib/src/client.dart.twig
@@ -70,8 +70,13 @@ abstract class Client {
   /// Get the current request headers.
   Map<String, String> getHeaders();
 
-  /// Sends a "ping" request to Appwrite to verify connectivity.
-  Future<String> ping();
+{% for clientMethodName, clientMethods in spec.clientMethods %}
+{% for clientMethod in clientMethods %}
+  /// {{ clientMethod.description | replace({'\n': '\n  /// '}) | raw }}
+  Future<String> {{ clientMethodName | caseCamel }}();
+
+{% endfor %}
+{% endfor %}
 
   /// Send the API request.
   Future<Response> call(

--- a/templates/flutter/lib/src/client_base.dart.twig
+++ b/templates/flutter/lib/src/client_base.dart.twig
@@ -26,19 +26,28 @@ abstract class ClientBase implements Client {
   @override
   Map<String, String> getHeaders();
 
+{% for clientMethodName, clientMethods in spec.clientMethods %}
+{% for clientMethod in clientMethods %}
   @override
-  Future<String> ping() async {
-    final String apiPath = '/ping';
+  Future<String> {{ clientMethodName | caseCamel }}() async {
+    final String apiPath = '{{ clientMethod.path }}';
     final response = await call(
-      HttpMethod.get,
+      HttpMethod.{{ clientMethod.method | caseLower }},
       path: apiPath,
       headers: {
-        'X-Appwrite-Project': config['project'] ?? '',
+        {%~ for key, security in clientMethod.securityHeaders %}
+        '{{ security.name }}': config['{{ key | caseLower }}'] ?? '',
+        {%~ endfor %}
+        {%~ for key, header in clientMethod.headers %}
+        '{{ key }}': '{{ header }}',
+        {%~ endfor %}
       },
       responseType: ResponseType.plain,
     );
     return response.data;
   }
+{% endfor %}
+{% endfor %}
 
   @override
   Future<Response> call(

--- a/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
@@ -191,27 +191,35 @@ class Client @JvmOverloads constructor(
      */
     fun getHeaders(): Map<String, String> = headers.toMap()
 
+    {%~ for clientMethodName, clientMethods in spec.clientMethods %}
+    {%~ for clientMethod in clientMethods %}
     /**
-     * Sends a "ping" request to Appwrite to verify connectivity.
+     * {{ clientMethod.description | replace({'\n': '\n     * '}) | raw }}
      *
      * @return String
      */
-    suspend fun ping(): String {
-        val apiPath = "/ping"
+    suspend fun {{ clientMethodName | caseCamel }}(): String {
+        val apiPath = "{{ clientMethod.path }}"
         val apiParams = mutableMapOf<String, Any?>()
         val apiHeaders = mutableMapOf(
-            "content-type" to "application/json",
-            "X-Appwrite-Project" to config["project"].orEmpty(),
+            {%~ for key, security in clientMethod.securityHeaders %}
+            "{{ security.name }}" to config["{{ key | caseLower }}"].orEmpty(),
+            {%~ endfor %}
+            {%~ for key, header in clientMethod.headers %}
+            "{{ key }}" to "{{ header }}",
+            {%~ endfor %}
         )
 
         return call(
-            "GET",
+            "{{ clientMethod.method | caseUpper }}",
             apiPath,
             apiHeaders,
             apiParams,
             responseType = String::class.java
         )
     }
+    {%~ endfor %}
+    {%~ endfor %}
 
     /**
      * Prepare the HTTP request

--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -520,11 +520,20 @@ class Client {
         return finalResponse ?? lastResponse;
     }
 
-    async ping(): Promise<unknown> {
-        return this.call('GET', new URL(this.config.endpoint + '/ping'), {
-            'X-Appwrite-Project': this.config.project,
+    {%~ for clientMethodName, clientMethods in spec.clientMethods %}
+    {%~ for clientMethod in clientMethods %}
+    async {{ clientMethodName | caseCamel }}(): Promise<unknown> {
+        return this.call('{{ clientMethod.method | caseUpper }}', new URL(this.config.endpoint + '{{ clientMethod.path }}'), {
+            {%~ for key, security in clientMethod.securityHeaders %}
+            '{{ security.name }}': this.config.{{ key | caseLower }},
+            {%~ endfor %}
+            {%~ for key, header in clientMethod.headers %}
+            '{{ key }}': '{{ header }}',
+            {%~ endfor %}
         });
     }
+    {%~ endfor %}
+    {%~ endfor %}
 
     async redirect(method: string, url: URL, headers: Headers = {}, params: Payload = {}): Promise<string> {
         const { uri, options } = this.prepareRequest(method, url, headers, params);

--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -545,11 +545,20 @@ class Client {
         }
     }
 
-    async ping(): Promise<unknown> {
-        return this.call('GET', new URL(this.config.endpoint + '/ping'), {
-            'X-Appwrite-Project': this.config.project,
+    {%~ for clientMethodName, clientMethods in spec.clientMethods %}
+    {%~ for clientMethod in clientMethods %}
+    async {{ clientMethodName | caseCamel }}(): Promise<unknown> {
+        return this.call('{{ clientMethod.method | caseUpper }}', new URL(this.config.endpoint + '{{ clientMethod.path }}'), {
+            {%~ for key, security in clientMethod.securityHeaders %}
+            '{{ security.name }}': this.config.{{ key | caseLower }},
+            {%~ endfor %}
+            {%~ for key, header in clientMethod.headers %}
+            '{{ key }}': '{{ header }}',
+            {%~ endfor %}
         });
     }
+    {%~ endfor %}
+    {%~ endfor %}
 
     async call(method: string, url: URL, headers: Headers = {}, params: Payload = {}, responseType = 'json'): Promise<any> {
         method = method.toUpperCase();

--- a/templates/swift/Sources/Client.swift.twig
+++ b/templates/swift/Sources/Client.swift.twig
@@ -205,26 +205,34 @@ open class Client {
        )?.replacingOccurrences(of: "+", with: "%2B") ?? "" // since urlHostAllowed doesn't include +
    }
 
+    {%~ for clientMethodName, clientMethods in spec.clientMethods %}
+    {%~ for clientMethod in clientMethods %}
     ///
-    /// Sends a "ping" request to Appwrite to verify connectivity.
+    /// {{ clientMethod.description | replace({'\n': '\n    /// '}) | raw }}
     ///
     /// @return String
     /// @throws Exception
     ///
-   open func ping() async throws -> String {
-       let apiPath: String = "/ping"
+   open func {{ clientMethodName | caseCamel }}() async throws -> String {
+       let apiPath: String = "{{ clientMethod.path }}"
 
        let apiHeaders: [String: String] = [
-           "content-type": "application/json",
-           "X-Appwrite-Project": config["project"] ?? ""
+           {%~ for key, security in clientMethod.securityHeaders %}
+           "{{ security.name }}": config["{{ key | caseLower }}"] ?? "",
+           {%~ endfor %}
+           {%~ for key, header in clientMethod.headers %}
+           "{{ key }}": "{{ header }}",
+           {%~ endfor %}
        ]
 
        return try await call(
-           method: "GET",
+           method: "{{ clientMethod.method | caseUpper }}",
            path: apiPath,
            headers: apiHeaders
        )
     }
+    {%~ endfor %}
+    {%~ endfor %}
 
     ///
     /// Make an API call

--- a/templates/unity/Assets/Runtime/AppwriteManager.cs.twig
+++ b/templates/unity/Assets/Runtime/AppwriteManager.cs.twig
@@ -102,8 +102,10 @@ namespace {{ spec.title | caseUcfirst }}
                 
                 if (config.AutoConnect)
                 {
+                    {%~ if spec.clientMethods.ping.get is defined %}
                     var pingResult = await _client.Ping();
                     Debug.Log($"{{ spec.title | caseUcfirst }} connected successfully: {pingResult}");
+                    {%~ endif %}
                 }
                 
                 if (needRealtime)

--- a/templates/unity/Assets/Runtime/Core/Client.cs.twig
+++ b/templates/unity/Assets/Runtime/Core/Client.cs.twig
@@ -223,23 +223,31 @@ namespace {{ spec.title | caseUcfirst }}
                 .Replace("https://", "wss://");
         }
 #if UNI_TASK
+        {%~ for clientMethodName, clientMethods in spec.clientMethods %}
+        {%~ for clientMethod in clientMethods %}
         /// <summary>
-        /// Sends a "ping" request to {{ spec.title | caseUcfirst }} to verify connectivity.
+        /// {{ clientMethod.description | replace({'\n': '\n        /// '}) | raw }}
         /// </summary>
-        /// <returns>Ping response as string</returns>
-        public async UniTask<string> Ping()
+        /// <returns>Response as string</returns>
+        public async UniTask<string> {{ clientMethodName | caseUcfirst }}()
         {
             var headers = new Dictionary<string, string>
             {
-                ["content-type"] = "application/json",
-                ["X-Appwrite-Project"] = _config.GetValueOrDefault("project", "")
+                {%~ for key, security in clientMethod.securityHeaders %}
+                ["{{ security.name }}"] = _config.GetValueOrDefault("{{ key | caseLower }}", ""),
+                {%~ endfor %}
+                {%~ for key, header in clientMethod.headers %}
+                ["{{ key }}"] = "{{ header }}",
+                {%~ endfor %}
             };
 
             var parameters = new Dictionary<string, object?>();
 
-            return await Call<string>("GET", "/ping", headers, parameters, 
+            return await Call<string>("{{ clientMethod.method | caseUpper }}", "{{ clientMethod.path }}", headers, parameters,
                 response => (response.TryGetValue("result", out var result) ? result?.ToString() : null) ?? string.Empty);
         }
+        {%~ endfor %}
+        {%~ endfor %}
 #endif
         private void SetHeader(string configKey, string header, string value, bool persist = false)
         {

--- a/templates/unity/Assets/Samples~/AppwriteExample/AppwriteExample.cs.twig
+++ b/templates/unity/Assets/Samples~/AppwriteExample/AppwriteExample.cs.twig
@@ -53,8 +53,10 @@ namespace Samples.{{ spec.title | caseUcfirst }}Example
             {
                 // Direct client access
                 var client = _manager.Client;
+                {%~ if spec.clientMethods.ping.get is defined %}
                 var pingResult = await client.Ping();
                 Debug.Log($"Ping result: {pingResult}");
+                {%~ endif %}
                 
                 // Service creation through DI container
                 // var account = _manager.GetService<Account>();
@@ -94,9 +96,11 @@ namespace Samples.{{ spec.title | caseUcfirst }}Example
                 // Create and configure client
                 var client = config.CreateClient();
 
+                {%~ if spec.clientMethods.ping.get is defined %}
                 // Test connection
                 var pingResult = await client.Ping();
                 Debug.Log($"Direct client ping: {pingResult}");
+                {%~ endif %}
 
                 // Create services manually
                 // var account = new Account(client);

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -948,11 +948,20 @@ class Client {
         return finalResponse ?? lastResponse;
     }
 
-    async ping(): Promise<unknown> {
-        return this.call('GET', new URL(this.config.endpoint + '/ping'), {
-            'X-Appwrite-Project': this.config.project,
+    {%~ for clientMethodName, clientMethods in spec.clientMethods %}
+    {%~ for clientMethod in clientMethods %}
+    async {{ clientMethodName | caseCamel }}(): Promise<unknown> {
+        return this.call('{{ clientMethod.method | caseUpper }}', new URL(this.config.endpoint + '{{ clientMethod.path }}'), {
+            {%~ for key, security in clientMethod.securityHeaders %}
+            '{{ security.name }}': this.config.{{ key | caseLower }},
+            {%~ endfor %}
+            {%~ for key, header in clientMethod.headers %}
+            '{{ key }}': '{{ header }}',
+            {%~ endfor %}
         });
     }
+    {%~ endfor %}
+    {%~ endfor %}
 
     async call(method: string, url: URL, headers: Headers = {}, params: Payload = {}, responseType = 'json'): Promise<any> {
         const { uri, options } = this.prepareRequest(method, url, headers, params);

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -24,6 +24,62 @@
     }
   ],
   "paths": {
+    "\/ping": {
+      "get": {
+        "summary": "Ping",
+        "operationId": "pingGet",
+        "tags": [
+          "ping"
+        ],
+        "description": "Send a ping to project as part of onboarding.",
+        "x-appwrite": {
+          "method": "get",
+          "group": null,
+          "cookies": false,
+          "type": "",
+          "demo": "ping\/get.md",
+          "rate-limit": 0,
+          "rate-time": 3600,
+          "rate-key": "url:{url},ip:{ip}",
+          "scope": "global",
+          "platforms": [
+            "client",
+            "server",
+            "console"
+          ],
+          "packaging": false,
+          "public": true,
+          "auth": {
+            "Project": [],
+            "Admin": [],
+            "Key": [],
+            "JWT": [],
+            "Session": []
+          }
+        },
+        "security": [
+          {
+            "Project": [],
+            "Admin": [],
+            "Key": [],
+            "JWT": [],
+            "Session": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Any",
+            "content": {
+              "application\/json": {
+                "schema": {
+                  "$ref": "#\/components\/schemas\/any"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "\/mock\/tests\/bar": {
       "get": {
         "summary": "Get Bar",

--- a/tests/resources/spec-swagger2.json
+++ b/tests/resources/spec-swagger2.json
@@ -88,6 +88,61 @@
     }
   },
   "paths": {
+    "\/ping": {
+      "get": {
+        "summary": "Ping",
+        "operationId": "pingGet",
+        "tags": [
+          "ping"
+        ],
+        "description": "Send a ping to project as part of onboarding.",
+        "x-appwrite": {
+          "method": "get",
+          "group": null,
+          "cookies": false,
+          "type": "",
+          "demo": "ping\/get.md",
+          "rate-limit": 0,
+          "rate-time": 3600,
+          "rate-key": "url:{url},ip:{ip}",
+          "scope": "global",
+          "platforms": [
+            "client",
+            "server",
+            "console"
+          ],
+          "packaging": false,
+          "public": true,
+          "auth": {
+            "Project": [],
+            "Admin": [],
+            "Key": [],
+            "JWT": [],
+            "Session": []
+          }
+        },
+        "security": [
+          {
+            "Project": [],
+            "Admin": [],
+            "Key": [],
+            "JWT": [],
+            "Session": []
+          }
+        ],
+        "produces": [
+          "application\/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Any",
+            "schema": {
+              "$ref": "#\/definitions\/any"
+            }
+          }
+        }
+      }
+    },
     "\/mock\/tests\/bar": {
       "get": {
         "summary": "Get Bar",


### PR DESCRIPTION
## What does this PR do?

Generates SDK client-class methods from spec operations instead of hardcoding `ping()` in each client template.

This adds an explicit generator allowlist for client-level methods, currently `ping.get`, keeps those methods out of normal service generation, and renders client methods only when the matching operation exists in the spec.

## Test Plan

- `vendor/bin/phpunit --testsuite Unit`
- `composer lint-twig`
- `composer refactor:check`
- Regenerated affected SDK examples from local Appwrite specs
- Verified Web client includes `client.ping()` when `/ping` exists and omits it when `/ping` is removed from a temporary spec

## Related PRs and Issues

- Depends on appwrite/appwrite#12604
