### PR TITLE
fix: include default region in self-hosted CLI console deployment URLs

### DIFF
--- a/templates/cli/lib/utils.ts
+++ b/templates/cli/lib/utils.ts
@@ -526,8 +526,6 @@ export const getConsoleProjectSlug = (
   try {
     const hostname = new URL(endpoint).hostname;
 
-    // Self-hosted / non-cloud consoles always use project-{region}-{id},
-    // with region defaulting to "default" (matches Appwrite console routes).
     if (!isCloudHostname(hostname)) {
       return `project-${projectRegion || "default"}-${projectId}`;
     }

--- a/templates/cli/lib/utils.ts
+++ b/templates/cli/lib/utils.ts
@@ -526,12 +526,10 @@ export const getConsoleProjectSlug = (
   try {
     const hostname = new URL(endpoint).hostname;
 
+    // Self-hosted / non-cloud consoles always use project-{region}-{id},
+    // with region defaulting to "default" (matches Appwrite console routes).
     if (!isCloudHostname(hostname)) {
-      if (projectRegion) {
-        return `project-${projectRegion}-${projectId}`;
-      }
-
-      return `project-${projectId}`;
+      return `project-${projectRegion || "default"}-${projectId}`;
     }
 
     const firstSubdomain = hostname.split(".")[0];
@@ -539,7 +537,7 @@ export const getConsoleProjectSlug = (
       ? `project-${firstSubdomain}-${projectId}`
       : `project-${projectId}`;
   } catch {
-    return `project-${projectId}`;
+    return `project-${projectRegion || "default"}-${projectId}`;
   }
 };
 

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -225,7 +225,7 @@ abstract class Base extends TestCase
     protected const CLI_CONSOLE_URL_RESPONSES = [
         'https://cloud.appwrite.io/console/project-sgp-chirag-project-prod/sites/site-chirag-profile-website/deployments/deployment-123',
         'https://cloud.appwrite.io/console/project-sgp-chirag-project-prod/functions/function-sample-function/deployment-123',
-        'https://abc.example.com/console/project-self-hosted-project/sites/site-docs/deployments/deployment-456',
+        'https://abc.example.com/console/project-default-self-hosted-project/sites/site-docs/deployments/deployment-456',
     ];
 
     protected const CLI_HEADERS_RESPONSES = [

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -826,7 +826,7 @@ async function runAuthChecks() {
   });
 
   await authCheck("console-slug-region", () => {
-    assert.equal(getConsoleProjectSlug("http://localhost/v1", "proj1"), "project-proj1");
+    assert.equal(getConsoleProjectSlug("http://localhost/v1", "proj1"), "project-default-proj1");
     assert.equal(getConsoleProjectSlug("http://localhost/v1", "proj1", "fra"), "project-fra-proj1");
     assert.equal(getConsoleProjectSlug("https://fra.cloud.appwrite.io/v1", "proj1"), "project-fra-proj1");
     assert.equal(getConsoleProjectSlug("https://cloud.appwrite.io/v1", "proj1"), "project-proj1");


### PR DESCRIPTION
## Summary
- Self-hosted console routes always use `project-{region}-{projectId}` (region defaults to `default`), matching Appwrite console and Builds worker URLs.
- `getConsoleProjectSlug` previously omitted the region when it wasn't fetched (common with API-key-only pushes), producing broken links like `/console/project-{id}/...` instead of `/console/project-default-{id}/...`.
- Default non-cloud slugs to `project-default-{id}` when no region is available; keep explicit regions and cloud subdomain behavior unchanged.

## Test plan
- [ ] `getConsoleProjectSlug("http://localhost/v1", "proj1")` → `project-default-proj1`
- [ ] `getConsoleProjectSlug("http://localhost/v1", "proj1", "fra")` → `project-fra-proj1`
- [ ] Cloud regional/non-regional endpoints unchanged
- [ ] CLI e2e `console-slug-region` assertion passes
