### PR TITLE
fix(php): send accept header on chunked upload requests

### DIFF
--- a/templates/php/base/requests/file.twig
+++ b/templates/php/base/requests/file.twig
@@ -95,9 +95,14 @@
 {% endfor %}
 
         $apiHeaders = [
-            'content-type' => 'multipart/form-data',
         {%~ for key, security in method.securityHeaders %}
             '{{ security.name }}' => $this->client->getConfig('{{ key | caseLower }}'),
+        {%~ endfor %}
+        {%~ for parameter in method.parameters.header %}
+            '{{ parameter.name }}' => ${{ parameter.name | caseCamel }},
+        {%~ endfor %}
+        {%~ for key, header in method.headers %}
+            '{{ key }}' => '{{ header }}',
         {%~ endfor %}
         ];
         $handle = null;


### PR DESCRIPTION
The PHP chunked-upload path rebuilds `$apiHeaders` from scratch, but only with `content-type` and the security headers — it drops the `accept` header that the standard request path and single-shot (`<= CHUNK_SIZE`) file uploads set.

As a result, large uploads (Storage files, Function and Site deployments above `Client::CHUNK_SIZE`) send their first chunk and parallel chunk requests **without** `Accept: application/json`, so content negotiation and response parsing can differ by upload size.

## Fix

`templates/php/base/requests/file.twig` — build the rebuilt chunk header array from the same `securityHeaders`, `parameters.header`, and `method.headers` loops used by `params.twig` and the single-shot inline arrays. `method.headers` already provides both `content-type` (multipart) and `accept`, so the previously hardcoded `content-type` line is removed to avoid duplication.

## Before
```php
$apiHeaders = [
    "content-type" => "multipart/form-data",
    "X-Appwrite-Project" => $this->client->getConfig("project"),
];
```

## After
```php
$apiHeaders = [
    "X-Appwrite-Project" => $this->client->getConfig("project"),
    "content-type" => "multipart/form-data",
    "accept" => "application/json",
];
```

## Verification
- Regenerated the PHP SDK from a real server spec; `createFile` (Storage), `createDeployment` (Functions), and the Sites deployment upload all now emit `accept` in the chunked rebuild.
- `composer lint-twig` passes (0 errors).
- Single-shot uploads and non-upload methods are unchanged.

Found via a Greptile review on appwrite/sdk-for-php#79.