### PR TITLE
Fix stale Homebrew version check in CLI update command

### DIFF
--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -73,6 +73,7 @@ class CLI extends Node
         'logoUnescaped' => '',
         'homebrewTapOwner' => 'appwrite',
         'homebrewTapName' => 'appwrite',
+        'homebrewTapBranch' => 'main',
     ];
 
     /**
@@ -151,14 +152,16 @@ class CLI extends Node
     /**
      * Configure the Homebrew tap (`<owner>/homebrew-<name>`) hosting the CLI formula.
      *
-     * @param string $owner Tap owner (e.g. "appwrite")
-     * @param string $name  Tap short name without the `homebrew-` prefix
+     * @param string $owner  Tap owner (e.g. "appwrite")
+     * @param string $name   Tap short name without the `homebrew-` prefix
+     * @param string $branch Default branch of the tap repository
      * @return $this
      */
-    public function setHomebrewTap(string $owner, string $name): self
+    public function setHomebrewTap(string $owner, string $name, string $branch = 'main'): self
     {
         $this->setParam('homebrewTapOwner', $owner);
         $this->setParam('homebrewTapName', $name);
+        $this->setParam('homebrewTapBranch', $branch);
 
         return $this;
     }

--- a/templates/cli/lib/constants.ts
+++ b/templates/cli/lib/constants.ts
@@ -15,6 +15,8 @@ export const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 // Homebrew — fully-qualified `<owner>/<tap>/<formula>` reference
 export const HOMEBREW_TAP = "appwrite/appwrite";
 export const HOMEBREW_FORMULA = `${HOMEBREW_TAP}/appwrite`;
+export const HOMEBREW_TAP_FORMULA_URL =
+  "https://raw.githubusercontent.com/appwrite/homebrew-appwrite/main/Formula/appwrite.rb";
 
 // NPM
 export const NPM_PACKAGE_NAME = "sdk-for-cli";

--- a/templates/cli/lib/constants.ts.twig
+++ b/templates/cli/lib/constants.ts.twig
@@ -15,6 +15,7 @@ export const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 // Homebrew — fully-qualified `<owner>/<tap>/<formula>` reference
 export const HOMEBREW_TAP = '{{ language.params.homebrewTapOwner }}/{{ language.params.homebrewTapName }}';
 export const HOMEBREW_FORMULA = `${HOMEBREW_TAP}/{{ language.params.executableName|caseLower }}`;
+export const HOMEBREW_TAP_FORMULA_URL = 'https://raw.githubusercontent.com/{{ language.params.homebrewTapOwner }}/homebrew-{{ language.params.homebrewTapName }}/main/Formula/{{ language.params.executableName|caseLower }}.rb';
 
 // NPM
 export const NPM_PACKAGE_NAME = '{{ language.params.npmPackage|caseDash }}';

--- a/templates/cli/lib/constants.ts.twig
+++ b/templates/cli/lib/constants.ts.twig
@@ -15,7 +15,7 @@ export const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 // Homebrew — fully-qualified `<owner>/<tap>/<formula>` reference
 export const HOMEBREW_TAP = '{{ language.params.homebrewTapOwner }}/{{ language.params.homebrewTapName }}';
 export const HOMEBREW_FORMULA = `${HOMEBREW_TAP}/{{ language.params.executableName|caseLower }}`;
-export const HOMEBREW_TAP_FORMULA_URL = 'https://raw.githubusercontent.com/{{ language.params.homebrewTapOwner }}/homebrew-{{ language.params.homebrewTapName }}/main/Formula/{{ language.params.executableName|caseLower }}.rb';
+export const HOMEBREW_TAP_FORMULA_URL = 'https://raw.githubusercontent.com/{{ language.params.homebrewTapOwner }}/homebrew-{{ language.params.homebrewTapName }}/{{ language.params.homebrewTapBranch }}/Formula/{{ language.params.executableName|caseLower }}.rb';
 
 // NPM
 export const NPM_PACKAGE_NAME = '{{ language.params.npmPackage|caseDash }}';

