### PR TITLE
Improve CLI logout account prompt

### DIFF
--- a/templates/cli/lib/questions.ts
+++ b/templates/cli/lib/questions.ts
@@ -910,7 +910,7 @@ export const questionsLogout: Question[] = [
   {
     type: "checkbox",
     name: "accounts",
-    message: "Select accounts to logout from",
+    message: "Select accounts to log out",
     validate: (value: any) => validateRequired("account", value),
     choices() {
       const sessions = globalConfig.getSessions();
@@ -918,18 +918,17 @@ export const questionsLogout: Question[] = [
 
       const data: Choice[] = [];
 
-      const longestEmail = sessions.reduce((prev: any, current: any) =>
-        prev && (prev.email ?? "").length > (current.email ?? "").length
-          ? prev
-          : current,
-      ).email.length;
-
       sessions.forEach((session: any) => {
         if (session.email) {
+          const isCurrent = current === session.id;
+          const currentLabel = isCurrent
+            ? ` ${chalk.green.bold("(current)")}`
+            : "";
           data.push({
-            current: current === session.id,
+            current: isCurrent,
             value: session.id,
-            name: `${session.email.padEnd(longestEmail)} ${current === session.id ? chalk.green.bold("current") : " ".repeat(6)} ${session.endpoint}`,
+            name: `${session.email}${currentLabel} - ${session.endpoint}`,
+            short: `${session.email}${isCurrent ? " (current)" : ""}`,
           });
         }
       });

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -260,6 +260,7 @@ abstract class Base extends TestCase
         'auth:session-legacy:passed',
         'auth:session-has-auth:passed',
         'auth:plan-session-logout:passed',
+        'auth:logout-question-choices:passed',
         'auth:restore-current-session-fallback:passed',
         'auth:poll-device-token-success:passed',
         'auth:poll-device-token-retry:passed',

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -49,6 +49,7 @@ const {
   globalConfig,
 } = require("./lib/config.ts");
 const { listenForBrowserOpen } = require("./lib/auth/login.ts");
+const { questionsLogout } = require("./lib/questions.ts");
 
 const extractFirstValue = (output) => {
   const firstLine =
@@ -900,6 +901,30 @@ async function runAuthChecks() {
     globalConfig.addSession("b1", { endpoint: "http://localhost/v1", email: "b@c.com" });
     assert.deepEqual([...planSessionLogout(["a1"])].sort(), ["a1", "a2"]);
     assert.deepEqual(planSessionLogout(["b1"]), ["b1"]);
+  });
+
+  await authCheck("logout-question-choices", () => {
+    globalConfig.clear();
+    globalConfig.addSession("a1", {
+      endpoint: "https://cloud.appwrite.io/v1",
+      email: "a@b.com",
+    });
+    globalConfig.addSession("b1", {
+      endpoint: "http://localhost/v1",
+      email: "b@c.com",
+    });
+    globalConfig.setCurrentSession("b1");
+
+    const choices = questionsLogout[0].choices().map((choice) => ({
+      ...choice,
+      name: stripAnsi(choice.name),
+    }));
+
+    assert.equal(choices[0].value, "b1");
+    assert.equal(choices[0].name, "b@c.com (current) - http://localhost/v1");
+    assert.equal(choices[0].short, "b@c.com (current)");
+    assert.equal(choices[1].name, "a@b.com - https://cloud.appwrite.io/v1");
+    assert.equal(choices[1].short, "a@b.com");
   });
 
   await authCheck("restore-current-session-fallback", () => {


### PR DESCRIPTION
## Summary
- Improves the CLI logout account checkbox labels so each row clearly shows email, current status, and endpoint.
- Uses Inquirer short labels so selected accounts echo without long endpoint wrapping.
- Adds CLI e2e coverage for logout choice ordering and labels.

## Testing
- `php example.php cli`
- `composer lint-twig`
- `composer refactor:check`
- `vendor/bin/phpunit tests/e2e/CLIBun13Test.php` reached and passed `auth:logout-question-choices` before the expected-output list was updated; after updating it, rerun failed before test execution because Docker reported `network mockapi not found`.
