### PR TITLE
Allow console Web SDK credentials toggle

### DIFF
--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -611,19 +611,25 @@ class Client {
                     case 'connected': {
                         const messageData = <RealtimeResponseConnected>message.data;
 
-                        let session = this.config.session;
-                        if (!session) {
-                            const cookie = JSONbig.parse(window.localStorage.getItem('cookieFallback') ?? '{}');
-                            session = cookie?.[`a_session_${this.config.project}`];
+{%~ if sdk.platform == 'console' %}
+                        if (this.config.credentials !== 'omit') {
+{%~ endif %}
+                            let session = this.config.session;
+                            if (!session) {
+                                const cookie = JSONbig.parse(window.localStorage.getItem('cookieFallback') ?? '{}');
+                                session = cookie?.[`a_session_${this.config.project}`];
+                            }
+                            if (session && !messageData?.user) {
+                                this.realtime.socket?.send(JSONbig.stringify(<RealtimeRequest>{
+                                    type: 'authentication',
+                                    data: {
+                                        session
+                                    }
+                                }));
+                            }
+{%~ if sdk.platform == 'console' %}
                         }
-                        if (session && !messageData?.user) {
-                            this.realtime.socket?.send(JSONbig.stringify(<RealtimeRequest>{
-                                type: 'authentication',
-                                data: {
-                                    session
-                                }
-                            }));
-                        }
+{%~ endif %}
 
                         this.realtime.subscriptions.forEach((sub, subscriptionId) => {
                             this.realtime.pendingSubscribes.set(subscriptionId, {
@@ -779,7 +785,7 @@ class Client {
 
         headers = Object.assign({}, this.headers, headers);
 
-        if (typeof window !== 'undefined' && window.localStorage) {
+        if (typeof window !== 'undefined' && window.localStorage{% if sdk.platform == 'console' %} && this.config.credentials !== 'omit'{% endif %}) {
             const cookieFallback = window.localStorage.getItem('cookieFallback');
             if (cookieFallback) {
                 headers['X-Fallback-Cookies'] = cookieFallback;
@@ -1027,7 +1033,7 @@ class Client {
 
         const cookieFallback = response.headers.get('X-Fallback-Cookies');
 
-        if (typeof window !== 'undefined' && window.localStorage && cookieFallback) {
+        if (typeof window !== 'undefined' && window.localStorage && cookieFallback{% if sdk.platform == 'console' %} && this.config.credentials !== 'omit'{% endif %}) {
             window.console.warn('{{spec.title | caseUcfirst}} is using localStorage for session management. Increase your security by adding a custom domain as your API endpoint.');
             window.localStorage.setItem('cookieFallback', cookieFallback);
         }

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -722,12 +722,6 @@ class Client {
         callback: (payload: RealtimeResponseEvent<T>) => void,
         queries: (string | Query)[] = []
     ): () => void {
-{%~ if sdk.platform == 'console' %}
-        if (this.config.credentials === 'omit') {
-            throw new {{spec.title | caseUcfirst}}Exception('Realtime is not supported when credentials are omitted because browser WebSocket handshakes can still include cookies.');
-        }
-
-{%~ endif %}
         const channelArray = Array.isArray(channels) ? channels : [channels];
         // Convert Channel instances to strings
         const channelStrings = channelArray.map(ch => {

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -722,6 +722,12 @@ class Client {
         callback: (payload: RealtimeResponseEvent<T>) => void,
         queries: (string | Query)[] = []
     ): () => void {
+{%~ if sdk.platform == 'console' %}
+        if (this.config.credentials === 'omit') {
+            throw new {{spec.title | caseUcfirst}}Exception('Realtime is not supported when credentials are omitted because browser WebSocket handshakes can still include cookies.');
+        }
+
+{%~ endif %}
         const channelArray = Array.isArray(channels) ? channels : [channels];
         // Convert Channel instances to strings
         const channelStrings = channelArray.map(ch => {

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -358,6 +358,7 @@ class Client {
 {%~ endfor %}
 {%~ if sdk.platform == 'console' %}
         selfSigned: boolean;
+        credentials: RequestCredentials;
 {%~ endif %}
     } = {
         endpoint: '{{ spec.endpoint }}',
@@ -367,6 +368,7 @@ class Client {
 {%~ endfor %}
 {%~ if sdk.platform == 'console' %}
         selfSigned: false,
+        credentials: 'include',
 {%~ endif %}
     };
     /**
@@ -448,6 +450,20 @@ class Client {
      */
     setSelfSigned(selfSigned: boolean): this {
         this.config.selfSigned = selfSigned;
+        return this;
+    }
+
+    /**
+     * Set credentials
+     *
+     * Controls whether fetch sends credentials like cookies with requests.
+     *
+     * @param {RequestCredentials} credentials
+     *
+     * @returns {this}
+     */
+    setCredentials(credentials: RequestCredentials): this {
+        this.config.credentials = credentials;
         return this;
     }
 
@@ -776,7 +792,11 @@ class Client {
         };
 
         if (headers['X-Appwrite-Dev-Key'] === undefined) {
+{%~ if sdk.platform == 'console' %}
+            options.credentials = this.config.credentials;
+{%~ else %}
             options.credentials = 'include';
+{%~ endif %}
         }
 
         if (method === 'GET') {

--- a/templates/web/src/services/realtime.ts.twig
+++ b/templates/web/src/services/realtime.ts.twig
@@ -194,12 +194,6 @@ export class Realtime {
     }
 
     private async createSocketLocked(): Promise<void> {
-{%~ if sdk.platform == 'console' %}
-        if (this.client.config.credentials === 'omit') {
-            throw new {{spec.title | caseUcfirst}}Exception('Realtime is not supported when credentials are omitted because browser WebSocket handshakes can still include cookies.');
-        }
-
-{%~ endif %}
         // Nothing to do if there's neither a subscription nor a queued presence
         // that needs the wire. (Reconnect cleanup path also flows through here.)
         if (this.activeSubscriptions.size === 0 && !this.pendingPresence) {

--- a/templates/web/src/services/realtime.ts.twig
+++ b/templates/web/src/services/realtime.ts.twig
@@ -194,6 +194,12 @@ export class Realtime {
     }
 
     private async createSocketLocked(): Promise<void> {
+{%~ if sdk.platform == 'console' %}
+        if (this.client.config.credentials === 'omit') {
+            throw new {{spec.title | caseUcfirst}}Exception('Realtime is not supported when credentials are omitted because browser WebSocket handshakes can still include cookies.');
+        }
+
+{%~ endif %}
         // Nothing to do if there's neither a subscription nor a queued presence
         // that needs the wire. (Reconnect cleanup path also flows through here.)
         if (this.activeSubscriptions.size === 0 && !this.pendingPresence) {


### PR DESCRIPTION
## Summary

- Add a console-only `setCredentials()` method to the generated Web SDK client.
- Default console SDK requests to `credentials: 'include'` so cookie session auth keeps working.
- Allow console JWT flows to call `setCredentials('omit')` to avoid sending browser cookies.

## Tests

- `php example.php web console`
- `composer refactor:check`
- `composer lint-twig`
- `npm ci` in `examples/web`
- `npm run build` in `examples/web`

## Notes

- `examples/*` is gitignored in this checkout, so regeneration was verified locally but only the template change is tracked.
