### PR TITLE
fix: prevent TypeError when parsing null object in CLI (#153)

### DIFF
--- a/templates/cli/lib/parser.ts
+++ b/templates/cli/lib/parser.ts
@@ -199,6 +199,7 @@ const maskSensitiveData = (
 
 const filterObject = (obj: JsonObject): JsonObject => {
   const result: JsonObject = {};
+  if (!obj) return result;
   for (const key of Object.keys(obj)) {
     const value = obj[key];
     if (typeof value === "function") continue;
@@ -341,12 +342,12 @@ export const parse = (data: unknown): void => {
 
       if (Array.isArray(section.value)) {
         const sectionTitle =
-          typeof section.value[0] === "object"
+          typeof section.value[0] === "object" && section.value[0] !== null
             ? `${section.key} (${section.value.length})`
             : section.key;
         console.log(`${chalk.yellow.bold.underline(sectionTitle)}`);
 
-        if (typeof section.value[0] === "object") {
+        if (typeof section.value[0] === "object" && section.value[0] !== null) {
           drawTable(section.value, { indent: "  ", sectionName: section.key });
         } else {
           drawScalarArray(section.value, { indent: "  " });

--- a/templates/cli/lib/parser.ts
+++ b/templates/cli/lib/parser.ts
@@ -199,7 +199,7 @@ const maskSensitiveData = (
 
 const filterObject = (obj: JsonObject): JsonObject => {
   const result: JsonObject = {};
-  if (!obj) return result;
+  if (obj == null) return result;
   for (const key of Object.keys(obj)) {
     const value = obj[key];
     if (typeof value === "function") continue;
@@ -341,13 +341,15 @@ export const parse = (data: unknown): void => {
       }
 
       if (Array.isArray(section.value)) {
-        const sectionTitle =
-          typeof section.value[0] === "object" && section.value[0] !== null
+        const hasObjects = section.value.some(
+          (item) => item !== null && typeof item === "object",
+        );
+        const sectionTitle = hasObjects
             ? `${section.key} (${section.value.length})`
             : section.key;
         console.log(`${chalk.yellow.bold.underline(sectionTitle)}`);
 
-        if (typeof section.value[0] === "object" && section.value[0] !== null) {
+        if (hasObjects) {
           drawTable(section.value, { indent: "  ", sectionName: section.key });
         } else {
           drawScalarArray(section.value, { indent: "  " });


### PR DESCRIPTION
Fixes appwrite/sdk-for-cli#153

Re-opening this PR from #1662 because the Git commit history of the original branch became orphaned during a force-push.

This PR prevents a TypeError in the CLI parsing logic and includes ONLY the targeted null-guards in templates/cli/lib/parser.ts as requested by the maintainers.