### PR TITLE
Fix fallback cookie credential handling

### DIFF
--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -467,6 +467,32 @@ class Client {
         return this;
     }
 
+    private shouldUseFallbackCredentials(url?: URL | string): boolean {
+        switch (this.config.credentials) {
+            case 'include':
+                return true;
+            case 'same-origin': {
+                if (typeof window === 'undefined' || typeof url === 'undefined') {
+                    return false;
+                }
+
+                try {
+                    const parsedUrl = typeof url === 'string' ? new URL(url) : url;
+                    const normalizedOrigin = parsedUrl.protocol === 'wss:' || parsedUrl.protocol === 'ws:'
+                        ? `${parsedUrl.protocol === 'wss:' ? 'https:' : 'http:'}//${parsedUrl.host}`
+                        : parsedUrl.origin;
+
+                    return normalizedOrigin === window.location.origin;
+                } catch {
+                    return false;
+                }
+            }
+            case 'omit':
+            default:
+                return false;
+        }
+    }
+
 {%~ endif %}
     {%~ for header in spec.global.headers %}
     /**
@@ -612,7 +638,7 @@ class Client {
                         const messageData = <RealtimeResponseConnected>message.data;
 
 {%~ if sdk.platform == 'console' %}
-                        if (this.config.credentials !== 'omit') {
+                        if (this.shouldUseFallbackCredentials(this.realtime.url)) {
 {%~ endif %}
                             let session = this.config.session;
                             if (!session) {
@@ -785,7 +811,7 @@ class Client {
 
         headers = Object.assign({}, this.headers, headers);
 
-        if (typeof window !== 'undefined' && window.localStorage{% if sdk.platform == 'console' %} && this.config.credentials !== 'omit'{% endif %}) {
+        if (typeof window !== 'undefined' && window.localStorage{% if sdk.platform == 'console' %} && this.shouldUseFallbackCredentials(url){% endif %}) {
             const cookieFallback = window.localStorage.getItem('cookieFallback');
             if (cookieFallback) {
                 headers['X-Fallback-Cookies'] = cookieFallback;
@@ -1033,7 +1059,7 @@ class Client {
 
         const cookieFallback = response.headers.get('X-Fallback-Cookies');
 
-        if (typeof window !== 'undefined' && window.localStorage && cookieFallback{% if sdk.platform == 'console' %} && this.config.credentials !== 'omit'{% endif %}) {
+        if (typeof window !== 'undefined' && window.localStorage && cookieFallback{% if sdk.platform == 'console' %} && this.shouldUseFallbackCredentials(url){% endif %}) {
             window.console.warn('{{spec.title | caseUcfirst}} is using localStorage for session management. Increase your security by adding a custom domain as your API endpoint.');
             window.localStorage.setItem('cookieFallback', cookieFallback);
         }


### PR DESCRIPTION
## Summary

- Respect fetch credential semantics before sending or storing fallback cookies in generated Console web clients.
- Reuse the same credential check for realtime fallback session authentication.
- Normalize websocket origins to their HTTP equivalents for same-origin comparisons.

## Testing

- php example.php web console
- composer lint-twig
- composer refactor:check

## Notes

- `examples/*` is ignored in this repository, so regenerated web output was verified locally but is not included in the diff.
