### PR TITLE
fix(templates): enum constants, null serialization, and object conversion

### DIFF
--- a/templates/dart/base/utils.twig
+++ b/templates/dart/base/utils.twig
@@ -1,6 +1,6 @@
 {% macro map_parameter(parameters) %}
 {% for parameter in parameters %}
-{% if not parameter.nullable and not parameter.required %}
+{% if not parameter.required %}
 if ({{ parameter.name | caseCamel | overrideIdentifier }} != null) '{{ parameter.name }}': {{ parameter.name | caseCamel | overrideIdentifier }}{% if parameter.enumValues | length > 0 and parameter.type == 'array' %}.map((e) => e.value).toList(){% elseif parameter.enumValues | length > 0 %}.value{% elseif parameter.array.model is not empty %}.map((p) => p.toMap()).toList(){% elseif parameter.model is not empty %}.toMap(){% endif %},
 {% else %}
 '{{ parameter.name }}': {{ parameter.name | caseCamel | overrideIdentifier }}{% if parameter.enumValues | length > 0 and parameter.type == 'array' %}{% if not parameter.required or parameter.nullable %}?{% endif %}.map((e) => e.value).toList(){% elseif parameter.enumValues | length > 0  %}{% if not parameter.required or parameter.nullable %}?{% endif %}.value{% elseif parameter.array.model is not empty %}{% if not parameter.required or parameter.nullable %}?{% endif %}.map((p) => p.toMap()).toList(){% elseif parameter.model is not empty %}{% if not parameter.required or parameter.nullable %}?{% endif %}.toMap(){% endif %},

--- a/templates/dotnet/Package/Models/Model.cs.twig
+++ b/templates/dotnet/Package/Models/Model.cs.twig
@@ -98,10 +98,18 @@ namespace {{ spec.title | caseUcfirst }}.Models
                                     ({{ property | typeName }})map["{{ property.name }}"]
                                 {%- endif %}
                             {%- else %}
-                                {%- if not property.required -%}
-                                    map.TryGetValue("{{ property.name }}", out var {{ property.name | caseCamel | escapeKeyword | removeDollarSign }}) ? {{ property.name | caseCamel | escapeKeyword | removeDollarSign }}?.ToString() : null
-                                {%- else -%}
-                                    map["{{ property.name }}"].ToString()
+                                {%- if property.type == "object" -%}
+                                    {%- if not property.required -%}
+                                        map.TryGetValue("{{ property.name }}", out var objectRaw{{ loop.index }}) ? objectRaw{{ loop.index }} : null
+                                    {%- else -%}
+                                        map["{{ property.name }}"]
+                                    {%- endif %}
+                                {%- else %}
+                                    {%- if not property.required -%}
+                                        map.TryGetValue("{{ property.name }}", out var {{ property.name | caseCamel | escapeKeyword | removeDollarSign }}) ? {{ property.name | caseCamel | escapeKeyword | removeDollarSign }}?.ToString() : null
+                                    {%- else -%}
+                                        map["{{ property.name }}"].ToString()
+                                    {%- endif %}
                                 {%- endif %}
                             {%- endif %}
                         {%- endif %}

--- a/templates/flutter/base/utils.twig
+++ b/templates/flutter/base/utils.twig
@@ -1,6 +1,6 @@
 {%- macro map_parameter(parameters) -%}
 {%- for parameter in parameters ~%}
-{% if not parameter.nullable and not parameter.required %}
+{% if not parameter.required %}
             if ({{ parameter.name | caseCamel | overrideIdentifier }} != null) '{{ parameter.name }}': {{ parameter.name | caseCamel | overrideIdentifier }}{% if parameter.enumValues | length > 0 and parameter.type == 'array' %}.map((e) => e.value).toList(){% elseif parameter.enumValues | length > 0 %}.value{% elseif parameter.array.model is not empty %}.map((p) => p.toMap()).toList(){% elseif parameter.model is not empty %}.toMap(){% endif %},
 {% else %}
             '{{ parameter.name }}': {{ parameter.name | caseCamel | overrideIdentifier }}{% if parameter.enumValues | length > 0 and parameter.type == 'array' %}{% if not parameter.required or parameter.nullable %}?{% endif %}.map((e) => e.value).toList(){% elseif parameter.enumValues | length > 0  %}{% if not parameter.required or parameter.nullable %}?{% endif %}.value{% elseif parameter.array.model is not empty %}{% if not parameter.required or parameter.nullable %}?{% endif %}.map((p) => p.toMap()).toList(){% elseif parameter.model is not empty %}{% if not parameter.required or parameter.nullable %}?{% endif %}.toMap(){% endif %},

