### PR TITLE
Use hosted MCP in tooling plugins

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -359,3 +359,84 @@ jobs:
           fi
           echo "All entry points verified."
           echo "::endgroup::"
+
+  validate-tooling-plugins:
+    name: Tooling plugins
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
+        with:
+          php-version: '8.5'
+          extensions: curl
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.11'
+
+      - name: Install Composer Dependencies
+        run: composer install
+
+      - name: Regenerate tooling plugins
+        run: |
+          php example.php cursor-plugin
+          php example.php claude-plugin
+          php example.php codex-plugin
+
+      - name: Verify tooling plugin generation is idempotent
+        run: |
+          find examples/cursor-plugin examples/claude-plugin examples/codex-plugin -type f -print0 \
+            | sort -z \
+            | xargs -0 sha256sum > /tmp/tooling-plugin-checksums
+
+          php example.php cursor-plugin
+          php example.php claude-plugin
+          php example.php codex-plugin
+
+          find examples/cursor-plugin examples/claude-plugin examples/codex-plugin -type f -print0 \
+            | sort -z \
+            | xargs -0 sha256sum \
+            | diff -u /tmp/tooling-plugin-checksums -
+
+      - name: Validate hosted MCP configurations
+        run: |
+          python3 <<'PY'
+          import json
+          import pathlib
+          import tomllib
+
+          root = pathlib.Path("examples")
+          expected_url = "https://mcp.appwrite.io/"
+
+          cursor = json.loads((root / "cursor-plugin/.mcp.json").read_text())
+          assert cursor["mcpServers"] == {
+              "appwrite": {"url": expected_url},
+          }
+
+          claude = json.loads((root / "claude-plugin/.mcp.json").read_text())
+          assert claude["mcpServers"] == {
+              "appwrite": {"type": "http", "url": expected_url},
+          }
+          claude_manifest = json.loads(
+              (root / "claude-plugin/.claude-plugin/plugin.json").read_text()
+          )
+          assert "userConfig" not in claude_manifest
+
+          codex = json.loads(
+              (root / "codex-plugin/plugins/appwrite/.mcp.json").read_text()
+          )
+          assert codex["mcpServers"] == {
+              "appwrite": {"type": "http", "url": expected_url},
+          }
+          codex_config = tomllib.loads(
+              (root / "codex-plugin/plugins/appwrite/config.toml").read_text()
+          )
+          assert codex_config["mcp_servers"] == {
+              "appwrite": {"url": expected_url},
+          }
+          PY

