### PR TITLE
Fix CLI OAuth login for stage Cloud

### DIFF
--- a/templates/cli/lib/utils.ts
+++ b/templates/cli/lib/utils.ts
@@ -364,6 +364,7 @@ const getHomebrewLatestVersion = async (
 
 // TODO: Derive this list from the regions in the API spec.
 const CLOUD_REGION_CODES = new Set(["fra", "nyc", "syd", "sfo", "sgp", "tor"]);
+const CLOUD_LOGIN_ENVIRONMENTS = new Set(["stage"]);
 
 export const isCloudHostname = (hostname: string): boolean => {
   if (hostname === "cloud.appwrite.io") {
@@ -389,11 +390,16 @@ export const isRegionalCloudEndpoint = (endpoint: string): boolean => {
 export const isLocalhostHostname = (hostname: string): boolean =>
   hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
 
+const isCloudEnvironmentHostname = (hostname: string): boolean =>
+  hostname.endsWith(".cloud.appwrite.io") &&
+  CLOUD_LOGIN_ENVIRONMENTS.has(hostname.split(".")[0]);
+
 export const isCloudLoginEndpoint = (endpoint: string): boolean => {
   try {
     const hostname = new URL(endpoint).hostname;
     return (
       isCloudHostname(hostname) ||
+      isCloudEnvironmentHostname(hostname) ||
       (isFlagEnabled("devCloudLogin") && isLocalhostHostname(hostname))
     );
   } catch (_error) {

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -766,6 +766,7 @@ async function runAuthChecks() {
     try {
       assert.equal(isFlagEnabled("devCloudLogin"), false);
       assert.equal(isCloudLoginEndpoint("https://cloud.appwrite.io/v1"), true);
+      assert.equal(isCloudLoginEndpoint("https://stage.cloud.appwrite.io/v1"), true);
       assert.equal(isCloudLoginEndpoint("http://localhost/v1"), false);
     } finally {
       if (prev === undefined) delete process.env.APPWRITE_CLI_DEV_CLOUD_LOGIN;


### PR DESCRIPTION
## Summary
- Allow CLI OAuth login flow for stage Cloud endpoints without treating stage as a regional production Cloud host.
- Cover stage Cloud login endpoint detection in the CLI e2e fixture.

## Testing
- Not run per request.
