### PR TITLE
(feat): use Appwrite Bot GitHub App token for Homebrew tap PRs

### DIFF
--- a/templates/cli/.github/workflows/publish.yml
+++ b/templates/cli/.github/workflows/publish.yml
@@ -154,11 +154,20 @@ jobs:
           GHR_REPLACE: false
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
+      - name: Generate Appwrite Bot token for Homebrew tap
+        id: bot-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.APPWRITE_BOT_APP_ID }}
+          private-key: ${{ secrets.APPWRITE_BOT_PRIVATE_KEY }}
+          owner: appwrite
+          repositories: homebrew-appwrite
+
       - name: Check out Homebrew tap
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ env.HOMEBREW_TAP_REPO }}
-          token: ${{ secrets.HOMEBREW_TAP_GH_TOKEN }}
+          token: ${{ steps.bot-token.outputs.token }}
           path: homebrew-tap
           fetch-depth: 0
 
@@ -225,7 +234,7 @@ jobs:
           FORMULA_PATH: ${{ steps.tap.outputs.formula_path }}
           SOURCE_REPO: ${{ github.repository }}
           SERVER_URL: ${{ github.server_url }}
-          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
         run: |
           set -euo pipefail
 
@@ -237,8 +246,8 @@ jobs:
           BASE_BRANCH="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')"
           BRANCH="release/${EXECUTABLE_NAME}-${RELEASE_TAG}"
 
-          git config user.name "appwrite-bot"
-          git config user.email "bot@appwrite.io"
+          git config user.name "appwrite-bot[bot]"
+          git config user.email "217594562+appwrite-bot[bot]@users.noreply.github.com"
 
           git checkout -B "$BRANCH"
           git add "$FORMULA_PATH"


### PR DESCRIPTION
## What does this PR do?

Replaces the `HOMEBREW_TAP_GH_TOKEN` personal access token in the CLI publish workflow with a short-lived installation token minted from the **Appwrite Bot** GitHub App (`appwrite-bot`, app ID `1447346`) via `actions/create-github-app-token` (same action/pin already used by `renovate.yml` in this repo). The token is used for both the Homebrew tap checkout and the `gh pr create` step, and the commit identity is updated to the app's bot identity so tap PRs show up as `appwrite-bot[bot]` instead of a personal account.

## Why?

The PAT requires manual rotation and the tap PRs are currently authored by a personal account. The app token is minted per-run, scoped to `appwrite/homebrew-appwrite` only, and never expires operationally.

## Required setup before merging (secrets audit findings)

I audited where the bot app credentials live: **no org or repo secret for the Appwrite Bot app currently exists that is visible to `sdk-for-cli`** (the org secrets visible to it are only `DOCKERHUB_*`, `GHCR_*`, `GH_AUTO_CLOSE_PR_TOKEN`, `NPM_TOKEN_NO_ORG`). The other GitHub Apps in use (`declarative-deployment`, Renovate) store their keys as **repo-level** secrets/vars per repo.

Before the next CLI release, an org admin needs to:

1. Add `APPWRITE_BOT_APP_ID` = `1447346` as a variable and `APPWRITE_BOT_PRIVATE_KEY` as a secret on `appwrite/sdk-for-cli` (or as org-level entries with `sdk-for-cli` in the selected-repos visibility).
2. Ensure the Appwrite Bot app is installed on `appwrite/homebrew-appwrite` (it already has `contents: write` and `pull_requests: write` permissions).
3. After that, `HOMEBREW_TAP_GH_TOKEN` can be deleted from `sdk-for-cli`.

## Notes

- `publish.yml` is `copy`-scoped; regenerated with `php example.php cli` and verified `examples/cli` output matches (examples are gitignored, so no example diff in this PR).