### PR TITLE
Fix nullable Kotlin model serialization

### DIFF
--- a/templates/android/library/src/main/java/io/package/models/Model.kt.twig
+++ b/templates/android/library/src/main/java/io/package/models/Model.kt.twig
@@ -30,9 +30,9 @@ import {{ sdk.namespace | caseDot }}.enums.{{ property.enumName | caseUcfirst }}
     val {{ 'data' | escapeKeyword | removeDollarSign }}: T
     {%~ endif %}
 ) {
-    fun toMap(): Map<String, Any> = mapOf(
+    fun toMap(): Map<String, Any{% if definition.properties | reduce((carry, property) => carry or not property.required) %}?{% endif %}> = mapOf(
         {%~ for property in definition.properties %}
-        "{{ property.name | escapeDollarSign }}" to {% if property.sub_schema %}{% if property.type == 'array' %}{{property.name | escapeKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.map { it.toMap() }{% else %}{{property.name | escapeKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.toMap(){% endif %}{% elseif property.enum %}{{property.name | escapeKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.value{% else %}{{property.name | escapeKeyword | removeDollarSign}}{% endif %} as Any,
+        "{{ property.name | escapeDollarSign }}" to {% if property.sub_schema %}{% if property.type == 'array' %}{{property.name | escapeKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.map { it.toMap() }{% else %}{{property.name | escapeKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.toMap(){% endif %}{% elseif property.enum %}{{property.name | escapeKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.value{% else %}{{property.name | escapeKeyword | removeDollarSign}}{% endif %} as Any{% if not property.required %}?{% endif %},
         {%~ endfor %}
         {%~ if definition.additionalProperties %}
         "{{ 'data' | escapeDollarSign }}" to {{ 'data' | escapeKeyword | removeDollarSign }}!!.jsonCast(to = Map::class.java)

--- a/templates/android/library/src/main/java/io/package/models/Model.kt.twig
+++ b/templates/android/library/src/main/java/io/package/models/Model.kt.twig
@@ -30,7 +30,7 @@ import {{ sdk.namespace | caseDot }}.enums.{{ property.enumName | caseUcfirst }}
     val {{ 'data' | escapeKeyword | removeDollarSign }}: T
     {%~ endif %}
 ) {
-    fun toMap(): Map<String, Any{% if definition.properties | reduce((carry, property) => carry or not property.required) %}?{% endif %}> = mapOf(
+    fun toMap(): Map<String, Any?> = mapOf(
         {%~ for property in definition.properties %}
         "{{ property.name | escapeDollarSign }}" to {% if property.sub_schema %}{% if property.type == 'array' %}{{property.name | escapeKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.map { it.toMap() }{% else %}{{property.name | escapeKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.toMap(){% endif %}{% elseif property.enum %}{{property.name | escapeKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.value{% else %}{{property.name | escapeKeyword | removeDollarSign}}{% endif %} as Any{% if not property.required %}?{% endif %},
         {%~ endfor %}

--- a/templates/kotlin/src/main/kotlin/io/appwrite/models/Model.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/models/Model.kt.twig
@@ -30,9 +30,9 @@ import {{ sdk.namespace | caseDot }}.enums.{{ property.enumName | caseUcfirst }}
     val {{ 'data' | escapeKeyword | removeDollarSign }}: T
     {%~ endif %}
 ) {
-    fun toMap(): Map<String, Any> = mapOf(
+    fun toMap(): Map<String, Any{% if definition.properties | reduce((carry, property) => carry or not property.required) %}?{% endif %}> = mapOf(
         {%~ for property in definition.properties %}
-        "{{ property.name | escapeDollarSign }}" to {% if property.sub_schema %}{% if property.type == 'array' %}{{property.name | escapeKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.map { it.toMap() }{% else %}{{property.name | escapeKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.toMap(){% endif %}{% elseif property.enum %}{{property.name | escapeKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.value{% else %}{{property.name | escapeKeyword | removeDollarSign}}{% endif %} as Any,
+        "{{ property.name | escapeDollarSign }}" to {% if property.sub_schema %}{% if property.type == 'array' %}{{property.name | escapeKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.map { it.toMap() }{% else %}{{property.name | escapeKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.toMap(){% endif %}{% elseif property.enum %}{{property.name | escapeKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.value{% else %}{{property.name | escapeKeyword | removeDollarSign}}{% endif %} as Any{% if not property.required %}?{% endif %},
         {%~ endfor %}
         {%~ if definition.additionalProperties %}
         "{{ 'data' | escapeDollarSign }}" to {{ 'data' | escapeKeyword | removeDollarSign }}!!.jsonCast(to = Map::class.java)

--- a/templates/kotlin/src/main/kotlin/io/appwrite/models/Model.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/models/Model.kt.twig
@@ -30,7 +30,7 @@ import {{ sdk.namespace | caseDot }}.enums.{{ property.enumName | caseUcfirst }}
     val {{ 'data' | escapeKeyword | removeDollarSign }}: T
     {%~ endif %}
 ) {
-    fun toMap(): Map<String, Any{% if definition.properties | reduce((carry, property) => carry or not property.required) %}?{% endif %}> = mapOf(
+    fun toMap(): Map<String, Any?> = mapOf(
         {%~ for property in definition.properties %}
         "{{ property.name | escapeDollarSign }}" to {% if property.sub_schema %}{% if property.type == 'array' %}{{property.name | escapeKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.map { it.toMap() }{% else %}{{property.name | escapeKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.toMap(){% endif %}{% elseif property.enum %}{{property.name | escapeKeyword | removeDollarSign}}{% if not property.required %}?{% endif %}.value{% else %}{{property.name | escapeKeyword | removeDollarSign}}{% endif %} as Any{% if not property.required %}?{% endif %},
         {%~ endfor %}

--- a/tests/e2e/languages/android/Tests.kt
+++ b/tests/e2e/languages/android/Tests.kt
@@ -137,6 +137,13 @@ class ServiceTest {
 
         runBlocking {
             var mock: Mock
+
+            val nullableMockMap = Mock.from(mapOf("result" to "Success")).toMap()
+            check(nullableMockMap.keys.containsAll(setOf("optionalResult", "status", "relatedMock")))
+            check(nullableMockMap["optionalResult"] == null)
+            check(nullableMockMap["status"] == null)
+            check(nullableMockMap["relatedMock"] == null)
+
             // Foo Tests
             mock = foo.get("string", 123, listOf("string in array"))
             writeToFile(mock.result)

--- a/tests/e2e/languages/kotlin/Tests.kt
+++ b/tests/e2e/languages/kotlin/Tests.kt
@@ -63,6 +63,13 @@ class ServiceTest {
 
         runBlocking {
             var mock: Mock
+
+            val nullableMockMap = Mock.from(mapOf("result" to "Success")).toMap()
+            check(nullableMockMap.keys.containsAll(setOf("optionalResult", "status", "relatedMock")))
+            check(nullableMockMap["optionalResult"] == null)
+            check(nullableMockMap["status"] == null)
+            check(nullableMockMap["relatedMock"] == null)
+
             // Foo Tests
             mock = foo.get("string", 123, listOf("string in array"))
             writeToFile(mock.result)

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -2643,6 +2643,12 @@
             "description": "Result message.",
             "x-example": "Success"
           },
+          "optionalResult": {
+            "type": "string",
+            "description": "Optional result message.",
+            "default": null,
+            "x-example": null
+          },
           "status": {
             "type": "string",
             "description": "Mock status. Possible values: `active`, `inactive`, `pending`, `completed`, or `cancelled`",

--- a/tests/resources/spec-swagger2.json
+++ b/tests/resources/spec-swagger2.json
@@ -2711,6 +2711,12 @@
           "description": "Result message.",
           "x-example": "Success"
         },
+        "optionalResult": {
+          "type": "string",
+          "description": "Optional result message.",
+          "default": null,
+          "x-example": null
+        },
         "status": {
           "type": "string",
           "description": "Mock status. Possible values: `active`, `inactive`, `pending`, `completed`, or `cancelled`",


### PR DESCRIPTION
## Summary

- serialize non-required Kotlin and Android response model properties as nullable `Any?` values
- standardize response-model `toMap()` on `Map<String, Any?>` for a stable serialization contract
- add regression coverage for absent primitive, enum, and nested model values

## Testing

- `vendor/bin/phpunit --testsuite Unit`
- `composer refactor:check`
- `composer lint-twig`
- `vendor/bin/phpunit tests/e2e/KotlinJava17Test.php`
- `vendor/bin/phpunit tests/e2e/Android16Java17Test.php`

