### PR TITLE
fix: skip generated CLI query flags that collide with spec parameters

### DIFF
--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -230,11 +230,19 @@ class CLI extends Node
     {
         $hasQueries = $this->hasArrayQueriesParameter($method);
         $methodName = $method['name'] ?? '';
+        $parameterNames = array_map(
+            fn (array $parameter): string => $parameter['name'] ?? '',
+            $method['parameters']['all'] ?? []
+        );
+        // Skip generated query flags whose names collide with the method's
+        // own parameters (e.g. usage endpoints declare literal limit/offset),
+        // otherwise Commander throws on the duplicate option binding.
+        $collides = fn (array $names): bool => array_intersect($names, $parameterNames) !== [];
         $hasOnlyLimitOffsetQueries = $hasQueries && $this->hasOnlyLimitOffsetQueries($method);
-        $hasSelectQueries = $hasQueries && in_array($methodName, ['listDocuments', 'getDocument', 'listRows', 'getRow'], true);
+        $hasSelectQueries = $hasQueries && in_array($methodName, ['listDocuments', 'getDocument', 'listRows', 'getRow'], true) && !$collides(['select']);
         $hasSelectionOnlyQueries = $hasQueries && in_array($methodName, ['getDocument', 'getRow'], true);
-        $hasFilteringQueries = $hasQueries && !$hasOnlyLimitOffsetQueries && !$hasSelectionOnlyQueries;
-        $hasPaginationQueries = $hasQueries && !$hasSelectionOnlyQueries;
+        $hasFilteringQueries = $hasQueries && !$hasOnlyLimitOffsetQueries && !$hasSelectionOnlyQueries && !$collides(['filter', 'where', 'sortAsc', 'sortDesc', 'cursorAfter', 'cursorBefore']);
+        $hasPaginationQueries = $hasQueries && !$hasSelectionOnlyQueries && !$collides(['limit', 'offset']);
 
         $builderParams = [];
         if ($hasQueries) {


### PR DESCRIPTION
The CLI generator adds `--filter`/`--sort-*`/`--limit`/`--offset`/`--cursor-*`/`--select` options to any command whose method has a `queries` array parameter. The new cloud `usage` endpoints (`listEvents`, `listGauges`) declare literal `limit` and `offset` parameters *alongside* `queries`, so the generated command binds `--limit`/`--offset` twice and Commander throws at registration:

```
error: "limit" cannot be bound multiple times in the same parameter list
```

This is what currently fails the `cli (console)` validation job (visible on #1653 after the 1.9.x specs sync).

`getCliQueryConfig()` now suppresses a generated flag group when any of its names collide with the method's own parameters, so the spec-declared options win.

Verified by generating from the current 1.9.x console spec: `usage` commands keep their single spec-declared `--limit`/`--offset`, `bun run linux-x64` compiles, `npm run build` passes, and `node dist/cli.cjs usage list-events --help` renders correctly (with `@appwrite.io/console@15.3.0` installed — the remaining validation dependency is the pin bump in #1653).