### PR TITLE
Bump Android/Kotlin Gradle wrappers and AGP to 9.2.1

### DIFF
--- a/templates/android/build.gradle.kts.twig
+++ b/templates/android/build.gradle.kts.twig
@@ -2,8 +2,8 @@ import java.util.Properties
 
 plugins {
     id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
-    id("com.android.library") version "9.1.1" apply false
-    id("com.android.application") version "9.1.1" apply false
+    id("com.android.library") version "9.2.1" apply false
+    id("com.android.application") version "9.2.1" apply false
 }
 
 version = System.getenv("SDK_VERSION") ?: "0.0.0"

--- a/templates/android/gradle/wrapper/gradle-wrapper.properties
+++ b/templates/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/templates/kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/templates/kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Related Issue
<!-- #XXXX -->

## Description
Bump Android/Kotlin Gradle wrappers from 9.3.1 → 9.4.1 and AGP from 9.1.1 → 9.2.1. AGP 9.2 requires Gradle 9.4.1; without this, Renovate AGP bumps fail validation/e2e.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Test Plan
- [ ] CI Android/Kotlin validation builds pass with Gradle 9.4.1 + AGP 9.2.1
- [ ] Android5Java17 / Android16Java17 / KotlinJava17 e2e stay green

## Checklist
- [x] Templates updated
- [x] Child SDKs considered (Kotlin wrapper bumped with Android)