--- a/templates/ruby/lib/container/models/model.rb.twig
+++ b/templates/ruby/lib/container/models/model.rb.twig
@@ -87,7 +87,7 @@ module {{ spec.title | caseUcfirst }}
             def validate_{{ property.name | caseSnake | escapeKeyword }}({{ property.name | caseSnake | escapeKeyword }})
                 valid_{{ property.name | caseSnake }} = [
 {% for value in property.enum %}
-                    {{ spec.title | caseUcfirst }}::Enums::{{ property.enumName | caseUcfirst }}::{{ value | caseUpper }},
+                    {{ spec.title | caseUcfirst }}::Enums::{{ property.enumName | caseUcfirst }}::{{ (property.enumKeys[loop.index0] ?? value) | caseEnumKey }},
 {% endfor %}
                 ]
 

--- a/templates/ruby/lib/container/models/request_model.rb.twig
+++ b/templates/ruby/lib/container/models/request_model.rb.twig
@@ -48,7 +48,7 @@ module {{ spec.title | caseUcfirst }}
             def validate_{{ property.name | caseSnake | escapeKeyword }}({{ property.name | caseSnake | escapeKeyword }})
                 valid_{{ property.name | caseSnake }} = [
 {% for value in property.enum %}
-                    {{ spec.title | caseUcfirst }}::Enums::{{ property.enumName | caseUcfirst }}::{{ value | caseUpper }},
+                    {{ spec.title | caseUcfirst }}::Enums::{{ property.enumName | caseUcfirst }}::{{ (property.enumKeys[loop.index0] ?? value) | caseEnumKey }},
 {% endfor %}
                 ]
 


### PR DESCRIPTION
Fixes three template bugs surfaced by Greptile reviews on the 1.9.x SDK release PRs (appwrite/sdk-for-ruby#68, appwrite/sdk-for-dart#122, appwrite/sdk-for-dotnet#100).

## Ruby: invalid enum constant references in model validation

`model.rb.twig` / `request_model.rb.twig` built enum constant references with `value | caseUpper`, while the enum module itself is generated with `caseEnumKey`. For hyphenated enum values this produced invalid Ruby — `DatabaseStatus::FAILING-OVER` parses as subtraction between two undefined constants, so **any `Database` response with a non-null status raised `NameError`**. Both templates now use the same keys-aware `caseEnumKey` conversion as the enum module.

## Dart/Flutter: optional nullable params serialized as explicit JSON null

The `map_parameter` macro only null-guarded optionals when `not parameter.nullable`. Dart has no `undefined`, so omitted nullable optionals were sent as explicit `"key": null` — e.g. `oauth2.authorizePost` sent `max_age: null`, and `organization.updateInstallation` sent `authorizationDetails: null` (which the server can interpret as clearing the field). Every non-required parameter is now guarded with `if (x != null)`; required nullable parameters are still always sent.

## .NET: object-typed model properties corrupted by ToString()

`Model.cs.twig`'s `From()` had no branch for plain `object`-typed properties, so they fell into the string fallback and were converted with `.ToString()` — `AppInstallation.authorizationDetails` came back as a type-name string instead of the structured data. Added an object branch that passes the raw map value through unchanged.

## Validation

Regenerated the server Ruby, Dart, and .NET SDKs plus the client Flutter SDK against the Appwrite Cloud 1.9.x spec with these templates:
- Ruby: `DatabaseStatus::FAILING_OVER` generated correctly; `ruby -c` passes on all generated models
- Dart: `if (maxAge != null)`, `if (authorizationDetails != null)`, `if (replicas != null)`, `if (targetReplicaId != null)` guards now emitted in all previously affected methods
- .NET: `authorizationDetails: map["authorizationDetails"]` passed through raw; all other property kinds unchanged