### PR TITLE
fix: hide optional security schemes from doc examples

### DIFF
--- a/templates/android/docs/java/example.md.twig
+++ b/templates/android/docs/java/example.md.twig
@@ -23,7 +23,7 @@ Client client = new Client(context)
     {%~ if method.auth|length > 0 %}
     .setEndpoint("{{ spec.endpointDocs | raw }}") // Your API Endpoint
     {%~ for node in method.auth %}
-    {%~ for key,header in node|keys %}
+    {%~ for key,header in node|keys|filter(h => not node[h]['x-appwrite']['optional']) %}
     .set{{header | caseUcfirst}}("{{node[header]['x-appwrite']['demo'] | raw }}"){% if loop.last %};{% endif %} // {{ node[header].description }}
     {%~ endfor %}
     {%~ endfor %}

--- a/templates/android/docs/kotlin/example.md.twig
+++ b/templates/android/docs/kotlin/example.md.twig
@@ -23,7 +23,7 @@ val client = Client(context)
     {%~ if method.auth|length > 0 %}
     .setEndpoint("{{ spec.endpointDocs | raw }}") // Your API Endpoint
     {%~ for node in method.auth %}
-    {%~ for key,header in node|keys %}
+    {%~ for key,header in node|keys|filter(h => not node[h]['x-appwrite']['optional']) %}
     .set{{header | caseUcfirst}}("{{node[header]['x-appwrite']['demo'] | raw }}") // {{node[header].description}}
     {%~ endfor %}
     {%~ endfor %}

--- a/templates/dart/docs/example.md.twig
+++ b/templates/dart/docs/example.md.twig
@@ -21,7 +21,7 @@ Client client = Client()
     {%~ if method.auth|length > 0 %}
     .setEndpoint('{{ spec.endpointDocs | raw }}') // Your API Endpoint
     {%~ for node in method.auth %}
-    {%~ for key,header in node|keys %}
+    {%~ for key,header in node|keys|filter(h => not node[h]['x-appwrite']['optional']) %}
     .set{{header}}('{{node[header]['x-appwrite']['demo'] | raw }}'){% if loop.last %};{% endif%} // {{node[header].description}}
     {%~ endfor %}
     {%~ endfor %}

--- a/templates/deno/docs/example.md.twig
+++ b/templates/deno/docs/example.md.twig
@@ -5,7 +5,7 @@ const client = new Client()
     {%~ if method.auth|length > 0 %}
     .setEndpoint('{{ spec.endpointDocs | raw }}') // Your API Endpoint
     {%~ for node in method.auth %}
-    {%~ for key,header in node|keys %}
+    {%~ for key,header in node|keys|filter(h => not node[h]['x-appwrite']['optional']) %}
     .set{{header}}('{{node[header]['x-appwrite']['demo'] | raw }}'){% if loop.last %};{% endif%} // {{node[header].description}}
     {%~ endfor %}
     {%~ endfor %}

--- a/templates/dotnet/docs/example.md.twig
+++ b/templates/dotnet/docs/example.md.twig
@@ -14,7 +14,7 @@ Client client = new Client()
 {% if method.auth|length > 0 %}
     .SetEndPoint("{{ spec.endpointDocs | raw }}") // Your API Endpoint
 {% for node in method.auth %}
-{% for key,header in node|keys %}
+{% for key,header in node|keys|filter(h => not node[h]['x-appwrite']['optional']) %}
     .Set{{header | caseUcfirst}}("{{node[header]['x-appwrite']['demo'] | raw }}"){% if loop.last %};{% endif %} // {{node[header].description}}
 {% endfor %}{% endfor %}{% endif %}
 

--- a/templates/flutter/docs/example.md.twig
+++ b/templates/flutter/docs/example.md.twig
@@ -21,7 +21,7 @@ Client client = Client()
     {%~ if method.auth|length > 0 %}
     .setEndpoint('{{ spec.endpointDocs | raw }}') // Your API Endpoint
     {%~ for node in method.auth %}
-    {%~ for key,header in node|keys %}
+    {%~ for key,header in node|keys|filter(h => not node[h]['x-appwrite']['optional']) %}
     .set{{header}}('{{node[header]['x-appwrite']['demo'] | raw }}'){% if loop.last %};{% endif%} // {{node[header].description}}
     {%~ endfor %}
     {%~ endfor %}

