### PR TITLE
Embed @napi-rs/keyring native bindings for all CLI release targets

### DIFF
--- a/templates/cli/.github/workflows/publish.yml
+++ b/templates/cli/.github/workflows/publish.yml
@@ -46,6 +46,18 @@ jobs:
       - name: Install dependencies and build for Linux and Windows
         run: |
           bun install --frozen-lockfile
+          # @napi-rs/keyring ships its native binding as os/cpu-gated platform
+          # packages, so `bun install` only fetches the host's. bun --compile
+          # embeds a binding only when its platform package is present on disk, so
+          # fetch the rest before cross-compiling; otherwise those binaries
+          # silently fall back to plaintext credential storage.
+          KEYRING_VERSION="$(sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' node_modules/@napi-rs/keyring/package.json | head -1)"
+          for triple in darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu win32-x64-msvc win32-arm64-msvc; do
+            dir="node_modules/@napi-rs/keyring-${triple}"
+            ls "${dir}"/*.node >/dev/null 2>&1 && continue
+            mkdir -p "${dir}"
+            curl -fsSL "https://registry.npmjs.org/@napi-rs/keyring-${triple}/-/keyring-${triple}-${KEYRING_VERSION}.tgz" | tar -xz -C "${dir}" --strip-components=1
+          done
           bun run linux-x64
           bun run linux-arm64
           bun run mac-x64

--- a/templates/cli/.github/workflows/publish.yml
+++ b/templates/cli/.github/workflows/publish.yml
@@ -43,21 +43,21 @@ jobs:
           sudo make
           sudo make install
 
-      - name: Install dependencies and build for Linux and Windows
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Fetch keyring native bindings for all targets
         run: |
-          bun install --frozen-lockfile
-          # @napi-rs/keyring ships its native binding as os/cpu-gated platform
-          # packages, so `bun install` only fetches the host's. bun --compile
-          # embeds a binding only when its platform package is present on disk, so
-          # fetch the rest before cross-compiling; otherwise those binaries
-          # silently fall back to plaintext credential storage.
-          KEYRING_VERSION="$(sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' node_modules/@napi-rs/keyring/package.json | head -1)"
+          version="$(bun -e 'console.log(require("@napi-rs/keyring/package.json").version)')"
           for triple in darwin-arm64 darwin-x64 linux-x64-gnu linux-arm64-gnu win32-x64-msvc win32-arm64-msvc; do
-            dir="node_modules/@napi-rs/keyring-${triple}"
-            ls "${dir}"/*.node >/dev/null 2>&1 && continue
-            mkdir -p "${dir}"
-            curl -fsSL "https://registry.npmjs.org/@napi-rs/keyring-${triple}/-/keyring-${triple}-${KEYRING_VERSION}.tgz" | tar -xz -C "${dir}" --strip-components=1
+            dir="node_modules/@napi-rs/keyring-$triple"
+            [ -d "$dir" ] && continue
+            mkdir -p "$dir"
+            curl -fsSL "https://registry.npmjs.org/@napi-rs/keyring-$triple/-/keyring-$triple-$version.tgz" | tar -xz -C "$dir" --strip-components=1
           done
+
+      - name: Build for Linux and Windows
+        run: |
           bun run linux-x64
           bun run linux-arm64
           bun run mac-x64


### PR DESCRIPTION
## What

The compiled CLI binaries ship **without** the `@napi-rs/keyring` native binding for every target except `linux-x64`, so on macOS/Windows/linux-arm64 the CLI silently stores OAuth refresh tokens in **plaintext** (`~/.appwrite/prefs.json`) instead of the OS keychain. No crash — silent downgrade.

Reproduced on a released `22.2.1` Homebrew binary (darwin-arm64): the native keyring symbols are absent, and `appwrite login` writes the refresh token in plaintext.

## Root cause

The keyring loader code (literal per-platform `require`) shipped already. The missing half is the **build**:

`templates/cli/.github/workflows/publish.yml` cross-compiles all six `bun --compile` targets on a single `ubuntu-latest` host after one `bun install --frozen-lockfile`. `@napi-rs/keyring`'s native binding is delivered as **`os`/`cpu`-gated platform packages**, so that install only fetches the host's — `@napi-rs/keyring-linux-x64-gnu`. `bun --compile` embeds a `.node` only when its platform package is present on disk, so every other target (`darwin-arm64`, `darwin-x64`, `linux-arm64`, `win32-*`) is compiled with no binding to embed and falls back to plaintext at runtime. bun does **not** error on the missing cross-target package — it silently omits it, which is why the broken build shipped green.

## Fix

Before cross-compiling, fetch each target's platform package directly from the npm registry (a plain tarball extract, which bypasses the `os`/`cpu` install skip) into `node_modules`, so `bun --compile` can embed the matching `.node` for every target.

## Verified locally

- Cross-built `linux-x64` on macOS with its platform package **missing** → builds fine, **0** embedded bindings (reproduces the shipped bug).
- Fetched the platform package via the tarball, rebuilt → binding **embedded**.
- The exact workflow snippet (version auto-detected from the installed umbrella package, loop over all six triples) fetches all six packages successfully.

## Scope

- `publish.yml` is `copy` scope; only the template is committed (generated `examples/cli` is gitignored).
- Once merged, regenerate `sdk-for-cli` and cut a `22.2.2` so released binaries actually use the keychain. The access token stays in `prefs.json` by design (short-lived); only the long-lived refresh token moves to the keychain.