### PR TITLE
Fix generated TypeScript path parameter encoding

### DIFF
--- a/mock-server/app/http.php
+++ b/mock-server/app/http.php
@@ -451,6 +451,21 @@ App::get('/v1/mock/tests/general/redirect/done')
     ->action(function () {
     });
 
+App::get('/v1/mock/tests/general/path/grant%2Fspecial%26id')
+    ->desc('Path Param')
+    ->groups(['mock'])
+    ->label('scope', 'public')
+    ->label('sdk.auth', [APP_AUTH_TYPE_SESSION, APP_AUTH_TYPE_KEY, APP_AUTH_TYPE_JWT])
+    ->label('sdk.namespace', 'general')
+    ->label('sdk.method', 'getPath')
+    ->label('sdk.description', 'Mock an encoded path parameter request.')
+    ->label('sdk.response.code', Response::STATUS_CODE_OK)
+    ->label('sdk.response.type', Response::CONTENT_TYPE_JSON)
+    ->label('sdk.response.model', Response::MODEL_MOCK)
+    ->label('sdk.mock', true)
+    ->action(function () {
+    });
+
 App::get('/v1/mock/tests/general/set-cookie')
     ->desc('Set Cookie')
     ->groups(['mock'])

--- a/src/Spec/OpenAPI3.php
+++ b/src/Spec/OpenAPI3.php
@@ -138,7 +138,11 @@ class OpenAPI3 extends Spec
         $methodSecurity = $method['security'][0] ?? [];
 
         foreach ($methodAuth as $i => $node) {
-            $methodAuth[$i] = (array_key_exists((string) $i, $security)) ? [...$security[$i], 'global' => $i !== 'Project'] : [];
+            $authKey = $this->getAuthSetterKey((string) $i, $security[(string) $i] ?? []);
+            $methodAuth[$authKey] = (array_key_exists((string) $i, $security)) ? [...$security[$i], 'global' => $i !== 'Project'] : [];
+            if ($authKey !== (string) $i) {
+                unset($methodAuth[$i]);
+            }
         }
         foreach ($methodSecurity as $i => $node) {
             $methodSecurity[$i] = (array_key_exists((string) $i, $security)) ? [...$security[$i], 'global' => $i !== 'Project'] : [];
@@ -710,6 +714,24 @@ class OpenAPI3 extends Spec
         }
 
         return $list;