--- a/templates/go/docs/example.md.twig
+++ b/templates/go/docs/example.md.twig
@@ -20,7 +20,7 @@ client := client.New(
 {% if method.auth|length > 0 %}
     client.WithEndpoint("{{ spec.endpointDocs | raw }}")
 {% for node in method.auth %}
-{% for key,header in node|keys %}
+{% for key,header in node|keys|filter(h => not node[h]['x-appwrite']['optional']) %}
     client.With{{header}}("{{node[header]['x-appwrite']['demo'] | raw }}")
 {% endfor %}
 {% endfor %}

--- a/templates/kotlin/docs/java/example.md.twig
+++ b/templates/kotlin/docs/java/example.md.twig
@@ -23,7 +23,7 @@ Client client = new Client()
 {% if method.auth|length > 0 %}
     .setEndpoint("{{ spec.endpointDocs | raw }}") // Your API Endpoint
 {% for node in method.auth %}
-{% for key,header in node|keys %}
+{% for key,header in node|keys|filter(h => not node[h]['x-appwrite']['optional']) %}
     .set{{header | caseUcfirst}}("{{node[header]['x-appwrite']['demo'] | raw }}"){% if loop.last %};{% endif %} // {{node[header].description}}
 {% endfor %}{% endfor %}{% endif %}
 

--- a/templates/kotlin/docs/kotlin/example.md.twig
+++ b/templates/kotlin/docs/kotlin/example.md.twig
@@ -23,7 +23,7 @@ val client = Client()
 {% if method.auth|length > 0 %}
     .setEndpoint("{{ spec.endpointDocs | raw }}") // Your API Endpoint
 {% for node in method.auth %}
-{% for key,header in node|keys %}
+{% for key,header in node|keys|filter(h => not node[h]['x-appwrite']['optional']) %}
     .set{{header | caseUcfirst}}("{{node[header]['x-appwrite']['demo'] | raw }}") // {{node[header].description}}
 {% endfor %}{% endfor %}{% endif %}
 

--- a/templates/node/docs/example.md.twig
+++ b/templates/node/docs/example.md.twig
@@ -8,7 +8,7 @@ const client = new sdk.Client()
     {%~ if method.auth|length > 0 %}
     .setEndpoint('{{ spec.endpointDocs | raw }}') // Your API Endpoint
     {%~ for node in method.auth %}
-    {%~ for key,header in node|keys %}
+    {%~ for key,header in node|keys|filter(h => not node[h]['x-appwrite']['optional']) %}
     .set{{header}}('{{node[header]['x-appwrite']['demo'] | raw }}'){% if loop.last %};{% endif%} // {{node[header].description}}
     {%~ endfor %}
     {%~ endfor %}

--- a/templates/php/docs/example.md.twig
+++ b/templates/php/docs/example.md.twig
@@ -24,7 +24,7 @@ $client = (new Client())
     {%~ if method.auth|length > 0 %}
     ->setEndpoint('{{ spec.endpointDocs | raw }}') // Your API Endpoint
     {%~ for node in method.auth %}
-    {%~ for key,header in node|keys %}
+    {%~ for key,header in node|keys|filter(h => not node[h]['x-appwrite']['optional']) %}
     ->set{{header}}('{{node[header]['x-appwrite']['demo'] | raw }}'){% if loop.last%};{% endif%} // {{node[header].description}}
     {%~ endfor %}
     {%~ endfor %}

--- a/templates/python/docs/example.md.twig
+++ b/templates/python/docs/example.md.twig
@@ -66,7 +66,7 @@ client = Client()
 {% if method.auth|length > 0 %}
 client.set_endpoint('{{ spec.endpointDocs | raw }}') # Your API Endpoint
 {% for node in method.auth %}
-{% for key,header in node|keys %}
+{% for key,header in node|keys|filter(h => not node[h]['x-appwrite']['optional']) %}
 client.set_{{header | caseSnake}}('{{node[header]['x-appwrite']['demo'] | raw }}') # {{node[header].description}}
 {% endfor %}
 {% endfor %}

--- a/templates/react-native/docs/example.md.twig
+++ b/templates/react-native/docs/example.md.twig
@@ -5,7 +5,7 @@ const client = new Client()
     {%~ if method.auth|length > 0 %}
     .setEndpoint('{{ spec.endpointDocs | raw }}') // Your API Endpoint
     {%~ for node in method.auth %}
-    {%~ for key,header in node|keys %}
+    {%~ for key,header in node|keys|filter(h => not node[h]['x-appwrite']['optional']) %}
     .set{{header}}('{{node[header]['x-appwrite']['demo'] | raw }}'){% if loop.last %};{% endif%} // {{node[header].description}}
     {%~ endfor %}
     {%~ endfor %}

--- a/templates/ruby/docs/example.md.twig
+++ b/templates/ruby/docs/example.md.twig
@@ -19,7 +19,7 @@ include {{ spec.title | caseUcfirst }}::Role
 client = Client.new
     .set_endpoint('{{ spec.endpointDocs | raw }}') # Your API Endpoint
     {%~ for node in method.auth %}
-    {%~ for key,header in node|keys %}
+    {%~ for key,header in node|keys|filter(h => not node[h]['x-appwrite']['optional']) %}
     .set_{{header|caseSnake}}('{{node[header]['x-appwrite']['demo'] | raw }}') # {{node[header].description}}
     {%~ endfor %}
     {%~ endfor %}

--- a/templates/rust/docs/example.md.twig
+++ b/templates/rust/docs/example.md.twig
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = Client::new();
     client.set_endpoint("{{ spec.endpointDocs | raw }}"); // Your API Endpoint
 {% for node in method.auth %}
-{% for key, header in node|keys %}
+{% for key, header in node|keys|filter(h => not node[h]['x-appwrite']['optional']) %}
     client.set_{{ header | caseSnake }}("{{ node[header]['x-appwrite']['demo'] | raw }}"); // {{ node[header].description }}
 {% endfor %}
 {% endfor %}

--- a/templates/swift/docs/example.md.twig
+++ b/templates/swift/docs/example.md.twig
@@ -12,7 +12,7 @@ let client = Client()
 {% if method.auth|length > 0 %}
     .setEndpoint("{{ spec.endpointDocs | raw }}") // Your API Endpoint
 {% for node in method.auth %}
-{% for key,header in node|keys %}
+{% for key,header in node|keys|filter(h => not node[h]['x-appwrite']['optional']) %}
     .set{{header | caseUcfirst}}("{{node[header]['x-appwrite']['demo'] | raw }}") // {{node[header].description}}
 {% endfor %}
 {% endfor %}

--- a/templates/web/docs/example.md.twig
+++ b/templates/web/docs/example.md.twig
@@ -5,7 +5,7 @@ const client = new Client()
     {%~ if method.auth|length > 0 %}
     .setEndpoint('{{ spec.endpointDocs | raw }}') // Your API Endpoint
     {%~ for node in method.auth %}
-    {%~ for key,header in node|keys %}
+    {%~ for key,header in node|keys|filter(h => not node[h]['x-appwrite']['optional']) %}
     .set{{header}}('{{node[header]['x-appwrite']['demo'] | raw }}'){% if loop.last %};{% endif%} // {{node[header].description}}
     {%~ endfor %}
     {%~ endfor %}


### PR DESCRIPTION
Location methods (file downloads, previews, views, avatars) include the impersonation security schemes (`ImpersonateUserId`/`Email`/`Phone`) so impersonation can flow through as a URL query param on redirect-style endpoints. These schemes are **optional**, but the doc example templates rendered a setter for every entry in `method.auth`, so examples showed:

```php
->setImpersonateUserId() // ...
```

as if impersonation were required auth.

## Fix

Adds support for a new `x-appwrite.optional` flag on security schemes (set on the impersonation schemes in `appwrite/appwrite` `Specs.php`). The doc example templates now filter the auth key list by that flag:

```twig
{%~ for key,header in node|keys|filter(h => not node[h]["x-appwrite"]["optional"]) %}
```

Filtering the key **list** (rather than skipping inside the loop) keeps `loop.last` line terminators correct — the real last setter still gets its `;`.

Applied to all 17 doc example templates (php, node, web, deno, dart, flutter, react-native, go, ruby, rust, python, swift, dotnet, kotlin java/kotlin, android java/kotlin).

## Not changed

Code-generation templates (`template.ts.twig`, `Service.kt.twig`, `params.twig`, `base/requests/location.twig`, etc.) still consume the full `method.auth` — they inject the auth schemes into location-method query params, which is exactly where impersonation must keep working. The generated SDK client classes also keep their `setImpersonateUserId` methods.

## Verification

- `composer lint-twig` — 0 errors.
- Regenerated examples for php, web, dotnet, go: **0** impersonation setters in any `docs/examples`; `setKey(...);` / `SetKey(...);` / `setProject(...);` retain their terminators; newline-style languages drop the line cleanly.
- Schemes without the flag (e.g. `Session`) are unaffected and still render.

Backward compatible: when a spec has no `x-appwrite.optional` flags, the filter is a no-op.