### PR TITLE
fix: kebab-case snake_case parameters in CLI flag names

### DIFF
--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -232,6 +232,14 @@ class CLI extends Node
         return false;
     }
 
+    private function getCliOptionName(string $name): string
+    {
+        $kebabName = strtolower((string) preg_replace('/(?<!^)([A-Z][a-z]|(?<=[a-z])[^a-z\s_]|(?<=[A-Z])\d)/', '-$1', $name));
+        $kebabName = trim((string) preg_replace('/-+/', '-', str_replace('_', '-', $kebabName)), '-');
+
+        return in_array(strtolower($name), $this->reservedKeywords) ? 'x' . $kebabName : $kebabName;
+    }
+
     private function getCliQueryConfig(array $method): array
     {
         $hasQueries = $this->hasArrayQueriesParameter($method);
@@ -866,9 +874,7 @@ class CLI extends Node
              * Returns array with: method, syntax, parser, customParserCode
              */
             new TwigFunction('getCliOption', function (array $parameter): array {
-                $name = $parameter['name'];
-                $kebabName = strtolower(preg_replace('/(?<!^)([A-Z][a-z]|(?<=[a-z])[^a-z\s]|(?<=[A-Z])[0-9_])/', '-$1', $name));
-                $optionName = in_array(strtolower($name), $this->reservedKeywords) ? 'x' . $kebabName : $kebabName;
+                $optionName = $this->getCliOptionName($parameter['name']);
                 $type = $parameter['type'] ?? 'string';
                 $required = $parameter['required'] ?? false;
 
@@ -931,9 +937,7 @@ class CLI extends Node
              * This matches the option name converted to camelCase.
              */
             new TwigFunction('getCliVarName', function (array $parameter): string {
-                $name = $parameter['name'];
-                $kebabName = strtolower(preg_replace('/(?<!^)([A-Z][a-z]|(?<=[a-z])[^a-z\s]|(?<=[A-Z])[0-9_])/', '-$1', $name));
-                $optionName = in_array(strtolower($name), $this->reservedKeywords) ? 'x' . $kebabName : $kebabName;
+                $optionName = $this->getCliOptionName($parameter['name']);
                 return lcfirst(str_replace(' ', '', ucwords(str_replace('-', ' ', $optionName))));
             }),
 
@@ -942,9 +946,7 @@ class CLI extends Node
              * Handles JSON parsing for objects, or plain variable.
              */
             new TwigFunction('getCliArgExpression', function (array $parameter): string {
-                $name = $parameter['name'];
-                $kebabName = strtolower(preg_replace('/(?<!^)([A-Z][a-z]|(?<=[a-z])[^a-z\s]|(?<=[A-Z])[0-9_])/', '-$1', $name));
-                $optionName = in_array(strtolower($name), $this->reservedKeywords) ? 'x' . $kebabName : $kebabName;
+                $optionName = $this->getCliOptionName($parameter['name']);
                 $varName = lcfirst(str_replace(' ', '', ucwords(str_replace('-', ' ', $optionName))));
                 $type = $parameter['type'] ?? 'string';
 


### PR DESCRIPTION
The CLI's kebab-casing regex splits on non-alphabetic characters but keeps the underscore, so the snake_case OAuth2 / OIDC spec parameters produced malformed flags:

```
--client-_id, --redirect-_uri, --response-_type, --request-_uri, --code-_challenge, --max-_age, ...
```

The duplicated kebab-casing logic in `getCliOption`, `getCliVarName`, and `getCliArgExpression` is now extracted into a `getCliOptionName()` helper that converts underscores to hyphens and collapses duplicates:

```php
private function getCliOptionName(string $name): string
{
    $kebabName = strtolower((string) preg_replace('/(?<!^)([A-Z][a-z]|(?<=[a-z])[^a-z\s_]|(?<=[A-Z])\d)/', '-$1', $name));
    $kebabName = trim((string) preg_replace('/-+/', '-', str_replace('_', '-', $kebabName)), '-');

    return in_array(strtolower($name), $this->reservedKeywords) ? 'x' . $kebabName : $kebabName;
}
```

| Parameter | Before | After |
|-----------|--------|-------|
| `request_uri` | `--request-_uri` | `--request-uri` |
| `client_id` | `--client-_id` | `--client-id` |
| `code_challenge_method` | `--code-_challenge-_method` | `--code-challenge-method` |
| `max_age` | `--max-_age` | `--max-age` |
| `databaseId` (camelCase, unchanged) | `--database-id` | `--database-id` |

**Breaking** for the `oauth2` CLI command family (the only snake_case parameters in the spec) — the underscore flags shipped in sdk-for-cli 22.5.0/22.6.0 get renamed on the next CLI release. camelCase parameters are unaffected, verified by regenerating the full CLI: the only flag diffs are the snake_case ones.

Verified: `bun run linux-x64` compiles, `npm run build` 0 errors, `oauth-2 authorize --help` renders `--client-id` / `--request-uri`. Rector + Pint clean.