### PR TITLE
Minify CLI standalone binaries

### DIFF
--- a/templates/cli/package.json.twig
+++ b/templates/cli/package.json.twig
@@ -43,12 +43,12 @@
     "generate": "tsx scripts/generate-commands.ts",
     "prepublishOnly": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "linux-x64": "bun build cli.ts --compile --sourcemap=inline --target=bun-linux-x64 --outfile build/appwrite-cli-linux-x64",
-    "linux-arm64": "bun build cli.ts --compile --sourcemap=inline --target=bun-linux-arm64 --outfile build/appwrite-cli-linux-arm64",
-    "mac-x64": "bun build cli.ts --compile --sourcemap=inline --target=bun-darwin-x64 --outfile build/appwrite-cli-darwin-x64",
-    "mac-arm64": "bun build cli.ts --compile --sourcemap=inline --target=bun-darwin-arm64 --outfile build/appwrite-cli-darwin-arm64",
-    "windows-x64": "bun build cli.ts --compile --sourcemap=inline --target=bun-windows-x64 --outfile build/appwrite-cli-win-x64.exe",
-    "windows-arm64": "bun build cli.ts --compile --sourcemap=inline --target=bun-windows-arm64 --outfile build/appwrite-cli-win-arm64.exe"
+    "linux-x64": "bun build cli.ts --compile --minify --target=bun-linux-x64 --outfile build/appwrite-cli-linux-x64",
+    "linux-arm64": "bun build cli.ts --compile --minify --target=bun-linux-arm64 --outfile build/appwrite-cli-linux-arm64",
+    "mac-x64": "bun build cli.ts --compile --minify --target=bun-darwin-x64 --outfile build/appwrite-cli-darwin-x64",
+    "mac-arm64": "bun build cli.ts --compile --minify --target=bun-darwin-arm64 --outfile build/appwrite-cli-darwin-arm64",
+    "windows-x64": "bun build cli.ts --compile --minify --target=bun-windows-x64 --outfile build/appwrite-cli-win-x64.exe",
+    "windows-arm64": "bun build cli.ts --compile --minify --target=bun-windows-arm64 --outfile build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
     "@appwrite.io/console": "^15.0.0",


### PR DESCRIPTION
## What changed

This updates the CLI standalone binary build scripts to use Bun minification instead of embedding inline sourcemaps:

- Replaces `--sourcemap=inline` with `--minify` for every Bun `--compile` target in `templates/cli/package.json.twig`
- Applies to Linux, macOS, and Windows standalone binary release targets generated from the CLI template
- Keeps the output format and target names unchanged, so release automation and Homebrew formula artifact paths continue to work as-is

## Why

The Homebrew/native CLI artifact was around 80 MB because Bun standalone executables embed the Bun runtime plus bundled application code. Inline sourcemaps add avoidable size to every release binary. Minifying the bundled application code and dropping inline sourcemaps reduces the distributed artifact without changing the packaging model.

## Size impact

Measured locally on macOS arm64 using the generated CLI source:

| Build | Size |
| --- | ---: |
| Current `--compile --sourcemap=inline` | 77,062,656 bytes / 73M |
| New `--compile --minify` | 63,242,112 bytes / 60M |
| Reduction | 13,820,544 bytes / ~18% |

Compressed artifact estimate with `gzip -9`:

| Build | Gzipped size |
| --- | ---: |
| Current inline sourcemap build | 26,367,837 bytes |
| New minified build | 22,556,884 bytes |

## Functional verification

Generated the CLI output and built the macOS arm64 standalone binary:

```bash
php example.php cli
cd examples/cli
npm run mac-arm64
```

Exercised the compiled binary with local, non-mutating commands:

```bash
./build/appwrite-cli-darwin-arm64 --version
./build/appwrite-cli-darwin-arm64 --help
./build/appwrite-cli-darwin-arm64 client --help
./build/appwrite-cli-darwin-arm64 databases --help
./build/appwrite-cli-darwin-arm64 update --help
./build/appwrite-cli-darwin-arm64 completion zsh
./build/appwrite-cli-darwin-arm64 completion bash
./build/appwrite-cli-darwin-arm64 completion fish
./build/appwrite-cli-darwin-arm64 definitely-not-a-command
```

Results:

- Help and completion output rendered as expected
- Invalid command exited with status `1`
- Binary remained a valid macOS arm64 Mach-O executable with ad-hoc/linker signature

## Benchmark

Benchmarked old vs new binaries with 40 measured runs per case after warmup. Used an isolated `HOME` with a fresh update-check cache to avoid network/update-check noise.

| Command | Old mean | New mean | Result |
| --- | ---: | ---: | --- |
| `--help` | 525.5ms | 524.7ms | same |
| `client --help` | 521.1ms | 525.1ms | same |
| `databases --help` | 539.9ms | 523.4ms | slightly faster |
| `completion zsh` | 615.6ms | 520.3ms | faster / less noisy |
| invalid command | 568.0ms | 523.3ms | faster / less noisy |

## Checks

```bash
npm run build
composer lint-twig
composer refactor:check
```

All passed.
