### PR TITLE
fix: repair nested sub-schema mocks and discriminated response test expectations

### DIFF
--- a/templates/dart/test/services/service_test.dart.twig
+++ b/templates/dart/test/services/service_test.dart.twig
@@ -1,6 +1,6 @@
 {% macro sub_schema(definitions, property) %}{% if property.sub_schema %}{% if property.type == 'array' %}List<<String, dynamic>>{% else %}<String, dynamic>{
   {% if definitions[property.sub_schema] %}{% for property in definitions[property.sub_schema].properties | filter(p => p.required) %}
-  '{{property.name | escapeDollarSign}}': {% if property.type == 'object' %}{% if property.sub_schema and (property.sub_schema != 'prefs' and property.sub_schema != 'preferences') %}{{_self.sub_schema(spec.definitions, property)}}{% else %}<String, dynamic>{}{% endif %}{% elseif property.type == 'array' %}[]{% elseif property.type == 'string' %}'{{property.example | escapeDollarSign}}'{% elseif property.type == 'boolean' %}true{% else %}{{property.example}}{% endif %},
+  '{{property.name | escapeDollarSign}}': {% if property.type == 'object' %}{% if property.sub_schema and (property.sub_schema != 'prefs' and property.sub_schema != 'preferences') %}{{_self.sub_schema(definitions, property)}}{% else %}<String, dynamic>{}{% endif %}{% elseif property.type == 'array' %}[]{% elseif property.type == 'string' %}'{{property.example | escapeDollarSign}}'{% elseif property.type == 'boolean' %}true{% else %}{{property.example}}{% endif %},
   {% endfor %}{% endif %}}{% endif %}{% else %}{% if property.type == 'object' and property.additionalProperties %}Map<String, dynamic>{% else %}{{property | typeName}}{% endif %}{% endif %}{% endmacro %}
 {% import 'flutter/base/utils.twig' as utils %}
 {% if 'dart' in language.params.packageName %}
