### PR TITLE
Improve CLI error handling, logout messaging, and OAuth scope update

### DIFF
--- a/templates/cli/lib/auth/session.ts
+++ b/templates/cli/lib/auth/session.ts
@@ -3,6 +3,7 @@ import type { SessionData } from "../types.js";
 import ClientLegacy from "../client.js";
 import { OAUTH2_CLIENT_ID } from "../constants.js";
 import { revokeRefreshToken } from "./oauth.js";
+import { getErrorMessage } from "../utils.js";
 import {
   deleteStoredRefreshToken,
   getStoredRefreshToken,
@@ -124,7 +125,7 @@ export const deleteServerSession = async (
   } catch (e) {
     return {
       deleted: false,
-      error: e instanceof Error ? e.message : String(e),
+      error: getErrorMessage(e),
     };
   }
 };

--- a/templates/cli/lib/commands/generic.ts
+++ b/templates/cli/lib/commands/generic.ts
@@ -158,12 +158,8 @@ export const logout = new Command("logout")
           remainingSessions[0];
         globalConfig.setCurrentSession(nextSession.id);
 
-        if (!logoutFailed) {
-          success(
-            nextSession.email
-              ? `Switched to ${nextSession.email}`
-              : `Switched to session at ${nextSession.endpoint}`,
-          );
+        if (!logoutFailed && nextSession.email) {
+          success(`Switched to ${nextSession.email}`);
         }
       } else if (remainingSessions.length === 0) {
         globalConfig.setCurrentSession("");

--- a/templates/cli/lib/commands/utils/deployment.ts
+++ b/templates/cli/lib/commands/utils/deployment.ts
@@ -9,6 +9,7 @@ import { Client, AppwriteException } from "@appwrite.io/console";
 import { error } from "../../parser.js";
 import { globalConfig } from "../../config.js";
 import { getValidAccessToken } from "../../sdks.js";
+import { getErrorMessage } from "../../utils.js";
 import { Spinner } from "../../spinner.js";
 
 const ignore: typeof ignoreModule =
@@ -598,7 +599,7 @@ export async function downloadDeploymentCode(params: {
     }
   } catch (e: unknown) {
     if (e instanceof AppwriteException) {
-      error(e.message);
+      error(getErrorMessage(e));
       return;
     } else {
       throw e;

--- a/templates/cli/lib/constants.ts
+++ b/templates/cli/lib/constants.ts
@@ -29,7 +29,7 @@ export const DEFAULT_ENDPOINT = "https://cloud.appwrite.io/v1";
 
 // OAuth2
 export const OAUTH2_CLIENT_ID = "appwrite-cli";
-export const OAUTH2_SCOPES = "openid email profile account.admin";
+export const OAUTH2_SCOPES = "openid email profile all";
 
 // Config resources
 export const CONFIG_RESOURCE_KEYS = [

--- a/templates/cli/lib/constants.ts.twig
+++ b/templates/cli/lib/constants.ts.twig
@@ -29,7 +29,7 @@ export const DEFAULT_ENDPOINT = '{{ spec.endpoint }}';
 
 // OAuth2
 export const OAUTH2_CLIENT_ID = "appwrite-cli";
-export const OAUTH2_SCOPES = "openid email profile account.admin";
+export const OAUTH2_SCOPES = "openid email profile all";
 
 // Config resources
 export const CONFIG_RESOURCE_KEYS = [

--- a/templates/cli/lib/parser.ts
+++ b/templates/cli/lib/parser.ts
@@ -11,7 +11,7 @@ const { description } = packageJson;
 import { globalConfig } from "./config.js";
 import os from "os";
 import { Client } from "@appwrite.io/console";
-import { isCloud } from "./utils.js";
+import { getErrorMessage, isCloud } from "./utils.js";
 import type { CliConfig } from "./types.js";
 import {
   SDK_VERSION,
@@ -664,35 +664,63 @@ const printQueryErrorHint = (err: Error): void => {
 };
 
 const ERROR_DETAIL_KEYS = ["code", "type", "response"] as const;
+const ERROR_DETAIL_INDENT = "  ";
+const ERROR_DETAIL_LABEL_WIDTH =
+  Math.max(...ERROR_DETAIL_KEYS.map((key) => key.length)) + 2;
+
+const formatErrorDetail = (value: unknown): string => {
+  if (typeof value === "string") {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      if (parsed && typeof parsed === "object") {
+        value = parsed;
+      }
+    } catch {
+      return value;
+    }
+  }
+
+  try {
+    const json = JSON.stringify(value, null, 2) ?? String(value);
+    return json
+      .split("\n")
+      .map((line, index) => (index === 0 ? line : ERROR_DETAIL_INDENT + line))
+      .join("\n");
+  } catch {
+    return String(value);
+  }
+};
 
 export const formatErrorForLog = (err: Error): string => {
-  const stack = err.stack || `${err.name}: ${err.message}`;
-  const detailLines = ERROR_DETAIL_KEYS.flatMap((key) => {
+  const lines = [
+    `${chalk.red.bold(err.name || "Error")}${chalk.red(`: ${getErrorMessage(err)}`)}`,
+  ];
+
+  for (const key of ERROR_DETAIL_KEYS) {
     if (!Object.prototype.hasOwnProperty.call(err, key)) {
-      return [];
+      continue;
     }
 
     const value = (err as unknown as Record<string, unknown>)[key];
-    let detail = "undefined";
-    try {
-      detail =
-        typeof value === "string"
-          ? JSON.stringify(value)
-          : JSON.stringify(value) ?? String(value);
-    } catch {
-      detail = String(value);
-    }
-
-    return [`${key}: ${detail}`];
-  });
-
-  if (detailLines.length === 0) {
-    return stack;
+    lines.push(
+      `${ERROR_DETAIL_INDENT}${chalk.cyan(`${key}:`.padEnd(ERROR_DETAIL_LABEL_WIDTH))}${formatErrorDetail(value)}`,
+    );
   }
 
-  const [summary, ...frames] = stack.split("\n");
+  const frames = (err.stack ?? "")
+    .split("\n")
+    .filter((line) => line.trim().startsWith("at "));
+  if (frames.length > 0) {
+    lines.push(
+      "",
+      chalk.dim(`${ERROR_DETAIL_INDENT}Stack trace:`),
+      ...frames.map((frame) =>
+        chalk.dim(`${ERROR_DETAIL_INDENT.repeat(2)}${frame.trim()}`),
+      ),
+    );
+  }
 
-  return [summary, ...detailLines, ...frames].join("\n");
+  return lines.join("\n");
 };
 
 export const parseError = (err: Error): void => {
@@ -726,7 +754,7 @@ export const parseError = (err: Error): void => {
       githubIssueUrl.searchParams.append("template", "bug.yaml");
       githubIssueUrl.searchParams.append(
         "title",
-        `🐛 Bug Report: ${err.message}`,
+        `🐛 Bug Report: ${getErrorMessage(err)}`,
       );
       githubIssueUrl.searchParams.append(
         "actual-behavior",
@@ -753,7 +781,7 @@ export const parseError = (err: Error): void => {
       printQueryErrorHint(err);
     } else {
       log("For detailed error pass the --verbose or --report flag");
-      error(err.message);
+      error(getErrorMessage(err));
       printQueryErrorHint(err);
     }
     process.exit(1);

--- a/templates/cli/lib/parser.ts
+++ b/templates/cli/lib/parser.ts
@@ -670,13 +670,14 @@ const ERROR_DETAIL_LABEL_WIDTH =
 
 const formatErrorDetail = (value: unknown): string => {
   if (typeof value === "string") {
+    const text = value;
     try {
-      const parsed: unknown = JSON.parse(value);
+      const parsed: unknown = JSON.parse(text);
       if (parsed && typeof parsed === "object") {
         value = parsed;
       }
     } catch {
-      return value;
+      return text;
     }
   }
 

--- a/templates/cli/lib/utils.ts
+++ b/templates/cli/lib/utils.ts
@@ -138,7 +138,21 @@ export const siteRequiresBuildCommand = (site: SiteBuildConfig): boolean => {
 
 export const getErrorMessage = (error: unknown): string => {
   if (error instanceof Error) {
-    return error.message;
+    const message =
+      typeof error.message === "string" ? error.message.trim() : "";
+    if (message) {
+      return message;
+    }
+
+    // Some error responses carry no `message` field, leaving the exception
+    // message empty. Fall back to the raw response body so users see more
+    // than a bare "✗ Error:".
+    const response = (error as { response?: unknown }).response;
+    if (typeof response === "string" && response.trim() !== "") {
+      return response.trim();
+    }
+
+    return "An unknown error occurred.";
   }
 
   return String(error);

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -1058,7 +1058,7 @@ class Client {
             } else {
                 responseText = data?.message;
             }
-            throw new {{spec.title | caseUcfirst}}Exception(data?.message, response.status, data?.type, responseText);
+            throw new {{spec.title | caseUcfirst}}Exception(data?.message ?? responseText, response.status, data?.type, responseText);
         }
 
         const cookieFallback = response.headers.get('X-Fallback-Cookies');


### PR DESCRIPTION
## What does this PR do?

A set of CLI (and one web SDK) fixes around error reporting and OAuth sessions:

### Empty error messages (CLI + web templates)
OAuth-style error bodies (`{"error": ..., "error_description": ...}`) carry no `message` field, so the console SDK constructed `AppwriteException` with an undefined message and the CLI printed a bare `✗ Error:` with nothing after it — details were only visible with `--verbose`.

- `templates/web/src/client.ts.twig`: construct the exception with `data?.message ?? responseText` so the message is never empty at the source.
- `templates/cli/lib/utils.ts`: `getErrorMessage` now falls back to the exception's raw `response` body when the message is empty (generic — no OAuth field knowledge), then to a generic line.
- Used by `parseError`, the `--report` issue title, session revocation (`auth/session.ts`), and deployment status (`utils/deployment.ts`) — the two call sites that surface console-SDK errors. The CLI's own client already falls back to raw text.

### Verbose error rendering
`formatErrorForLog` now renders a structured block instead of a raw stack dump: bold red summary, aligned `code`/`type` fields, the `response` body pretty-printed as JSON instead of a double-escaped one-liner, and the stack frames dimmed under a `Stack trace:` heading.

### Confusing logout message
Logging out all accounts printed `✓ Success: Switched to session at <endpoint>` when the only remaining prefs entry was an endpoint-only config stub (created by `client --endpoint`), which is not a signed-in account. The stub is still kept as the current session so endpoint/API-key config isn't orphaned, but the switch message is only printed when the destination is an actual signed-in account.

### OAuth scope rename
`OAUTH2_SCOPES` updated from `account.admin` to `all`, matching the server-side scope rename (old scope now fails device authorization with `invalid_scope`).

## Test plan

- Regenerated CLI and Web SDKs (`php example.php cli` / `web`) and verified output.
- Exercised `getErrorMessage` and `formatErrorForLog` against the real failure cases: OAuth `invalid_scope` body with undefined message, missing-scopes 401 with escaped JSON response, non-JSON body, and plain errors.
- `composer refactor:check` and djLint pass.

## Related PRs and issues

- Server-side counterpart for the `all` scope expansion: appwrite-labs/cloud#4583