--- a/templates/cli/lib/utils.ts
+++ b/templates/cli/lib/utils.ts
@@ -15,6 +15,7 @@ import {
   DEFAULT_ENDPOINT,
   EXECUTABLE_NAME,
   HOMEBREW_FORMULA,
+  HOMEBREW_TAP_FORMULA_URL,
   UPDATE_CHECK_INTERVAL_MS,
 } from "./constants.js";
 
@@ -343,6 +344,32 @@ const getHomebrewLatestVersion = async (
     options.homebrewFormula ??
     getInstalledHomebrewFormula(options) ??
     HOMEBREW_FORMULA;
+
+  // `brew info` reads the local tap clone, which is only refreshed by
+  // `brew update` and can report a stale version. For the official tap,
+  // resolve the latest version from the tap repo itself and fall back to
+  // local metadata only when the fetch fails (e.g. offline).
+  if (formulaName === HOMEBREW_FORMULA) {
+    try {
+      const signal = AbortSignal.timeout(
+        options.timeoutMs ?? DEFAULT_HOMEBREW_COMMAND_TIMEOUT_MS,
+      );
+
+      const response = await fetch(HOMEBREW_TAP_FORMULA_URL, { signal });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const match = (await response.text()).match(/^\s*version\s+"([^"]+)"/m);
+      if (!match) {
+        throw new Error("Could not find a version in the tap formula.");
+      }
+
+      return normalizeHomebrewVersion(match[1].trim());
+    } catch (_error) {
+      // Fall through to local Homebrew metadata below.
+    }
+  }
 
   try {
     const output = childProcess.execFileSync(

--- a/templates/cli/lib/utils.ts
+++ b/templates/cli/lib/utils.ts
@@ -360,7 +360,13 @@ const getHomebrewLatestVersion = async (
         throw new Error(`HTTP ${response.status}`);
       }
 
-      const match = (await response.text()).match(/^\s*version\s+"([^"]+)"/m);
+      // Strip resource blocks so their `version` lines cannot shadow the
+      // formula-level version.
+      const formulaSource = (await response.text()).replace(
+        /^\s*resource\s+"[^"]*"\s+do[\s\S]*?^\s*end/gm,
+        "",
+      );
+      const match = formulaSource.match(/^\s*version\s+"([^"]+)"/m);
       if (!match) {
         throw new Error("Could not find a version in the tap formula.");
       }


### PR DESCRIPTION
## What does this PR do?

Fixes `appwrite update` reporting "You're already running the latest version" while `brew upgrade` finds a newer release.

For Homebrew installs, the CLI resolved the latest version via `brew info --json=v2`, which only reads the **local tap clone** — it never hits the network (and the check additionally sets `HOMEBREW_NO_AUTO_UPDATE=1`). If the user hasn't run `brew update` since a release, `brew info` reports the stale version, which equals the installed one, so the CLI says it's up to date. `brew upgrade` runs Homebrew's auto-update first, so it sees the new version.

### Changes

- Added `HOMEBREW_TAP_FORMULA_URL` constant pointing at the raw formula file in the tap repo (built from the `homebrewTapOwner`/`homebrewTapName` params).
- `getHomebrewLatestVersion()` now fetches the formula file from the tap repo (source of truth, always current) and parses its `version "x.y.z"` line. It falls back to the previous local `brew info` path when the fetch fails (e.g. offline) or when the installed formula is not the official tap formula.

This fixes all three consumers at once: `appwrite update`, `appwrite --version`, and the daily update notice.

## Test plan

- Regenerated the CLI with `php example.php cli`; inspected `examples/cli/` output.
- `tsc --emitDeclarationOnly` typecheck of the generated CLI passes.
- Reproduced the original bug on a machine with a stale tap (CLI reported 22.3.0 as latest); with this change `getLatestVersionForInstallation("homebrew")` returns 22.4.0 from the tap repo.
- Forced `fetch` to throw and confirmed the `brew info` fallback still resolves.
- Twig linter passes (562 files, 0 errors).

## Related PRs and Issues

None