### PR TITLE
Allow CLI OAuth login on Appwrite subdomains

### DIFF
--- a/templates/cli/lib/utils.ts
+++ b/templates/cli/lib/utils.ts
@@ -456,10 +456,6 @@ export const getCloudEndpointRegion = (endpoint: string): string | null => {
 export const isLocalhostHostname = (hostname: string): boolean =>
   hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
 
-const isCloudEnvironmentHostname = (hostname: string): boolean =>
-  hostname.endsWith(".cloud.appwrite.io") &&
-  CLOUD_LOGIN_ENVIRONMENTS.has(hostname.split(".")[0]);
-
 const getCloudConsoleHostname = (hostname: string): string | null => {
   if (hostname === "cloud.appwrite.io") {
     return hostname;
@@ -490,8 +486,7 @@ export const isCloudLoginEndpoint = (endpoint: string): boolean => {
   try {
     const hostname = new URL(endpoint).hostname;
     return (
-      isCloudHostname(hostname) ||
-      isCloudEnvironmentHostname(hostname) ||
+      hostname.endsWith(".appwrite.io") ||
       (isFlagEnabled("devCloudLogin") && isLocalhostHostname(hostname))
     );
   } catch (_error) {

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -796,6 +796,10 @@ async function runAuthChecks() {
       assert.equal(isCloudLoginEndpoint("https://new.appwrite.io/v1"), true);
       assert.equal(isCloudLoginEndpoint("https://appwrite.io/v1"), false);
       assert.equal(isCloudLoginEndpoint("https://notappwrite.io/v1"), false);
+      assert.equal(
+        isCloudLoginEndpoint("https://real.appwrite.io.attacker.com/v1"),
+        false,
+      );
       assert.equal(isCloudLoginEndpoint("http://localhost/v1"), false);
     } finally {
       if (prev === undefined) delete process.env.APPWRITE_CLI_DEV_CLOUD_LOGIN;

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -793,6 +793,9 @@ async function runAuthChecks() {
       assert.equal(isFlagEnabled("devCloudLogin"), false);
       assert.equal(isCloudLoginEndpoint("https://cloud.appwrite.io/v1"), true);
       assert.equal(isCloudLoginEndpoint("https://stage.cloud.appwrite.io/v1"), true);
+      assert.equal(isCloudLoginEndpoint("https://new.appwrite.io/v1"), true);
+      assert.equal(isCloudLoginEndpoint("https://appwrite.io/v1"), false);
+      assert.equal(isCloudLoginEndpoint("https://notappwrite.io/v1"), false);
       assert.equal(isCloudLoginEndpoint("http://localhost/v1"), false);
     } finally {
       if (prev === undefined) delete process.env.APPWRITE_CLI_DEV_CLOUD_LOGIN;


### PR DESCRIPTION
## Summary
- allow the OAuth login feature flag for any `*.appwrite.io` endpoint
- keep bare and lookalike domains excluded
- add CLI authentication coverage for the new endpoint pattern

## Test plan
- [x] Regenerate the CLI SDK
- [x] Run CLI TypeScript type checks
- [x] Run Twig linting
- [x] Verify positive and negative endpoint matching assertions


Made with [Cursor](https://cursor.com)