### PR TITLE
Allow CLI push with API key via capability-based auth

### DIFF
--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -481,6 +481,11 @@ class CLI extends Node
             ],
             [
                 'scope'         => 'copy',
+                'destination'   => 'lib/auth/capabilities.ts',
+                'template'      => 'cli/lib/auth/capabilities.ts',
+            ],
+            [
+                'scope'         => 'copy',
                 'destination'   => 'lib/auth/login.ts',
                 'template'      => 'cli/lib/auth/login.ts',
             ],

--- a/templates/cli/lib/auth/capabilities.ts
+++ b/templates/cli/lib/auth/capabilities.ts
@@ -1,0 +1,72 @@
+import { EXECUTABLE_NAME } from "../constants.js";
+import { globalConfig } from "../config.js";
+import { AppwriteException } from "@appwrite.io/console";
+import { hasAuthSession } from "./session.js";
+
+export type AuthMode = "session" | "apiKey" | "none";
+
+export const hasApiKey = (): boolean => globalConfig.getKey() !== "";
+
+export const getAuthMode = (): AuthMode => {
+  if (hasAuthSession()) {
+    return "session";
+  }
+
+  if (hasApiKey()) {
+    return "apiKey";
+  }
+
+  return "none";
+};
+
+export const canUseConsole = (): boolean => hasAuthSession();
+
+export const requireProjectAuth = (): void => {
+  if (getAuthMode() !== "none") {
+    return;
+  }
+
+  throw new Error(
+    `Authentication not found. Run \`${EXECUTABLE_NAME} login\` or \`${EXECUTABLE_NAME} client --key <API_KEY>\`.`,
+  );
+};
+
+export const requireConsoleAuth = (action: string): void => {
+  if (canUseConsole()) {
+    return;
+  }
+
+  if (hasApiKey()) {
+    throw new Error(
+      `${action} requires a console session. API keys work for project commands (e.g. \`${EXECUTABLE_NAME} push functions\`), not console-only commands. Run \`${EXECUTABLE_NAME} login\`.`,
+    );
+  }
+
+  throw new Error(
+    `${action} requires a console session. Run \`${EXECUTABLE_NAME} login\`.`,
+  );
+};
+
+export const isAuthScopeError = (error: unknown): boolean => {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const message = error.message.toLowerCase();
+  const isScopeMessage =
+    message.includes("missing scope") ||
+    message.includes("missing scopes") ||
+    message.includes("session not found") ||
+    message.includes("unauthorized") ||
+    message.includes("console session required");
+
+  if (error instanceof AppwriteException) {
+    return (
+      isScopeMessage ||
+      Number(error.code) === 401 ||
+      Number(error.code) === 403
+    );
+  }
+
+  return isScopeMessage;
+};

--- a/templates/cli/lib/auth/capabilities.ts
+++ b/templates/cli/lib/auth/capabilities.ts
@@ -47,6 +47,12 @@ export const requireConsoleAuth = (action: string): void => {
   );
 };
 
