### PR TITLE
Update Go SDK target version

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -161,7 +161,7 @@ jobs:
         if: matrix.sdk == 'go' || matrix.sdk == 'dart' || matrix.sdk == 'flutter'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.25.11'
+          go-version: '1.26.5'
 
       - name: Install OSV Scanner
         if: matrix.sdk == 'dart' || matrix.sdk == 'flutter'

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ php example.php skills
 | Python | `python` | Python >=3.9 | [PEP8] | pip | `examples/python/` |
 | Ruby | `ruby` | Ruby 3.1 in CI | [Ruby Style Guide] | RubyGems, Bundler | `examples/ruby/` |
 | Dart | `dart` | Dart >=2.17 <4 | [Effective Dart] | pub | `examples/dart/` |
-| Go | `go` | Go 1.22.5 | [Effective Go] | Go modules | `examples/go/` |
+| Go | `go` | Go 1.26.5 | [Effective Go] | Go modules | `examples/go/` |
 | Swift | `swift` | Swift 5.1+; Swift 5.9.2 in CI | [Swift Style Guide] | Swift Package Manager | `examples/swift/` |
 | .NET | `dotnet` | .NET Standard 2.0; .NET Framework 4.6.2 | [C# Coding Conventions] | NuGet | `examples/dotnet/` |
 | Kotlin | `kotlin` | JVM 1.8 target; Java 17 in CI | [Kotlin style guide] | Gradle, Maven | `examples/kotlin/` |

--- a/templates/go/go.mod.twig
+++ b/templates/go/go.mod.twig
@@ -1,3 +1,3 @@
 module {{ sdk | goPackagePath }}
 
-go 1.22.5
+go 1.26.5


### PR DESCRIPTION
## What

- Updates the Go SDK `go.mod` template from Go 1.22.5 to Go 1.26.4.
- Updates the generator support matrix in the README to match the generated SDK target.

## Why

Go 1.22 is no longer supported under the Go release policy, which supports each major release until two newer major releases are available. The generated Go SDK should not advertise or emit an EOL Go version.

## Testing

- `php example.php go`
- `composer lint-twig`
- `vendor/bin/phpunit --testsuite Unit`
- `composer refactor:check`

Related issue: #XXXX