@@ -74,9 +74,12 @@ void main() {
             {%- else -%}
 
                 {%~ if responseModelName ~%}
+{% set discriminatorConditions = (responseModels|length > 1 and method.responseDiscriminator is defined and method.responseDiscriminator[responseModelName] is defined) ? method.responseDiscriminator[responseModelName] : {} %}
             final Map<String, dynamic> data = {
-                {%- for definition in spec.definitions ~%}{%~ if definition.name == responseModelName -%}{%~ for property in definition.properties | filter((param) => param.required) ~%}
+                {%- for definition in spec.definitions ~%}{%~ if definition.name == responseModelName -%}{%~ for property in definition.properties | filter((param) => param.required and param.name not in (discriminatorConditions|keys)) ~%}
                 '{{property.name | escapeDollarSign}}': {% if property.type == 'object' %}{% if property.sub_schema and (property.sub_schema != 'prefs' and property.sub_schema != 'preferences') %}{{_self.sub_schema(spec.definitions, property)}}{% else %}<String, dynamic>{}{% endif %}{% elseif property.type == 'array' %}[]{% elseif property.type == 'string' %}'{{property.example | escapeDollarSign}}'{% elseif property.type == 'boolean' %}true{% else %}{{property.example}}{% endif %},{%~ endfor ~%}{% set break = true %}{%- else -%}{% set continue = true %}{%- endif -%}{%~ endfor -%}
+{%~ for field, value in discriminatorConditions ~%}
+                '{{field | escapeDollarSign}}': '{{value | escapeDollarSign}}',{%~ endfor ~%}
 
             };
                 {%~ else ~%}

--- a/templates/flutter/test/services/service_test.dart.twig
+++ b/templates/flutter/test/services/service_test.dart.twig
@@ -1,6 +1,6 @@
 {% macro sub_schema(definitions, property) %}{% if property.sub_schema %}{% if property.type == 'array' %}List<<String, dynamic>>{% else %}<String, dynamic>{
   {% if definitions[property.sub_schema] %}{% for property in definitions[property.sub_schema].properties | filter(p => p.required) %}
-  '{{property.name | escapeDollarSign}}': {% if property.type == 'object' %}{% if property.sub_schema and (property.sub_schema != 'prefs' and property.sub_schema != 'preferences') %}{{_self.sub_schema(spec.definitions, property)}}{% else %}<String, dynamic>{}{% endif %}{% elseif property.type == 'array' %}[]{% elseif property.type == 'string' %}'{{property.example | escapeDollarSign}}'{% elseif property.type == 'boolean' %}true{% else %}{{property.example}}{% endif %},
+  '{{property.name | escapeDollarSign}}': {% if property.type == 'object' %}{% if property.sub_schema and (property.sub_schema != 'prefs' and property.sub_schema != 'preferences') %}{{_self.sub_schema(definitions, property)}}{% else %}<String, dynamic>{}{% endif %}{% elseif property.type == 'array' %}[]{% elseif property.type == 'string' %}'{{property.example | escapeDollarSign}}'{% elseif property.type == 'boolean' %}true{% else %}{{property.example}}{% endif %},
   {% endfor %}{% endif %}}{% endif %}{% else %}{% if property.type == 'object' and property.additionalProperties %}Map<String, dynamic>{% else %}{{property | typeName}}{% endif %}{% endif %}{% endmacro %}
 {% import 'flutter/base/utils.twig' as utils %}
 {% if 'dart' in language.params.packageName %}
@@ -79,9 +79,12 @@ void main() {
             {%- else -%}
 
                 {%~ if responseModelName ~%}
+{% set discriminatorConditions = (responseModels|length > 1 and method.responseDiscriminator is defined and method.responseDiscriminator[responseModelName] is defined) ? method.responseDiscriminator[responseModelName] : {} %}
             final Map<String, dynamic> data = {
-                {%- for definition in spec.definitions ~%}{%~ if definition.name == responseModelName -%}{%~ for property in definition.properties | filter((param) => param.required) ~%}
+                {%- for definition in spec.definitions ~%}{%~ if definition.name == responseModelName -%}{%~ for property in definition.properties | filter((param) => param.required and param.name not in (discriminatorConditions|keys)) ~%}
                 '{{property.name | escapeDollarSign}}': {% if property.type == 'object' %}{% if property.sub_schema and (property.sub_schema != 'prefs' and property.sub_schema != 'preferences') %}{{_self.sub_schema(spec.definitions, property)}}{% else %}<String, dynamic>{}{% endif %}{% elseif property.type == 'array' %}[]{% elseif property.type == 'string' %}'{{property.example | escapeDollarSign}}'{% elseif property.type == 'boolean' %}true{% else %}{{property.example}}{% endif %},{%~ endfor ~%}{% set break = true %}{%- else -%}{% set continue = true %}{%- endif -%}{%~ endfor -%}
+{%~ for field, value in discriminatorConditions ~%}
+                '{{field | escapeDollarSign}}': '{{value | escapeDollarSign}}',{%~ endfor ~%}
 
             };
                 {%~ else ~%}


### PR DESCRIPTION
Fixes the failing `test` job on appwrite/sdk-for-dart#122 (5 generated-test failures). Two independent template bugs in the Dart and Flutter service test templates:

## Nested sub-schema mocks rendered empty

The `sub_schema` macro recursed with `{{_self.sub_schema(spec.definitions, property)}}`, but Twig macros don't inherit template context — `spec` is undefined inside the macro, so any sub-schema nested two levels deep (e.g. `Organization → BillingPlan → UsageBillingPlan`) rendered as an empty map, and `fromMap` crashed with `type 'Null' is not a subtype of type 'Map<String, dynamic>'`. The macro now recurses with its own `definitions` parameter (the model test template already did this correctly).

## Discriminated union mocks dispatched to the wrong variant

For methods with a `responseDiscriminator` (e.g. `project.getOAuth2Provider`), the test asserts the last response model (`OAuth2Microsoft`) but built the mock purely from that model's example values — whose `$id` example is `'github'`, so the runtime dispatch returned `OAuth2Github` and the assertion failed. The mock now excludes discriminator fields from the example loop and injects the expected model's discriminator conditions (`'$id': 'microsoft'`), so dispatch matches the assertion.

## Validation

Regenerated the server Dart SDK against the cloud 1.9.x spec and ran the full suite locally: **1006 tests passed, 0 failed** (previously 5 failures).