### PR TITLE
Bump CLI console dependency to 15.1.0

### DIFF
--- a/templates/cli/bun.lock.twig
+++ b/templates/cli/bun.lock.twig
@@ -5,7 +5,7 @@
     "": {
       "name": "{{ language.params.npmPackage|caseDash }}",
       "dependencies": {
-        "@appwrite.io/console": "^15.0.0",
+        "@appwrite.io/console": "^15.1.0",
         "chalk": "4.1.2",
         "chokidar": "^3.6.0",
         "cli-progress": "^3.12.0",
@@ -51,7 +51,7 @@
     "tmp": "^0.2.6",
   },
   "packages": {
-    "@appwrite.io/console": ["@appwrite.io/console@15.0.0", "", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-yjCjsUTcOUacR/O0/XEm9ax+EpcxxG3+h7TsY0YEd2fW32T2AimASOVMcRoEb8DrSHWqCn5kH1VRL/U6ZfAoJw=="],
+    "@appwrite.io/console": ["@appwrite.io/console@15.1.0", "", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-uQ8can9vDKoP6zxqhp8JzOYma/w40eKuYzZzsI9ATCRHSzRig0WQ6fue8rZEgOuD3eF3S2GbtHZK4drotAT8Ug=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 

--- a/templates/cli/package-lock.json.twig
+++ b/templates/cli/package-lock.json.twig
@@ -9,7 +9,7 @@
       "version": "{{ sdk.version }}",
       "license": "{{ sdk.license }}",
       "dependencies": {
-        "@appwrite.io/console": "^15.0.0",
+        "@appwrite.io/console": "^15.1.0",
         "chalk": "4.1.2",
         "chokidar": "^3.6.0",
         "cli-progress": "^3.12.0",
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@appwrite.io/console": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@appwrite.io/console/-/console-15.0.0.tgz",
-      "integrity": "sha512-yjCjsUTcOUacR/O0/XEm9ax+EpcxxG3+h7TsY0YEd2fW32T2AimASOVMcRoEb8DrSHWqCn5kH1VRL/U6ZfAoJw==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@appwrite.io/console/-/console-15.1.0.tgz",
+      "integrity": "sha512-uQ8can9vDKoP6zxqhp8JzOYma/w40eKuYzZzsI9ATCRHSzRig0WQ6fue8rZEgOuD3eF3S2GbtHZK4drotAT8Ug==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "json-bigint": "1.0.0"

--- a/templates/cli/package.json
+++ b/templates/cli/package.json
@@ -48,7 +48,7 @@
     "windows-arm64": "esbuild cli.ts --bundle --loader:.hbs=text --platform=node --target=node18 --format=esm --external:fsevents --external:terminal-image --outfile=dist/bundle-win-arm64.mjs && pkg dist/bundle-win-arm64.mjs --fallback-to-source -t node18-win-arm64 -o build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
-    "@appwrite.io/console": "^15.0.0",
+    "@appwrite.io/console": "^15.1.0",
     "chalk": "4.1.2",
     "chokidar": "^3.6.0",
     "cli-progress": "^3.12.0",

--- a/templates/cli/package.json.twig
+++ b/templates/cli/package.json.twig
@@ -51,7 +51,7 @@
     "windows-arm64": "bun build cli.ts --compile --minify --target=bun-windows-arm64 --outfile build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
-    "@appwrite.io/console": "^15.0.0",
+    "@appwrite.io/console": "^15.1.0",
     "chalk": "4.1.2",
     "chokidar": "^3.6.0",
     "cli-progress": "^3.12.0",


### PR DESCRIPTION
## What

Bumps the CLI template dependency on `@appwrite.io/console` from `^15.0.0` to `^15.1.0` and updates the CLI npm/Bun lock templates.

## Why

The generated CLI needs the latest console SDK signatures for the OAuth2 service methods.

## Testing

- `php example.php cli`
- `composer refactor:check`
- `composer lint-twig`
- `vendor/bin/phpunit --testsuite Unit`
- `npm install --min-release-age=0 && npm run build` in `examples/cli`
