### PR TITLE
Fix CLI verbose error formatting

### DIFF
--- a/templates/cli/lib/parser.ts
+++ b/templates/cli/lib/parser.ts
@@ -663,6 +663,38 @@ const printQueryErrorHint = (err: Error): void => {
   );
 };
 
+const ERROR_DETAIL_KEYS = ["code", "type", "response"] as const;
+
+export const formatErrorForLog = (err: Error): string => {
+  const stack = err.stack || `${err.name}: ${err.message}`;
+  const detailLines = ERROR_DETAIL_KEYS.flatMap((key) => {
+    if (!Object.prototype.hasOwnProperty.call(err, key)) {
+      return [];
+    }
+
+    const value = (err as unknown as Record<string, unknown>)[key];
+    let detail = "undefined";
+    try {
+      detail =
+        typeof value === "string"
+          ? JSON.stringify(value)
+          : JSON.stringify(value) ?? String(value);
+    } catch {
+      detail = String(value);
+    }
+
+    return [`${key}: ${detail}`];
+  });
+
+  if (detailLines.length === 0) {
+    return stack;
+  }
+
+  const [summary, ...frames] = stack.split("\n");
+
+  return [summary, ...detailLines, ...frames].join("\n");
+};
+
 export const parseError = (err: Error): void => {
   if (cliConfig.report) {
     void (async () => {
@@ -712,12 +744,12 @@ export const parseError = (err: Error): void => {
       printQueryErrorHint(err);
 
       error("\n Stack Trace: \n");
-      console.error(err);
+      console.error(formatErrorForLog(err));
       process.exit(1);
     })();
   } else {
     if (cliConfig.verbose) {
-      console.error(err);
+      console.error(formatErrorForLog(err));
       printQueryErrorHint(err);
     } else {
       log("For detailed error pass the --verbose or --report flag");


### PR DESCRIPTION
## What

Fix CLI verbose and report error logging so compiled Bun binaries print a compact stack trace instead of dumping bundled source context from the raw error object.

## Why

`console.error(err)` can include noisy `$bunfs` bundled code frames in compiled CLI binaries, making `--verbose` output hard to read. Formatting the error explicitly preserves the stack plus useful Appwrite SDK fields like `code`, `type`, and `response`.

## Testing

- `php example.php cli`
- `composer lint-twig`
- `npm run build` in `examples/cli`
- `git diff --check`
- Manually forced `getValidAccessToken()` through the CLI helper after relogin; refresh succeeded and returned a fresh `openid email profile account.admin` access token while persisting the rotated credentials through the normal path.
