### PR TITLE
Fix CLI OAuth login cookie cleanup

### DIFF
--- a/templates/cli/lib/auth/login.ts
+++ b/templates/cli/lib/auth/login.ts
@@ -416,6 +416,7 @@ const loginWithOAuthDevice = async ({
   }
 
   globalConfig.setEmail(account.email);
+  globalConfig.removeCookie();
 
   const { removed: removedLegacySessions, failed: failedLegacySessions } =
     await removeLegacySessionsExcept(id);

--- a/templates/cli/lib/config.ts
+++ b/templates/cli/lib/config.ts
@@ -1345,6 +1345,10 @@ class Global extends Config<GlobalConfigData> {
     this.setTo(Global.PREFERENCE_COOKIE, cookie);
   }
 
+  removeCookie(): void {
+    this.deleteFrom(Global.PREFERENCE_COOKIE);
+  }
+
   getProject(): string {
     if (!this.hasFrom(Global.PREFERENCE_PROJECT)) {
       return "";
@@ -1440,6 +1444,19 @@ class Global extends Config<GlobalConfigData> {
 
       (config as any)[key] = value;
       this.write();
+    }
+  }
+
+  deleteFrom(key: string): void {
+    const current = this.getCurrentSession();
+
+    if (current) {
+      const config = this.get(current as any);
+
+      if (config && (config as any)[key] !== undefined) {
+        delete (config as any)[key];
+        this.write();
+      }
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes CLI OAuth device login so the newly created token-based session removes any legacy `cookie` value from the active CLI configuration.

Previously, `appwrite login --new` could report that legacy cookie session data was removed while the new account entry still retained a stale `cookie` field written during account verification.

## Test Plan

- `php example.php cli`
- `composer refactor:check`
- `composer lint-twig`

## Related Issue

#XXXX