--- a/templates/claude-plugin/.mcp.json.twig
+++ b/templates/claude-plugin/.mcp.json.twig
@@ -1,18 +1,8 @@
 {
   "mcpServers": {
-    "appwrite-api": {
-      "type": "stdio",
-      "command": "uvx",
-      "args": ["mcp-server-appwrite"],
-      "env": {
-        "APPWRITE_ENDPOINT": "${user_config.appwrite_endpoint}",
-        "APPWRITE_PROJECT_ID": "${user_config.appwrite_project_id}",
-        "APPWRITE_API_KEY": "${user_config.appwrite_api_key}"
-      }
-    },
-    "appwrite-docs": {
+    "{{ spec.title | caseLower }}": {
       "type": "http",
-      "url": "https://mcp-for-docs.appwrite.io"
+      "url": "https://mcp.appwrite.io/"
     }
   }
 }

--- a/templates/claude-plugin/README.md.twig
+++ b/templates/claude-plugin/README.md.twig
@@ -5,13 +5,13 @@
 [![Twitter Account](https://img.shields.io/twitter/follow/appwrite?color=00acee&label=twitter&style=flat-square)](https://twitter.com/appwrite)
 [![Discord](https://img.shields.io/discord/564160730845151244?label=discord&style=flat-square)](https://appwrite.io/discord)
 
-Appwrite tools for Claude Code. This plugin packages Appwrite SDK skills, Appwrite MCP servers, and deployment commands in Claude Code's native plugin format.
+Appwrite tools for Claude Code. This plugin packages Appwrite SDK skills, the hosted Appwrite MCP server, and deployment commands in Claude Code's native plugin format.
 
 ## Structure
 
 ```text
 .claude-plugin/
-├── plugin.json              # Plugin manifest and user config schema
+├── plugin.json              # Plugin manifest
 └── marketplace.json         # Marketplace manifest for install-by-name flows
 skills/                      # Claude Code skills (per language)
 ├── typescript/
@@ -39,7 +39,7 @@ skills/                      # Claude Code skills (per language)
 commands/                    # Manual commands with side effects
 ├── deploy-site.md
 └── deploy-function.md
-.mcp.json                    # Appwrite API and docs MCP servers
+.mcp.json                    # Hosted Appwrite MCP server
 ```
 
 ## Included Skills
@@ -65,18 +65,21 @@ These skills give Claude Code language-specific Appwrite context for authenticat
 
 These commands are marked as manual-only so Claude will not invoke deployment workflows automatically.
 
-## Included MCP Servers
+## Hosted MCP Server
 
-- `appwrite-api` uses `uvx mcp-server-appwrite`
-- `appwrite-docs` connects to `https://mcp-for-docs.appwrite.io`
+The plugin configures one `{{ spec.title | caseLower }}` server at `https://mcp.appwrite.io/`. It provides tools for working with your {{ spec.title }} workspace and projects and for searching the latest {{ spec.title }} documentation.
 
-The plugin declares these `userConfig` keys for Appwrite credentials:
+The hosted server uses browser-based OAuth, so the plugin does not require an API key, project ID, endpoint, or other manually configured secret. In an interactive Claude Code session, open `/mcp` and authenticate the `{{ spec.title | caseLower }}` plugin server, or run:
 
-- `appwrite_endpoint`
-- `appwrite_project_id`
-- `appwrite_api_key`
+```sh
+claude mcp login plugin:{{ spec.title | caseLower }}:{{ spec.title | caseLower }}
+```
 
-Those values are wired into the packaged `.mcp.json` automatically through Claude Code `userConfig`.
+After authentication, try:
+
+> Use {{ spec.title }} to show my workspace context and list my projects.
+
+If authentication expires, run `claude mcp login plugin:{{ spec.title | caseLower }}:{{ spec.title | caseLower }}` again or choose **Re-authenticate** from `/mcp`. If the browser does not open, use the URL printed by Claude Code. Use `claude mcp get plugin:{{ spec.title | caseLower }}:{{ spec.title | caseLower }}` and `/mcp` to inspect approval, authentication, and connection status.
 
 ## Local Development
 

--- a/templates/claude-plugin/marketplace.json.twig
+++ b/templates/claude-plugin/marketplace.json.twig
@@ -12,7 +12,7 @@
         {
             "name": "{{ spec.title | caseLower }}",
             "source": "./",
-            "description": "{{ spec.title }} tools for Claude Code, including SDK skills, Appwrite MCP servers, and deployment commands.",
+            "description": "{{ spec.title }} tools for Claude Code, including SDK skills, the hosted {{ spec.title }} MCP server, and deployment commands.",
             "author": {
                 "name": "Appwrite",
                 "email": "team@appwrite.io"

--- a/templates/claude-plugin/plugin.json.twig
+++ b/templates/claude-plugin/plugin.json.twig
@@ -1,7 +1,7 @@
 {
     "name": "{{ spec.title | caseLower }}",
     "version": "{{ sdk.version }}",
-    "description": "{{ spec.title }} tools for Claude Code, including SDK skills, Appwrite MCP servers, and deployment commands.",
+    "description": "{{ spec.title }} tools for Claude Code, including SDK skills, the hosted {{ spec.title }} MCP server, and deployment commands.",
     "author": {
         "name": "Appwrite",
         "email": "team@appwrite.io"
@@ -14,25 +14,5 @@
         "claude-code",
         "mcp",
         "skills"
-    ],
-    "userConfig": {
-        "appwrite_endpoint": {
-            "type": "string",
-            "title": "Appwrite Endpoint",
-            "description": "Your Appwrite endpoint URL, for example https://<REGION>.cloud.appwrite.io/v1",
-            "sensitive": false
-        },
-        "appwrite_project_id": {
-            "type": "string",
-            "title": "Appwrite Project ID",
-            "description": "Your Appwrite project ID",
-            "sensitive": false
-        },
-        "appwrite_api_key": {
-            "type": "string",
-            "title": "Appwrite API Key",
-            "description": "Your Appwrite API key",
-            "sensitive": true
-        }
-    }
+    ]
 }

--- a/templates/codex-plugin/.mcp.json.twig
+++ b/templates/codex-plugin/.mcp.json.twig
@@ -1,8 +1,8 @@
 {
     "mcpServers": {
-        "{{ spec.title | caseLower }}-docs": {
+        "{{ spec.title | caseLower }}": {
             "type": "http",
-            "url": "https://mcp-for-docs.appwrite.io"
+            "url": "https://mcp.appwrite.io/"
         }
     }
 }

--- a/templates/codex-plugin/README.md.twig
+++ b/templates/codex-plugin/README.md.twig
@@ -5,7 +5,7 @@
 [![Twitter Account](https://img.shields.io/twitter/follow/appwrite?color=00acee&label=twitter&style=flat-square)](https://twitter.com/appwrite)
 [![Discord](https://img.shields.io/discord/564160730845151244?label=discord&style=flat-square)](https://appwrite.io/discord)
 
-{{ spec.title }} tools for the [OpenAI Codex CLI](https://github.com/openai/codex). This plugin packages {{ spec.title }} SDK skills, {{ spec.title }} deployment workflow skills, and the {{ spec.title }} docs MCP server.
+{{ spec.title }} tools for the [OpenAI Codex CLI](https://github.com/openai/codex). This plugin packages {{ spec.title }} SDK skills, {{ spec.title }} deployment workflow skills, and the hosted {{ spec.title }} MCP server.
 
 ## Structure
 
@@ -89,11 +89,21 @@ Deployment workflows are exposed as explicit skills:
 
 Use these to walk through deploying {{ spec.title }} sites and functions with the {{ spec.title }} CLI. Codex can also load them automatically when a task matches the skill description.
 
-## Included MCP Servers
+## Hosted MCP Server
 
-The bundled `plugins/{{ spec.title | caseLower }}/config.toml` registers one MCP server:
+The bundled plugin and `plugins/{{ spec.title | caseLower }}/config.toml` register one `{{ spec.title | caseLower }}` server at `https://mcp.appwrite.io/`. It provides tools for working with your {{ spec.title }} workspace and projects and for searching the latest {{ spec.title }} documentation.
 
-- `{{ spec.title | caseLower }}-docs` proxies `https://mcp-for-docs.appwrite.io` through `npx mcp-remote` so Codex can search the {{ spec.title }} documentation.
+The hosted server uses browser-based OAuth, so no API key, project ID, endpoint, or other manually configured secret is required. After installing the plugin or merging the manual configuration, authenticate with:
+
+```sh
+codex mcp login {{ spec.title | caseLower }}
+```
+
+Then try:
+
+> Use {{ spec.title }} to show my workspace context and list my projects.
+
+If the browser does not open, use the authorization URL printed by Codex. Run `codex mcp logout {{ spec.title | caseLower }}` followed by `codex mcp login {{ spec.title | caseLower }}` to refresh the OAuth session, and use `codex mcp get {{ spec.title | caseLower }}` to inspect the server configuration and status.
 
 ## Verify
 
@@ -101,7 +111,7 @@ After copying, run `codex` and check:
 
 - A session about {{ spec.title }} TypeScript work loads the `{{ spec.title | caseLower }}-typescript` skill (visible in the session header).
 - Typing `$` lets you invoke the `{{ spec.title | caseLower }}-deploy-*` skills explicitly.
-- `codex mcp list` (or `codex --debug`) lists the `{{ spec.title | caseLower }}-docs` server.
+- `codex mcp list` (or `codex --debug`) lists the `{{ spec.title | caseLower }}` server.
 
 ## Contribution
 

--- a/templates/codex-plugin/config.toml.twig
+++ b/templates/codex-plugin/config.toml.twig
@@ -2,6 +2,5 @@
 #
 # Merge the contents of this file into your ~/.codex/config.toml.
 
-[mcp_servers.{{ spec.title | caseLower }}-docs]
-command = "npx"
-args = ["mcp-remote", "https://mcp-for-docs.appwrite.io"]
+[mcp_servers.{{ spec.title | caseLower }}]
+url = "https://mcp.appwrite.io/"

--- a/templates/codex-plugin/plugin.json.twig
+++ b/templates/codex-plugin/plugin.json.twig
@@ -1,7 +1,7 @@
 {
     "name": "{{ spec.title | caseLower }}",
     "version": "{{ sdk.version }}",
-    "description": "{{ spec.title }} tools for Codex, including SDK skills, MCP servers, and deployment workflow skills.",
+    "description": "{{ spec.title }} tools for Codex, including SDK skills, the hosted {{ spec.title }} MCP server, and deployment workflow skills.",
     "author": {
         "name": "Appwrite",
         "email": "team@appwrite.io",
@@ -20,8 +20,8 @@
     "mcpServers": "./.mcp.json",
     "interface": {
         "displayName": "{{ spec.title }}",
-        "shortDescription": "{{ spec.title }} SDK skills, MCP servers, and deployment workflow skills for Codex.",
-        "longDescription": "Use {{ spec.title }} with Codex through language-specific SDK skills, project and documentation MCP servers, and guided deployment skills for sites and functions.",
+        "shortDescription": "{{ spec.title }} SDK skills, hosted MCP tools, and deployment workflow skills for Codex.",
+        "longDescription": "Use {{ spec.title }} with Codex through language-specific SDK skills, the OAuth-enabled hosted MCP server, and guided deployment skills for sites and functions.",
         "developerName": "Appwrite",
         "category": "Developer Tools",
         "capabilities": [

--- a/templates/cursor-plugin/.mcp.json.twig
+++ b/templates/cursor-plugin/.mcp.json.twig
@@ -1,17 +1,7 @@
 {
   "mcpServers": {
-    "appwrite-api": {
-      "command": "uvx",
-      "args": ["mcp-server-appwrite", "--users"],
-      "env": {
-        "APPWRITE_API_KEY": "your-api-key",
-        "APPWRITE_PROJECT_ID": "your-project-id",
-        "APPWRITE_ENDPOINT": "https://<REGION>.cloud.appwrite.io/v1"
-      }
-    },
-    "appwrite-docs": {
-      "command": "npx",
-      "args": ["mcp-remote", "https://mcp-for-docs.appwrite.io"]
+    "{{ spec.title | caseLower }}": {
+      "url": "https://mcp.appwrite.io/"
     }
   }
 }

--- a/templates/cursor-plugin/README.md.twig
+++ b/templates/cursor-plugin/README.md.twig
@@ -33,7 +33,7 @@ skills/                      # Agent skills (per language)
 commands/                    # Agent-executable commands
 ├── deploy-site.md
 └── deploy-function.md
-.mcp.json                    # MCP server definitions
+.mcp.json                    # Hosted Appwrite MCP server
 ```
 
 ## Skills
@@ -46,12 +46,17 @@ This plugin includes {{ spec.title }} SDK skills for the following languages:
 
 Each skill provides comprehensive SDK usage examples including authentication, database operations, file storage, real-time subscriptions, and more.
 
-## MCP Servers
+## Hosted MCP Server
 
-This plugin comes with two MCP (Model Context Protocol) servers pre-configured in `.mcp.json`:
+This plugin configures the hosted {{ spec.title }} MCP server at `https://mcp.appwrite.io/`. It gives Cursor access to your {{ spec.title }} workspace and projects as well as the latest {{ spec.title }} documentation.
 
-- **{{ spec.title }} API MCP** — Lets AI agents access the {{ spec.title }} API to manage users, databases, storage, and more.
-- **{{ spec.title }} Docs MCP** — Access {{ spec.title }} documentation inline for quick reference while coding.
+Cursor starts a browser-based OAuth flow when the server first connects. Sign in to {{ spec.title }} and approve access; no API key, project ID, endpoint, or other secret needs to be added to `.mcp.json`.
+
+After authentication, try:
+
+> Use {{ spec.title }} to show my workspace context and list my projects.
+
+If the server does not connect, open Cursor's MCP settings, restart the `{{ spec.title | caseLower }}` server, and complete the sign-in prompt. Clear or reauthenticate the server from the same settings when the OAuth session expires, and inspect Cursor's MCP output logs for connection errors.
 
 ## Commands
 

--- a/templates/cursor-plugin/plugin.json.twig
+++ b/templates/cursor-plugin/plugin.json.twig
@@ -1,7 +1,7 @@
 {
     "name": "{{ spec.title | caseLower }}-plugin",
     "version": "{{ sdk.version }}",
-    "description": "The Appwrite plugin for Cursor includes skills and MCP servers, allowing AI agents to access your projects and correctly integrate with your projects.",
+    "description": "The Appwrite plugin for Cursor includes skills and the hosted Appwrite MCP server, allowing AI agents to access your projects and correctly integrate with your projects.",
     "author": {
         "name": "Appwrite",
         "email": "team@appwrite.io"


### PR DESCRIPTION
## Summary

- replace the legacy Appwrite API and docs MCP configurations in the Cursor, Claude, and Codex plugin targets with the hosted Streamable HTTP server
- use the shared `appwrite` server name and browser-based OAuth without API keys, project IDs, endpoints, headers, `uvx`, or `mcp-remote`
- update plugin manifests and READMEs with authentication, verification, and troubleshooting guidance
- add consolidated CI coverage that regenerates the ignored examples, verifies idempotency, and validates the generated MCP schemas

This PR is intentionally separate from #1668. Generated examples remain ignored and are not committed.

## Testing

- `php example.php cursor-plugin`
- `php example.php claude-plugin`
- `php example.php codex-plugin`
- repeated generation with full-output checksum comparison for idempotency
- `composer lint`
- `composer lint-twig`
- `composer refactor:check`
- `vendor/bin/phpunit --testsuite Unit`
- `claude plugin validate examples/claude-plugin`
- verified Claude loads `plugin:appwrite:appwrite` as an HTTP server requiring authentication
- verified Codex recognizes `https://mcp.appwrite.io/` as native Streamable HTTP
- validated generated JSON, TOML, workflow YAML, OAuth metadata, and the hosted endpoint response