+    }
+
+    private function getAuthSetterKey(string $key, array $security): string
+    {
+        if (($security['x-appwrite']['location'] ?? '') !== 'path') {
+            return $key;
+        }
+
+        $name = $security['name'] ?? '';
+        if ($name === '') {
+            return $key;
+        }
+
+        return \ucfirst((string) \preg_replace_callback(
+            '/[-_\\s]+([a-zA-Z0-9])/',
+            fn(array $matches): string => \strtoupper($matches[1]),
+            (string) $name
+        ));
     }
 
     /**

--- a/templates/node/src/services/template.ts.twig
+++ b/templates/node/src/services/template.ts.twig
@@ -109,7 +109,7 @@ export class {{ service.name | caseUcfirst }} {
         {%~ endif %}
         {%~ endfor %}
 
-        const apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replace('{{ '{' }}{{ parameter.name }}{{ '}' }}', {% if parameter.source|default('') == 'security' %}this.client.config.{{ parameter.config | caseLower }}{% else %}{{ parameter.name | caseCamel | escapeKeyword }}{% endif %}){% endfor %};
+        const apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replace('{{ '{' }}{{ parameter.name }}{{ '}' }}', encodeURIComponent(String({% if parameter.source|default('') == 'security' %}this.client.config.{{ parameter.config | caseLower }}{% else %}{{ parameter.name | caseCamel | escapeKeyword }}{% endif %}))){% endfor %};
         const payload: Payload = {};
         {%~ for parameter in method.parameters.query %}
         if (typeof {{ parameter.name | caseCamel | escapeKeyword }} !== 'undefined') {

--- a/templates/react-native/src/services/template.ts.twig
+++ b/templates/react-native/src/services/template.ts.twig
@@ -110,7 +110,7 @@ export class {{ service.name | caseUcfirst }} extends Service {
 
 {% endif %}
 {% endfor %}
-        const apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replace('{{ '{' }}{{ parameter.name }}{{ '}' }}', {% if parameter.source|default('') == 'security' %}this.client.config.{{ parameter.config | caseLower }}{% else %}{{ parameter.name | caseCamel | escapeKeyword }}{% endif %}){% endfor %};
+        const apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replace('{{ '{' }}{{ parameter.name }}{{ '}' }}', encodeURIComponent(String({% if parameter.source|default('') == 'security' %}this.client.config.{{ parameter.config | caseLower }}{% else %}{{ parameter.name | caseCamel | escapeKeyword }}{% endif %}))){% endfor %};
         const payload: Payload = {};
 
 {% for parameter in method.parameters.query %}
@@ -360,7 +360,7 @@ export class {{ service.name | caseUcfirst }} extends Service {
     {%~ endif %}
     */
     {{ method.name | caseCamel }}URL({% for parameter in method.parameters.all %}{{ parameter.name | caseCamel | escapeKeyword }}{% if not parameter.required or parameter.nullable %}?{% endif %}: {{ parameter | getPropertyType(method) | raw }}{% if not loop.last %}, {% endif %}{% endfor %}{% if 'multipart/form-data' in method.consumes %}, onProgress = (progress: UploadProgress) => void{% endif %}): URL {
-        const apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replace('{{ '{' }}{{ parameter.name }}{{ '}' }}', {% if parameter.source|default('') == 'security' %}this.client.config.{{ parameter.config | caseLower }}{% else %}{{ parameter.name | caseCamel | escapeKeyword }}{% endif %}){% endfor %};
+        const apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replace('{{ '{' }}{{ parameter.name }}{{ '}' }}', encodeURIComponent(String({% if parameter.source|default('') == 'security' %}this.client.config.{{ parameter.config | caseLower }}{% else %}{{ parameter.name | caseCamel | escapeKeyword }}{% endif %}))){% endfor %};
         const payload: Payload = {};
 
 {% for parameter in method.parameters.query %}

--- a/templates/web/src/services/template.ts.twig
+++ b/templates/web/src/services/template.ts.twig
@@ -106,7 +106,7 @@ export class {{ service.name | caseUcfirst }} {
         {%~ endif %}
         {%~ endfor %}
 
-        const apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replace('{{ '{' }}{{ parameter.name }}{{ '}' }}', {% if parameter.source|default('') == 'security' %}this.client.config.{{ parameter.config | caseLower }}{% else %}{{ parameter.name | caseCamel | escapeKeyword }}{% endif %}){% endfor %};
+        const apiPath = '{{ method.path }}'{% for parameter in method.parameters.path %}.replace('{{ '{' }}{{ parameter.name }}{{ '}' }}', encodeURIComponent(String({% if parameter.source|default('') == 'security' %}this.client.config.{{ parameter.config | caseLower }}{% else %}{{ parameter.name | caseCamel | escapeKeyword }}{% endif %}))){% endfor %};
         const payload: Payload = {};
         {%~ for parameter in method.parameters.query %}
         if (typeof {{ parameter.name | caseCamel | escapeKeyword }} !== 'undefined') {

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -47,6 +47,10 @@ abstract class Base extends TestCase
         'GET:/v1/mock/tests/general/redirect/done:passed',
     ];
 
+    protected const PATH_PARAM_RESPONSES = [
+        'GET:/v1/mock/tests/general/path/grant%2Fspecial%26id:passed',
+    ];
+
     protected const OAUTH_RESPONSES = [
         'https://localhost?code=abcdef&state=123456',
     ];

--- a/tests/e2e/Node18Test.php
+++ b/tests/e2e/Node18Test.php
@@ -40,6 +40,7 @@ final class Node18Test extends Base
         ...Base::BAR_RESPONSES,
         ...Base::BAR_RESPONSES, // Object params
         ...Base::GENERAL_RESPONSES,
+        ...Base::PATH_PARAM_RESPONSES,
         ...Base::UPLOAD_RESPONSES,
         ...Base::LARGE_FILE_RESPONSES,
         ...Base::LARGE_FILE_RESPONSES,

--- a/tests/e2e/Node20Test.php
+++ b/tests/e2e/Node20Test.php
@@ -40,6 +40,7 @@ final class Node20Test extends Base
         ...Base::BAR_RESPONSES,
         ...Base::BAR_RESPONSES, // Object params
         ...Base::GENERAL_RESPONSES,
+        ...Base::PATH_PARAM_RESPONSES,
         ...Base::UPLOAD_RESPONSES,
         ...Base::LARGE_FILE_RESPONSES,
         ...Base::LARGE_FILE_RESPONSES,

--- a/tests/e2e/Node26Test.php
+++ b/tests/e2e/Node26Test.php
@@ -40,6 +40,7 @@ final class Node26Test extends Base
         ...Base::BAR_RESPONSES,
         ...Base::BAR_RESPONSES, // Object params
         ...Base::GENERAL_RESPONSES,
+        ...Base::PATH_PARAM_RESPONSES,
         ...Base::UPLOAD_RESPONSES,
         ...Base::LARGE_FILE_RESPONSES,
         ...Base::LARGE_FILE_RESPONSES,

--- a/tests/e2e/WebChromiumTest.php
+++ b/tests/e2e/WebChromiumTest.php
@@ -41,6 +41,7 @@ final class WebChromiumTest extends Base
         ...Base::BAR_RESPONSES,
         ...Base::BAR_RESPONSES, // Object params
         ...Base::GENERAL_RESPONSES,
+        ...Base::PATH_PARAM_RESPONSES,
         ...Base::UPLOAD_RESPONSES,
         ...Base::UPLOAD_RESPONSES, // Object params
         ...Base::ENUM_RESPONSES,

--- a/tests/e2e/WebNodeTest.php
+++ b/tests/e2e/WebNodeTest.php
@@ -42,6 +42,7 @@ final class WebNodeTest extends Base
         ...Base::BAR_RESPONSES,
         ...Base::BAR_RESPONSES, // Object params
         ...Base::GENERAL_RESPONSES,
+        ...Base::PATH_PARAM_RESPONSES,
         ...Base::UPLOAD_RESPONSES,
         ...Base::ENUM_RESPONSES,
         ...Base::MODEL_RESPONSES,

--- a/tests/e2e/languages/node/test.js
+++ b/tests/e2e/languages/node/test.js
@@ -145,6 +145,9 @@ async function start() {
     response = await general.redirect();
     console.log(response.result);
 
+    response = await general.getPath({ pathId: 'grant/special&id' });
+    console.log(response.result);
+
     // Upload
     response = await general.upload('string', 123, ['string in array'], InputFile.fromPath(__dirname + '/../../../resources/file.png', 'file.png'));
     console.log(response.result);

--- a/tests/e2e/languages/web/index.html
+++ b/tests/e2e/languages/web/index.html
@@ -191,6 +191,9 @@
             response = await general.redirect();
             console.log(response.result);
 
+            response = await general.getPath({ pathId: 'grant/special&id' });
+            console.log(response.result);
+
             // Upload
             response = await general.upload(
                 "string",

--- a/tests/e2e/languages/web/node.js
+++ b/tests/e2e/languages/web/node.js
@@ -123,6 +123,9 @@ async function start() {
     // General
     response = await general.redirect();
     console.log(response.result);
+
+    response = await general.getPath({ pathId: 'grant/special&id' });
+    console.log(response.result);
   
     console.log('POST:/v1/mock/tests/general/upload:passed'); // Skip file upload test on Node.js
     console.log('POST:/v1/mock/tests/general/upload:passed'); // Skip big file upload test on Node.js

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -1988,6 +1988,71 @@
         }
       }
     },
+    "\/mock\/tests\/general\/path\/{pathId}": {
+      "get": {
+        "summary": "Path Param",
+        "operationId": "generalGetPath",
+        "tags": [
+          "general"
+        ],
+        "description": "",
+        "x-appwrite": {
+          "method": "getPath",
+          "weight": 280,
+          "cookies": false,
+          "type": "",
+          "demo": "general\/get-path.md",
+          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock an encoded path parameter request.",
+          "rate-limit": 0,
+          "rate-time": 3600,
+          "rate-key": "url:{url},ip:{ip}",
+          "scope": "public",
+          "platforms": [
+            "client",
+            "server",
+            "server"
+          ],
+          "packaging": false,
+          "offline-model": "",
+          "offline-key": "",
+          "offline-response-key": "$id",
+          "auth": {
+            "Project": []
+          }
+        },
+        "security": [
+          {
+            "Project": [],
+            "Key": [],
+            "JWT": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Mock",
+            "content": {
+              "application\/json": {
+                "schema": {
+                  "$ref": "#\/components\/schemas\/mock"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pathId",
+            "description": "Path ID.",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "x-example": "grant\/special&id"
+            }
+          }
+        ]
+      }
+    },
     "\/mock\/tests\/general\/set-cookie": {
       "get": {
         "summary": "Set Cookie",

--- a/tests/resources/spec-swagger2.json
+++ b/tests/resources/spec-swagger2.json
@@ -2062,6 +2062,69 @@
         ]
       }
     },
+    "\/mock\/tests\/general\/path\/{pathId}": {
+      "get": {
+        "summary": "Path Param",
+        "operationId": "generalGetPath",
+        "consumes": [],
+        "produces": [
+          "application\/json"
+        ],
+        "tags": [
+          "general"
+        ],
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "Mock",
+            "schema": {
+              "$ref": "#\/definitions\/mock"
+            }
+          }
+        },
+        "x-appwrite": {
+          "method": "getPath",
+          "weight": 280,
+          "cookies": false,
+          "type": "",
+          "demo": "general\/get-path.md",
+          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock an encoded path parameter request.",
+          "rate-limit": 0,
+          "rate-time": 3600,
+          "rate-key": "url:{url},ip:{ip}",
+          "scope": "public",
+          "platforms": [
+            "client",
+            "server",
+            "server"
+          ],
+          "packaging": false,
+          "offline-model": "",
+          "offline-key": "",
+          "offline-response-key": "$id",
+          "auth": {
+            "Project": []
+          }
+        },
+        "security": [
+          {
+            "Project": [],
+            "Key": [],
+            "JWT": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "pathId",
+            "description": "Path ID.",
+            "required": true,
+            "type": "string",
+            "in": "path",
+            "x-example": "grant\/special&id"
+          }
+        ]
+      }
+    },
     "\/mock\/tests\/general\/set-cookie": {
       "get": {
         "summary": "Set Cookie",

--- a/tests/unit/OpenAPI3SpecTest.php
+++ b/tests/unit/OpenAPI3SpecTest.php
@@ -94,6 +94,88 @@ final class OpenAPI3SpecTest extends TestCase
         $this->assertSame('X-Appwrite-Key', $headers['Key']);
     }
 
+    public function testPathLocatedProjectAuthUsesPublicSetterName(): void
+    {
+        $spec = new OpenAPI3(\json_encode([
+            'openapi' => '3.0.0',
+            'info' => [
+                'title' => 'Appwrite',
+                'description' => 'Test spec',
+                'version' => '1.0.0',
+            ],
+            'servers' => [
+                ['url' => 'https://example.com/v1'],
+            ],
+            'tags' => [
+                ['name' => 'oauth2'],
+            ],
+            'paths' => [
+                '/projects/{project_id}/oauth2/grants/{grant_id}' => [
+                    'get' => [
+                        'summary' => 'Get Grant',
+                        'operationId' => 'oauth2GetGrant',
+                        'tags' => ['oauth2'],
+                        'x-appwrite' => [
+                            'method' => 'getGrant',
+                            'auth' => [
+                                'ProjectPath' => [],
+                            ],
+                        ],
+                        'security' => [
+                            [
+                                'ProjectPath' => [],
+                            ],
+                        ],
+                        'parameters' => [
+                            [
+                                'name' => 'project_id',
+                                'description' => 'Project ID.',
+                                'required' => true,
+                                'in' => 'path',
+                                'schema' => ['type' => 'string'],
+                            ],
+                            [
+                                'name' => 'grant_id',
+                                'description' => 'Grant ID.',
+                                'required' => true,
+                                'in' => 'path',
+                                'schema' => ['type' => 'string'],
+                            ],
+                        ],
+                        'responses' => [
+                            '200' => [
+                                'description' => 'OK',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'components' => [
+                'securitySchemes' => [
+                    'ProjectPath' => [
+                        'type' => 'apiKey',
+                        'name' => 'project',
+                        'description' => 'Your project ID',
+                        'in' => 'query',
+                        'x-appwrite' => [
+                            'location' => 'path',
+                            'param' => 'project_id',
+                            'demo' => '<YOUR_PROJECT_ID>',
+                        ],
+                    ],
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR));
+
+        $methods = $spec->getMethods('oauth2');
+
+        $this->assertSame('getGrant', $methods[0]['name']);
+        $this->assertArrayHasKey('Project', $methods[0]['auth'][0]);
+        $this->assertArrayNotHasKey('ProjectPath', $methods[0]['auth'][0]);
+        $this->assertSame('project', $methods[0]['parameters']['path'][0]['config']);
+        $this->assertSame('security', $methods[0]['parameters']['path'][0]['source']);
+    }
+
     public function testRequestBodyBecomesBodyParameters(): void
     {
         $method = $this->getMethod('foo', 'post');


### PR DESCRIPTION
## Summary

- Encode generated TypeScript path parameters with `encodeURIComponent(String(...))` for Web, Node, and React Native SDKs.
- Normalize path-located auth schemes such as `ProjectPath` to use their public security `name` for docs setters, so examples generate `.setProject(...)` instead of `.setProjectPath(...)`.
- Add Node/Web e2e fixture coverage for a path parameter containing `/` and `&`.

## Testing

- `php example.php` regenerated all SDK examples from the live console spec.
- Scanned 16,328 generated docs example files: no `ProjectPath`, `setProjectPath`, `set_project_path`, `SetProjectPath`, or `WithProjectPath` output remains.
- `vendor/bin/phpunit --testsuite Unit`
- `composer lint-twig`
- `composer refactor:check`
- `vendor/bin/phpunit tests/e2e/Node18Test.php`

Note: full SDK regeneration completed successfully, but emitted existing Dart/Flutter Twig `Array to string conversion` warnings unrelated to this change.
