### PR TITLE
Fix CLI OAuth review comments

### DIFF
--- a/templates/cli/lib/auth/login.ts
+++ b/templates/cli/lib/auth/login.ts
@@ -382,8 +382,6 @@ export const loginCommand = async ({
   switch?: boolean;
   new?: boolean;
 }): Promise<void> => {
-  let oldCurrent = globalConfig.getCurrentSession();
-
   if (switchAccount && newAccount) {
     throw new Error("Use either --switch or --new, not both.");
   }
@@ -400,7 +398,7 @@ export const loginCommand = async ({
   const shouldUseCloudLogin =
     isFlagEnabled("oauthLogin") && isCloudLoginEndpoint(configEndpoint);
 
-  oldCurrent = globalConfig.getCurrentSession();
+  let oldCurrent = globalConfig.getCurrentSession();
 
   if (oldCurrent !== "" && !newAccount) {
     let account: Models.User | null = null;
@@ -409,6 +407,7 @@ export const loginCommand = async ({
     } catch (_err) {
       account = null;
     }
+    // Refresh the current session after account lookup.
     oldCurrent = globalConfig.getCurrentSession();
 
     if (account) {

--- a/templates/cli/lib/commands/services/services.ts.twig
+++ b/templates/cli/lib/commands/services/services.ts.twig
@@ -160,6 +160,9 @@ const {{ commandVar }} = {{ service.name | caseCamel }}
       async ({{ actionParams }}) => {
         const url = await (await get{{ service.name | caseUcfirst }}Client()).{{ method.name | caseCamel }}({{ argExpressions | join(', ') | raw }});
         const response = await fetch(url);
+        if (!response.ok) {
+          throw new Error(`Failed to download file: ${response.status} ${response.statusText}`);
+        }
         const buffer = Buffer.from(await response.arrayBuffer());
         fs.writeFileSync(destination, buffer);
         success(`File saved to ${destination}`);

--- a/templates/cli/lib/sdks.ts
+++ b/templates/cli/lib/sdks.ts
@@ -28,6 +28,10 @@ export const getValidAccessToken = async (
     return accessToken;
   }
 
+  if (accessToken && tokenExpiry === 0 && !refreshToken) {
+    return accessToken;
+  }
+
   if (!refreshToken) {
     throw new Error(
       `Session expired. Please run \`${EXECUTABLE_NAME} login\` to create a new session.`,

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -265,6 +265,7 @@ abstract class Base extends TestCase
         'auth:poll-device-token-empty-error:passed',
         'auth:poll-device-token-default-interval:passed',
         'auth:valid-access-token-cached:passed',
+        'auth:valid-access-token-missing-expiry:passed',
         'auth:oauth-login-flag:passed',
     ];
 

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -1008,6 +1008,17 @@ async function runAuthChecks() {
     assert.equal(token, "cached-token");
   });
 
+  await authCheck("valid-access-token-missing-expiry", async () => {
+    globalConfig.clear();
+    globalConfig.addSession("tok2", {
+      endpoint: "http://localhost/v1",
+      accessToken: "cached-token-without-expiry",
+    });
+    globalConfig.setCurrentSession("tok2");
+    const token = await getValidAccessToken("http://localhost/v1");
+    assert.equal(token, "cached-token-without-expiry");
+  });
+
   await authCheck("oauth-login-flag", () => {
     const prev = process.env.APPWRITE_CLI_OAUTH_LOGIN;
     delete process.env.APPWRITE_CLI_OAUTH_LOGIN;


### PR DESCRIPTION
## Summary
- add an HTTP status guard before generated CLI location/download commands write response bodies to disk
- clean up CLI login `oldCurrent` handling after account lookup
- allow stored OAuth access tokens without persisted expiry to be reused, with e2e coverage

## Context
Addresses review feedback from appwrite/sdk-for-cli#325 in the generator templates so regenerated CLI output includes the fixes.

## Testing
- `php example.php cli`
- `composer lint-twig`
- `composer refactor:check`
- `vendor/bin/phpunit --testsuite Unit`
- `vendor/bin/phpunit tests/e2e/CLIBun13Test.php`