+/**
+ * True only for missing-scope / missing-session failures that optional
+ * console side-effects (e.g. default domain rules) should soft-fail on.
+ * Intentionally narrow: do not treat generic "unauthorized" text or all
+ * HTTP 403s as scope errors, so real authorization failures still surface.
+ */
 export const isAuthScopeError = (error: unknown): boolean => {
   if (!(error instanceof Error)) {
     return false;
@@ -57,14 +63,12 @@ export const isAuthScopeError = (error: unknown): boolean => {
     message.includes("missing scope") ||
     message.includes("missing scopes") ||
     message.includes("session not found") ||
-    message.includes("unauthorized") ||
     message.includes("console session required");
 
   if (error instanceof AppwriteException) {
     return (
       isScopeMessage ||
-      Number(error.code) === 401 ||
-      Number(error.code) === 403
+      String(error.type ?? "").toLowerCase() === "general_unauthorized_scope"
     );
   }
 

--- a/templates/cli/lib/commands/pull.ts
+++ b/templates/cli/lib/commands/pull.ts
@@ -25,6 +25,7 @@ import { applyConfigFilters } from "../config-filters.js";
 import {
   canUseConsole,
   requireConsoleAuth,
+  requireProjectAuth,
 } from "../auth/capabilities.js";
 import { paginate } from "../paginate.js";
 import {
@@ -108,6 +109,7 @@ async function createPullInstance(
   } = {},
 ): Promise<Pull> {
   const { silent = false, resource } = options;
+  requireProjectAuth();
   const projectClient = await sdkForProject();
   // Console credentials are attached when present. Console-required ops
   // call requireConsoleAuth() themselves instead of gating the whole pull.

--- a/templates/cli/lib/commands/pull.ts
+++ b/templates/cli/lib/commands/pull.ts
@@ -22,6 +22,10 @@ import { getFunctionsService, getSitesService } from "../services.js";
 import { sdkForProject, sdkForConsole } from "../sdks.js";
 import { localConfig } from "../config.js";
 import { applyConfigFilters } from "../config-filters.js";
+import {
+  canUseConsole,
+  requireConsoleAuth,
+} from "../auth/capabilities.js";
 import { paginate } from "../paginate.js";
 import {
   questionsPullFunctions,
@@ -100,14 +104,15 @@ export interface PullSettingsResult {
 async function createPullInstance(
   options: {
     silent?: boolean;
-    requiresConsoleAuth?: boolean;
     resource?: "functions" | "sites";
   } = {},
 ): Promise<Pull> {
-  const { silent = false, requiresConsoleAuth = false, resource } = options;
+  const { silent = false, resource } = options;
   const projectClient = await sdkForProject();
+  // Console credentials are attached when present. Console-required ops
+  // call requireConsoleAuth() themselves instead of gating the whole pull.
   const consoleClient = await sdkForConsole({
-    requiresAuth: requiresConsoleAuth,
+    requiresAuth: canUseConsole(),
   });
 
   const pullInstance = new Pull(projectClient, consoleClient, silent);
@@ -851,9 +856,8 @@ export const pullResources = async ({
 };
 
 const pullSettings = async (): Promise<void> => {
-  const pullInstance = await createPullInstance({
-    requiresConsoleAuth: true,
-  });
+  requireConsoleAuth("Pulling project settings");
+  const pullInstance = await createPullInstance();
   const project = localConfig.getProject();
   const projectId = project.projectId;
   const settings = await pullInstance.pullSettings(

--- a/templates/cli/lib/commands/push.ts
+++ b/templates/cli/lib/commands/push.ts
@@ -21,7 +21,11 @@ import {
   KeysTable,
 } from "../config.js";
 import { applyConfigFilters } from "../config-filters.js";
-import { hasAuthSession } from "../auth/session.js";
+import {
+  canUseConsole,
+  isAuthScopeError,
+  requireConsoleAuth,
+} from "../auth/capabilities.js";
 import {
   ConfigSchema,
   type SettingsType,
@@ -749,22 +753,6 @@ const formatPushResourceErrors = (results: Record<string, unknown>): string => {
 const nullablePolicyTotal = (value: number | bigint | null): number | null =>
   value === null || Number(value) === 0 ? null : Number(value);
 
-const isProxyRuleAuthError = (error: unknown): boolean => {
-  if (!(error instanceof AppwriteException) && !(error instanceof Error)) {
-    return false;
-  }
-
-  const message = error.message.toLowerCase();
-  return (
-    message.includes("missing scope") ||
-    message.includes("missing scopes") ||
-    message.includes("session not found") ||
-    message.includes("unauthorized") ||
-    (error instanceof AppwriteException &&
-      (Number(error.code) === 401 || Number(error.code) === 403))
-  );
-};
-
 const normalizeIgnoreRules = (value: unknown): string[] => {
   if (Array.isArray(value)) {
     return value.filter(
@@ -839,7 +827,7 @@ export class Push {
   }
 
   private async createDefaultFunctionRule(functionId: string): Promise<boolean> {
-    if (!hasAuthSession()) {
+    if (!canUseConsole()) {
       this.warn(
         `Skipping default domain rule for ${functionId}: console session required to read function domains. Run \`${EXECUTABLE_NAME} login\` or create the domain in the Console.`,
       );
@@ -861,7 +849,7 @@ export class Push {
 
       domain = ID.unique() + "." + this.getFunctionRuleDomain(domains[0]);
     } catch (err) {
-      if (isProxyRuleAuthError(err)) {
+      if (isAuthScopeError(err)) {
         this.warn(
           `Skipping default domain rule for ${functionId}: ${getPushErrorMessage(err)}`,
         );
@@ -878,7 +866,7 @@ export class Push {
       await proxyService.createFunctionRule(domain, functionId);
       return true;
     } catch (err) {
-      if (isProxyRuleAuthError(err)) {
+      if (isAuthScopeError(err)) {
         this.warn(
           `Skipping default domain rule for ${functionId}: ${getPushErrorMessage(err)}`,
         );
@@ -910,7 +898,7 @@ export class Push {
         return;
       }
     } catch (err) {
-      if (isProxyRuleAuthError(err)) {
+      if (isAuthScopeError(err)) {
         this.warn(
           `Skipping default domain rule check for ${functionId}: ${getPushErrorMessage(err)}`,
         );
@@ -923,7 +911,7 @@ export class Push {
   }
 
   private async createDefaultSiteRule(siteId: string): Promise<boolean> {
-    if (!hasAuthSession()) {
+    if (!canUseConsole()) {
       this.warn(
         `Skipping default domain rule for ${siteId}: console session required to read site domains. Run \`${EXECUTABLE_NAME} login\` or create the domain in the Console.`,
       );
@@ -945,7 +933,7 @@ export class Push {
 
       domain = ID.unique() + "." + domains[0];
     } catch (err) {
-      if (isProxyRuleAuthError(err)) {
+      if (isAuthScopeError(err)) {
         this.warn(
           `Skipping default domain rule for ${siteId}: ${getPushErrorMessage(err)}`,
         );
@@ -962,7 +950,7 @@ export class Push {
       await proxyService.createSiteRule(domain, siteId);
       return true;
     } catch (err) {
-      if (isProxyRuleAuthError(err)) {
+      if (isAuthScopeError(err)) {
         this.warn(
           `Skipping default domain rule for ${siteId}: ${getPushErrorMessage(err)}`,
         );
@@ -1043,7 +1031,7 @@ export class Push {
         (shouldPushAll || options.settings) &&
         (config.projectName || config.settings)
       ) {
-        if (!hasAuthSession()) {
+        if (!canUseConsole()) {
           this.warn(
             `Skipping project settings: console session required. Run \`${EXECUTABLE_NAME} login\` to push settings.`,
           );
@@ -1317,6 +1305,7 @@ export class Push {
     projectName?: string;
     settings?: SettingsType;
   }): Promise<void> {
+    requireConsoleAuth("Pushing project settings");
     await applyConfigFilters({
       config,
       consoleClient: this.consoleClient,
@@ -3184,17 +3173,17 @@ export class Push {
 async function createPushInstance(
   options: {
     silent?: boolean;
-    requiresConsoleAuth?: boolean;
     organizationId?: string;
   } = {
     silent: false,
-    requiresConsoleAuth: false,
   },
 ): Promise<Push> {
-  const { silent, requiresConsoleAuth, organizationId } = options;
+  const { silent, organizationId } = options;
   const projectClient = await sdkForProject();
+  // Console credentials are attached when present. Console-required ops
+  // call requireConsoleAuth() themselves instead of gating the whole push.
   const consoleClient = await sdkForConsole({
-    requiresAuth: requiresConsoleAuth,
+    requiresAuth: canUseConsole(),
     organizationId,
   });
 
@@ -3244,10 +3233,7 @@ const pushResources = async ({
     const sites = localConfig.getSites();
 
     const project = localConfig.getProject();
-    // Settings still need console auth; other resources work with an API key.
-    // Default domain rules soft-fail when no console session is available.
     const pushInstance = await createPushInstance({
-      requiresConsoleAuth: hasAuthSession(),
       organizationId: project.organizationId,
     });
     const config: ConfigType = {
@@ -3319,6 +3305,7 @@ const pushResources = async ({
 
 const pushSettings = async (): Promise<void> => {
   checkDeployConditions(localConfig);
+  requireConsoleAuth("Pushing project settings");
 
   let resolvedOrganizationId: string | undefined;
 
@@ -3383,7 +3370,6 @@ const pushSettings = async (): Promise<void> => {
 
     const config = localConfig.getProject();
     const pushInstance = await createPushInstance({
-      requiresConsoleAuth: true,
       organizationId: config.organizationId ?? resolvedOrganizationId,
     });
 
@@ -3494,9 +3480,7 @@ const pushSite = async ({
   log("Pushing sites ...");
 
   const pushStartTime = Date.now();
-  // Domain rule creation needs console auth; soft-fails with an API key only.
   const pushInstance = await createPushInstance({
-    requiresConsoleAuth: hasAuthSession(),
     organizationId: localConfig.getProject().organizationId,
   });
   const result = await pushInstance.pushSites(
@@ -3659,9 +3643,7 @@ const pushFunction = async ({
   log("Pushing functions ...");
 
   const pushStartTime = Date.now();
-  // Domain rule creation needs console auth; soft-fails with an API key only.
   const pushInstance = await createPushInstance({
-    requiresConsoleAuth: hasAuthSession(),
     organizationId: localConfig.getProject().organizationId,
   });
   const result = await pushInstance.pushFunctions(

--- a/templates/cli/lib/commands/push.ts
+++ b/templates/cli/lib/commands/push.ts
@@ -25,6 +25,7 @@ import {
   canUseConsole,
   isAuthScopeError,
   requireConsoleAuth,
+  requireProjectAuth,
 } from "../auth/capabilities.js";
 import {
   ConfigSchema,
@@ -3179,6 +3180,7 @@ async function createPushInstance(
   },
 ): Promise<Push> {
   const { silent, organizationId } = options;
+  requireProjectAuth();
   const projectClient = await sdkForProject();
   // Console credentials are attached when present. Console-required ops
   // call requireConsoleAuth() themselves instead of gating the whole push.

--- a/templates/cli/lib/commands/push.ts
+++ b/templates/cli/lib/commands/push.ts
@@ -21,6 +21,7 @@ import {
   KeysTable,
 } from "../config.js";
 import { applyConfigFilters } from "../config-filters.js";
+import { hasAuthSession } from "../auth/session.js";
 import {
   ConfigSchema,
   type SettingsType,
@@ -748,6 +749,22 @@ const formatPushResourceErrors = (results: Record<string, unknown>): string => {
 const nullablePolicyTotal = (value: number | bigint | null): number | null =>
   value === null || Number(value) === 0 ? null : Number(value);
 
+const isProxyRuleAuthError = (error: unknown): boolean => {
+  if (!(error instanceof AppwriteException) && !(error instanceof Error)) {
+    return false;
+  }
+
+  const message = error.message.toLowerCase();
+  return (
+    message.includes("missing scope") ||
+    message.includes("missing scopes") ||
+    message.includes("session not found") ||
+    message.includes("unauthorized") ||
+    (error instanceof AppwriteException &&
+      (Number(error.code) === 401 || Number(error.code) === 403))
+  );
+};
+
 const normalizeIgnoreRules = (value: unknown): string[] => {
   if (Array.isArray(value)) {
     return value.filter(
@@ -821,7 +838,14 @@ export class Push {
     return parts.join(".");
   }
 
-  private async createDefaultFunctionRule(functionId: string): Promise<void> {
+  private async createDefaultFunctionRule(functionId: string): Promise<boolean> {
+    if (!hasAuthSession()) {
+      this.warn(
+        `Skipping default domain rule for ${functionId}: console session required to read function domains. Run \`${EXECUTABLE_NAME} login\` or create the domain in the Console.`,
+      );
+      return false;
+    }
+
     let domain = "";
     try {
       const consoleService = await getConsoleService(this.consoleClient);
@@ -837,6 +861,13 @@ export class Push {
 
       domain = ID.unique() + "." + this.getFunctionRuleDomain(domains[0]);
     } catch (err) {
+      if (isProxyRuleAuthError(err)) {
+        this.warn(
+          `Skipping default domain rule for ${functionId}: ${getPushErrorMessage(err)}`,
+        );
+        return false;
+      }
+
       this.error("Error fetching console variables.");
       throw err;
     }
@@ -845,7 +876,15 @@ export class Push {
       const proxyService = await getProxyService(this.projectClient);
       this.log(`Creating function proxy rule for ${domain} ...`);
       await proxyService.createFunctionRule(domain, functionId);
+      return true;
     } catch (err) {
+      if (isProxyRuleAuthError(err)) {
+        this.warn(
+          `Skipping default domain rule for ${functionId}: ${getPushErrorMessage(err)}`,
+        );
+        return false;
+      }
+
       this.error("Error creating function rule.");
       throw err;
     }
@@ -863,6 +902,76 @@ export class Push {
     });
 
     return rules.length > 0;
+  }
+
+  private async ensureDefaultFunctionRule(functionId: string): Promise<void> {
+    try {
+      if (await this.hasDefaultFunctionRule(functionId)) {
+        return;
+      }
+    } catch (err) {
+      if (isProxyRuleAuthError(err)) {
+        this.warn(
+          `Skipping default domain rule check for ${functionId}: ${getPushErrorMessage(err)}`,
+        );
+        return;
+      }
+      throw err;
+    }
+
+    await this.createDefaultFunctionRule(functionId);
+  }
+
+  private async createDefaultSiteRule(siteId: string): Promise<boolean> {
+    if (!hasAuthSession()) {
+      this.warn(
+        `Skipping default domain rule for ${siteId}: console session required to read site domains. Run \`${EXECUTABLE_NAME} login\` or create the domain in the Console.`,
+      );
+      return false;
+    }
+
+    let domain = "";
+    try {
+      const consoleService = await getConsoleService(this.consoleClient);
+      const variables = await consoleService.variables();
+      const domains = variables["_APP_DOMAIN_SITES"]
+        .split(",")
+        .map((value) => value.trim())
+        .filter((value) => value.length > 0);
+
+      if (domains.length === 0) {
+        throw new Error("_APP_DOMAIN_SITES is not configured.");
+      }
+
+      domain = ID.unique() + "." + domains[0];
+    } catch (err) {
+      if (isProxyRuleAuthError(err)) {
+        this.warn(
+          `Skipping default domain rule for ${siteId}: ${getPushErrorMessage(err)}`,
+        );
+        return false;
+      }
+
+      this.error("Error fetching console variables.");
+      throw err;
+    }
+
+    try {
+      const proxyService = await getProxyService(this.projectClient);
+      this.log(`Creating site proxy rule for ${domain} ...`);
+      await proxyService.createSiteRule(domain, siteId);
+      return true;
+    } catch (err) {
+      if (isProxyRuleAuthError(err)) {
+        this.warn(
+          `Skipping default domain rule for ${siteId}: ${getPushErrorMessage(err)}`,
+        );
+        return false;
+      }
+
+      this.error("Error creating site rule.");
+      throw err;
+    }
   }
 
   /**
@@ -934,25 +1043,36 @@ export class Push {
         (shouldPushAll || options.settings) &&
         (config.projectName || config.settings)
       ) {
-        try {
-          this.log("Pushing settings ...");
-          await this.pushSettings({
-            organizationId: config.organizationId,
-            projectId: config.projectId,
-            projectName: config.projectName,
-            settings: config.settings,
-          });
-          this.success(
-            `Successfully pushed ${chalk.bold("all")} project settings.`,
+        if (!hasAuthSession()) {
+          this.warn(
+            `Skipping project settings: console session required. Run \`${EXECUTABLE_NAME} login\` to push settings.`,
           );
-          results.settings = { success: true };
-        } catch (e: any) {
-          allErrors.push(e);
           results.settings = {
             success: false,
-            error: getPushErrorMessage(e),
-            errors: [e],
+            error: "Console session required to push project settings.",
+            errors: [],
           };
+        } else {
+          try {
+            this.log("Pushing settings ...");
+            await this.pushSettings({
+              organizationId: config.organizationId,
+              projectId: config.projectId,
+              projectName: config.projectName,
+              settings: config.settings,
+            });
+            this.success(
+              `Successfully pushed ${chalk.bold("all")} project settings.`,
+            );
+            results.settings = { success: true };
+          } catch (e: any) {
+            allErrors.push(e);
+            results.settings = {
+              success: false,
+              error: getPushErrorMessage(e),
+              errors: [e],
+            };
+          }
         }
       }
 
@@ -1736,7 +1856,7 @@ export class Push {
                 deploymentRetention: func.deploymentRetention,
               });
 
-              await this.createDefaultFunctionRule(func.$id);
+              await this.ensureDefaultFunctionRule(func.$id);
               updaterRow.update({ status: "Created" });
             } catch (e: any) {
               errors.push(e);
@@ -1748,9 +1868,7 @@ export class Push {
             }
           } else {
             try {
-              if (!(await this.hasDefaultFunctionRule(func.$id))) {
-                await this.createDefaultFunctionRule(func.$id);
-              }
+              await this.ensureDefaultFunctionRule(func.$id);
             } catch (e: any) {
               errors.push(e);
               updaterRow.fail({
@@ -2243,26 +2361,7 @@ export class Push {
                 deploymentRetention: site.deploymentRetention,
               });
 
-              let domain = "";
-              try {
-                const consoleService = await getConsoleService(
-                  this.consoleClient,
-                );
-                const variables = await consoleService.variables();
-                const domains = variables["_APP_DOMAIN_SITES"].split(",");
-                domain = ID.unique() + "." + domains[0].trim();
-              } catch (err) {
-                this.error("Error fetching console variables.");
-                throw err;
-              }
-
-              try {
-                const proxyService = await getProxyService(this.projectClient);
-                await proxyService.createSiteRule(domain, site.$id);
-              } catch (err) {
-                this.error("Error creating site rule.");
-                throw err;
-              }
+              await this.createDefaultSiteRule(site.$id);
 
               updaterRow.update({ status: "Created" });
             } catch (e: any) {
@@ -3145,8 +3244,10 @@ const pushResources = async ({
     const sites = localConfig.getSites();
 
     const project = localConfig.getProject();
+    // Settings still need console auth; other resources work with an API key.
+    // Default domain rules soft-fail when no console session is available.
     const pushInstance = await createPushInstance({
-      requiresConsoleAuth: true,
+      requiresConsoleAuth: hasAuthSession(),
       organizationId: project.organizationId,
     });
     const config: ConfigType = {
@@ -3393,8 +3494,9 @@ const pushSite = async ({
   log("Pushing sites ...");
 
   const pushStartTime = Date.now();
+  // Domain rule creation needs console auth; soft-fails with an API key only.
   const pushInstance = await createPushInstance({
-    requiresConsoleAuth: true,
+    requiresConsoleAuth: hasAuthSession(),
     organizationId: localConfig.getProject().organizationId,
   });
   const result = await pushInstance.pushSites(
@@ -3557,8 +3659,9 @@ const pushFunction = async ({
   log("Pushing functions ...");
 
   const pushStartTime = Date.now();
+  // Domain rule creation needs console auth; soft-fails with an API key only.
   const pushInstance = await createPushInstance({
-    requiresConsoleAuth: true,
+    requiresConsoleAuth: hasAuthSession(),
     organizationId: localConfig.getProject().organizationId,
   });
   const result = await pushInstance.pushFunctions(

--- a/templates/cli/lib/sdks.ts
+++ b/templates/cli/lib/sdks.ts
@@ -106,8 +106,11 @@ export const sdkForConsole = async ({
   const cookie = globalConfig.getCookie();
 
   if (requiresAuth && !accessToken && !cookie) {
+    const hasKey = globalConfig.getKey() !== "";
     throw new Error(
-      `Session not found. Please run \`${EXECUTABLE_NAME} login\` to create a session`,
+      hasKey
+        ? `Session not found. Run \`${EXECUTABLE_NAME} login\`. API keys work for project commands (e.g. \`${EXECUTABLE_NAME} push functions\`), not console-only commands (e.g. \`${EXECUTABLE_NAME} push settings\`).`
+        : `Session not found. Please run \`${EXECUTABLE_NAME} login\` to create a session`,
     );
   }
 

--- a/templates/cli/lib/sdks.ts
+++ b/templates/cli/lib/sdks.ts
@@ -204,6 +204,6 @@ export const sdkForProject = async (): Promise<Client> => {
   }
 
   throw new Error(
-    `Session not found. Please run \`${EXECUTABLE_NAME} login\` to create a session.`,
+    `Authentication not found. Run \`${EXECUTABLE_NAME} login\` or \`${EXECUTABLE_NAME} client --key <API_KEY>\`.`,
   );
 };


### PR DESCRIPTION
## Summary

- Fixes CLI CI regression where `appwrite client --key` + `appwrite push functions` failed with `Session not found. Please run appwrite login`
- Introduces capability-based auth (`session` | `apiKey` | `none`) so project-scoped push/pull works with API keys, console-only ops hard-fail clearly, and optional domain-rule side-effects soft-fail
- Removes eager `requiresConsoleAuth: true` gating from push/pull instance factories; gates by capability at the operation instead

Related: Discord report / docs non-interactive CI flow; earlier partial fix in #1312 was later regressed when functions/sites re-required console auth.

## Type of Change

- [x] Bug fix
- [x] Enhancement / refactor

## Changes

- Add [`templates/cli/lib/auth/capabilities.ts`](templates/cli/lib/auth/capabilities.ts): `getAuthMode`, `canUseConsole`, `requireProjectAuth`, `requireConsoleAuth`, `isAuthScopeError`
- Register new file in [`src/SDK/Language/CLI.php`](src/SDK/Language/CLI.php) `getFiles()`
- [`push.ts`](templates/cli/lib/commands/push.ts) / [`pull.ts`](templates/cli/lib/commands/pull.ts): drop `requiresConsoleAuth` from factories; hard-fail settings; soft-fail default domain rules; skip settings in `push --all` when only an API key is present
- [`sdks.ts`](templates/cli/lib/sdks.ts): clearer `sdkForConsole` error when an API key is configured but a console session is required

## Verification

Built both **main** and **fixed** CLI binaries locally from templates, then ran them against **Appwrite Cloud prod** (`https://fra.cloud.appwrite.io/v1`, project `pj-test`) using an **isolated `HOME`** (did not touch real `~/.appwrite/prefs.json`) and a short-lived ephemeral API key (functions.read/write only). Used `--no-code` for function push to avoid uploading a new deployment package beyond metadata sync. Cleaned up ephemeral key / temp artifacts afterward.

### Setup

1. Copied updated templates into `examples/cli/` and built:
   ```bash
   cd examples/cli && npm run build:cli
   ```
2. Built a **main** baseline binary by swapping in `main` versions of `push.ts` / `sdks.ts`, then restored fixed sources and rebuilt.
3. Created isolated env:
   ```bash
   HOME=/tmp/cli-auth-verify/home
   WORKDIR=/tmp/cli-auth-verify/workdir   # local appwrite.config.json + stub function
   ```
4. Configured API-key-only auth (no login session):
   ```bash
   HOME=... node cli-fixed.cjs client \
     --endpoint https://fra.cloud.appwrite.io/v1 \
     --project-id pj-test \
     --key <ephemeral-api-key>
   ```
5. Confirmed isolated prefs had **key only** (no `accessToken` / `cookie`):
   ```
   fields ['endpoint', 'key']
   has accessToken False
   has cookie False
   has key True
   endpoint https://fra.cloud.appwrite.io/v1
   ```

### Case 1 — Reproduce bug on `main` (API key + push functions)

```bash
HOME=... node cli-main.cjs push functions \
  --function-id cliAuthVerifyTmp --force --no-code --verbose
```

**Result (exit 1):** progressed through validation/diff, then failed at console auth gate:

```
ℹ Info: Validating functions ...
ℹ Info: Checking for changes ...
ℹ Info: Pushing functions ...
Error: Session not found. Please run `appwrite login` to create a session
  at sdkForConsole (.../cli-main.cjs)
  at createPushInstance (.../cli-main.cjs)
  at async pushFunction (.../cli-main.cjs)
```

This matches the reported CI failure.

### Case 2 — Fixed build (API key + push functions)

```bash
HOME=... node cli-fixed.cjs push functions \
  --function-id cliAuthVerifyTmp --force --no-code --verbose
```

**Result (exit 0):** passed the session gate and completed push; soft-failed optional domain-rule check due to missing `rules.read` on the API key (expected; not a session error):

```
ℹ Info: Validating functions ...
ℹ Info: Checking for changes ...
ℹ Info: Pushing functions ...
ℹ Warning: Skipping default domain rule check for cliAuthVerifyTmp: app.pj-test@service.fra.cloud.appwrite.io (role: applications) missing scopes (["rules.read"])
✓ Pushed       • cliAuthVerifyTmp (cliAuthVerifyTmp)
✓ Success: Successfully deployed 1 function in 0.8s.
```

### Case 3 — Fixed build (API key + push settings) — console-required hard-fail

```bash
HOME=... node cli-fixed.cjs push settings --force --verbose
```

**Result (exit 1):** clear capability error (not the old generic session message):

```
Error: Pushing project settings requires a console session. API keys work for project commands (e.g. `appwrite push functions`), not console-only commands. Run `appwrite login`.
  at requireConsoleAuth (.../cli-fixed.cjs)
  at pushSettings (.../cli-fixed.cjs)
```

### Case 4 — `main` settings (control)

```bash
HOME=... node cli-main.cjs push settings --force --verbose
```

**Result (exit 1):** old session gate:

```
ℹ Info: Pushing project settings ...
Error: Session not found. Please run `appwrite login` to create a session
```

### Assertions (all passed)

```
PASS - main functions hits session gate
PASS - fixed functions does NOT hit old session gate
PASS - fixed functions progressed past auth
PASS - fixed settings requires console session
PASS - main settings fails session
OVERALL PASS
```

### Cleanup

- Deleted ephemeral API key (or confirmed expired/not found)
- Confirmed no leftover `cliAuthVerifyTmp` function on `pj-test` (`functions_list` total 0)
- Removed `/tmp/cli-auth-verify` workdir/home/binaries
- Verified real `~/.appwrite/prefs.json` current session remained unchanged (`http://localhost:9520/v1`)

## Notes / follow-ups

- Default domain/proxy rule creation still needs either a console session or server-side `rules.*` scopes on API keys; with API keys the CLI now **warns and continues** instead of blocking the deploy.
- `push settings` / `pull settings` remain console-session-only by design.
