### PR TITLE
(fix): bump @appwrite.io/console to 15.4.0 in CLI template

### DIFF
--- a/templates/cli/package.json.twig
+++ b/templates/cli/package.json.twig
@@ -51,7 +51,7 @@
     "windows-arm64": "bun build cli.ts --compile --minify --target=bun-windows-arm64 --outfile build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
-    "@appwrite.io/console": "15.3.0",
+    "@appwrite.io/console": "15.4.0",
     "@napi-rs/keyring": "^1.3.0",
     "chalk": "4.1.2",
     "chokidar": "^3.6.0",


### PR DESCRIPTION
Bumps the CLI template's `@appwrite.io/console` dependency to 15.4.0 (published today) so the regenerated CLI can use the new console SDK methods. Required for [appwrite/sdk-for-cli#342](https://github.com/appwrite/sdk-for-cli/pull/342) build validation.