### PR TITLE
feat(cli): press Enter to open browser during OAuth device login

### DIFF
--- a/templates/cli/lib/auth/login.ts
+++ b/templates/cli/lib/auth/login.ts
@@ -8,7 +8,11 @@ import {
   OAUTH2_SCOPES,
 } from "../constants.js";
 import { success, hint, warn, log } from "../parser.js";
-import { isCloudLoginEndpoint, isRegionalCloudEndpoint } from "../utils.js";
+import {
+  isCloudLoginEndpoint,
+  isRegionalCloudEndpoint,
+  openBrowser,
+} from "../utils.js";
 import { isFlagEnabled } from "../flags.js";
 import ID from "../id.js";
 import {
@@ -65,6 +69,45 @@ const startWaitingForApprovalSpinner = (): (() => void) => {
     clearInterval(interval);
     process.stdout.write("\r\x1b[K");
   };
+};
+
+const listenForBrowserOpen = (
+  url: string,
+  onCancel: () => void,
+): (() => void) => {
+  const stdin = process.stdin;
+  if (!stdin.isTTY) {
+    return () => {};
+  }
+
+  // Raw mode so keypresses aren't echoed onto the spinner line; the trade-off
+  // is that the terminal no longer turns Ctrl+C/Ctrl+D into a signal for us.
+  const wasRaw = stdin.isRaw;
+  stdin.setRawMode(true);
+  stdin.resume();
+
+  const cleanup = (): void => {
+    stdin.off("data", onData);
+    if (!wasRaw) {
+      stdin.setRawMode(false);
+    }
+    stdin.pause();
+  };
+
+  const onData = (data: Buffer): void => {
+    if (data.includes(0x03) || data.includes(0x04)) {
+      cleanup();
+      onCancel();
+      return;
+    }
+    if (data.includes(0x0d) || data.includes(0x0a)) {
+      openBrowser(url);
+    }
+  };
+
+  stdin.on("data", onData);
+
+  return cleanup;
 };
 
 export const getCurrentAccount = async (): Promise<Models.User | null> => {
@@ -299,11 +342,24 @@ const loginWithOAuthDevice = async ({
   process.stdout.write(
     "\nTo sign in, confirm the code below in your browser:\n\n" +
       `  Code: ${deviceAuth.user_code}\n` +
-      `  URL:  ${verificationUri}\n\n`,
+      `  URL:  ${verificationUri}\n\n` +
+      (process.stdin.isTTY
+        ? "Press Enter to open this URL in your browser.\n\n"
+        : ""),
   );
 
   let token: Models.Oauth2Token | null = null;
   const stopWaitingForApprovalSpinner = startWaitingForApprovalSpinner();
+  const stopListeningForBrowserOpen = listenForBrowserOpen(
+    verificationUri,
+    () => {
+      stopWaitingForApprovalSpinner();
+      globalConfig.removeSession(id);
+      globalConfig.setCurrentSession(oldCurrent);
+      log("Login cancelled.");
+      process.exit(130);
+    },
+  );
 
   try {
     token = await pollForDeviceToken(oauth2, deviceAuth, clientId);
@@ -313,6 +369,7 @@ const loginWithOAuthDevice = async ({
     throw err;
   } finally {
     stopWaitingForApprovalSpinner();
+    stopListeningForBrowserOpen();
   }
 
   if (!token || !token.access_token) {

--- a/templates/cli/lib/auth/login.ts
+++ b/templates/cli/lib/auth/login.ts
@@ -94,13 +94,17 @@ const listenForBrowserOpen = (
     stdin.pause();
   };
 
+  // Open the browser at most once; keep listening afterwards so Ctrl+C still
+  // cancels cleanly even after the user has opened the URL.
+  let opened = false;
   const onData = (data: Buffer): void => {
     if (data.includes(0x03) || data.includes(0x04)) {
       cleanup();
       onCancel();
       return;
     }
-    if (data.includes(0x0d) || data.includes(0x0a)) {
+    if (!opened && (data.includes(0x0d) || data.includes(0x0a))) {
+      opened = true;
       openBrowser(url);
     }
   };

--- a/templates/cli/lib/utils.ts
+++ b/templates/cli/lib/utils.ts
@@ -821,7 +821,10 @@ export function systemHasCommand(command: string): boolean {
   return true;
 }
 
-export function openBrowser(url: string): boolean {
+// Best-effort, fire-and-forget: spawn reports a missing/failed opener via an
+// async `error` event (not a throw), so there's no reliable success value to
+// return — failures just mean the user opens the printed URL manually.
+export function openBrowser(url: string): void {
   let command: string;
   let args: string[];
 
@@ -849,9 +852,8 @@ export function openBrowser(url: string): boolean {
     });
     child.on("error", () => {});
     child.unref();
-    return true;
   } catch {
-    return false;
+    // Ignore synchronous spawn failures; opening the browser is best-effort.
   }
 }
 

--- a/templates/cli/lib/utils.ts
+++ b/templates/cli/lib/utils.ts
@@ -821,6 +821,38 @@ export function systemHasCommand(command: string): boolean {
   return true;
 }
 
+export function openBrowser(url: string): boolean {
+  let command: string;
+  let args: string[];
+
+  switch (process.platform) {
+    case "win32":
+      command = "cmd";
+      args = ["/c", "start", "", url]; // "" is the window-title arg for start
+      break;
+    case "darwin":
+      command = "open";
+      args = [url];
+      break;
+    default:
+      command = "xdg-open";
+      args = [url];
+      break;
+  }
+
+  try {
+    const child = childProcess.spawn(command, args, {
+      stdio: "ignore",
+      detached: true,
+    });
+    child.on("error", () => {});
+    child.unref();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 type DeployLocalConfig = {
   keys: () => string[];
 };

--- a/templates/cli/lib/utils.ts
+++ b/templates/cli/lib/utils.ts
@@ -828,7 +828,9 @@ export function openBrowser(url: string): boolean {
   switch (process.platform) {
     case "win32":
       command = "cmd";
-      args = ["/c", "start", "", url]; // "" is the window-title arg for start
+      // "" is start's window-title arg; quoting the URL stops cmd from
+      // splitting it on `&` (and running the remainder as a command).
+      args = ["/c", "start", "", `"${url}"`];
       break;
     case "darwin":
       command = "open";

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -271,6 +271,7 @@ abstract class Base extends TestCase
         'auth:valid-access-token-cached:passed',
         'auth:valid-access-token-missing-expiry:passed',
         'auth:oauth-login-flag:passed',
+        'auth:open-browser:passed',
     ];
 
     protected const CLI_LOCAL_FUNCTION_EMULATION_RESPONSES = [

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -1037,18 +1037,21 @@ async function runAuthChecks() {
   await authCheck("open-browser", () => {
     const childProcess = require("child_process");
     const originalSpawn = childProcess.spawn;
+    const url = "https://cloud.appwrite.io/device";
     try {
       let captured = null;
+      let errorHandler = null;
       childProcess.spawn = (command, args) => {
         captured = { command, args };
-        return { on() {}, unref() {} };
+        return {
+          on(event, cb) {
+            if (event === "error") errorHandler = cb;
+          },
+          unref() {},
+        };
       };
-      assert.equal(openBrowser("https://cloud.appwrite.io/device"), true);
+      openBrowser(url);
       assert.ok(captured, "expected openBrowser to spawn an open command");
-      assert.ok(
-        captured.args.includes("https://cloud.appwrite.io/device"),
-        "expected the verification URL to be passed to the open command",
-      );
       const expectedCommand =
         process.platform === "win32"
           ? "cmd"
@@ -1056,11 +1059,22 @@ async function runAuthChecks() {
             ? "open"
             : "xdg-open";
       assert.equal(captured.command, expectedCommand);
+      // win32 quotes the URL arg, so match by substring rather than equality.
+      assert.ok(
+        captured.args.some((arg) => arg.includes(url)),
+        "expected the verification URL to be passed to the open command",
+      );
 
+      // A missing opener (e.g. no xdg-open) surfaces as an async 'error' event;
+      // it must be swallowed, not crash the process.
+      assert.equal(typeof errorHandler, "function");
+      assert.doesNotThrow(() => errorHandler(new Error("spawn ENOENT")));
+
+      // A synchronous spawn failure must also not propagate.
       childProcess.spawn = () => {
         throw new Error("spawn ENOENT");
       };
-      assert.equal(openBrowser("https://cloud.appwrite.io/device"), false);
+      assert.doesNotThrow(() => openBrowser(url));
     } finally {
       childProcess.spawn = originalSpawn;
     }

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -41,6 +41,7 @@ const {
   isLocalhostHostname,
   isCloudLoginEndpoint,
   getConsoleProjectSlug,
+  openBrowser,
 } = require("./lib/utils.ts");
 const { isFlagEnabled } = require("./lib/flags.ts");
 const {
@@ -1030,6 +1031,38 @@ async function runAuthChecks() {
     } finally {
       if (prev === undefined) delete process.env.APPWRITE_CLI_OAUTH_LOGIN;
       else process.env.APPWRITE_CLI_OAUTH_LOGIN = prev;
+    }
+  });
+
+  await authCheck("open-browser", () => {
+    const childProcess = require("child_process");
+    const originalSpawn = childProcess.spawn;
+    try {
+      let captured = null;
+      childProcess.spawn = (command, args) => {
+        captured = { command, args };
+        return { on() {}, unref() {} };
+      };
+      assert.equal(openBrowser("https://cloud.appwrite.io/device"), true);
+      assert.ok(captured, "expected openBrowser to spawn an open command");
+      assert.ok(
+        captured.args.includes("https://cloud.appwrite.io/device"),
+        "expected the verification URL to be passed to the open command",
+      );
+      const expectedCommand =
+        process.platform === "win32"
+          ? "cmd"
+          : process.platform === "darwin"
+            ? "open"
+            : "xdg-open";
+      assert.equal(captured.command, expectedCommand);
+
+      childProcess.spawn = () => {
+        throw new Error("spawn ENOENT");
+      };
+      assert.equal(openBrowser("https://cloud.appwrite.io/device"), false);
+    } finally {
+      childProcess.spawn = originalSpawn;
     }
   });
 


### PR DESCRIPTION
## What

Adds a "press Enter to open the browser" shortcut to the CLI OAuth **device authorization** login flow, matching the behavior of many CLIs (gh, etc.).

Before, the flow printed a code + verification URL and silently waited:

```
To sign in, confirm the code below in your browser:

  Code: FFV7T67N
  URL:  https://cloud.appwrite.io/console/oauth2/device?user_code=FFV7T67N

⠹ Waiting for approval...
```

Now it invites the user to open the URL automatically:

```
To sign in, confirm the code below in your browser:

  Code: FFV7T67N
  URL:  https://cloud.appwrite.io/console/oauth2/device?user_code=FFV7T67N

Press Enter to open this URL in your browser.

⠹ Waiting for approval...
```

## How

- **`openBrowser()`** (`templates/cli/lib/utils.ts`) — cross-platform, non-blocking, best-effort launcher (`open` / `cmd start` / `xdg-open`). The child is detached and errors are swallowed, so a headless/no-browser environment just no-ops and the user opens the URL manually.
- **`listenForBrowserOpen()`** (`templates/cli/lib/auth/login.ts`) — attaches a stdin listener while polling. Pressing **Enter** opens the verification URL. stdin is put in **raw mode** so the keypress isn't echoed onto the spinner line (an earlier non-raw attempt caused a duplicated "Waiting for approval..." line). It's a no-op on non-interactive stdin (piped input).
- **Graceful cancel** — raw mode disables the terminal's own Ctrl+C handling, so the listener detects **Ctrl+C / Ctrl+D** and runs a clean cancel: stop the spinner, roll back the half-created local session, print `Login cancelled.`, and exit `130`.

## Tests

- Adds an `auth:open-browser` e2e check (`tests/e2e/languages/cli/test.js` + golden line in `tests/e2e/Base.php`) that stubs `child_process.spawn` to verify the correct platform command + URL are used, and that the spawn-failure path returns `false`. No real browser is opened.
- Regenerated `examples/cli/`; `tsc --noEmit` passes clean.

## Note on revoking the pending authorization

On cancel we only tear down **local** state. The OAuth 2.0 Device Authorization Grant (RFC 8628) defines **no device-side endpoint to revoke a pending `device_code`** — and the Appwrite OAuth2 API exposes none either (`revoke` needs an issued token; `reject` needs a `grantId` the device never sees). This is safe: the token is only delivered to whoever polls `/token` with the confidential `device_code`, which lives only in the (now-exited) CLI process, so an abandoned authorization is unclaimable and expires on its own. A backend cancel endpoint would be a nice defense-in-depth / UX improvement but is out of scope for the SDK generator.

## Inheritance

CLI extends Node, but these are CLI-only `copy`-scoped files under `templates/cli/`, so no child SDKs are affected.