### PR TITLE
Add self-hosted Renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,41 @@
+name: renovate
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # Daily 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: "Dry run (log what would change, open no PRs)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
+          owner: appwrite
+          repositories: sdk-generator
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: enable dry run
+        if: inputs.dryRun
+        run: echo "RENOVATE_DRY_RUN=full" >> "$GITHUB_ENV"
+
+      - name: renovate
+        uses: renovatebot/github-action@dd5302ec17783b2fc721b19ae7209b57b1587765 # v46.1.17
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+        env:
+          RENOVATE_ALLOWED_COMMANDS: '["^./scripts/update-lockfiles\\.sh renovate$"]'
+          RENOVATE_REPOSITORIES: ${{ github.repository }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,233 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "labels": ["dependencies"],
+  "dependencyDashboard": true,
+  "branchPrefix": "renovate/",
+  "ignorePaths": [
+    "examples/**",
+    "tests/e2e/sdks/**",
+    "vendor/**",
+    "node_modules/**"
+  ],
+  "rangeStrategy": "bump",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 5am on monday"]
+  },
+  "postUpgradeTasks": {
+    "commands": ["./scripts/update-lockfiles.sh renovate"],
+    "executionMode": "branch",
+    "fileFilters": [
+      "templates/**",
+      "examples/**"
+    ]
+  },
+  "npm": {
+    "managerFilePatterns": [
+      "/(^|/)package\\.json$/",
+      "/(^|/)package\\.json\\.twig$/"
+    ]
+  },
+  "gradle": {
+    "managerFilePatterns": [
+      "/\\.gradle(\\.kts)?$/",
+      "/\\.gradle(\\.kts)?\\.twig$/",
+      "/(^|/)gradle\\.properties$/",
+      "/(^|/)gradle/.+\\.toml$/",
+      "/(^|/)buildSrc/.+\\.kt$/",
+      "/\\.versions\\.toml$/",
+      "/(^|/)versions.props$/",
+      "/(^|/)versions.lock$/"
+    ]
+  },
+  "gradle-wrapper": {
+    "managerFilePatterns": [
+      "/(^|/)gradle/wrapper/gradle-wrapper\\.properties$/"
+    ]
+  },
+  "cargo": {
+    "managerFilePatterns": [
+      "/(^|/)Cargo\\.toml$/",
+      "/(^|/)Cargo\\.toml\\.twig$/"
+    ]
+  },
+  "gomod": {
+    "managerFilePatterns": [
+      "/(^|/)go\\.mod$/",
+      "/(^|/)go\\.mod\\.twig$/"
+    ]
+  },
+  "nuget": {
+    "managerFilePatterns": [
+      "/\\.csproj$/",
+      "/\\.csproj\\.twig$/"
+    ]
+  },
+  "pip_requirements": {
+    "managerFilePatterns": [
+      "/(^|/)([\\w-]*)requirements(?:\\.(?<constraints>constraints|pip))?\\.(?<ext>txt|in)$/",
+      "/(^|/)requirements\\.txt\\.twig$/"
+    ]
+  },
+  "pub": {
+    "managerFilePatterns": [
+      "/(^|/)pubspec\\.ya?ml$/",
+      "/(^|/)pubspec\\.ya?ml\\.twig$/"
+    ]
+  },
+  "swift": {
+    "managerFilePatterns": [
+      "/(^|/)Package\\.swift$/",
+      "/(^|/)Package\\.swift\\.twig$/"
+    ]
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "NPM package versions in SDK templates",
+      "managerFilePatterns": ["/^templates/(web|node|react-native|cli)/package\\.json\\.twig$/"],
+      "matchStrings": [
+        "\"(?<depName>(?:@[^/\\\"]+/)?[^/\\\"]+)\"\\s*:\\s*\"(?<currentValue>[~^<>=\" ]*\\d[^\\\"]*)\""
+      ],
+      "datasourceTemplate": "npm",
+      "versioningTemplate": "npm"
+    },
+    {
+      "customType": "regex",
+      "description": "Composer package versions in SDK templates",
+      "managerFilePatterns": ["/^templates/php/composer\\.json\\.twig$/"],
+      "matchStrings": [
+        "\"(?<depName>[a-z0-9_.-]+/[a-z0-9_.-]+)\"\\s*:\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "packagist",
+      "versioningTemplate": "composer"
+    },
+    {
+      "customType": "regex",
+      "description": "Ruby gem versions in SDK templates",
+      "managerFilePatterns": ["/^templates/ruby/gemspec\\.twig$/"],
+      "matchStrings": [
+        "spec\\.add_dependency\\s+['\"](?<depName>[^'\"]+)['\"]\\s*,\\s*['\"](?<currentValue>[^'\"]+)['\"]"
+      ],
+      "datasourceTemplate": "rubygems",
+      "versioningTemplate": "ruby"
+    },
+    {
+      "customType": "regex",
+      "description": "Cargo crate versions in SDK templates",
+      "managerFilePatterns": ["/^templates/rust/Cargo\\.toml\\.twig$/"],
+      "matchStrings": [
+        "^[ \\t]*(?<depName>[A-Za-z0-9_-]+)\\s*=\\s*\"(?<currentValue>[^\"]+)\"",
+        "^[ \\t]*(?<depName>[A-Za-z0-9_-]+)\\s*=\\s*\\{[^\\n]*version\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "crate",
+      "versioningTemplate": "cargo"
+    },
+    {
+      "customType": "regex",
+      "description": "Maven package versions in JVM SDK templates",
+      "managerFilePatterns": ["/^templates/(android|kotlin)/.*\\.gradle\\.kts\\.twig$/"],
+      "matchStrings": [
+        "(?:api|implementation|testImplementation|androidTestImplementation)\\((?:platform\\()?\"(?<depName>[^:\"]+:[^:\"]+):(?<currentValue>[^\"]+)\"\\)?\\)"
+      ],
+      "datasourceTemplate": "maven",
+      "versioningTemplate": "maven"
+    },
+    {
+      "customType": "regex",
+      "description": "Android Gradle plugin versions in SDK templates",
+      "managerFilePatterns": ["/^templates/android/build\\.gradle\\.kts\\.twig$/"],
+      "matchStrings": [
+        "id\\(\"(?<pluginId>com\\.android\\.[^\"]+)\"\\)\\s+version\\s+\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "maven",
+      "depNameTemplate": "{{{pluginId}}}:{{{pluginId}}}.gradle.plugin",
+      "versioningTemplate": "maven"
+    },
+    {
+      "customType": "regex",
+      "description": "Kotlin Gradle plugin versions in SDK templates",
+      "managerFilePatterns": ["/^templates/kotlin/build\\.gradle\\.kts\\.twig$/"],
+      "matchStrings": [
+        "kotlin\\(\"(?<pluginName>[^\"]+)\"\\)\\s+version\\s+\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "maven",
+      "depNameTemplate": "org.jetbrains.kotlin.{{{pluginName}}}:org.jetbrains.kotlin.{{{pluginName}}}.gradle.plugin",
+      "versioningTemplate": "maven"
+    },
+    {
+      "customType": "regex",
+      "description": "Gradle Nexus publish plugin versions in SDK templates",
+      "managerFilePatterns": ["/^templates/(android|kotlin)/build\\.gradle\\.kts\\.twig$/"],
+      "matchStrings": [
+        "id\\(\"(?<pluginId>io\\.github\\.gradle-nexus\\.publish-plugin)\"\\)\\s+version\\s+\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "maven",
+      "depNameTemplate": "{{{pluginId}}}:{{{pluginId}}}.gradle.plugin",
+      "versioningTemplate": "maven"
+    },
+    {
+      "customType": "regex",
+      "description": "Swift package versions in SDK templates",
+      "managerFilePatterns": ["/^templates/(swift|apple)/Package\\.swift\\.twig$/"],
+      "matchStrings": [
+        "\\.package\\(url:\\s*\"https://github\\.com/(?<depName>[^\"]+)\\.git\",\\s*from:\\s*\"(?<currentValue>[^\"]+)\"\\)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDepNames": ["node", "rust-version"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchFileNames": [
+        "templates/web/package.json.twig",
+        "templates/node/package.json.twig",
+        "templates/react-native/package.json.twig",
+        "templates/cli/package.json.twig"
+      ],
+      "groupName": "typescript sdk template dependencies"
+    },
+    {
+      "matchManagers": ["gradle", "gradle-wrapper"],
+      "groupName": "jvm sdk template dependencies"
+    },
+    {
+      "matchManagers": ["pub"],
+      "groupName": "dart and flutter sdk template dependencies"
+    },
+    {
+      "matchManagers": ["cargo"],
+      "groupName": "rust sdk template dependencies"
+    },
+    {
+      "matchManagers": ["nuget"],
+      "groupName": "dotnet sdk template dependencies"
+    },
+    {
+      "matchManagers": ["pip_requirements"],
+      "groupName": "python sdk template dependencies"
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "groupName": "sdk template dependencies"
+    },
+    {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    }
+  ]
+}

--- a/scripts/update-lockfiles.sh
+++ b/scripts/update-lockfiles.sh
@@ -5,6 +5,7 @@
 # Usage:
 #   ./scripts/update-lockfiles.sh           # update all
 #   ./scripts/update-lockfiles.sh web       # update one (web | node | react-native | cli)
+#   ./scripts/update-lockfiles.sh renovate  # update lock files and regenerate examples
 
 set -euo pipefail
 
@@ -122,6 +123,33 @@ restore_cli_bin() {
     validate_no_placeholders "$ROOT/templates/cli/package-lock.json.twig"
 }
 
+update_all() {
+    update_npm web "{{ language.params.npmPackage }}"
+    validate_no_placeholders "$ROOT/templates/web/package-lock.json.twig"
+    update_npm node "{{ language.params.npmPackage | caseDash }}"
+    validate_no_placeholders "$ROOT/templates/node/package-lock.json.twig"
+    update_npm react-native "{{ language.params.npmPackage }}"
+    validate_no_placeholders "$ROOT/templates/react-native/package-lock.json.twig"
+    update_npm cli "{{ language.params.npmPackage|caseDash }}"
+    restore_cli_bin
+    update_bun "{{ language.params.npmPackage|caseDash }}"
+}
+
+regenerate_examples() {
+    cd "$ROOT"
+
+    if [ ! -f vendor/autoload.php ]; then
+        composer install --ignore-platform-reqs --no-interaction --prefer-dist
+    fi
+
+    php example.php
+
+    if grep -R '"PLACEHOLDER"' "$ROOT"/templates/*/*lock*.twig >/dev/null 2>&1; then
+        echo "ERROR: unresolved PLACEHOLDER values remain in generated lockfile templates" >&2
+        exit 1
+    fi
+}
+
 case "$TARGET" in
     web)
         update_npm web "{{ language.params.npmPackage }}"
@@ -141,18 +169,14 @@ case "$TARGET" in
         update_bun "{{ language.params.npmPackage|caseDash }}"
         ;;
     all)
-        update_npm web "{{ language.params.npmPackage }}"
-        validate_no_placeholders "$ROOT/templates/web/package-lock.json.twig"
-        update_npm node "{{ language.params.npmPackage | caseDash }}"
-        validate_no_placeholders "$ROOT/templates/node/package-lock.json.twig"
-        update_npm react-native "{{ language.params.npmPackage }}"
-        validate_no_placeholders "$ROOT/templates/react-native/package-lock.json.twig"
-        update_npm cli "{{ language.params.npmPackage|caseDash }}"
-        restore_cli_bin
-        update_bun "{{ language.params.npmPackage|caseDash }}"
+        update_all
+        ;;
+    renovate)
+        update_all
+        regenerate_examples
         ;;
     *)
-        echo "Unknown target: $TARGET. Use web | node | react-native | cli | all"
+        echo "Unknown target: $TARGET. Use web | node | react-native | cli | all | renovate"
         exit 1
         ;;
 esac


### PR DESCRIPTION
## What

Adds a self-hosted Renovate setup for `sdk-generator`.

- Adds a daily `.github/workflows/renovate.yml` workflow using a GitHub App token from `RENOVATE_APP_ID` and `RENOVATE_APP_PRIVATE_KEY`.
- Adds root `renovate.json` configuration for SDK dependency templates across package ecosystems.
- Extends `scripts/update-lockfiles.sh` with a `renovate` target that refreshes TS lockfile templates and regenerates checked-in examples after Renovate updates.

## Notes

Automerge is not enabled. Renovate will create PRs only.

GitHub cannot dispatch this workflow from the PR branch because new workflow files must exist on the default branch before `workflow_dispatch` is available. I validated the config locally instead.

## Verification

- `jq empty renovate.json`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/renovate.yml")'`
- `bash -n scripts/update-lockfiles.sh`
- `git diff --check`
- `npx --yes --package renovate renovate-config-validator renovate.json`
- `RENOVATE_PLATFORM=local RENOVATE_DRY_RUN=full LOG_LEVEL=info npx --yes --package renovate renovate`
  - extracted 340 dependencies across 82 files
  - regex custom managers extracted 126 dependencies across 15 template files

Did not run `./scripts/update-lockfiles.sh renovate` because it regenerates checked-in SDK examples and is intended for Renovate update branches.
