### PR TITLE
fix(cli): send X-Appwrite-Project header when resolving organizationId

### DIFF
--- a/templates/cli/lib/config-filters.ts
+++ b/templates/cli/lib/config-filters.ts
@@ -41,7 +41,9 @@ const configFilters: ConfigFilter[] = [
           new URL(
             `${consoleClient.config.endpoint}/projects/${encodeURIComponent(config.projectId)}`,
           ),
-          {},
+          {
+            "X-Appwrite-Project": "console",
+          },
           {},
         );
 

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -278,6 +278,7 @@ abstract class Base extends TestCase
         'auth:valid-access-token-missing-expiry:passed',
         'auth:oauth-login-flag:passed',
         'auth:open-browser:passed',
+        'auth:config-filters-project-header:passed',
     ];
 
     protected const CLI_LOCAL_FUNCTION_EMULATION_RESPONSES = [

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -56,6 +56,7 @@ const {
   globalConfig,
 } = require("./lib/config.ts");
 const { listenForBrowserOpen } = require("./lib/auth/login.ts");
+const { applyConfigFilters } = require("./lib/config-filters.ts");
 const { questionsLogout } = require("./lib/questions.ts");
 
 const extractFirstValue = (output) => {
@@ -1250,6 +1251,49 @@ async function runAuthChecks() {
     } finally {
       childProcess.spawn = originalSpawn;
     }
+  });
+
+  await authCheck("config-filters-project-header", async () => {
+    // organizationId missing: the org is resolved via a raw projects lookup.
+    // That call bypasses the generated service methods, so it must set
+    // X-Appwrite-Project itself — without it the API treats the request as a
+    // guest and rejects it with a missing-scopes 401.
+    const calls = [];
+    const consoleClient = {
+      headers: {},
+      config: { endpoint: "http://mockapi/v1" },
+      call: async (method, url, headers) => {
+        calls.push({ method, url: url.toString(), headers });
+        return { teamId: "team-1" };
+      },
+    };
+
+    await muteStdout(() =>
+      applyConfigFilters({
+        config: { projectId: "project-1" },
+        consoleClient,
+      }),
+    );
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, "get");
+    assert.equal(calls[0].url, "http://mockapi/v1/projects/project-1");
+    assert.equal(calls[0].headers["X-Appwrite-Project"], "console");
+    assert.equal(consoleClient.headers["X-Appwrite-Organization"], "team-1");
+
+    // organizationId present: applied directly, no lookup request.
+    const directClient = {
+      headers: {},
+      config: { endpoint: "http://mockapi/v1" },
+      call: async () => {
+        throw new Error("unexpected API call when organizationId is set");
+      },
+    };
+    await applyConfigFilters({
+      config: { organizationId: "org-1", projectId: "project-1" },
+      consoleClient: directClient,
+    });
+    assert.equal(directClient.headers["X-Appwrite-Organization"], "org-1");
   });
 
   globalConfig.clear();


### PR DESCRIPTION
## What does this PR do?

Fixes CLI OAuth sessions failing with `User (role: guests) missing scopes (["project.read"])` against Appwrite Cloud whenever `appwrite.config.json` has a `projectId` but no `organizationId`.

The `organization-id-header` config filter resolves a missing `organizationId` with a raw `consoleClient.call()` to `GET /projects/{projectId}`. Raw `call()` bypasses the generated service methods, which are what normally inject `X-Appwrite-Project` per request — so the lookup reached the API with a valid Bearer token but no project header. On the API, `GET /v1/projects/:projectId` is served via the `httpAlias` of `GET /v1/project` and the auth project is taken from the URI; without the `console` project header the request mode is never upgraded to admin, the console OAuth token can't be validated, and the request is rejected as a guest.

The fix passes `X-Appwrite-Project: console` on that raw lookup call.

## Test plan

- New `auth:config-filters-project-header` check in the CLI e2e suite covering both filter paths: `organizationId` missing (asserts the lookup sends `X-Appwrite-Project: console` and applies the resolved `teamId` as `X-Appwrite-Organization`) and `organizationId` present (applied directly, no API call).
- Verified the check fails against the pre-fix template (header was `undefined`).
- `composer test tests/e2e/CLIBun13Test.php` passes locally: OK (1 test, 2132 assertions).
- Reproduced the original failure against production with `appwrite pull settings` on a config missing `organizationId`; the same request succeeds once the header is present.

## Related PRs and issues

- None