### PR TITLE
Request account admin scope for CLI OAuth

### DIFF
--- a/templates/cli/lib/constants.ts
+++ b/templates/cli/lib/constants.ts
@@ -29,7 +29,7 @@ export const DEFAULT_ENDPOINT = "https://cloud.appwrite.io/v1";
 
 // OAuth2
 export const OAUTH2_CLIENT_ID = "appwrite-cli";
-export const OAUTH2_SCOPES = "openid email profile";
+export const OAUTH2_SCOPES = "openid email profile account.admin";
 
 // Config resources
 export const CONFIG_RESOURCE_KEYS = [

--- a/templates/cli/lib/constants.ts.twig
+++ b/templates/cli/lib/constants.ts.twig
@@ -29,7 +29,7 @@ export const DEFAULT_ENDPOINT = '{{ spec.endpoint }}';
 
 // OAuth2
 export const OAUTH2_CLIENT_ID = "appwrite-cli";
-export const OAUTH2_SCOPES = "openid email profile";
+export const OAUTH2_SCOPES = "openid email profile account.admin";
 
 // Config resources
 export const CONFIG_RESOURCE_KEYS = [


### PR DESCRIPTION
## What changed

Updates the generated CLI OAuth device-login scope request to include `account.admin` alongside the OIDC scopes.

This matches the Cloud-side console OAuth server scope model, where the CLI explicitly requests account-admin access instead of relying on implicit full account access.

## Testing

- `php example.php cli console`
- `npm run build` from `examples/cli`
- `git diff --check`
