### PR TITLE
Generate bearer setter from global headers in PHP, Unity, and Rust

### DIFF
--- a/templates/php/src/Client.php.twig
+++ b/templates/php/src/Client.php.twig
@@ -119,21 +119,35 @@ class Client
      */
     public function set{{header.key | caseUcfirst}}(string $value): Client
     {
-{% if header.type is defined and header.type == 'bearer' %}
-        $this->key = $value;
-        $this->authorization = null;
-        $this->authorizationExpiresAt = null;
-{% else %}
         {%~ if header.global %}
         $this->addHeader('{{header.name}}', $value);
         {%~ endif %}
         $this->config['{{ header.key | caseLower }}'] = $value;
-{% endif %}
 
         return $this;
     }
 
 {% endfor %}
+{% if spec.global.headers | hasBearerAuth %}
+    /**
+     * Set Signing Key
+     *
+     * Set a secret key used to self-sign short-lived JWTs for the Authorization header
+     *
+     * @param string $key
+     *
+     * @return Client
+     */
+    public function setSigningKey(string $key): Client
+    {
+        $this->key = $key;
+        $this->authorization = null;
+        $this->authorizationExpiresAt = null;
+
+        return $this;
+    }
+
+{% endif %}
 
     public function getConfig(string $key): string
     {

--- a/templates/php/src/Client.php.twig
+++ b/templates/php/src/Client.php.twig
@@ -123,6 +123,11 @@ class Client
         $this->addHeader('{{header.name}}', $value);
         {%~ endif %}
         $this->config['{{ header.key | caseLower }}'] = $value;
+{% if header.type is defined and header.type == 'bearer' %}
+        $this->key = null;
+        $this->authorization = null;
+        $this->authorizationExpiresAt = null;
+{% endif %}
 
         return $this;
     }
@@ -143,6 +148,11 @@ class Client
         $this->key = $key;
         $this->authorization = null;
         $this->authorizationExpiresAt = null;
+{% for header in spec.global.headers %}
+{% if header.type is defined and header.type == 'bearer' %}
+        unset($this->headers['{{ header.name | caseLower }}'], $this->config['{{ header.key | caseLower }}']);
+{% endif %}
+{% endfor %}
 
         return $this;
     }

--- a/templates/rust/src/client.rs.twig
+++ b/templates/rust/src/client.rs.twig
@@ -224,6 +224,17 @@ impl Client {
         self.clone()
     }
 
