### PR TITLE
fix(cli): bump @appwrite.io/console to 15.5.0

### DIFF
--- a/templates/cli/bun.lock.twig
+++ b/templates/cli/bun.lock.twig
@@ -5,7 +5,7 @@
     "": {
       "name": "{{ language.params.npmPackage|caseDash }}",
       "dependencies": {
-        "@appwrite.io/console": "15.4.0",
+        "@appwrite.io/console": "15.5.0",
         "@napi-rs/keyring": "^1.3.0",
         "chalk": "4.1.2",
         "chokidar": "^3.6.0",
@@ -52,7 +52,7 @@
     "tmp": "^0.2.6",
   },
   "packages": {
-    "@appwrite.io/console": ["@appwrite.io/console@15.4.0", "", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-ybnYahBSNDYOKkl2wALMZ6ip2QpJpKlxMmTLrNBxNN27PmVu9GZGQOnLhDNgA9wkwSD6bMIC61CZTwBS6H1LKg=="],
+    "@appwrite.io/console": ["@appwrite.io/console@15.5.0", "", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-oVs0GB8aYGpdLyYY5GuS1Om5IJB49WUv3iv4Ev9E3mvbZ4KPOhJXZ5jVozBaGWMy1PuDHOHDXs3k5ANfAQBfYw=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 

--- a/templates/cli/package-lock.json.twig
+++ b/templates/cli/package-lock.json.twig
@@ -9,7 +9,7 @@
       "version": "{{ sdk.version }}",
       "license": "{{ sdk.license }}",
       "dependencies": {
-        "@appwrite.io/console": "15.4.0",
+        "@appwrite.io/console": "15.5.0",
         "@napi-rs/keyring": "^1.3.0",
         "chalk": "4.1.2",
         "chokidar": "^3.6.0",
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@appwrite.io/console": {
-      "version": "15.4.0",
-      "resolved": "https://registry.npmjs.org/@appwrite.io/console/-/console-15.4.0.tgz",
-      "integrity": "sha512-ybnYahBSNDYOKkl2wALMZ6ip2QpJpKlxMmTLrNBxNN27PmVu9GZGQOnLhDNgA9wkwSD6bMIC61CZTwBS6H1LKg==",
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/@appwrite.io/console/-/console-15.5.0.tgz",
+      "integrity": "sha512-oVs0GB8aYGpdLyYY5GuS1Om5IJB49WUv3iv4Ev9E3mvbZ4KPOhJXZ5jVozBaGWMy1PuDHOHDXs3k5ANfAQBfYw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "json-bigint": "1.0.0"

--- a/templates/cli/package.json
+++ b/templates/cli/package.json
@@ -48,7 +48,7 @@
     "windows-arm64": "esbuild cli.ts --bundle --loader:.hbs=text --platform=node --target=node18 --format=esm --external:fsevents --external:terminal-image --outfile=dist/bundle-win-arm64.mjs && pkg dist/bundle-win-arm64.mjs --fallback-to-source -t node18-win-arm64 -o build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
-    "@appwrite.io/console": "15.4.0",
+    "@appwrite.io/console": "15.5.0",
     "@napi-rs/keyring": "^1.3.0",
     "chalk": "4.1.2",
     "chokidar": "^3.6.0",

--- a/templates/cli/package.json.twig
+++ b/templates/cli/package.json.twig
@@ -51,7 +51,7 @@
     "windows-arm64": "bun build cli.ts --compile --minify --target=bun-windows-arm64 --outfile build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
-    "@appwrite.io/console": "15.4.0",
+    "@appwrite.io/console": "15.5.0",
     "@napi-rs/keyring": "^1.3.0",
     "chalk": "4.1.2",
     "chokidar": "^3.6.0",


### PR DESCRIPTION
Bumps the CLI's `@appwrite.io/console` dependency from 15.4.0 to 15.5.0 in `package.json.twig`, `package-lock.json.twig`, and `bun.lock.twig` (plus the static `package.json`).

The generated CLI now includes `apps` key/installation commands and `organization`/`teams` installation commands, which call console SDK methods that only exist as of [`@appwrite.io/console@15.5.0`](https://www.npmjs.com/package/@appwrite.io/console/v/15.5.0). Against 15.4.0 the CLI build fails to compile (see the failing Build Validation on appwrite/sdk-for-cli#343).

Lockfile entries updated surgically with the registry's published integrity hash — 15.5.0's dependency tree is unchanged (`json-bigint@1.0.0` only).