### PR TITLE
Disable Renovate status checks until installation token can write statuses

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -53,10 +53,5 @@ jobs:
         env:
           RENOVATE_ALLOWED_COMMANDS: '["^./scripts/update-lockfiles\\.sh renovate$"]'
           RENOVATE_REPOSITORIES: ${{ github.repository }}
-          # TODO: remove once the renovate-appwrite installation token can POST commit
-          # statuses (statuses:write). The app definition already grants Commit statuses
-          # R/W, but the org installation token still 403s and Renovate aborts with
-          # repository-changed before refreshing the Dependency Dashboard. Accept any
-          # pending installation permission update, then delete this env + renovate.json
-          # statusCheckNames workaround.
+          # TODO: remove when renovate-appwrite installation token has statuses:write
           RENOVATE_STATUS_CHECK_NAMES: '{"artifactError":null,"configValidation":null,"mergeConfidence":null,"minimumReleaseAge":null}'

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -53,3 +53,10 @@ jobs:
         env:
           RENOVATE_ALLOWED_COMMANDS: '["^./scripts/update-lockfiles\\.sh renovate$"]'
           RENOVATE_REPOSITORIES: ${{ github.repository }}
+          # TODO: remove once the renovate-appwrite installation token can POST commit
+          # statuses (statuses:write). The app definition already grants Commit statuses
+          # R/W, but the org installation token still 403s and Renovate aborts with
+          # repository-changed before refreshing the Dependency Dashboard. Accept any
+          # pending installation permission update, then delete this env + renovate.json
+          # statusCheckNames workaround.
+          RENOVATE_STATUS_CHECK_NAMES: '{"artifactError":null,"configValidation":null,"mergeConfidence":null,"minimumReleaseAge":null}'

--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,12 @@
   "vulnerabilityAlerts": {
     "enabled": false
   },
+  "statusCheckNames": {
+    "artifactError": null,
+    "configValidation": null,
+    "mergeConfidence": null,
+    "minimumReleaseAge": null
+  },
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 5am on monday"]

--- a/renovate.json
+++ b/renovate.json
@@ -16,12 +16,6 @@
   "vulnerabilityAlerts": {
     "enabled": false
   },
-  "statusCheckNames": {
-    "artifactError": null,
-    "configValidation": null,
-    "mergeConfidence": null,
-    "minimumReleaseAge": null
-  },
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 5am on monday"]


### PR DESCRIPTION
## Related Issue
<!-- #XXXX -->

## Description
Work around Renovate aborting with `repository-changed` when the `renovate-appwrite` installation token cannot `POST /statuses` (`statuses=write` 403), even though the app definition already has Commit statuses R/W.

Nulls Renovate's status check names (`artifactError`, `configValidation`, `mergeConfidence`, `minimumReleaseAge`) via `renovate.json` and `RENOVATE_STATUS_CHECK_NAMES`.

Includes a TODO in `.github/workflows/renovate.yml` to remove this once the org installation token can write commit statuses (accept any pending installation permission update).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Test Plan
- [ ] Dispatch `renovate` workflow with `debug=true` on this branch or after merge
- [ ] Confirm logs show `Repository result: done` (not `repository-changed`)
- [ ] Confirm Dependency Dashboard (#1628) updates

## Checklist
- [x] TODO documents how/when to remove the workaround
