### PR TITLE
[codex] Fix CLI login stdin cleanup

### DIFF
--- a/templates/cli/lib/auth/login.ts
+++ b/templates/cli/lib/auth/login.ts
@@ -71,7 +71,7 @@ const startWaitingForApprovalSpinner = (): (() => void) => {
   };
 };
 
-const listenForBrowserOpen = (
+export const listenForBrowserOpen = (
   url: string,
   onCancel: () => void,
 ): (() => void) => {
@@ -90,7 +90,6 @@ const listenForBrowserOpen = (
   if (shouldRestoreRawMode) {
     stdin.setRawMode?.(true);
   }
-  const shouldPause = stdin.isPaused();
   stdin.resume();
 
   const cleanup = (): void => {
@@ -98,9 +97,7 @@ const listenForBrowserOpen = (
     if (shouldRestoreRawMode) {
       stdin.setRawMode?.(false);
     }
-    if (shouldPause) {
-      stdin.pause();
-    }
+    stdin.pause();
   };
 
   // Open the browser at most once; keep listening afterwards so Ctrl+C still

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -48,6 +48,7 @@ const {
   normalizeCloudConsoleEndpoint,
   globalConfig,
 } = require("./lib/config.ts");
+const { listenForBrowserOpen } = require("./lib/auth/login.ts");
 
 const extractFirstValue = (output) => {
   const firstLine =
@@ -1075,6 +1076,59 @@ async function runAuthChecks() {
         throw new Error("spawn ENOENT");
       };
       assert.doesNotThrow(() => openBrowser(url));
+
+      const listeners = new Map();
+      const stdin = process.stdin;
+      const originalIsTTY = stdin.isTTY;
+      const originalIsRaw = stdin.isRaw;
+      const originalSetRawMode = stdin.setRawMode;
+      const originalResume = stdin.resume;
+      const originalPause = stdin.pause;
+      const originalOn = stdin.on;
+      const originalOff = stdin.off;
+      let paused = false;
+
+      try {
+        stdin.isTTY = true;
+        stdin.isRaw = false;
+        stdin.setRawMode = (mode) => {
+          stdin.isRaw = mode;
+          return stdin;
+        };
+        stdin.resume = () => {
+          paused = false;
+          return stdin;
+        };
+        stdin.pause = () => {
+          paused = true;
+          return stdin;
+        };
+        stdin.on = (event, listener) => {
+          listeners.set(event, listener);
+          return stdin;
+        };
+        stdin.off = (event, listener) => {
+          if (listeners.get(event) === listener) {
+            listeners.delete(event);
+          }
+          return stdin;
+        };
+
+        const cleanup = listenForBrowserOpen(url, () => {});
+        cleanup();
+
+        assert.equal(paused, true);
+        assert.equal(stdin.isRaw, false);
+        assert.equal(listeners.has("data"), false);
+      } finally {
+        stdin.isTTY = originalIsTTY;
+        stdin.isRaw = originalIsRaw;
+        stdin.setRawMode = originalSetRawMode;
+        stdin.resume = originalResume;
+        stdin.pause = originalPause;
+        stdin.on = originalOn;
+        stdin.off = originalOff;
+      }
     } finally {
       childProcess.spawn = originalSpawn;
     }


### PR DESCRIPTION
## What changed

- Always pause `process.stdin` when the CLI OAuth device-login browser listener is cleaned up.
- Export the listener helper so the generated CLI auth behavior can be covered directly.
- Add CLI e2e coverage that verifies cleanup removes the data listener, restores raw mode, and pauses stdin.

## Why

`appwrite login` could finish successfully but leave stdin resumed after the device-flow listener cleaned up. That open input handle kept the process alive, so users had to terminate the command manually with Ctrl+C after seeing the success message.

## Validation

- `php example.php cli`
- `composer lint-twig`
- `composer refactor:check`
- `vendor/bin/phpunit --testsuite Unit`
- `vendor/bin/phpunit tests/e2e/CLIBun13Test.php`
