### PR TITLE
Fix SDK generator issues found in release reviews

### DIFF
--- a/src/SDK/Language/Kotlin.php
+++ b/src/SDK/Language/Kotlin.php
@@ -796,13 +796,21 @@ class Kotlin extends Language
             $nestedTypeParam = $hasGenericType !== '' && $hasGenericType !== '0' ? ', nestedType' : '';
 
             if ($property['type'] === 'array') {
-                return "($mapKey as List<Map<String, Any>>).map { " .
+                $safeCast = $property['required'] ? 'as' : 'as?';
+                $safeCall = $property['required'] ? '' : '?';
+
+                return "($mapKey $safeCast List<Map<String, Any>>)$safeCall.map { " .
                        "$subSchemaClass.from(map = it$nestedTypeParam) }";
-            } else {
-                return "$subSchemaClass.from(" .
-                       "map = $mapKey as Map<String, Any>$nestedTypeParam" .
-                       ")";
             }
+
+            if (!$property['required']) {
+                return "($mapKey as? Map<String, Any>)?.let { " .
+                       "$subSchemaClass.from(map = it$nestedTypeParam) }";
+            }
+
+            return "$subSchemaClass.from(" .
+                   "map = $mapKey as Map<String, Any>$nestedTypeParam" .
+                   ")";
         }
 
         // Handle enum properties

