### PR TITLE
fix: audit the committed lockfile without regenerating it in CLI publish workflow

### DIFF
--- a/templates/cli/.github/workflows/publish.yml
+++ b/templates/cli/.github/workflows/publish.yml
@@ -143,12 +143,7 @@ jobs:
           fi
 
       - name: Audit npm dependencies
-        run: |
-          # CLI builds with Bun, but npm audit reads package-lock.json.
-          # update-lockfiles.sh updates both lockfiles; this catches npm lock drift.
-          npm install --package-lock-only --ignore-scripts
-          git diff --exit-code package-lock.json
-          npm audit --audit-level=high --omit=dev
+        run: npm audit --package-lock-only --audit-level=high --omit=dev
 
       - name: Publish
         run: npm publish --provenance --access public --tag ${{ steps.release_tag.outputs.tag }}


### PR DESCRIPTION
Template counterpart of [appwrite/sdk-for-cli#340](https://github.com/appwrite/sdk-for-cli/pull/340).

The CLI publish workflow's audit step rewrote `package-lock.json` with CI's pinned npm and failed on any diff. Since the lock is generated from `package-lock.json.twig` (the single source of truth) and npm versions differ in the lockfile metadata they emit (`libc` fields, `overrides` placement), the check failed whenever the template was regenerated with a different npm than CI's pin — this blocked the sdk-for-cli 22.6.1 release.

The step now only runs the vulnerability scan against the committed lock:

```yaml
npm audit --package-lock-only --audit-level=high --omit=dev
```

Without this template fix, the next CLI regeneration would reintroduce the removed drift check. Lockfile integrity remains covered by `npm ci` in validation.