### PR TITLE
Fix CLI Windows browser launch and bump console SDK

### DIFF
--- a/templates/cli/bun.lock.twig
+++ b/templates/cli/bun.lock.twig
@@ -5,7 +5,7 @@
     "": {
       "name": "{{ language.params.npmPackage|caseDash }}",
       "dependencies": {
-        "@appwrite.io/console": "^15.1.0",
+        "@appwrite.io/console": "^15.1.1",
         "@napi-rs/keyring": "^1.3.0",
         "chalk": "4.1.2",
         "chokidar": "^3.6.0",
@@ -52,7 +52,7 @@
     "tmp": "^0.2.6",
   },
   "packages": {
-    "@appwrite.io/console": ["@appwrite.io/console@15.1.0", "", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-uQ8can9vDKoP6zxqhp8JzOYma/w40eKuYzZzsI9ATCRHSzRig0WQ6fue8rZEgOuD3eF3S2GbtHZK4drotAT8Ug=="],
+    "@appwrite.io/console": ["@appwrite.io/console@15.1.1", "", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-W4t9xNuHoNUYGypcZtgPaHvuS/AFjSdDDleeNQl3cWMiOrS9wasVyIwygAHeQjis9evwPC4WUbfpx8WWYXijDg=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 

--- a/templates/cli/lib/utils.ts
+++ b/templates/cli/lib/utils.ts
@@ -830,10 +830,8 @@ export function openBrowser(url: string): void {
 
   switch (process.platform) {
     case "win32":
-      command = "cmd";
-      // "" is start's window-title arg; escape shell metacharacters without
-      // adding nested quotes that Windows can pass through as part of the URL.
-      args = ["/c", "start", '""', "/b", url.replaceAll("&", "^&")];
+      command = "rundll32";
+      args = ["url.dll,FileProtocolHandler", url];
       break;
     case "darwin":
       command = "open";
@@ -849,7 +847,6 @@ export function openBrowser(url: string): void {
     const child = childProcess.spawn(command, args, {
       stdio: "ignore",
       detached: true,
-      windowsVerbatimArguments: process.platform === "win32",
     });
     child.on("error", () => {});
     child.unref();

--- a/templates/cli/lib/utils.ts
+++ b/templates/cli/lib/utils.ts
@@ -831,9 +831,9 @@ export function openBrowser(url: string): void {
   switch (process.platform) {
     case "win32":
       command = "cmd";
-      // "" is start's window-title arg; quoting the URL stops cmd from
-      // splitting it on `&` (and running the remainder as a command).
-      args = ["/c", "start", "", `"${url}"`];
+      // "" is start's window-title arg; escape shell metacharacters without
+      // adding nested quotes that Windows can pass through as part of the URL.
+      args = ["/c", "start", '""', "/b", url.replaceAll("&", "^&")];
       break;
     case "darwin":
       command = "open";
@@ -849,6 +849,7 @@ export function openBrowser(url: string): void {
     const child = childProcess.spawn(command, args, {
       stdio: "ignore",
       detached: true,
+      windowsVerbatimArguments: process.platform === "win32",
     });
     child.on("error", () => {});
     child.unref();

--- a/templates/cli/package-lock.json.twig
+++ b/templates/cli/package-lock.json.twig
@@ -9,7 +9,7 @@
       "version": "{{ sdk.version }}",
       "license": "{{ sdk.license }}",
       "dependencies": {
-        "@appwrite.io/console": "^15.1.0",
+        "@appwrite.io/console": "^15.1.1",
         "@napi-rs/keyring": "^1.3.0",
         "chalk": "4.1.2",
         "chokidar": "^3.6.0",
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@appwrite.io/console": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@appwrite.io/console/-/console-15.1.0.tgz",
-      "integrity": "sha512-uQ8can9vDKoP6zxqhp8JzOYma/w40eKuYzZzsI9ATCRHSzRig0WQ6fue8rZEgOuD3eF3S2GbtHZK4drotAT8Ug==",
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@appwrite.io/console/-/console-15.1.1.tgz",
+      "integrity": "sha512-W4t9xNuHoNUYGypcZtgPaHvuS/AFjSdDDleeNQl3cWMiOrS9wasVyIwygAHeQjis9evwPC4WUbfpx8WWYXijDg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "json-bigint": "1.0.0"

--- a/templates/cli/package.json
+++ b/templates/cli/package.json
@@ -48,7 +48,7 @@
     "windows-arm64": "esbuild cli.ts --bundle --loader:.hbs=text --platform=node --target=node18 --format=esm --external:fsevents --external:terminal-image --outfile=dist/bundle-win-arm64.mjs && pkg dist/bundle-win-arm64.mjs --fallback-to-source -t node18-win-arm64 -o build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
-    "@appwrite.io/console": "^15.1.0",
+    "@appwrite.io/console": "^15.1.1",
     "@napi-rs/keyring": "^1.3.0",
     "chalk": "4.1.2",
     "chokidar": "^3.6.0",

--- a/templates/cli/package.json.twig
+++ b/templates/cli/package.json.twig
@@ -51,7 +51,7 @@
     "windows-arm64": "bun build cli.ts --compile --minify --target=bun-windows-arm64 --outfile build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
-    "@appwrite.io/console": "^15.1.0",
+    "@appwrite.io/console": "^15.1.1",
     "@napi-rs/keyring": "^1.3.0",
     "chalk": "4.1.2",
     "chokidar": "^3.6.0",

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -1146,14 +1146,13 @@ async function runAuthChecks() {
       assert.ok(captured, "expected openBrowser to spawn an open command");
       const expectedCommand =
         process.platform === "win32"
-          ? "cmd"
+          ? "rundll32"
           : process.platform === "darwin"
             ? "open"
             : "xdg-open";
       assert.equal(captured.command, expectedCommand);
-      // win32 quotes the URL arg, so match by substring rather than equality.
       assert.ok(
-        captured.args.some((arg) => arg.includes(url)),
+        captured.args.includes(url),
         "expected the verification URL to be passed to the open command",
       );
 

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -1168,6 +1168,34 @@ async function runAuthChecks() {
       };
       assert.doesNotThrow(() => openBrowser(url));
 
+      const originalPlatform = process.platform;
+      try {
+        Object.defineProperty(process, "platform", {
+          value: "win32",
+        });
+
+        const windowsUrl =
+          "https://cloud.appwrite.io/device?user=a b&next=one|two<three>four^five";
+        captured = null;
+        childProcess.spawn = (command, args) => {
+          captured = { command, args };
+          return {
+            on() {},
+            unref() {},
+          };
+        };
+
+        openBrowser(windowsUrl);
+        assert.deepEqual(captured, {
+          command: "rundll32",
+          args: ["url.dll,FileProtocolHandler", windowsUrl],
+        });
+      } finally {
+        Object.defineProperty(process, "platform", {
+          value: originalPlatform,
+        });
+      }
+
       const listeners = new Map();
       const stdin = process.stdin;
       const originalIsTTY = stdin.isTTY;


### PR DESCRIPTION
## Summary
- Fix Windows CLI browser launch by avoiding `cmd /c start` and passing the URL directly to `rundll32 url.dll,FileProtocolHandler`.
- Bump `@appwrite.io/console` to `^15.1.1` and refresh CLI npm/bun lock templates.
- Add a regression test that verifies Windows browser launch preserves URLs containing spaces and cmd metacharacters.

## Testing
- `php example.php cli`
- `./scripts/update-lockfiles.sh cli`
- `composer refactor:check`
- `composer lint-twig`
- `vendor/bin/phpunit tests/e2e/CLIBun13Test.php`

## Related Issue
- #XXXX
