### PR TITLE
Fix CLI logout revoke error output

### DIFF
--- a/templates/cli/lib/auth/session.ts
+++ b/templates/cli/lib/auth/session.ts
@@ -82,10 +82,10 @@ export const removeCurrentSession = (): void => {
  */
 export const deleteServerSession = async (
   sessionId: string,
-): Promise<boolean> => {
+): Promise<{ deleted: boolean; error?: string }> => {
   const session = getSession(sessionId);
   if (!session?.endpoint) {
-    return false;
+    return { deleted: false };
   }
 
   try {
@@ -95,7 +95,7 @@ export const deleteServerSession = async (
         session.refreshToken,
         session.clientId || OAUTH2_CLIENT_ID,
       );
-      return true;
+      return { deleted: true };
     }
 
     if (session.cookie) {
@@ -110,12 +110,15 @@ export const deleteServerSession = async (
       await legacyClient.call("DELETE", "/account/sessions/current", {
         "content-type": "application/json",
       });
-      return true;
+      return { deleted: true };
     }
 
-    return false;
-  } catch (_e) {
-    return false;
+    return { deleted: false };
+  } catch (e) {
+    return {
+      deleted: false,
+      error: e instanceof Error ? e.message : String(e),
+    };
   }
 };
 
@@ -126,9 +129,10 @@ export const deleteServerSession = async (
  */
 export const logoutSessions = async (
   sessionIds: string[],
-): Promise<{ failed: number; failedIds: string[] }> => {
+): Promise<{ failed: number; failedIds: string[]; errors: string[] }> => {
   let failed = 0;
   const failedIds: string[] = [];
+  const errors: string[] = [];
 
   for (const sessionId of sessionIds) {
     if (isLocalOnlySession(sessionId)) {
@@ -137,16 +141,19 @@ export const logoutSessions = async (
     }
 
     globalConfig.setCurrentSession(sessionId);
-    const serverDeleted = await deleteServerSession(sessionId);
-    if (serverDeleted) {
+    const result = await deleteServerSession(sessionId);
+    if (result.deleted) {
       globalConfig.removeSession(sessionId);
     } else {
       failed++;
       failedIds.push(sessionId);
+      if (result.error) {
+        errors.push(result.error);
+      }
     }
   }
 
-  return { failed, failedIds };
+  return { failed, failedIds, errors };
 };
 
 export const removeLegacySessionsExcept = async (
@@ -160,8 +167,8 @@ export const removeLegacySessionsExcept = async (
       continue;
     }
 
-    const serverDeleted = await deleteServerSession(sessionId);
-    if (serverDeleted) {
+    const result = await deleteServerSession(sessionId);
+    if (result.deleted) {
       globalConfig.removeSession(sessionId);
       removed++;
     } else {

--- a/templates/cli/lib/commands/generic.ts
+++ b/templates/cli/lib/commands/generic.ts
@@ -10,7 +10,6 @@ import {
   commandDescriptions,
   error,
   parse,
-  hint,
   log,
   drawTable,
   cliConfig,
@@ -26,6 +25,16 @@ import {
 } from "../auth/session.js";
 
 export { loginCommand };
+
+const logMessages = {
+  noActiveSessions: "No active sessions found.",
+  logoutFailure: (errors: string[] = []): string => {
+    const details = errors[0] ? `: ${errors[0]}` : "";
+    return `Could not log out because the server session could not be revoked${details}. Kept local session data.`;
+  },
+  logoutSuccess: "Logged out successfully",
+  clientConfigUpdated: "Client configuration updated",
+} as const;
 
 export const whoami = new Command("whoami")
   .description(commandDescriptions["whoami"])
@@ -101,38 +110,37 @@ export const logout = new Command("logout")
       const originalCurrent = current;
 
       if (current === "" || !sessions.length) {
-        log("No active sessions found.");
+        log(logMessages.noActiveSessions);
         return;
       }
       if (sessions.length === 1) {
-        const { failed, failedIds } = await logoutSessions(
+        const { failed, failedIds, errors } = await logoutSessions(
           planSessionLogout([current]),
         );
 
         if (failed > 0) {
           restoreCurrentSessionFallback(originalCurrent, failedIds);
-          hint(
-            "Could not reach server for all sessions; kept local session data",
-          );
+          error(logMessages.logoutFailure(errors));
+          return;
         } else {
           globalConfig.setCurrentSession("");
         }
-        success("Logged out successfully");
+        success(logMessages.logoutSuccess);
 
         return;
       }
 
       const answers = await inquirer.prompt(questionsLogout);
+      let logoutFailed = false;
 
       if (answers.accounts?.length) {
-        const { failed } = await logoutSessions(
+        const { failed, errors } = await logoutSessions(
           planSessionLogout(answers.accounts as string[]),
         );
 
         if (failed > 0) {
-          hint(
-            "Could not reach server for all sessions; kept local session data",
-          );
+          logoutFailed = true;
+          error(logMessages.logoutFailure(errors));
         }
       }
 
@@ -158,7 +166,9 @@ export const logout = new Command("logout")
         globalConfig.setCurrentSession("");
       }
 
-      success("Logged out successfully");
+      if (!logoutFailed) {
+        success(logMessages.logoutSuccess);
+      }
     }),
   );
 
@@ -288,22 +298,21 @@ export const client = new Command("client")
 
         if (reset !== undefined) {
           const originalCurrent = globalConfig.getCurrentSession();
-          const { failed, failedIds } = await logoutSessions(
+          const { failed, failedIds, errors } = await logoutSessions(
             globalConfig.getSessionIds(),
           );
 
           if (failed > 0) {
             restoreCurrentSessionFallback(originalCurrent, failedIds);
-            hint(
-              "Could not reach server for all sessions; kept local session data",
-            );
+            error(logMessages.logoutFailure(errors));
+            return;
           } else {
             globalConfig.setCurrentSession("");
           }
         }
 
         if (!debug) {
-          success("Setting client");
+          success(logMessages.clientConfigUpdated);
         }
       },
     ),

--- a/templates/cli/lib/commands/generic.ts
+++ b/templates/cli/lib/commands/generic.ts
@@ -29,7 +29,8 @@ export { loginCommand };
 const logMessages = {
   noActiveSessions: "No active sessions found.",
   logoutFailure: (errors: string[] = []): string => {
-    const details = errors[0] ? `: ${errors[0]}` : "";
+    const uniqueErrors = [...new Set(errors)];
+    const details = uniqueErrors.length ? `: ${uniqueErrors.join("; ")}` : "";
     return `Could not log out because the server session could not be revoked${details}. Kept local session data.`;
   },
   logoutSuccess: "Logged out successfully",
@@ -157,11 +158,13 @@ export const logout = new Command("logout")
           remainingSessions[0];
         globalConfig.setCurrentSession(nextSession.id);
 
-        success(
-          nextSession.email
-            ? `Switched to ${nextSession.email}`
-            : `Switched to session at ${nextSession.endpoint}`,
-        );
+        if (!logoutFailed) {
+          success(
+            nextSession.email
+              ? `Switched to ${nextSession.email}`
+              : `Switched to session at ${nextSession.endpoint}`,
+          );
+        }
       } else if (remainingSessions.length === 0) {
         globalConfig.setCurrentSession("");
       }


### PR DESCRIPTION
## Summary

Updates the generated Appwrite CLI logout flow so failed server-side session revocation is reported as an error instead of a misleading success.

Previously, when logout could not revoke the server session, the CLI printed a hint saying local session data was kept and then still printed:

```text
✓ Success: Logged out successfully
```

That made OAuth logout failures look successful even though the local session remained available and `appwrite whoami` continued to work.

This PR changes the generated CLI templates to:

- preserve the existing behavior of keeping local session data when server revocation fails
- capture the server revocation error message in `deleteServerSession`
- return collected errors from `logoutSessions`
- print a red `✗ Error:` message when logout cannot revoke the server session
- suppress `Logged out successfully` when any selected server session failed to revoke
- apply the same error behavior to `client --reset` session cleanup failures
- centralize the touched generic command messages in `logMessages`
- rename the client success message to `Client configuration updated`

The CLI generation output was regenerated with `php example.php cli`. The generated `examples/cli` files are ignored in this worktree, but were verified after generation.

## Test Plan

Ran CLI generation:

```text
php example.php cli
```

Ran TypeScript declaration build:

```text
cd examples/cli
npm run build:types
```

Ran runtime bundle build:

```text
cd examples/cli
npm run build:runtime
```

Ran focused ESLint on the generated files affected by these template changes:

```text
cd examples/cli
npx eslint lib/auth/session.ts lib/commands/generic.ts
```

All commands passed.

Note: the full `npm run lint` command still reports unrelated existing lint issues across generated service command files, so the validation here is scoped to the touched generated files.