--- a/src/SDK/Language/Kotlin.php
+++ b/src/SDK/Language/Kotlin.php
@@ -809,7 +809,7 @@ class Kotlin extends Language
         if (isset($property['enum']) && !empty($property['enum'])) {
             $enumName = $property['enumName'] ?? $property['name'];
             $enumClass = $this->toPascalCase($enumName);
-            $nullCheck = $property['required'] ? '!!' : ' ?: null';
+            $nullCheck = $property['required'] ? '!!' : '';
 
             if ($property['required']) {
                 return "$enumClass.values().find { " .

--- a/templates/android/library/src/main/java/io/package/Client.kt.twig
+++ b/templates/android/library/src/main/java/io/package/Client.kt.twig
@@ -121,7 +121,7 @@ class Client @JvmOverloads constructor(
     fun set{{header.key | caseUcfirst}}(value: String): Client {
         config["{{ header.key | caseCamel }}"] = value
         {%~ if header.global %}
-        addHeader("{{ header.name | caseLower }}", value)
+        addHeader("{{ header.name | caseLower }}", {% if header.type is defined and header.type == 'bearer' %}"Bearer $value"{% else %}value{% endif %})
         {%~ endif %}
         return this
     }

--- a/templates/android/library/src/main/java/io/package/Query.kt.twig
+++ b/templates/android/library/src/main/java/io/package/Query.kt.twig
@@ -413,10 +413,31 @@ class Query(
          */
         fun distanceLessThan(attribute: String, values: List<Any>, distance: Number, meters: Boolean = true) = Query("distanceLessThan", attribute, listOf(listOf(values, distance, meters))).toJson()
 
+        /**
+         * Filter resources by dot product similarity between attribute and the given vector.
+         *
+         * @param attribute The attribute to filter on.
+         * @param vector The query vector.
+         * @returns The query string.
+         */
         fun vectorDot(attribute: String, vector: List<Number>) = Query("vectorDot", attribute, listOf(vector)).toJson()
 
+        /**
+         * Filter resources by cosine similarity between attribute and the given vector.
+         *
+         * @param attribute The attribute to filter on.
+         * @param vector The query vector.
+         * @returns The query string.
+         */
         fun vectorCosine(attribute: String, vector: List<Number>) = Query("vectorCosine", attribute, listOf(vector)).toJson()
 
+        /**
+         * Filter resources by Euclidean distance between attribute and the given vector.
+         *
+         * @param attribute The attribute to filter on.
+         * @param vector The query vector.
+         * @returns The query string.
+         */
         fun vectorEuclidean(attribute: String, vector: List<Number>) = Query("vectorEuclidean", attribute, listOf(vector)).toJson()
 
         /**

--- a/templates/apple/Sources/Client.swift.twig
+++ b/templates/apple/Sources/Client.swift.twig
@@ -116,7 +116,7 @@ open class Client {
     open func set{{ header.key | caseUcfirst }}(_ value: String) -> Client {
         config["{{ header.key | caseLower }}"] = value
         {%~ if header.global %}
-        _ = addHeader(key: "{{header.name}}", value: value)
+        _ = addHeader(key: "{{header.name}}", value: {% if header.type is defined and header.type == 'bearer' %}"Bearer \(value)"{% else %}value{% endif %})
         {%~ endif %}
         return self
     }

--- a/templates/dart/lib/src/client_base.dart.twig
+++ b/templates/dart/lib/src/client_base.dart.twig
@@ -9,6 +9,7 @@ abstract class ClientBase implements Client {
 {% endif %}
   @override
   ClientBase set{{header.key | caseUcfirst}}(value);
+
 {% endfor %}
 
   @override

--- a/templates/dart/lib/src/client_browser.dart.twig
+++ b/templates/dart/lib/src/client_browser.dart.twig
@@ -56,7 +56,7 @@ class ClientBrowser extends ClientBase with ClientMixin {
   ClientBrowser set{{header.key | caseUcfirst}}(value) {
         config['{{ header.key | caseCamel }}'] = value;
         {%~ if header.global %}
-        addHeader('{{ header.name }}', value);
+        addHeader('{{ header.name }}', {% if header.type is defined and header.type == 'bearer' %}'Bearer $value'{% else %}value{% endif %});
         {%~ endif %}
         return this;
     }

--- a/templates/dart/lib/src/client_io.dart.twig
+++ b/templates/dart/lib/src/client_io.dart.twig
@@ -66,7 +66,7 @@ class ClientIO extends ClientBase with ClientMixin {
   ClientIO set{{header.key | caseUcfirst}}(value) {
         config['{{ header.key | caseCamel }}'] = value;
         {%~ if header.global %}
-        addHeader('{{ header.name }}', value);
+        addHeader('{{ header.name }}', {% if header.type is defined and header.type == 'bearer' %}'Bearer $value'{% else %}value{% endif %});
         {%~ endif %}
         return this;
     }

--- a/templates/dart/lib/src/models/model.dart.twig
+++ b/templates/dart/lib/src/models/model.dart.twig
@@ -28,9 +28,13 @@ class {{ definition.name | caseUcfirst | overrideIdentifier }} implements Model 
             {{ property.name | escapeKeyword }}:{{' '}}
             {%- if property.sub_schema -%}
                 {%- if property.type == 'array' -%}
+                    {%- if not property.required -%}map['{{property.name | escapeDollarSign }}'] != null ? {% endif -%}
                     List<{{property.sub_schema | caseUcfirst | overrideIdentifier}}>.from(map['{{property.name | escapeDollarSign }}'].map((p) => {{property.sub_schema | caseUcfirst | overrideIdentifier}}.fromMap(p)))
+                    {%- if not property.required %} : null{% endif -%}
                 {%- else -%}
+                    {%- if not property.required -%}map['{{property.name | escapeDollarSign }}'] != null ? {% endif -%}
                     {{property.sub_schema | caseUcfirst | overrideIdentifier}}.fromMap(map['{{property.name | escapeDollarSign }}'])
+                    {%- if not property.required %} : null{% endif -%}
                 {%- endif -%}
             {%- elseif property.enum -%}
                 {%- set enumName = property['enumName'] ?? property.name -%}

--- a/templates/dotnet/Package/Client.cs.twig
+++ b/templates/dotnet/Package/Client.cs.twig
@@ -126,7 +126,7 @@ namespace {{ spec.title | caseUcfirst }}
         public Client Set{{header.key | caseUcfirst}}(string value) {
             _config["{{ header.key | caseCamel }}"] = value;
             {%~ if header.global %}
-            AddHeader("{{header.name}}", value);
+            AddHeader("{{header.name}}", {% if header.type is defined and header.type == 'bearer' %}"Bearer " + value{% else %}value{% endif %});
             {%~ endif %}
 
             return this;

--- a/templates/flutter/lib/src/client_base.dart.twig
+++ b/templates/flutter/lib/src/client_base.dart.twig
@@ -9,6 +9,7 @@ abstract class ClientBase implements Client {
 {% endif %}
   @override
   ClientBase set{{header.key | caseUcfirst}}(value);
+
 {% endfor %}
 
   @override

--- a/templates/flutter/lib/src/client_browser.dart.twig
+++ b/templates/flutter/lib/src/client_browser.dart.twig
@@ -66,7 +66,7 @@ class ClientBrowser extends ClientBase with ClientMixin {
   ClientBrowser set{{header.key | caseUcfirst}}(value) {
     config['{{ header.key | caseCamel }}'] = value;
     {%~ if header.global %}
-    addHeader('{{ header.name }}', value);
+    addHeader('{{ header.name }}', {% if header.type is defined and header.type == 'bearer' %}'Bearer $value'{% else %}value{% endif %});
     {%~ endif %}
     return this;
   }

--- a/templates/flutter/lib/src/client_io.dart.twig
+++ b/templates/flutter/lib/src/client_io.dart.twig
@@ -92,7 +92,7 @@ class ClientIO extends ClientBase with ClientMixin {
   ClientIO set{{header.key | caseUcfirst}}(value) {
     config['{{ header.key | caseCamel }}'] = value;
     {%~ if header.global %}
-    addHeader('{{ header.name }}', value);
+    addHeader('{{ header.name }}', {% if header.type is defined and header.type == 'bearer' %}'Bearer $value'{% else %}value{% endif %});
     {%~ endif %}
     return this;
   }

--- a/templates/go/appwrite.go.twig
+++ b/templates/go/appwrite.go.twig
@@ -68,9 +68,9 @@ func WithChunkSize(size int64) client.ClientOption {
 func With{{header.key | caseUcfirst}}(value string) client.ClientOption {
 	return func(clt *client.Client) error {
 		clt.Config["{{ header.key | caseLower }}"] = value
-{% if header.global %}
-		clt.Headers["{{header.name}}"] = {% if header.type is defined and header.type == 'bearer' %}"Bearer " + value{% else %}value{% endif %}{{- "\n" -}}
-{% endif %}
+		{%~ if header.global %}
+		clt.Headers["{{header.name}}"] = {{ header.type is defined and header.type == 'bearer' ? '"Bearer " + value' : 'value' }}
+		{%~ endif %}
 		return nil
 	}
 }

--- a/templates/go/appwrite.go.twig
+++ b/templates/go/appwrite.go.twig
@@ -68,9 +68,9 @@ func WithChunkSize(size int64) client.ClientOption {
 func With{{header.key | caseUcfirst}}(value string) client.ClientOption {
 	return func(clt *client.Client) error {
 		clt.Config["{{ header.key | caseLower }}"] = value
-		{%~ if header.global %}
-		clt.Headers["{{header.name}}"] = value
-		{%~ endif %}
+{% if header.global %}
+		clt.Headers["{{header.name}}"] = {% if header.type is defined and header.type == 'bearer' %}"Bearer " + value{% else %}value{% endif %}{{- "\n" -}}
+{% endif %}
 		return nil
 	}
 }

--- a/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
@@ -96,7 +96,7 @@ class Client @JvmOverloads constructor(
     fun set{{header.key | caseUcfirst}}(value: String): Client {
         config["{{ header.key | caseCamel }}"] = value
         {%~ if header.global %}
-        addHeader("{{ header.name | caseLower }}", value)
+        addHeader("{{ header.name | caseLower }}", {% if header.type is defined and header.type == 'bearer' %}"Bearer $value"{% else %}value{% endif %})
         {%~ endif %}
         return this
     }

--- a/templates/kotlin/src/main/kotlin/io/appwrite/Query.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/Query.kt.twig
@@ -177,10 +177,31 @@ class Query(
          */
         fun distanceLessThan(attribute: String, values: List<Any>, distance: Number, meters: Boolean = true) = Query("distanceLessThan", attribute, listOf(listOf(values, distance, meters))).toJson()
 
+        /**
+         * Filter resources by dot product similarity between attribute and the given vector.
+         *
+         * @param attribute The attribute to filter on.
+         * @param vector The query vector.
+         * @returns The query string.
+         */
         fun vectorDot(attribute: String, vector: List<Number>) = Query("vectorDot", attribute, listOf(vector)).toJson()
 
+        /**
+         * Filter resources by cosine similarity between attribute and the given vector.
+         *
+         * @param attribute The attribute to filter on.
+         * @param vector The query vector.
+         * @returns The query string.
+         */
         fun vectorCosine(attribute: String, vector: List<Number>) = Query("vectorCosine", attribute, listOf(vector)).toJson()
 
+        /**
+         * Filter resources by Euclidean distance between attribute and the given vector.
+         *
+         * @param attribute The attribute to filter on.
+         * @param vector The query vector.
+         * @returns The query string.
+         */
         fun vectorEuclidean(attribute: String, vector: List<Number>) = Query("vectorEuclidean", attribute, listOf(vector)).toJson()
 
         fun intersects(attribute: String, values: List<Any>) = Query("intersects", attribute, listOf(values)).toJson()

--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -212,7 +212,7 @@ class Client {
      */
     set{{header.key | caseUcfirst}}(value: string): this {
         {%~ if header.global %}
-        this.headers['{{ header.name }}'] = value;
+        this.headers['{{ header.name }}'] = {% if header.type is defined and header.type == 'bearer' %}`Bearer ${value}`{% else %}value{% endif %};
         {%~ endif %}
         this.config.{{ header.key | caseLower }} = value;
         return this;

--- a/templates/php/src/Client.php.twig
+++ b/templates/php/src/Client.php.twig
@@ -120,7 +120,7 @@ class Client
     public function set{{header.key | caseUcfirst}}(string $value): Client
     {
         {%~ if header.global %}
-        $this->addHeader('{{header.name}}', $value);
+        $this->addHeader('{{header.name}}', {% if header.type is defined and header.type == 'bearer' %}"Bearer {$value}"{% else %}$value{% endif %});
         {%~ endif %}
         $this->config['{{ header.key | caseLower }}'] = $value;
 {% if header.type is defined and header.type == 'bearer' %}

--- a/templates/python/base/params.twig
+++ b/templates/python/base/params.twig
@@ -12,7 +12,7 @@
 {% endfor %}
 
 {% for parameter in method.parameters.query %}
-{% if not parameter.nullable and not parameter.required %}
+{% if not parameter.required %}
         if {{ parameter.name | escapeKeyword | caseSnake }} is not None:
             api_params['{{ parameter.name }}'] = self._normalize_value({{ parameter.name | escapeKeyword | caseSnake }})
 {% else %}
@@ -23,7 +23,7 @@
 {% set paramName = parameter.name | escapeKeyword | caseSnake %}
 {% set isMultipart = method.consumes|length > 0 and method.consumes[0] == "multipart/form-data" %}
 {% set formattedValue = paramName | formatParamValue(parameter.type, isMultipart) %}
-{% if not parameter.nullable and not parameter.required %}
+{% if not parameter.required %}
         if {{ paramName }} is not None:
             api_params['{{ parameter.name }}'] = self._normalize_value({{ formattedValue }})
 {% else %}

--- a/templates/python/package/client.py.twig
+++ b/templates/python/package/client.py.twig
@@ -55,9 +55,9 @@ class Client:
         """{{header.description}}"""
 
 {% endif %}
-        {%~ if header.global %}
-        self._global_headers['{{header.name|lower}}'] = value
-        {%~ endif %}
+{% if header.global %}
+        self._global_headers['{{header.name|lower}}'] = {% if header.type is defined and header.type == 'bearer' %}'Bearer ' + value{% else %}value{% endif %}{{- "\n" -}}
+{% endif %}
         self._config['{{ header.key | caseLower }}'] = value
         return self
 {% endfor %}

--- a/templates/python/package/client.py.twig
+++ b/templates/python/package/client.py.twig
@@ -55,9 +55,9 @@ class Client:
         """{{header.description}}"""
 
 {% endif %}
-{% if header.global %}
-        self._global_headers['{{header.name|lower}}'] = {% if header.type is defined and header.type == 'bearer' %}'Bearer ' + value{% else %}value{% endif %}{{- "\n" -}}
-{% endif %}
+        {%~ if header.global %}
+        self._global_headers['{{header.name|lower}}'] = {{ header.type is defined and header.type == 'bearer' ? "'Bearer ' + value" : 'value' }}
+        {%~ endif %}
         self._config['{{ header.key | caseLower }}'] = value
         return self
 {% endfor %}

--- a/templates/react-native/src/client.ts.twig
+++ b/templates/react-native/src/client.ts.twig
@@ -267,7 +267,7 @@ class Client {
      */
     set{{header.key | caseUcfirst}}(value: string): this {
         {%~ if header.global %}
-        this.headers['{{ header.name }}'] = value;
+        this.headers['{{ header.name }}'] = {% if header.type is defined and header.type == 'bearer' %}`Bearer ${value}`{% else %}value{% endif %};
         {%~ endif %}
         this.config.{{ header.key | caseLower }} = value;
         return this;

--- a/templates/ruby/lib/container/client.rb.twig
+++ b/templates/ruby/lib/container/client.rb.twig
@@ -38,7 +38,7 @@ module {{ spec.title | caseUcfirst }}
         # @return [self]
         def set_{{header.key | caseSnake}}(value)
             {%~ if header.global %}
-            add_header('{{header.name | caseLower}}', value)
+            add_header('{{header.name | caseLower}}', {% if header.type is defined and header.type == 'bearer' %}"Bearer #{value}"{% else %}value{% endif %})
             {%~ endif %}
             @config['{{ header.key | caseLower }}'] = value
 

--- a/templates/ruby/lib/container/models/model.rb.twig
+++ b/templates/ruby/lib/container/models/model.rb.twig
@@ -39,7 +39,7 @@ module {{ spec.title | caseUcfirst }}
             def self.from(map:)
                 {{ definition.name | caseUcfirst }}.new(
 {% for property in definition.properties %}
-                    {{ property.name | caseSnake | escapeKeyword | removeDollarSign }}: {% if property.sub_schema %}{% if property.type == 'array' %}map["{{ property.name }}"].map { |it| {{ property.sub_schema | caseUcfirst }}.from(map: it) }{% else %}{{property.sub_schema | caseUcfirst}}.from(map: map["{{property.name }}"]){% endif %}{% else %}map["{{ property.name }}"]{% endif %}{% if not loop.last or (loop.last and definition.additionalProperties) %},{% endif %}
+                    {{ property.name | caseSnake | escapeKeyword | removeDollarSign }}: {% if property.sub_schema %}{% if property.type == 'array' %}map["{{ property.name }}"]{% if not property.required %}&.{% else %}.{% endif %}map { |it| {{ property.sub_schema | caseUcfirst }}.from(map: it) }{% else %}{% if not property.required %}map["{{property.name }}"].nil? ? nil : {% endif %}{{property.sub_schema | caseUcfirst}}.from(map: map["{{property.name }}"]){% endif %}{% else %}map["{{ property.name }}"]{% endif %}{% if not loop.last or (loop.last and definition.additionalProperties) %},{% endif %}
 
 {% endfor %}
 {% if definition.additionalProperties %}
@@ -51,7 +51,7 @@ module {{ spec.title | caseUcfirst }}
             def to_map
                 {
 {% for property in definition.properties %}
-                    "{{ property.name }}": {% if property.sub_schema %}{% if property.type == 'array' %}@{{ property.name | caseSnake | escapeKeyword | removeDollarSign }}.map { |it| it.to_map }{% else %}@{{property.name | caseSnake | escapeKeyword | removeDollarSign }}.to_map{% endif %}{% else %}@{{property.name | caseSnake | escapeKeyword }}{% endif %}{% if not loop.last or (loop.last and definition.additionalProperties) %},{% endif %}
+                    "{{ property.name }}": {% if property.sub_schema %}{% if property.type == 'array' %}@{{ property.name | caseSnake | escapeKeyword | removeDollarSign }}{% if not property.required %}&.{% else %}.{% endif %}map { |it| it.to_map }{% else %}@{{property.name | caseSnake | escapeKeyword | removeDollarSign }}{% if not property.required %}&.{% else %}.{% endif %}to_map{% endif %}{% else %}@{{property.name | caseSnake | escapeKeyword }}{% endif %}{% if not loop.last or (loop.last and definition.additionalProperties) %},{% endif %}
 
 {% endfor %}
 {% if definition.additionalProperties %}

--- a/templates/rust/src/client.rs.twig
+++ b/templates/rust/src/client.rs.twig
@@ -165,7 +165,7 @@ impl Client {
         let value = value.into();
         self.state.rcu(|state| {
             let mut next = (**state).clone();
-            next.config.headers.insert("{{header.name | caseLower}}", value.clone().parse().unwrap());
+            next.config.headers.insert("{{header.name | caseLower}}", {% if header.type is defined and header.type == 'bearer' %}format!("Bearer {}", value){% else %}value.clone(){% endif %}.parse().unwrap());
             Arc::new(next)
         });
         self.clone()

--- a/templates/swift/Sources/Client.swift.twig
+++ b/templates/swift/Sources/Client.swift.twig
@@ -109,7 +109,7 @@ open class Client {
     open func set{{ header.key | caseUcfirst }}(_ value: String) -> Client {
         config["{{ header.key | caseLower }}"] = value
         {%~ if header.global %}
-        _ = addHeader(key: "{{header.name}}", value: value)
+        _ = addHeader(key: "{{header.name}}", value: {% if header.type is defined and header.type == 'bearer' %}"Bearer \(value)"{% else %}value{% endif %})
         {%~ endif %}
         return self
     }

--- a/templates/swift/Sources/Models/Model.swift.twig
+++ b/templates/swift/Sources/Models/Model.swift.twig
@@ -111,7 +111,7 @@ open class {{ definition | modelType(spec) | raw }}: Codable {
                 {%- if property.type == 'array' -%}
                     (map["{{property.name }}"] as{% if isDocument %}?{% else %}{% if property.required %}!{% else %}?{% endif %}{% endif %} [[String: Any]]{% if isDocument %} ?? []{% elseif not property.required %} ?? []{% endif %}).map { {{property.sub_schema | caseUcfirst}}.from(map: $0) }
                 {%- else -%}
-                    {% if isDocument %}map["{{property.name }}"] as? [String: Any] != nil ? {{property.sub_schema | caseUcfirst}}.from(map: map["{{property.name }}"] as! [String: Any]) : nil{% else %}{{property.sub_schema | caseUcfirst}}.from(map: map["{{property.name }}"] as! [String: Any]){% endif %}
+                    {% if isDocument or not property.required %}map["{{property.name }}"] as? [String: Any] != nil ? {{property.sub_schema | caseUcfirst}}.from(map: map["{{property.name }}"] as! [String: Any]) : nil{% else %}{{property.sub_schema | caseUcfirst}}.from(map: map["{{property.name }}"] as! [String: Any]){% endif %}
                 {%- endif -%}
             {%- else -%}
                 {%- if property | isAnyCodableArray(spec) -%}

--- a/templates/unity/Assets/Runtime/Core/Client.cs.twig
+++ b/templates/unity/Assets/Runtime/Core/Client.cs.twig
@@ -161,17 +161,17 @@ namespace {{ spec.title | caseUcfirst }}
 
             if (!string.IsNullOrEmpty(userId))
             {
-                client.SetHeader("impersonateUserId", "X-{{ spec.title | caseUcfirst }}-Impersonate-User-Id", userId);
+                client.SetHeader("impersonateuserid", "X-{{ spec.title | caseUcfirst }}-Impersonate-User-Id", userId);
             }
 
             if (!string.IsNullOrEmpty(userEmail))
             {
-                client.SetHeader("impersonateUserEmail", "X-{{ spec.title | caseUcfirst }}-Impersonate-User-Email", userEmail);
+                client.SetHeader("impersonateuseremail", "X-{{ spec.title | caseUcfirst }}-Impersonate-User-Email", userEmail);
             }
 
             if (!string.IsNullOrEmpty(userPhone))
             {
-                client.SetHeader("impersonateUserPhone", "X-{{ spec.title | caseUcfirst }}-Impersonate-User-Phone", userPhone);
+                client.SetHeader("impersonateuserphone", "X-{{ spec.title | caseUcfirst }}-Impersonate-User-Phone", userPhone);
             }
 
             return client;
@@ -290,7 +290,12 @@ namespace {{ spec.title | caseUcfirst }}
         /// <returns>Client instance for method chaining</returns>
         public Client Set{{header.key | caseUcfirst}}(string value)
         {
+{% if header.type is defined and header.type == 'bearer' %}
+            _config["{{header.key | caseLower}}"] = value;
+            _headers["{{header.name}}"] = "Bearer " + value;
+{% else %}
             SetHeader("{{header.key | caseLower}}", "{{header.name}}", value);
+{% endif %}
             return this;
         }
 

--- a/templates/web/src/client.ts.twig
+++ b/templates/web/src/client.ts.twig
@@ -508,7 +508,7 @@ class Client {
      */
     set{{header.key | caseUcfirst}}(value: string): this {
         {%~ if header.global %}
-        this.headers['{{ header.name }}'] = value;
+        this.headers['{{ header.name }}'] = {% if header.type is defined and header.type == 'bearer' %}`Bearer ${value}`{% else %}value{% endif %};
         {%~ endif %}
         this.config.{{ header.key | caseLower }} = value;
         return this;
@@ -643,7 +643,6 @@ class Client {
 
 {%~ if sdk.platform == 'console' %}
                         if (this.shouldUseFallbackCredentials(this.realtime.url)) {
-{%~ endif %}
                             let session = this.config.session;
                             if (!session) {
                                 const cookie = JSONbig.parse(window.localStorage.getItem('cookieFallback') ?? '{}');
@@ -657,7 +656,20 @@ class Client {
                                     }
                                 }));
                             }
-{%~ if sdk.platform == 'console' %}
+                        }
+{%~ else %}
+                        let session = this.config.session;
+                        if (!session) {
+                            const cookie = JSONbig.parse(window.localStorage.getItem('cookieFallback') ?? '{}');
+                            session = cookie?.[`a_session_${this.config.project}`];
+                        }
+                        if (session && !messageData?.user) {
+                            this.realtime.socket?.send(JSONbig.stringify(<RealtimeRequest>{
+                                type: 'authentication',
+                                data: {
+                                    session
+                                }
+                            }));
                         }
 {%~ endif %}
 

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -1767,6 +1767,13 @@
                     "x-example": "[NULLABLE]",
                     "x-nullable": true
                   },
+                  "optionalNullable": {
+                    "type": "string",
+                    "description": "Optional nullable string param",
+                    "default": null,
+                    "x-example": "[OPTIONAL_NULLABLE]",
+                    "x-nullable": true
+                  },
                   "optional": {
                     "type": "string",
                     "description": "Sample string param",
@@ -2648,6 +2655,12 @@
               "cancelled"
             ],
             "x-enum-name": "MockStatus"
+          },
+          "relatedMock": {
+            "type": "object",
+            "description": "Optional nested mock.",
+            "x-example": null,
+            "$ref": "#\/components\/schemas\/unionMock"
           }
         },
         "required": [
@@ -2930,6 +2943,11 @@
         "x-appwrite": {
           "demo": "<YOUR_PROJECT_ID>"
         }
+      },
+      "Bearer": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "The OAuth access token to authenticate with"
       },
       "Key": {
         "type": "apiKey",

--- a/tests/resources/spec-swagger2.json
+++ b/tests/resources/spec-swagger2.json
@@ -38,6 +38,11 @@
         "demo": "<YOUR_PROJECT_ID>"
       }
     },
+    "Bearer": {
+      "type": "http",
+      "scheme": "bearer",
+      "description": "The OAuth access token to authenticate with"
+    },
     "Key": {
       "type": "apiKey",
       "name": "X-Appwrite-Key",
@@ -1843,6 +1848,13 @@
                   "x-example": "[NULLABLE]",
                   "x-nullable": true
                 },
+                "optionalNullable": {
+                  "type": "string",
+                  "description": "Optional nullable string param",
+                  "default": null,
+                  "x-example": "[OPTIONAL_NULLABLE]",
+                  "x-nullable": true
+                },
                 "optional": {
                   "type": "string",
                   "description": "Sample string param",
@@ -2711,6 +2723,12 @@
             "cancelled"
           ],
           "x-enum-name": "MockStatus"
+        },
+        "relatedMock": {
+          "type": "object",
+          "description": "Optional nested mock.",
+          "x-example": null,
+          "$ref": "#\/definitions\/unionMock"
         }
       },
       "required": [

--- a/tests/unit/OpenAPI3SpecTest.php
+++ b/tests/unit/OpenAPI3SpecTest.php
@@ -88,10 +88,15 @@ final class OpenAPI3SpecTest extends TestCase
 
     public function testGlobalHeadersComeFromSecuritySchemes(): void
     {
-        $headers = \array_column($this->spec->getGlobalHeaders(), 'name', 'key');
+        $globalHeaders = $this->spec->getGlobalHeaders();
+        $headers = \array_column($globalHeaders, 'name', 'key');
+        $headersByKey = \array_column($globalHeaders, null, 'key');
 
         $this->assertSame('X-Appwrite-Project', $headers['Project']);
         $this->assertSame('X-Appwrite-Key', $headers['Key']);
+        $this->assertSame('Authorization', $headers['Bearer']);
+        $this->assertSame('bearer', $headersByKey['Bearer']['type']);
+        $this->assertTrue($headersByKey['Bearer']['global']);
     }
 
     public function testPathLocatedProjectAuthUsesPublicSetterName(): void


### PR DESCRIPTION
## Summary

- address actionable Greptile feedback found across the 16 SDK release PRs
- emit OAuth bearer credentials consistently while preserving raw SDK configuration values
- harden generated Python optional parameters and Swift optional nested model decoding
- clean up generated Kotlin, Dart, Web, and Unity output identified during release review

## Test plan

- [x] `composer lint`
- [x] `vendor/bin/phpunit --testsuite Unit` (33 tests, 124 assertions)
- [x] `composer refactor:check`
- [x] `composer lint-twig`
- [x] regenerate all 16 affected SDK examples from the shared local fixture
- [x] run targeted generated SDK compiler, parser, and formatter checks
