### PR TITLE
fix: pin CLI template @appwrite.io/console to 15.3.0 and dedupe generated query flags

### DIFF
--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -8,14 +8,7 @@ use Twig\TwigFunction;
 
 class CLI extends Node
 {
-    /**
-     * Generated query flag options per group, keyed by the config flag that
-     * enables them. A group is skipped when any of its option names collides
-     * with a parameter the method already declares in the spec (e.g. usage
-     * endpoints declare literal limit/offset), otherwise Commander throws on
-     * the duplicate option binding.
-     */
-    private const QUERY_FLAG_PARAMS = [
+    private const array QUERY_FLAG_PARAMS = [
         'filtering' => ['filter', 'where', 'sortAsc', 'sortDesc', 'cursorAfter', 'cursorBefore'],
         'pagination' => ['limit', 'offset'],
         'select' => ['select'],

--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -9,6 +9,19 @@ use Twig\TwigFunction;
 class CLI extends Node
 {
     /**
+     * Generated query flag options per group, keyed by the config flag that
+     * enables them. A group is skipped when any of its option names collides
+     * with a parameter the method already declares in the spec (e.g. usage
+     * endpoints declare literal limit/offset), otherwise Commander throws on
+     * the duplicate option binding.
+     */
+    private const QUERY_FLAG_PARAMS = [
+        'filtering' => ['filter', 'where', 'sortAsc', 'sortDesc', 'cursorAfter', 'cursorBefore'],
+        'pagination' => ['limit', 'offset'],
+        'select' => ['select'],
+    ];
+
+    /**
      * List of functions to ignore for console preview.
      */
     private array $consoleIgnoreFunctions = [
@@ -234,36 +247,27 @@ class CLI extends Node
             fn (array $parameter): string => $parameter['name'] ?? '',
             $method['parameters']['all'] ?? []
         );
-        // Skip generated query flags whose names collide with the method's
-        // own parameters (e.g. usage endpoints declare literal limit/offset),
-        // otherwise Commander throws on the duplicate option binding.
-        $collides = fn (array $names): bool => array_intersect($names, $parameterNames) !== [];
+        $collides = fn (string $group): bool => array_intersect(self::QUERY_FLAG_PARAMS[$group], $parameterNames) !== [];
         $hasOnlyLimitOffsetQueries = $hasQueries && $this->hasOnlyLimitOffsetQueries($method);
-        $hasSelectQueries = $hasQueries && in_array($methodName, ['listDocuments', 'getDocument', 'listRows', 'getRow'], true) && !$collides(['select']);
+        $hasSelectQueries = $hasQueries && in_array($methodName, ['listDocuments', 'getDocument', 'listRows', 'getRow'], true) && !$collides('select');
         $hasSelectionOnlyQueries = $hasQueries && in_array($methodName, ['getDocument', 'getRow'], true);
-        $hasFilteringQueries = $hasQueries && !$hasOnlyLimitOffsetQueries && !$hasSelectionOnlyQueries && !$collides(['filter', 'where', 'sortAsc', 'sortDesc', 'cursorAfter', 'cursorBefore']);
-        $hasPaginationQueries = $hasQueries && !$hasSelectionOnlyQueries && !$collides(['limit', 'offset']);
+        $hasFilteringQueries = $hasQueries && !$hasOnlyLimitOffsetQueries && !$hasSelectionOnlyQueries && !$collides('filtering');
+        $hasPaginationQueries = $hasQueries && !$hasSelectionOnlyQueries && !$collides('pagination');
 
         $builderParams = [];
         if ($hasQueries) {
             $builderParams[] = 'queries';
 
             if ($hasFilteringQueries) {
-                $builderParams[] = 'filter';
-                $builderParams[] = 'where';
-                $builderParams[] = 'sortAsc';
-                $builderParams[] = 'sortDesc';
-                $builderParams[] = 'cursorAfter';
-                $builderParams[] = 'cursorBefore';
+                $builderParams = array_merge($builderParams, self::QUERY_FLAG_PARAMS['filtering']);
             }
 
             if ($hasPaginationQueries) {
-                $builderParams[] = 'limit';
-                $builderParams[] = 'offset';
+                $builderParams = array_merge($builderParams, self::QUERY_FLAG_PARAMS['pagination']);
             }
 
             if ($hasSelectQueries) {
-                $builderParams[] = 'select';
+                $builderParams = array_merge($builderParams, self::QUERY_FLAG_PARAMS['select']);
             }
         }
 

--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -230,11 +230,19 @@ class CLI extends Node
     {
         $hasQueries = $this->hasArrayQueriesParameter($method);
         $methodName = $method['name'] ?? '';
+        $parameterNames = array_map(
+            fn (array $parameter): string => $parameter['name'] ?? '',
+            $method['parameters']['all'] ?? []
+        );
+        // Skip generated query flags whose names collide with the method's
+        // own parameters (e.g. usage endpoints declare literal limit/offset),
+        // otherwise Commander throws on the duplicate option binding.
+        $collides = fn (array $names): bool => array_intersect($names, $parameterNames) !== [];
         $hasOnlyLimitOffsetQueries = $hasQueries && $this->hasOnlyLimitOffsetQueries($method);
-        $hasSelectQueries = $hasQueries && in_array($methodName, ['listDocuments', 'getDocument', 'listRows', 'getRow'], true);
+        $hasSelectQueries = $hasQueries && in_array($methodName, ['listDocuments', 'getDocument', 'listRows', 'getRow'], true) && !$collides(['select']);
         $hasSelectionOnlyQueries = $hasQueries && in_array($methodName, ['getDocument', 'getRow'], true);
-        $hasFilteringQueries = $hasQueries && !$hasOnlyLimitOffsetQueries && !$hasSelectionOnlyQueries;
-        $hasPaginationQueries = $hasQueries && !$hasSelectionOnlyQueries;
+        $hasFilteringQueries = $hasQueries && !$hasOnlyLimitOffsetQueries && !$hasSelectionOnlyQueries && !$collides(['filter', 'where', 'sortAsc', 'sortDesc', 'cursorAfter', 'cursorBefore']);
+        $hasPaginationQueries = $hasQueries && !$hasSelectionOnlyQueries && !$collides(['limit', 'offset']);
 
         $builderParams = [];
         if ($hasQueries) {

--- a/templates/cli/bun.lock.twig
+++ b/templates/cli/bun.lock.twig
@@ -5,7 +5,7 @@
     "": {
       "name": "{{ language.params.npmPackage|caseDash }}",
       "dependencies": {
-        "@appwrite.io/console": "^15.1.1",
+        "@appwrite.io/console": "15.3.0",
         "@napi-rs/keyring": "^1.3.0",
         "chalk": "4.1.2",
         "chokidar": "^3.6.0",
@@ -52,7 +52,7 @@
     "tmp": "^0.2.6",
   },
   "packages": {
-    "@appwrite.io/console": ["@appwrite.io/console@15.2.0", "", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-tBDEipq5ZE4ubV5Pisj6LvVCgiRBUPAiaEAIYMKG3CiLFAL1Y0aEibx90w3WN+J1/Set+NrteSuBeIQoKcv7tQ=="],
+    "@appwrite.io/console": ["@appwrite.io/console@15.3.0", "", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-YzWCyJGI8EZv+1Lk6uBJCI+BPALK9A8W362pffw7ljM116Jk/etw5K1gNXWIkKn5XrcAtaWk4AXsap2d/w00EA=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
@@ -624,7 +624,7 @@
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
-    "prettier": ["prettier@3.9.4", "", { "bin": "bin/prettier.cjs" }, "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg=="],
+    "prettier": ["prettier@3.9.5", "", { "bin": "bin/prettier.cjs" }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
 
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 

--- a/templates/cli/package-lock.json.twig
+++ b/templates/cli/package-lock.json.twig
@@ -9,7 +9,7 @@
       "version": "{{ sdk.version }}",
       "license": "{{ sdk.license }}",
       "dependencies": {
-        "@appwrite.io/console": "^15.1.1",
+        "@appwrite.io/console": "15.3.0",
         "@napi-rs/keyring": "^1.3.0",
         "chalk": "4.1.2",
         "chokidar": "^3.6.0",
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@appwrite.io/console": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@appwrite.io/console/-/console-15.2.0.tgz",
-      "integrity": "sha512-tBDEipq5ZE4ubV5Pisj6LvVCgiRBUPAiaEAIYMKG3CiLFAL1Y0aEibx90w3WN+J1/Set+NrteSuBeIQoKcv7tQ==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@appwrite.io/console/-/console-15.3.0.tgz",
+      "integrity": "sha512-YzWCyJGI8EZv+1Lk6uBJCI+BPALK9A8W362pffw7ljM116Jk/etw5K1gNXWIkKn5XrcAtaWk4AXsap2d/w00EA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "json-bigint": "1.0.0"
@@ -1959,9 +1959,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1977,9 +1974,6 @@
       "integrity": "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1997,9 +1991,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2016,9 +2007,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2034,9 +2022,6 @@
       "integrity": "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5050,9 +5035,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
-      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/templates/cli/package-lock.json.twig
+++ b/templates/cli/package-lock.json.twig
@@ -1959,6 +1959,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1974,6 +1977,9 @@
       "integrity": "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1991,6 +1997,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2007,6 +2016,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2022,6 +2034,9 @@
       "integrity": "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/templates/cli/package.json
+++ b/templates/cli/package.json
@@ -48,7 +48,7 @@
     "windows-arm64": "esbuild cli.ts --bundle --loader:.hbs=text --platform=node --target=node18 --format=esm --external:fsevents --external:terminal-image --outfile=dist/bundle-win-arm64.mjs && pkg dist/bundle-win-arm64.mjs --fallback-to-source -t node18-win-arm64 -o build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
-    "@appwrite.io/console": "^15.1.1",
+    "@appwrite.io/console": "15.3.0",
     "@napi-rs/keyring": "^1.3.0",
     "chalk": "4.1.2",
     "chokidar": "^3.6.0",

--- a/templates/cli/package.json.twig
+++ b/templates/cli/package.json.twig
@@ -51,7 +51,7 @@
     "windows-arm64": "bun build cli.ts --compile --minify --target=bun-windows-arm64 --outfile build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
-    "@appwrite.io/console": "^15.1.1",
+    "@appwrite.io/console": "15.3.0",
     "@napi-rs/keyring": "^1.3.0",
     "chalk": "4.1.2",
     "chokidar": "^3.6.0",

--- a/templates/dart/test/src/models/model_test.dart.twig
+++ b/templates/dart/test/src/models/model_test.dart.twig
@@ -1,9 +1,9 @@
 {% macro sub_schema(definitions, property) %}{% if property.sub_schema %}{% if property.type == 'array' %}List<{{property.sub_schema | caseUcfirst | overrideIdentifier}}>{% else %}{{property.sub_schema | caseUcfirst | overrideIdentifier }}(
   {% if definitions[property.sub_schema] %}{% for property in definitions[property.sub_schema].properties | filter(p => p.required) %}
-  {{ property.name | escapeKeyword }}: {% if property.type == 'array' %}[]{% elseif property.type == 'object' and (property.sub_schema == 'prefs' or property.sub_schema == 'preferences') %}Preferences(data: {}){% elseif property.type == 'object' and property.sub_schema %}{{_self.sub_schema(definitions, property)}}{% elseif property.type == 'string' %}'{{property['x-example'] | escapeDollarSign}}'{% elseif property.type == 'boolean' %}true{% else %}{{property['x-example']}}{% endif %},
+  {{ property.name | escapeKeyword }}: {% if property.type == 'array' %}[]{% elseif property.type == 'object' and (property.sub_schema == 'prefs' or property.sub_schema == 'preferences') %}Preferences(data: {}){% elseif property.type == 'object' and property.sub_schema %}{{_self.sub_schema(definitions, property)}}{% elseif property.enum %}{{ property.enumName | caseUcfirst }}.{{ (property.enumKeys[0] ?? property.enum[0]) | caseEnumKey }}{% elseif property.type == 'string' %}'{{property['x-example'] | escapeDollarSign}}'{% elseif property.type == 'boolean' %}true{% else %}{{property['x-example']}}{% endif %},
   {% endfor %}{% endif %}){% endif %}{% else %}{% if property.type == 'object' and property.additionalProperties %}Map<String, dynamic>{% else %}{{property | typeName}}{% endif %}{% endif %}{% endmacro %}
 import 'package:{{ language.params.packageName }}/models.dart';
-{% if definition.properties | filter(p => p.enum) | length > 0 %}
+{% if (definition.properties | filter(p => p.enum) | length > 0) or (definition.properties | filter(p => p.required and p.sub_schema and spec.definitions[p.sub_schema] and (spec.definitions[p.sub_schema].properties | filter(sp => sp.required and sp.enum) | length > 0)) | length > 0) %}
 import 'package:{{ language.params.packageName }}/enums.dart';
 {% endif %}
 {% if 'dart' in language.params.packageName %}

--- a/templates/python/base/requests/api.twig
+++ b/templates/python/base/requests/api.twig
@@ -30,7 +30,7 @@
 {% set isGenericResponse = method.responseModel | hasGenericType(spec) %}
 {% if isGenericResponse %}
 
-        return {{ method.responseModel | caseUcfirst }}.with_data(response, model_type)
+        return {% if (method.responseModel | caseUcfirst) == (service.name | caseUcfirst) %}{{ method.responseModel | caseUcfirst }}Model{% else %}{{ method.responseModel | caseUcfirst }}{% endif %}.with_data(response, model_type)
 {% else %}
 
         return self._parse_response(response, model={% if (method.responseModel | caseUcfirst) == (service.name | caseUcfirst) %}{{ method.responseModel | caseUcfirst }}Model{% else %}{{ method.responseModel | caseUcfirst }}{% endif %})

--- a/templates/python/package/services/service.py.twig
+++ b/templates/python/package/services/service.py.twig
@@ -100,7 +100,7 @@ Union[{% for responseModel in validResponseModels %}{% if not loop.first %}, {% 
 {% elseif validResponseModels|length == 1 %}
 {% if (validResponseModels[0] | caseUcfirst) == (service.name | caseUcfirst) %}{{ validResponseModels[0] | caseUcfirst }}Model{% else %}{{ validResponseModels[0] | caseUcfirst }}{% endif %}
 {% elseif method.responseModel and method.responseModel != 'any' %}
-{% if isGenericResponse %}{{ method.responseModel | caseUcfirst }}[T]{% elseif (method.responseModel | caseUcfirst) == (service.name | caseUcfirst) %}{{ method.responseModel | caseUcfirst }}Model{% else %}{{ method.responseModel | caseUcfirst }}{% endif %}
+{% if isGenericResponse %}{% if (method.responseModel | caseUcfirst) == (service.name | caseUcfirst) %}{{ method.responseModel | caseUcfirst }}Model{% else %}{{ method.responseModel | caseUcfirst }}{% endif %}[T]{% elseif (method.responseModel | caseUcfirst) == (service.name | caseUcfirst) %}{{ method.responseModel | caseUcfirst }}Model{% else %}{{ method.responseModel | caseUcfirst }}{% endif %}
 {% else %}
 Dict[str, Any]
 {% endif %}
@@ -149,7 +149,7 @@ Dict[str, Any]
             API response as one of the typed response models
         {% elseif validResponseModels|length == 1 %}{{ validResponseModels[0] | caseUcfirst }}
             API response as a typed Pydantic model
-        {% elseif method.responseModel and method.responseModel != 'any' %}{% if isGenericResponse %}{{ method.responseModel | caseUcfirst }}[T]
+        {% elseif method.responseModel and method.responseModel != 'any' %}{% if isGenericResponse %}{% if (method.responseModel | caseUcfirst) == (service.name | caseUcfirst) %}{{ method.responseModel | caseUcfirst }}Model{% else %}{{ method.responseModel | caseUcfirst }}{% endif %}[T]
 {% else %}{{ method | getResponseType(service.name) }}
 {% endif %}            API response as a typed Pydantic model
         {% else %}Dict[str, Any]


### PR DESCRIPTION
This PR carries the fixes needed for the full validation matrix to pass against the current 1.9.x specs (synced in appwrite/specs#86). Four independent issues, all surfaced by the new spec:

## 1. Pin `@appwrite.io/console` to `15.3.0` in the CLI template

The CLI depends on the console web SDK. The template pinned a caret range:

```diff
-    "@appwrite.io/console": "^15.1.1",
+    "@appwrite.io/console": "15.3.0",
```

`sdk-for-cli` is already pinned to exactly `15.3.0` ([appwrite/sdk-for-cli@f232e97](https://github.com/appwrite/sdk-for-cli/commit/f232e97)), so every regeneration reverted it back to `^15.1.1` — which can resolve to console SDKs missing the new APIs (organization memberships, OAuth2 PAR, TablesDB migrations, addons) and fail the build with errors like:

```
error: No matching export in "node_modules/@appwrite.io/console/dist/esm/sdk.js" for import "Mongo"
```

`package-lock.json.twig` and `bun.lock.twig` were regenerated via `scripts/update-lockfiles.sh cli` (with npm 11 — an earlier regeneration with npm 10 dropped the `libc` fields on optional native-binary entries, caught by Greptile and fixed).

An exact pin keeps the template byte-identical with the generated repo and makes console bumps an explicit, reviewed change here.

## 2. CLI: generated query flags collided with spec-declared parameters

The CLI generator adds convenience flags (`--filter`, `--sort-*`, `--limit`, `--offset`, `--cursor-*`, `--select`) to any command whose method has a `queries` array parameter. The new cloud `usage` endpoints (`listEvents`, `listGauges`) declare **literal** `limit`/`offset` parameters *alongside* `queries`, so the generated command registered the same option twice and Commander threw at startup:

```
error: "limit" cannot be bound multiple times in the same parameter list
```

The generated flag groups are now tracked in a constant and a group is skipped when any of its option names collides with a parameter the method already declares — the spec-declared options win:

```php
private const array QUERY_FLAG_PARAMS = [
    'filtering' => ['filter', 'where', 'sortAsc', 'sortDesc', 'cursorAfter', 'cursorBefore'],
    'pagination' => ['limit', 'offset'],
    'select' => ['select'],
];
```

```php
$collides = fn (string $group): bool => array_intersect(self::QUERY_FLAG_PARAMS[$group], $parameterNames) !== [];
...
$hasPaginationQueries = $hasQueries && !$hasSelectionOnlyQueries && !$collides('pagination');
```

The same constant now also feeds the `buildQueries` builder params, removing the previously duplicated hardcoded lists.

## 3. Python: service/model name collision broke generic responses

The new `organization` **service** returns the `organization` **model**. The service template aliases the import on collision:

```python
from ..models.organization import Organization as OrganizationModel
```

…but the generic-response paths still emitted the bare name in the return annotation and the response parsing:

```python
def get(self, model_type: Type[T] = dict) -> Organization[T]:   # NameError
    ...
    return Organization.with_data(response, model_type)          # resolves to the service class
```

On Python ≤ 3.13, return annotations are evaluated at function-definition time, so importing the module raised:

```
NameError: name 'Organization' is not defined
```

(this was the `python (server)` validation failure — it doesn't reproduce on Python 3.14, which defers annotation evaluation). The collision alias is now applied in all three places (return annotation, docstring, `.with_data()` call):

```python
def get(self, model_type: Type[T] = dict) -> OrganizationModel[T]:
    ...
    return OrganizationModel.with_data(response, model_type)
```

## 4. Dart: enum properties in nested model-test fixtures

The model test template handles enum properties at the top level, but its `sub_schema` macro (used for embedded models) fell through to the string branch, so `organization_test.dart` built the nested `BillingPlan` with a raw string:

```dart
BillingPlan(
  ...
  group: 'pro',   // error: The argument type 'String' can't be assigned to 'BillingPlanGroup'
)
```

The macro now emits enum literals, matching the top-level behavior:

```dart
BillingPlan(
  ...
  group: BillingPlanGroup.starter,
)
```

…and the `enums.dart` import condition also triggers when an enum appears only in a nested schema (previously it only checked the definition's own properties). This was the `dart (server)` validation failure (`dart analyze` exit 3).

## Verification

All generated from the current 1.9.x specs into clean output dirs:

| SDK | Check | Result |
|-----|-------|--------|
| cli | `bun run linux-x64` binary compile | ✅ compiles |
| cli | `tsc` + `npm run build` | ✅ 0 errors |
| cli | `node dist/cli.cjs usage list-events --help` | ✅ single `--limit`/`--offset` |
| python | `python -m unittest` (full suite) | ✅ 649 tests OK |
| dart | `dart analyze` | ✅ 0 errors |
| repo | `vendor/bin/rector process --dry-run` | ✅ clean |