+    /// Set the request mode, e.g. `admin` to act as a console administrator
+    pub fn set_mode<S: Into<String>>(&self, mode: S) -> Self {
+        let mode = mode.into();
+        self.state.rcu(|state| {
+            let mut next = (**state).clone();
+            next.config.headers.insert("x-appwrite-mode", mode.clone().parse().unwrap());
+            Arc::new(next)
+        });
+        self.clone()
+    }
+
     /// Enable or disable self-signed certificates
     pub fn set_self_signed(&self, self_signed: bool) -> Self {
         self.state.rcu(|state| {

--- a/templates/rust/src/client.rs.twig
+++ b/templates/rust/src/client.rs.twig
@@ -186,6 +186,21 @@ impl Client {
         });
         self.clone()
     }
+{% for header in spec.global.headers %}
+{% if header.type is defined and header.type == 'bearer' %}
+
+    /// {{header.description}}
+    pub fn set_{{header.key | caseSnake}}<S: Into<String>>(&self, value: S) -> Self {
+        let value = value.into();
+        self.state.rcu(|state| {
+            let mut next = (**state).clone();
+            next.config.headers.insert("{{header.name | caseLower}}", value.clone().parse().unwrap());
+            Arc::new(next)
+        });
+        self.clone()
+    }
+{% endif %}
+{% endfor %}
 
     /// Set the locale
     pub fn set_locale<S: Into<String>>(&self, locale: S) -> Self {

--- a/templates/rust/src/client.rs.twig
+++ b/templates/rust/src/client.rs.twig
@@ -154,42 +154,13 @@ impl Client {
         self.clone()
     }
 
-    /// Set the project ID
-    pub fn set_project<S: Into<String>>(&self, project: S) -> Self {
-        let project = project.into();
-        self.state.rcu(|state| {
-            let mut next = (**state).clone();
-            next.config.headers.insert("x-appwrite-project", project.clone().parse().unwrap());
-            Arc::new(next)
-        });
-        self.clone()
-    }
-
-    /// Set the API key
-    pub fn set_key<S: Into<String>>(&self, key: S) -> Self {
-        let key = key.into();
-        self.state.rcu(|state| {
-            let mut next = (**state).clone();
-            next.config.headers.insert("x-appwrite-key", key.clone().parse().unwrap());
-            Arc::new(next)
-        });
-        self.clone()
-    }
-
-    /// Set the JWT token
-    pub fn set_jwt<S: Into<String>>(&self, jwt: S) -> Self {
-        let jwt = jwt.into();
-        self.state.rcu(|state| {
-            let mut next = (**state).clone();
-            next.config.headers.insert("x-appwrite-jwt", jwt.clone().parse().unwrap());
-            Arc::new(next)
-        });
-        self.clone()
-    }
 {% for header in spec.global.headers %}
-{% if header.type is defined and header.type == 'bearer' %}
 
+    /// Set {{header.key | caseUcfirst}}
+{% if header.description %}
+    ///
     /// {{header.description}}
+{% endif %}
     pub fn set_{{header.key | caseSnake}}<S: Into<String>>(&self, value: S) -> Self {
         let value = value.into();
         self.state.rcu(|state| {
@@ -199,41 +170,7 @@ impl Client {
         });
         self.clone()
     }
-{% endif %}
 {% endfor %}
-
-    /// Set the locale
-    pub fn set_locale<S: Into<String>>(&self, locale: S) -> Self {
-        let locale = locale.into();
-        self.state.rcu(|state| {
-            let mut next = (**state).clone();
-            next.config.headers.insert("x-appwrite-locale", locale.clone().parse().unwrap());
-            Arc::new(next)
-        });
-        self.clone()
-    }
-
-    /// Set the session
-    pub fn set_session<S: Into<String>>(&self, session: S) -> Self {
-        let session = session.into();
-        self.state.rcu(|state| {
-            let mut next = (**state).clone();
-            next.config.headers.insert("x-appwrite-session", session.clone().parse().unwrap());
-            Arc::new(next)
-        });
-        self.clone()
-    }
-
-    /// Set the request mode, e.g. `admin` to act as a console administrator
-    pub fn set_mode<S: Into<String>>(&self, mode: S) -> Self {
-        let mode = mode.into();
-        self.state.rcu(|state| {
-            let mut next = (**state).clone();
-            next.config.headers.insert("x-appwrite-mode", mode.clone().parse().unwrap());
-            Arc::new(next)
-        });
-        self.clone()
-    }
 
     /// Enable or disable self-signed certificates
     pub fn set_self_signed(&self, self_signed: bool) -> Self {

--- a/templates/unity/Assets/Runtime/Core/Client.cs.twig
+++ b/templates/unity/Assets/Runtime/Core/Client.cs.twig
@@ -110,7 +110,7 @@ namespace {{ spec.title | caseUcfirst }}
             bool selfSigned = false)
         {
             var client = From(projectId, endpoint, endpointRealtime, locale, selfSigned);
-            client.SetHeader("session", "X-{{ spec.title | caseUcfirst }}-Session", session, persist: true);
+            client.SetHeader("session", "X-{{ spec.title | caseUcfirst }}-Session", session);
             return client;
         }
 
@@ -249,12 +249,12 @@ namespace {{ spec.title | caseUcfirst }}
         {%~ endfor %}
         {%~ endfor %}
 #endif
-        private void SetHeader(string configKey, string header, string value, bool persist = false)
+        private void SetHeader(string configKey, string header, string value)
         {
             _config[configKey] = value;
             _headers[header] = value;
 
-            if (persist)
+            if (header == "X-{{ spec.title | caseUcfirst }}-Session" || header == "X-{{ spec.title | caseUcfirst }}-JWT")
             {
                 SaveSession();
             }
@@ -278,47 +278,23 @@ namespace {{ spec.title | caseUcfirst }}
             return _config.GetValueOrDefault("jwt") ?? _config.GetValueOrDefault("jWT");
         }
 
-        /// <summary>
-        /// Set the current JWT and persist it for future requests
-        /// </summary>
-        /// <param name="jwt">JWT token returned by Account.CreateJWT()</param>
-        /// <returns>Client instance for method chaining</returns>
-        public Client SetJWT(string jwt)
-        {
-            SetHeader("jwt", "X-{{ spec.title | caseUcfirst }}-JWT", jwt, persist: true);
-            _config.Remove("jWT");
-            return this;
-        }
-
 {% for header in spec.global.headers %}
-{% if header.type is defined and header.type == 'bearer' %}
         /// <summary>
         /// Set {{header.key | caseUcfirst}}
+{% if header.description %}
         ///
         /// {{header.description}}
+{% endif %}
         /// </summary>
-        /// <param name="value">Bearer token value</param>
+        /// <param name="value">The value to set</param>
         /// <returns>Client instance for method chaining</returns>
         public Client Set{{header.key | caseUcfirst}}(string value)
         {
-            SetHeader("{{header.key | caseCamel}}", "{{header.name}}", value);
+            SetHeader("{{header.key | caseLower}}", "{{header.name}}", value);
             return this;
         }
 
-{% endif %}
-{% endfor %}
-        /// <summary>
-        /// Set the request mode, e.g. `admin` to act as a console administrator
-        /// </summary>
-        /// <param name="mode">Request mode</param>
-        /// <returns>Client instance for method chaining</returns>
-        public Client SetMode(string mode)
-        {
-            SetHeader("mode", "X-{{ spec.title | caseUcfirst }}-Mode", mode);
-            return this;
-        }
-
-        /// <summary>
+{% endfor %}        /// <summary>
         /// Clear session and JWT from client
         /// </summary>
         /// <returns>Client instance for method chaining</returns>

--- a/templates/unity/Assets/Runtime/Core/Client.cs.twig
+++ b/templates/unity/Assets/Runtime/Core/Client.cs.twig
@@ -308,6 +308,17 @@ namespace {{ spec.title | caseUcfirst }}
 {% endif %}
 {% endfor %}
         /// <summary>
+        /// Set the request mode, e.g. `admin` to act as a console administrator
+        /// </summary>
+        /// <param name="mode">Request mode</param>
+        /// <returns>Client instance for method chaining</returns>
+        public Client SetMode(string mode)
+        {
+            SetHeader("mode", "X-{{ spec.title | caseUcfirst }}-Mode", mode);
+            return this;
+        }
+
+        /// <summary>
         /// Clear session and JWT from client
         /// </summary>
         /// <returns>Client instance for method chaining</returns>

--- a/templates/unity/Assets/Runtime/Core/Client.cs.twig
+++ b/templates/unity/Assets/Runtime/Core/Client.cs.twig
@@ -290,6 +290,23 @@ namespace {{ spec.title | caseUcfirst }}
             return this;
         }
 
+{% for header in spec.global.headers %}
+{% if header.type is defined and header.type == 'bearer' %}
+        /// <summary>
+        /// Set {{header.key | caseUcfirst}}
+        ///
+        /// {{header.description}}
+        /// </summary>
+        /// <param name="value">Bearer token value</param>
+        /// <returns>Client instance for method chaining</returns>
+        public Client Set{{header.key | caseUcfirst}}(string value)
+        {
+            SetHeader("{{header.key | caseCamel}}", "{{header.name}}", value);
+            return this;
+        }
+
+{% endif %}
+{% endfor %}
         /// <summary>
         /// Clear session and JWT from client
         /// </summary>


### PR DESCRIPTION
## What does this PR do?

Appwrite is adding OAuth login to the SDKs by exposing a `Bearer` security scheme (`type: http`, `scheme: bearer`) and the `Mode` scheme (`X-Appwrite-Mode`, needed to act as admin with OAuth2 tokens) in the API specs for the client, server, and console platforms. This PR makes every SDK client generate its global-header setters from `spec.global.headers` with consistent behavior — no hardcoded or special-cased setters in any SDK:

- **PHP**: `setBearer` previously treated the value as an HMAC secret and self-signed a short-lived JWT for the `Authorization` header (behavior built for the cloud manager platform). It now forwards the value as a plain header like every other SDK. The old behavior is preserved under a new dedicated `setSigningKey()` method — the JWT machinery (`getAuthorization()`, hourly refresh, `adhocore/php-jwt` dependency) is unchanged and still gated behind `hasBearerAuth`.
- **Unity**: the client hardcoded `SetJWT` and generated nothing from the spec. It now generates all setters (`SetProject`, `SetJWT`, `SetBearer`, `SetSession`, `SetMode`, `SetDevKey`, `SetCookie`, `SetImpersonateUser*`, ...) from `spec.global.headers`. The Unity-specific PlayerPrefs persistence moved into the private `SetHeader` helper (keyed by the session/JWT header names), so generated setters stay uniform while `FromSession`/`FromJWT` behavior is unchanged. Config keys use `caseLower`, matching what the client-method security headers and session persistence already read.
- **Rust**: hardcoded `set_project`/`set_key`/`set_jwt`/`set_locale`/`set_session` replaced by the same spec-driven loop. All existing method names are preserved (`caseSnake` yields identical names), and the missing setters (`set_bearer`, `set_mode`, `set_dev_key`, `set_cookie`, `set_impersonate_user_*`, ...) now appear automatically.

## Breaking change

For SDKs generated from specs with a bearer scheme (currently the cloud manager platform), the generated bearer setter (`setKey` on manager) no longer performs the key→JWT exchange — callers relying on that behavior must switch to `setSigningKey()`.

## Test plan

- Regenerated PHP, Unity, and Rust SDKs against local specs containing the new `Bearer` and `Mode` schemes; verified all setters generate with unchanged names and Unity session persistence call sites are intact.
- `composer refactor:check`, `composer lint-twig`, and `vendor/bin/phpunit --testsuite Unit` all pass.

## Related PRs

- Spec change exposing the `Bearer` and `Mode` schemes: appwrite/appwrite#12769
