### PR TITLE
Use Renovate app client ID

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -21,7 +21,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.RENOVATE_APP_ID }}
+          client-id: ${{ vars.RENOVATE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
           owner: appwrite
           repositories: sdk-generator

--- a/renovate.json
+++ b/renovate.json
@@ -184,6 +184,11 @@
       "enabled": false
     },
     {
+      "matchManagers": ["pub"],
+      "matchDepNames": ["dart", "flutter"],
+      "enabled": false
+    },
+    {
       "matchManagers": ["github-actions"],
       "groupName": "github actions"
     },


### PR DESCRIPTION
## What

Updates the Renovate setup after the first real run.

- Uses `client-id` instead of deprecated `app-id` in the GitHub App token step.
- Ignores Pub-managed `dart` and `flutter` SDK environment constraints so Renovate does not turn broad SDK ranges into pinned SDK versions.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/renovate.yml")'`
- `jq empty renovate.json`
- `npx --yes --package renovate renovate-config-validator renovate.json`
- `git diff --check`
- `RENOVATE_PLATFORM=local RENOVATE_DRY_RUN=full LOG_LEVEL=info npx --yes --package renovate renovate`

## Notes

Repository variable `RENOVATE_APP_CLIENT_ID` is set. `RENOVATE_APP_ID` is still temporarily present because `main` uses it until this PR is merged.
