### PR TITLE
Use OpenAPI service descriptions in CLI command help

### DIFF
--- a/templates/cli/lib/commands/services/services.ts.twig
+++ b/templates/cli/lib/commands/services/services.ts.twig
@@ -83,7 +83,7 @@ const get{{ service.name | caseUcfirst }}Client = async (): Promise<{{ service.n
 
 export const {{ service.name | caseCamel }} = new Command("{{ service.name | caseKebab }}")
 {% if service.description %}
-  .description(commandDescriptions["{{ service.name | caseCamel }}"] || `{{ service.description | stripMarkdown | replace({'`': '\\`'}) | raw }}`)
+  .description(commandDescriptions["{{ service.name | caseCamel }}"] || {{ service.description | stripMarkdown | json_encode | raw }})
 {% else %}
   .description(commandDescriptions["{{ service.name | caseCamel }}"] ?? "")
 {% endif %}

--- a/templates/cli/lib/commands/services/services.ts.twig
+++ b/templates/cli/lib/commands/services/services.ts.twig
@@ -82,7 +82,11 @@ const get{{ service.name | caseUcfirst }}Client = async (): Promise<{{ service.n
 };
 
 export const {{ service.name | caseCamel }} = new Command("{{ service.name | caseKebab }}")
+{% if service.description %}
+  .description(commandDescriptions["{{ service.name | caseCamel }}"] || `{{ service.description | stripMarkdown | replace({'`': '\\`'}) | raw }}`)
+{% else %}
   .description(commandDescriptions["{{ service.name | caseCamel }}"] ?? "")
+{% endif %}
   .configureHelp({
     helpWidth: process.stdout.columns || 80,
   });

--- a/templates/cli/lib/parser.ts
+++ b/templates/cli/lib/parser.ts
@@ -872,10 +872,6 @@ export const error = (message?: string): void => {
 
 export const logo = SDK_LOGO;
 
-/**
- * CLI-only / override descriptions. Service commands prefer OpenAPI tag
- * descriptions from specs (services.php subtitles); keys here win when set.
- */
 export const commandDescriptions: Record<string, string> = {
   account: `The account command allows you to authenticate and manage a user account.`,
   activities: `The activities command allows you to list and inspect project activity events.`,

--- a/templates/cli/lib/parser.ts
+++ b/templates/cli/lib/parser.ts
@@ -872,12 +872,18 @@ export const error = (message?: string): void => {
 
 export const logo = SDK_LOGO;
 
+/**
+ * CLI-only / override descriptions. Service commands prefer OpenAPI tag
+ * descriptions from specs (services.php subtitles); keys here win when set.
+ */
 export const commandDescriptions: Record<string, string> = {
   account: `The account command allows you to authenticate and manage a user account.`,
+  activities: `The activities command allows you to list and inspect project activity events.`,
   graphql: `The graphql command allows you to query and mutate any resource type on your Appwrite server.`,
   avatars: `The avatars command aims to help you complete everyday tasks related to your app image, icons, and avatars.`,
+  backups: `The backups command allows you to manage backup policies, archives, and restorations for your project.`,
   databases: `(Legacy) The databases command allows you to create structured collections of documents and query and filter lists of documents.`,
-  "tables-db": `The tables-db command allows you to create structured tables of columns and query and filter lists of rows.`,
+  tablesDB: `The tables-db command allows you to create structured tables of columns and query and filter lists of rows.`,
   init: `The init command provides a convenient wrapper for creating and initializing projects, functions, collections, buckets, teams, messaging-topics, and skills in ${SDK_TITLE}.`,
   push: `The push command provides a convenient wrapper for pushing your functions, collections, buckets, teams, and messaging-topics.`,
   run: `The run command allows you to run the project locally to allow easy development and quick debugging.`,
@@ -893,6 +899,7 @@ export const commandDescriptions: Record<string, string> = {
   users: `The users command allows you to manage your project users.`,
   projects: `The projects command allows you to manage your projects, add platforms, manage API keys, Dev Keys etc.`,
   project: `The project command allows you to manage project related resources like usage, variables, etc.`,
+  proxy: `The proxy command allows you to configure actions for your domains beyond DNS configuration.`,
   client: `The client command allows you to configure your CLI`,
   login: `The login command allows you to authenticate and manage a user account.`,
   logout: `The logout command allows you to log out of your ${SDK_TITLE} account.`,
@@ -901,6 +908,12 @@ export const commandDescriptions: Record<string, string> = {
   console: `The console command gives you access to the APIs used by the Appwrite Console.`,
   messaging: `The messaging command allows you to manage topics and targets and send messages.`,
   migrations: `The migrations command allows you to migrate data between services.`,
+  notifications: `The notifications command allows you to read and manage your Appwrite Console notifications.`,
+  oauth2: `The oauth-2 command allows you to authorize apps and issue standards-based OAuth2 and OpenID Connect tokens.`,
+  organization: `The organization command allows you to manage organization-level projects.`,
+  organizations: `The organizations command allows you to manage organization billing, plans, invoices, and add-ons.`,
+  presences: `The presences command allows you to track and manage real-time user presence in your project.`,
+  tokens: `The tokens command allows you to create and manage resource tokens for secure file access.`,
   vcs: `The vcs command allows you to interact with VCS providers and manage your code repositories.`,
   webhooks: `The webhooks command allows you to manage your project webhooks.`,
   main: chalk.redBright(`${logo}${description}`),


### PR DESCRIPTION
## Summary
- Prefer OpenAPI service/tag descriptions when generating CLI service commands
- Add `commandDescriptions` overrides for services that previously rendered empty help (including `tablesDB` key fix)

## Related
- https://github.com/appwrite/appwrite/pull/12945

## Test plan
- [ ] Regenerate CLI SDK against specs that include service tag descriptions
- [ ] `appwrite --help` shows descriptions for activities, backups, oauth-2, organization, proxy, tables-db, tokens, etc.


Made with [Cursor](https://cursor.com)