### PR TITLE
fix: pin npm for lockfile generation to match publish audit

### DIFF
--- a/scripts/update-lockfiles.sh
+++ b/scripts/update-lockfiles.sh
@@ -14,6 +14,11 @@ TARGET="${1:-all}"
 WORKDIR="$(mktemp -d)"
 trap 'rm -rf "$WORKDIR"' EXIT
 
+# Must match the npm pin in sdk-for-cli's publish workflow: its audit step
+# regenerates the lock with this exact version and fails on any diff, and
+# npm versions differ in the lockfile metadata they emit (libc, overrides).
+SDK_GEN_NPM_VERSION="${SDK_GEN_NPM_VERSION:-11.10.0}"
+
 ensure_tool() {
     local command_name="$1" tool_name="$2" version="${3:-}"
 
@@ -74,27 +79,6 @@ validate_no_placeholders() {
     fi
 }
 
-sync_npm_overrides() {
-    local lockfile="$1"
-    local packagefile="$2"
-
-    node - "$lockfile" "$packagefile" <<'NODE'
-const fs = require('fs');
-
-const [lockfile, packagefile] = process.argv.slice(2);
-const lock = JSON.parse(fs.readFileSync(lockfile, 'utf8'));
-const pkg = JSON.parse(fs.readFileSync(packagefile, 'utf8'));
-
-if (pkg.overrides) {
-  lock.packages ??= {};
-  lock.packages[''] ??= {};
-  lock.packages[''].overrides = pkg.overrides;
-}
-
-fs.writeFileSync(lockfile, `${JSON.stringify(lock, null, 2)}\n`);
-NODE
-}
-
 restore_twig_npm() {
     # Replace PLACEHOLDER values in package-lock.json with the correct
     # Twig expressions extracted from the corresponding package.json.twig.
@@ -131,9 +115,8 @@ update_npm() {
     echo "→ $lang (npm)"
     mkdir -p "$dir"
     strip_twig "$template" > "$dir/package.json"
-    (cd "$dir" && npm_config_legacy_peer_deps=false npm install --package-lock-only --ignore-scripts --silent 2>/dev/null)
+    (cd "$dir" && npm_config_legacy_peer_deps=false npx -y "npm@${SDK_GEN_NPM_VERSION}" install --package-lock-only --ignore-scripts --silent 2>/dev/null)
     cp "$dir/package-lock.json" "$dest"
-    sync_npm_overrides "$dest" "$template"
     restore_twig_npm "$dest" "$twig_name"
     echo "  updated templates/$lang/package-lock.json.twig"
 }

--- a/templates/cli/package-lock.json.twig
+++ b/templates/cli/package-lock.json.twig
@@ -49,12 +49,6 @@
         "tsx": "^4.21.0",
         "typescript": "^5.3.3",
         "typescript-eslint": "^8.0.0"
-      },
-      "overrides": {
-        "phin": "3.7.1",
-        "@xmldom/xmldom": "^0.9.10",
-        "tmp": "^0.2.6",
-        "esbuild": "^0.28.1"
       }
     },
     "node_modules/@appwrite.io/console": {
@@ -1959,9 +1953,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1977,9 +1968,6 @@
       "integrity": "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1997,9 +1985,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2016,9 +2001,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2034,9 +2016,6 @@
       "integrity": "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
The sdk-for-cli 22.6.1 publish failed at its `Audit npm dependencies` step, which regenerates `package-lock.json` with the workflow-pinned **npm 11.10.0** and fails on any diff. The committed lock came from `update-lockfiles.sh`, which used whatever npm is installed locally — npm 11.16.0 in this case, which emits `libc` fields on optional native-binary entries that 11.10.0 doesn't. The `sync_npm_overrides` step made it worse: it injected an `overrides` block into `packages[""]` that npm 11.10.0's own `--package-lock-only` output never contains, guaranteeing drift.

Changes:

1. `update-lockfiles.sh` now runs lockfile generation through `npx -y npm@${SDK_GEN_NPM_VERSION}` (default **11.10.0**, matching the sdk-for-cli publish workflow pin), instead of the ambient npm.
2. Removed `sync_npm_overrides` — npm resolves `overrides` from `package.json` at install time and its canonical `--package-lock-only` output does not include the block in `packages[""]`; injecting it breaks the audit's `git diff --exit-code`.
3. Regenerated `templates/cli/package-lock.json.twig` with the pinned version. Verified the de-twigged output is a **fixed point** of the audit's rewrite: running `npm@11.10.0 install --package-lock-only` over it produces zero diff, and it byte-matches the normalized lock now on sdk-for-cli master ([appwrite/sdk-for-cli#339](https://github.com/appwrite/sdk-for-cli/pull/339)). `bun.lock.twig` was regenerated and is unchanged.

`npm ci && npm run build` verified working against the normalized lock. If the publish workflow's npm pin is ever bumped, regenerate with `SDK_GEN_NPM_VERSION=<version> ./scripts/update-lockfiles.sh`.