### PR TITLE
fix: rename Skills language class to AgentSkills

### DIFF
--- a/example.php
+++ b/example.php
@@ -25,7 +25,7 @@ use Appwrite\SDK\Language\Android;
 use Appwrite\SDK\Language\Kotlin;
 use Appwrite\SDK\Language\ReactNative;
 use Appwrite\SDK\Language\Unity;
-use Appwrite\SDK\Language\Skills;
+use Appwrite\SDK\Language\AgentSkills;
 use Appwrite\SDK\Language\ClaudePlugin;
 use Appwrite\SDK\Language\CodexPlugin;
 use Appwrite\SDK\Language\CursorPlugin;
@@ -378,7 +378,7 @@ try {
 
     // Skills
     if (!$requestedSdk || $requestedSdk === 'skills') {
-        $sdk = new SDK(new Skills(), buildStaticSpec());
+        $sdk = new SDK(new AgentSkills(), buildStaticSpec());
         configureSDK($sdk);
         $sdk->generate(__DIR__ . '/examples/skills');
     }

--- a/src/SDK/Language/AgentSkills.php
+++ b/src/SDK/Language/AgentSkills.php
@@ -6,7 +6,7 @@ use Override;
 use Appwrite\SDK\Language;
 use Twig\TwigFilter;
 
-class Skills extends Language
+class AgentSkills extends Language
 {
     protected array $skillLanguages = [
         'typescript',
@@ -27,7 +27,7 @@ class Skills extends Language
 
     public function getName(): string
     {
-        return 'Skills';
+        return 'AgentSkills';
     }
 
     public function getKeywords(): array

--- a/src/SDK/Language/ClaudePlugin.php
+++ b/src/SDK/Language/ClaudePlugin.php
@@ -6,7 +6,7 @@ namespace Appwrite\SDK\Language;
 
 use Override;
 
-class ClaudePlugin extends Skills
+class ClaudePlugin extends AgentSkills
 {
     #[Override]
     protected string $skillDestination = 'skills/%s/SKILL.md';

--- a/src/SDK/Language/CodexPlugin.php
+++ b/src/SDK/Language/CodexPlugin.php
@@ -6,7 +6,7 @@ namespace Appwrite\SDK\Language;
 
 use Override;
 
-class CodexPlugin extends Skills
+class CodexPlugin extends AgentSkills
 {
     #[Override]
     public function getName(): string

--- a/src/SDK/Language/CursorPlugin.php
+++ b/src/SDK/Language/CursorPlugin.php
@@ -6,7 +6,7 @@ namespace Appwrite\SDK\Language;
 
 use Override;
 
-class CursorPlugin extends Skills
+class CursorPlugin extends AgentSkills
 {
     #[Override]
     public function getName(): string


### PR DESCRIPTION
Renames the `Appwrite\SDK\Language\Skills` class to `AgentSkills` and updates its subclasses (`CursorPlugin`, `ClaudePlugin`, `CodexPlugin`) and `example.php`.

appwrite/server-ce's `SDKs.php` instantiates `new AgentSkills()` for the `agent-skills` static SDK, but the class here was named `Skills` — so any `sdks --platform=*` run (e.g. the cloud "Generate Specs" workflow's examples step) crashes with:

```
PHP Fatal error: Uncaught Error: Class "Appwrite\SDK\Language\AgentSkills" not found in .../Tasks/SDKs.php:449
```

`getName()` now returns `AgentSkills`; the skills templates don't reference `language.name`, so generated output is unchanged.