### PR TITLE
Fix Rust generated model type references

### DIFF
--- a/src/SDK/Language/Rust.php
+++ b/src/SDK/Language/Rust.php
@@ -272,16 +272,16 @@ class Rust extends Language
 
         // Handle enum types
         if (!$isArray && isset($parameter["enumName"])) {
-            return "crate::enums::" . ucfirst($parameter["enumName"]);
+            return "crate::enums::" . $this->toPascalCase($parameter["enumName"]);
         }
         if (!$isArray && !empty($parameter["enumValues"])) {
-            return "crate::enums::" . ucfirst($parameter["name"]);
+            return "crate::enums::" . $this->toPascalCase($parameter["name"]);
         }
         if ($isArray && isset($parameter["enumName"])) {
-            return "Vec<crate::enums::" . ucfirst($parameter["enumName"]) . ">";
+            return "Vec<crate::enums::" . $this->toPascalCase($parameter["enumName"]) . ">";
         }
         if ($isArray && !empty($parameter["enumValues"])) {
-            return "Vec<crate::enums::" . ucfirst($parameter["name"]) . ">";
+            return "Vec<crate::enums::" . $this->toPascalCase($parameter["name"]) . ">";
         }
 
         if (
@@ -297,6 +297,14 @@ class Rust extends Language
             $parameter["array"] = $parameter["items"];
         }
 
+        if (($parameter["array"]["model"] ?? null) === "any") {
+            return "Vec<serde_json::Value>";
+        }
+
+        if (($parameter["model"] ?? null) === "any") {
+            return "serde_json::Value";
+        }
+
         return match ($parameter["type"]) {
             self::TYPE_INTEGER => "i64",
             self::TYPE_NUMBER => "f64",
@@ -305,12 +313,12 @@ class Rust extends Language
             self::TYPE_BOOLEAN => "bool",
             self::TYPE_OBJECT => "serde_json::Value",
             self::TYPE_ARRAY => isset($parameter["array"]["model"])
-                ? "Vec<crate::models::" . ucfirst($parameter["array"]["model"]) . ">"
+                ? "Vec<crate::models::" . $this->toPascalCase($parameter["array"]["model"]) . ">"
                 : (!empty(($parameter["array"] ?? [])["type"]) && !\is_array($parameter["array"]["type"])
                     ? "Vec<" . $this->getTypeName($parameter["array"]) . ">"
                     : "Vec<String>"),
             default => isset($parameter["model"])
-                ? "crate::models::" . ucfirst($parameter["model"])
+                ? "crate::models::" . $this->toPascalCase($parameter["model"])
                 : $parameter["type"],
         };
     }
@@ -544,7 +552,9 @@ class Rust extends Language
         }
 
         if (\array_key_exists("sub_schema", $property)) {
-            $type = "crate::models::" . ucfirst((string) $property["sub_schema"]);
+            $type = $property["sub_schema"] === "any"
+                ? "serde_json::Value"
+                : "crate::models::" . $this->toPascalCase((string) $property["sub_schema"]);
 
             if ($property["type"] === "array") {
                 $type = "Vec<" . $type . ">";
@@ -780,7 +790,7 @@ class Rust extends Language
             return "crate::error::Result<serde_json::Value>";
         }
 
-        $ret = ucfirst((string) $method["responseModel"]);
+        $ret = $this->toPascalCase((string) $method["responseModel"]);
 
         return "crate::error::Result<crate::models::" . $ret . ">";
     }


### PR DESCRIPTION
## Summary

This updates the Rust SDK generator so generated Rust type references use the same naming and `any` handling as the Rust model files that the templates emit.

The Rust model templates export structs with PascalCase names, for example `estimation_item` becomes `EstimationItem`. Several generator-side Rust type references were built with `ucfirst()`, which only capitalizes the first character and leaves underscores intact. This could emit references such as `crate::models::Estimation_item`, while the actual generated struct is `crate::models::EstimationItem`.

This PR also maps Appwrite `any` schema references to `serde_json::Value` in Rust type references. The `any` schema is intentionally not generated as a model, so references such as `crate::models::Any` cannot compile.

## What Changed

- Use `toPascalCase()` for Rust enum and model references produced by `getTypeName()`.
- Use `toPascalCase()` for Rust response model references produced by `getReturnType()`.
- Use `toPascalCase()` for Rust model property `sub_schema` references produced by `getPropertyType()`.
- Treat `model = any`, array item `model = any`, and property `sub_schema = any` as `serde_json::Value` / `Vec<serde_json::Value>`.

## Why This Matters

Generated Rust crates can fail to compile when a schema name contains underscores or when a property/parameter points at the Appwrite `any` schema. These failures are compile-time missing type errors, and because they are emitted into model/service definitions they break the whole generated crate.

The generator now emits references that match the actual Rust model exports and uses `serde_json::Value` for open JSON values.

## Repro Proof

I verified the issue with a local OpenAPI fixture containing:

- a snake_case schema named `estimation_item`
- a wrapper schema with `items: { "$ref": "#/components/schemas/estimation_item" }`
- a wrapper schema with `plan: { "type": "array", "items": { "$ref": "#/components/schemas/any" } }`
- a response model named `repro_wrapper`

Before this change, the generated Rust contained these invalid references:

```rust
pub items: Vec<crate::models::Estimation_item>
pub plan: Vec<crate::models::Any>

// service return type
crate::error::Result<crate::models::Repro_wrapper>
```

A clean `cargo build` failed with `E0425` missing type errors for `Estimation_item`, `Any`, and `Repro_wrapper`.

With this change, the same fixture generates:

```rust
pub items: Vec<crate::models::EstimationItem>
pub plan: Vec<serde_json::Value>

// service return type
crate::error::Result<crate::models::ReproWrapper>
```

The generated crate then builds successfully.

## Validation

Ran the repro fixture through `example.php` with `SDK_GEN_SPEC_FILE` and confirmed `cargo clean && cargo build` fails before the change and passes after it.

Also regenerated the normal Rust server SDK and ran:

```bash
docker run --rm -v "$PWD":/app -w /app php:8.5-cli php example.php rust server
cargo clean && cargo build
docker run --rm -v "$PWD":/app -w /app php:8.5-cli php -l src/SDK/Language/Rust.php
docker run --rm -v "$PWD":/app -w /app php:8.5-cli php vendor/bin/rector process --dry-run src/SDK/Language/Rust.php
docker run --rm -v "$PWD":/app -w /app php:8.5-cli php vendor/bin/phpunit --testsuite Unit
```

All final validation passed.

Note: this repo requires PHP >= 8.5, so PHP commands were run in the `php:8.5-cli` Docker image.