### PR TITLE
Restore Renovate commit status checks after statuses:write grant

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -53,5 +53,3 @@ jobs:
         env:
           RENOVATE_ALLOWED_COMMANDS: '["^./scripts/update-lockfiles\\.sh renovate$"]'
           RENOVATE_REPOSITORIES: ${{ github.repository }}
-          # TODO: remove when renovate-appwrite installation token has statuses:write
-          RENOVATE_STATUS_CHECK_NAMES: '{"artifactError":null,"configValidation":null,"mergeConfidence":null,"minimumReleaseAge":null}'


### PR DESCRIPTION
## Related Issue
<!-- Reverts workaround from #1647 -->

## Description
Remove `RENOVATE_STATUS_CHECK_NAMES` nulling now that the `renovate-appwrite` installation token has `statuses:write`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe):

## Test Plan
- [ ] After merge, dispatch Renovate with debug and confirm logs show status check writes (not "Status check is null") and `Repository result: done` with no statuses 403
