### PR TITLE
feat: python asyncio connection pooling

### DIFF
--- a/example.php
+++ b/example.php
@@ -287,7 +287,7 @@ try {
     // Python
     if (!$requestedSdk || $requestedSdk === 'python') {
         $sdk  = new SDK(new Python(), buildSpec($specFormat, $spec));
-        configureSDK($sdk);
+        configureSDK($sdk, ['platform' => $platform]);
         $sdk->generate(__DIR__ . '/examples/python');
     }
 

--- a/src/SDK/Language/Python.php
+++ b/src/SDK/Language/Python.php
@@ -10,7 +10,6 @@ use Twig\TwigFilter;
 
 class Python extends Language
 {
-    #[Override]
     protected $params = [
         'pipPackage' => 'packageName',
     ];
@@ -155,6 +154,11 @@ class Python extends Language
                 'scope' => 'default',
                 'destination' => '{{ spec.title | caseSnake}}/client.py',
                 'template' => 'python/package/client.py.twig',
+            ],
+            [
+                'scope' => 'default',
+                'destination' => 'test/test_client.py',
+                'template' => 'python/test/test_client.py.twig',
             ],
             [
                 'scope' => 'default',
@@ -304,6 +308,27 @@ class Python extends Language
         ];
     }
 
+    protected function isModelDefined(string $name, array $spec): bool
+    {
+        if (empty($name) || $spec === []) {
+            return false;
+        }
+        $pascal = $this->toPascalCase($name);
+        foreach (($spec['definitions'] ?? []) as $key => $definition) {
+            $modelName = \is_array($definition) && isset($definition['name']) ? $definition['name'] : (string) $key;
+            if ($this->toPascalCase($modelName) === $pascal) {
+                return true;
+            }
+        }
+        foreach (($spec['requestModels'] ?? []) as $key => $requestModel) {
+            $modelName = \is_array($requestModel) && isset($requestModel['name']) ? $requestModel['name'] : (string) $key;
+            if ($this->toPascalCase($modelName) === $pascal) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * @throws Exception
      */
@@ -319,11 +344,11 @@ class Python extends Language
                 ? \ucfirst($parameter['enumName'])
                 : \ucfirst((string) $parameter['name']);
 
-            $typeName = 'List[' . $enumType . ']';
+            $typeName = 'List[' . $enumType . 'Enum]';
         } elseif (isset($parameter['enumName'])) {
-            $typeName = \ucfirst($parameter['enumName']);
+            $typeName = \ucfirst($parameter['enumName']) . 'Enum';
         } elseif (!empty($parameter['enumValues'])) {
-            $typeName = \ucfirst((string) $parameter['name']);
+            $typeName = \ucfirst((string) $parameter['name']) . 'Enum';
         } elseif (!empty($parameter['array']['model'])) {
             $typeName = 'List[' . $this->toPascalCase($parameter['array']['model']) . ']';
         } elseif (!empty($parameter['model'])) {
@@ -647,7 +672,7 @@ class Python extends Language
         return $modelType;
     }
 
-    protected function getServicePropertyType(array $parameter, string $serviceName): string
+    protected function getServicePropertyType(array $parameter, string $serviceName, array $spec = []): string
     {
         if (!empty($parameter['array']['model'])) {
             $typeName = 'List[' . $this->getServiceModelTypeName($parameter['array']['model'], $serviceName) . ']';
@@ -655,7 +680,7 @@ class Python extends Language
             $modelType = $this->getServiceModelTypeName($parameter['model'], $serviceName);
             $typeName = ($parameter['type'] ?? '') === self::TYPE_ARRAY ? 'List[' . $modelType . ']' : $modelType;
         } else {
-            return $this->getTypeName($parameter);
+            return $this->getTypeName($parameter, $spec);
         }
 
         if (!($parameter['required'] ?? true) || ($parameter['nullable'] ?? false)) {
@@ -762,7 +787,8 @@ class Python extends Language
             new TwigFilter('getPropertyType', fn(array $value, array $method = []): string => $this->getTypeName($value, $method)),
             new TwigFilter('hasGenericType', fn(string $model, array $spec): bool => $this->hasGenericType($model, $spec)),
             new TwigFilter('hasGenericTypeProperty', fn(array $properties, array $spec): bool => array_any($properties, fn($property): bool => !empty($property['sub_schema']) && $this->hasGenericType($property['sub_schema'], $spec))),
-            new TwigFilter('getServicePropertyType', fn(array $value, string $serviceName): string => $this->getServicePropertyType($value, $serviceName)),
+            new TwigFilter('hasModelDefinition', fn(string $name, array $spec): bool => $this->isModelDefined($name, $spec)),
+            new TwigFilter('getServicePropertyType', fn(array $value, string $serviceName, array $spec = []): string => $this->getServicePropertyType($value, $serviceName, $spec)),
             new TwigFilter('getModelPropertyType', fn(array $value, string $ownerName = ''): string => $this->getModelPropertyType($value, $ownerName)),
             new TwigFilter('getModelFieldName', fn(array $value, array $properties): string => $this->getModelFieldName($value, $properties)),
             new TwigFilter('getResponseType', fn(array $method, string $serviceName = ''): string => $this->getResponseType($method, $serviceName)),

--- a/templates/python/base/requests/api_async.twig
+++ b/templates/python/base/requests/api_async.twig
@@ -1,18 +1,4 @@
-{% for parameter in method.parameters.all %}
-{% if parameter.type == 'file' %}
-        param_name = '{{ parameter.name }}'
-
-{% endif %}
-{% endfor %}
-
-        upload_id = ''
-{% for parameter in method.parameters.all %}
-{% if parameter.isUploadID %}
-        upload_id = {{ parameter.name | escapeKeyword | caseSnake }}
-{% endif %}
-{% endfor %}
-
-        response = self.client.chunked_upload(api_path, {
+        response = await self.client.call_async('{{ method.method | caseLower }}', api_path, {
 {%~ for key, security in method.securityHeaders %}
             '{{ security.name }}': self.client.get_config('{{ key | caseLower }}'),
 {%~ endfor %}
@@ -22,7 +8,7 @@
 {% for key, header in method.headers %}
             '{{ key }}': '{{ header }}',
 {% endfor %}
-        }, api_params, param_name, on_progress, upload_id)
+        }, api_params{% if method.type == 'webAuth' %}, response_type='location'{% endif %})
 {% if method.responseModels is defined and method.responseModels|length > 1 %}
 {% set hasResponseDiscriminator = method.responseDiscriminator is defined and method.responseDiscriminator is not empty %}
 {% set responseDiscriminator = method.responseDiscriminator ?? {} %}

--- a/templates/python/base/requests/file_async.twig
+++ b/templates/python/base/requests/file_async.twig
@@ -12,17 +12,24 @@
 {% endif %}
 {% endfor %}
 
-        response = self.client.chunked_upload(api_path, {
+        response = await self.client.chunked_upload_async(
+            api_path,
+            {
 {%~ for key, security in method.securityHeaders %}
-            '{{ security.name }}': self.client.get_config('{{ key | caseLower }}'),
+                '{{ security.name }}': self.client.get_config('{{ key | caseLower }}'),
 {%~ endfor %}
 {% for parameter in method.parameters.header %}
-            '{{ parameter.name }}': self._normalize_value({{ parameter.name | escapeKeyword | caseSnake }}),
+                '{{ parameter.name }}': self._normalize_value({{ parameter.name | escapeKeyword | caseSnake }}),
 {% endfor %}
 {% for key, header in method.headers %}
-            '{{ key }}': '{{ header }}',
+                '{{ key }}': '{{ header }}',
 {% endfor %}
-        }, api_params, param_name, on_progress, upload_id)
+            },
+            api_params,
+            param_name,
+            on_progress,
+            upload_id
+        )
 {% if method.responseModels is defined and method.responseModels|length > 1 %}
 {% set hasResponseDiscriminator = method.responseDiscriminator is defined and method.responseDiscriminator is not empty %}
 {% set responseDiscriminator = method.responseDiscriminator ?? {} %}
@@ -44,7 +51,7 @@
 {% set isGenericResponse = method.responseModel | hasGenericType(spec) %}
 {% if isGenericResponse %}
 
-        return {% if (method.responseModel | caseUcfirst) == (service.name | caseUcfirst) %}{{ method.responseModel | caseUcfirst }}Model{% else %}{{ method.responseModel | caseUcfirst }}{% endif %}.with_data(response, model_type)
+        return {{ method.responseModel | caseUcfirst }}.with_data(response, model_type)
 {% else %}
 
         return self._parse_response(response, model={% if (method.responseModel | caseUcfirst) == (service.name | caseUcfirst) %}{{ method.responseModel | caseUcfirst }}Model{% else %}{{ method.responseModel | caseUcfirst }}{% endif %})

--- a/templates/python/package/client.py.twig
+++ b/templates/python/package/client.py.twig
@@ -1,11 +1,13 @@
-import io
+import asyncio
+import inspect
 import json
 import os
 import platform
 import sys
-import requests
+import threading
+import warnings
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from threading import Lock
+import httpx
 from .input_file import InputFile
 from .exception import {{spec.title | caseUcfirst}}Exception
 from .encoders.value_class_encoder import ValueClassEncoder
@@ -15,6 +17,8 @@ class Client:
         self._chunk_size = 5*1024*1024
         self._self_signed = False
         self._endpoint = '{{spec.endpoint}}'
+        self._http_client = None
+        self._async_http_client = None
         self._global_headers = {
             'content-type': '',
             'user-agent' : f'{{spec.title | caseUcfirst}}{{ language.name | caseUcfirst }}SDK/{{ sdk.version }} ({platform.uname().system}; {platform.uname().version}; {platform.uname().machine})',
@@ -27,9 +31,158 @@ class Client:
 {% endfor %}
         }
         self._config = {}
+        self._async_client_loop = None      # event loop the async client was last created on
+        self._async_client_thread_id = None  # OS thread that owned that loop
+
+    def _get_http_client(self) -> httpx.Client:
+        if self._http_client is None or self._http_client.is_closed:
+            self._http_client = httpx.Client(
+                verify=(not self._self_signed),
+                timeout=httpx.Timeout(30.0, connect=10.0),
+            )
+        return self._http_client
+
+    def _get_async_http_client(self) -> httpx.AsyncClient:
+        current_loop = None
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+
+        loop_changed = (
+            current_loop is not None
+            and self._async_client_loop is not None
+            and self._async_client_loop is not current_loop
+        )
+
+        if self._async_http_client is None or self._async_http_client.is_closed or loop_changed:
+            if loop_changed and not self._async_http_client.is_closed:
+                old_client = self._async_http_client
+                old_loop = self._async_client_loop
+                old_thread_id = self._async_client_thread_id
+
+                if old_loop.is_running() and old_thread_id != threading.get_ident():
+                    future = asyncio.run_coroutine_threadsafe(old_client.aclose(), old_loop)
+                    future.result()
+                else:
+                    warnings.warn(
+                        "Async HTTP client's event loop changed while its previous "
+                        "connection pool was still open; the previous pool could not "
+                        "be closed safely and its connections may leak until garbage "
+                        "collection. Call `await client.aclose()` before switching "
+                        "event loops to avoid this.",
+                        ResourceWarning,
+                    )
+
+            self._async_http_client = httpx.AsyncClient(
+                verify=(not self._self_signed),
+                timeout=httpx.Timeout(30.0, connect=10.0),
+            )
+            self._async_client_loop = current_loop
+            self._async_client_thread_id = threading.get_ident() if current_loop is not None else None
+
+        return self._async_http_client
+
+    def _close_async_client_sync(self, client_to_close):
+        """Close an AsyncClient synchronously from any calling context.
+
+        - If the client's owning loop is running in a different OS thread,
+          closure is scheduled via run_coroutine_threadsafe on that loop.
+        - If an event loop was associated with this client but is stopped, closed,
+          or running on the current thread, running a fresh loop is unsafe.
+          A ResourceWarning is emitted and the reference is cleared for GC.
+        - If no event loop was attached or active, asyncio.run() attempts a
+          fresh synchronous close.
+        """
+        if client_to_close is None or client_to_close.is_closed:
+            return
+
+        owning_loop = getattr(self, '_async_client_loop', None)
+        owning_thread_id = getattr(self, '_async_client_thread_id', None)
+
+        if owning_loop is not None:
+            if owning_loop.is_running() and owning_thread_id != threading.get_ident():
+                future = asyncio.run_coroutine_threadsafe(
+                    client_to_close.aclose(), owning_loop
+                )
+                future.result()
+                return
+
+            warnings.warn(
+                "Async HTTP client's event loop is not active on a separate thread; "
+                "underlying connections could not be closed gracefully synchronously. "
+                "Call `await client.aclose()` or use `async with Client()` for async cleanup.",
+                ResourceWarning,
+            )
+            return
+
+        coro = client_to_close.aclose()
+        try:
+            asyncio.run(coro)
+        except RuntimeError:
+            coro.close()
+            warnings.warn(
+                "Synchronous close() was called while an event loop was running on the "
+                "same thread. Use `await client.aclose()` or `async with Client()`.",
+                ResourceWarning,
+            )
+
+    def _teardown_clients(self):
+        if self._http_client and not self._http_client.is_closed:
+            try:
+                self._http_client.close()
+            finally:
+                self._http_client = None
+        if self._async_http_client and not self._async_http_client.is_closed:
+            try:
+                self._close_async_client_sync(self._async_http_client)
+            finally:
+                self._async_http_client = None
+
+    def close(self):
+        self._teardown_clients()
+
+    async def aclose(self):
+        if self._async_http_client and not self._async_http_client.is_closed:
+            await self._async_http_client.aclose()
+        if self._http_client and not self._http_client.is_closed:
+            self._http_client.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.aclose()
+
+    def __del__(self):
+        try:
+            if self._http_client and not self._http_client.is_closed:
+                self._http_client.close()
+            if self._async_http_client and not self._async_http_client.is_closed:
+                warnings.warn(
+                    "Unclosed AsyncClient was garbage collected. "
+                    "Use `await client.aclose()` or `async with Client()` to ensure clean shutdown.",
+                    ResourceWarning,
+                )
+        except Exception:
+            pass
 
     def set_self_signed(self, status=True):
+        if self._self_signed == status:
+            return self
+        old_self_signed = self._self_signed
         self._self_signed = status
+        try:
+            self._teardown_clients()
+        except Exception:
+            self._self_signed = old_self_signed
+            raise
         return self
 
     def set_endpoint(self, endpoint):
@@ -62,7 +215,7 @@ class Client:
         return self
 {% endfor %}
 
-    def call(self, method, path='', headers=None, params=None, response_type='json'):
+    def _prepare_request(self, method, path='', headers=None, params=None):
         if headers is None:
             headers = {}
 
@@ -82,53 +235,99 @@ class Client:
         if headers['content-type'].startswith('application/json'):
             data = json.dumps(data, cls=ValueClassEncoder)
 
-        if headers['content-type'].startswith('multipart/form-data'):
+        if headers.get('content-type', '').startswith('multipart/form-data'):
             del headers['content-type']
             stringify = True
-            for key in data.copy():
+            for key in list(data.keys()):
                 if isinstance(data[key], InputFile):
-                    files[key] = (data[key].filename, data[key].data)
+                    file_content = data[key].data
+                    if isinstance(file_content, bytearray):
+                        file_content = bytes(file_content)
+                    files[key] = (data[key].filename, file_content)
                     del data[key]
             data = self.flatten(data, stringify=stringify)
 
+        return self._endpoint + path, headers, self.flatten(params, stringify=stringify), data, files
+
+    def _handle_response(self, response, response_type):
+        warnings = response.headers.get('x-{{ spec.title | lower }}-warning')
+        if warnings:
+            for warning in warnings.split(';'):
+                print(f'Warning: {warning}', file=sys.stderr)
+
+        content_type = response.headers.get('Content-Type', '')
+
+        if response_type == 'location':
+            return response.headers.get('Location')
+
+        if content_type.startswith('application/json'):
+            return response.json()
+
+        return response.content
+
+    def _handle_exception(self, e, response=None):
+        if response is not None:
+            content_type = response.headers.get('Content-Type', '')
+            if content_type.startswith('application/json'):
+                try:
+                    body = response.json()
+                except Exception:
+                    raise {{spec.title | caseUcfirst}}Exception(response.text, response.status_code, None, response.text)
+                raise {{spec.title | caseUcfirst}}Exception(body.get('message', ''), response.status_code, body.get('type'), response.text)
+            else:
+                raise {{spec.title | caseUcfirst}}Exception(response.text, response.status_code, None, response.text)
+        else:
+            raise {{spec.title | caseUcfirst}}Exception(str(e))
+
+    def call(self, method, path='', headers=None, params=None, response_type='json'):
+        url, headers, params, data, files = self._prepare_request(method, path, headers, params)
+
         response = None
         try:
-            response = requests.request(  # call method dynamically https://stackoverflow.com/a/4246075/2299554
+            http_client = self._get_http_client()
+            response = http_client.request(
                 method=method,
-                url=self._endpoint + path,
-                params=self.flatten(params, stringify=stringify),
+                url=url,
+                params=params,
                 data=data,
                 files=files,
                 headers=headers,
-                verify=(not self._self_signed),
-                allow_redirects=False if response_type == 'location' else True
+                follow_redirects=False if response_type == 'location' else True,
             )
 
-            response.raise_for_status()
+            if response_type != 'location':
+                response.raise_for_status()
 
-            warnings = response.headers.get('x-{{ spec.title | lower }}-warning')
-            if warnings:
-                for warning in warnings.split(';'):
-                    print(f'Warning: {warning}', file=sys.stderr)
-
-            content_type = response.headers['Content-Type']
-
-            if response_type == 'location':
-                return response.headers.get('Location')
-
-            if content_type.startswith('application/json'):
-                return response.json()
-
-            return response._content
+            return self._handle_response(response, response_type)
+        except httpx.HTTPStatusError as e:
+            self._handle_exception(e, e.response)
         except Exception as e:
-            if response != None:
-                content_type = response.headers['Content-Type']
-                if content_type.startswith('application/json'):
-                    raise {{spec.title | caseUcfirst}}Exception(response.json()['message'], response.status_code, response.json().get('type'), response.text)
-                else:
-                    raise {{spec.title | caseUcfirst}}Exception(response.text, response.status_code, None, response.text)
-            else:
-                raise {{spec.title | caseUcfirst}}Exception(e)
+            self._handle_exception(e, response)
+
+    async def call_async(self, method, path='', headers=None, params=None, response_type='json'):
+        url, headers, params, data, files = self._prepare_request(method, path, headers, params)
+
+        response = None
+        try:
+            http_client = self._get_async_http_client()
+            response = await http_client.request(
+                method=method,
+                url=url,
+                params=params,
+                data=data,
+                files=files,
+                headers=headers,
+                follow_redirects=False if response_type == 'location' else True,
+            )
+
+            if response_type != 'location':
+                response.raise_for_status()
+
+            return self._handle_response(response, response_type)
+        except httpx.HTTPStatusError as e:
+            self._handle_exception(e, e.response)
+        except Exception as e:
+            self._handle_exception(e, response)
 
     def chunked_upload(
         self,
@@ -139,19 +338,19 @@ class Client:
         on_progress = None,
         upload_id = ''
     ):
+        headers = headers.copy() if headers else {}
         input_file = params[param_name]
 
         if input_file.source_type == 'path':
             size = os.stat(input_file.path).st_size
-            input = None
         elif input_file.source_type == 'bytes':
             size = len(input_file.data)
             input = input_file.data
 
         if size < self._chunk_size:
             if input_file.source_type == 'path':
-                with open(input_file.path, 'rb') as input:
-                    input_file.data = input.read()
+                with open(input_file.path, 'rb') as f:
+                    input_file.data = f.read()
 
             params[param_name] = input_file
             return self.call(
@@ -167,7 +366,7 @@ class Client:
         try:
             result = self.call('get', path + '/' + upload_id, headers)
             counter = result['chunksUploaded']
-        except:
+        except Exception:
             pass
 
         if counter > 0:
@@ -198,7 +397,7 @@ class Client:
         upload_id_header = upload_id
         completed_count = chunks[0]['index']
         uploaded_size = chunks[0]['start']
-        progress_lock = Lock()
+        progress_lock = threading.Lock()
         last_result = None
         final_result = None
 
@@ -267,6 +466,158 @@ class Client:
             futures = [executor.submit(upload_remaining_chunk, chunk) for chunk in chunks[1:]]
             for future in as_completed(futures):
                 future.result()
+
+        return final_result or last_result
+
+    # Note: Textual parallelism between chunked_upload and chunked_upload_async is intentional
+    # to maintain call-site readability in generated output and isolate asyncio.to_thread I/O operations.
+    async def chunked_upload_async(
+        self,
+        path,
+        headers = None,
+        params = None,
+        param_name = '',
+        on_progress = None,
+        upload_id = ''
+    ):
+        headers = headers.copy() if headers else {}
+        input_file = params[param_name]
+
+        if input_file.source_type == 'path':
+            stat_result = await asyncio.to_thread(os.stat, input_file.path)
+            size = stat_result.st_size
+        elif input_file.source_type == 'bytes':
+            size = len(input_file.data)
+
+        if size < self._chunk_size:
+            if input_file.source_type == 'path':
+                def _read():
+                    with open(input_file.path, 'rb') as f:
+                        return f.read()
+                input_file.data = await asyncio.to_thread(_read)
+
+            params[param_name] = input_file
+            return await self.call_async(
+                'post',
+                path,
+                headers,
+                params
+            )
+
+        offset = 0
+        counter = 0
+
+        try:
+            result = await self.call_async('get', path + '/' + upload_id, headers)
+            counter = result['chunksUploaded']
+        except Exception:
+            pass
+
+        if counter > 0:
+            offset = counter * self._chunk_size
+
+        total_chunks = (size + self._chunk_size - 1) // self._chunk_size
+        chunks = []
+        while offset < size:
+            end = min(offset + self._chunk_size, size)
+            chunks.append({
+                'index': counter,
+                'start': offset,
+                'end': end,
+            })
+            offset = end
+            counter = counter + 1
+
+        if not chunks:
+            return result
+
+        async def read_chunk_async(start, end):
+            if input_file.source_type == 'path':
+                def _read():
+                    with open(input_file.path, 'rb') as f:
+                        f.seek(start)
+                        return f.read(end - start)
+                return await asyncio.to_thread(_read)
+            return input_file.data[start:end]
+
+        upload_id_header = upload_id
+        completed_count = chunks[0]['index']
+        uploaded_size = chunks[0]['start']
+        progress_lock = asyncio.Lock()
+        last_result = None
+        final_result = None
+
+        def is_upload_complete(chunk_result):
+            chunks_uploaded = chunk_result.get('chunksUploaded')
+            if chunks_uploaded is None:
+                return False
+            chunks_total = chunk_result.get('chunksTotal', total_chunks)
+            return int(chunks_uploaded) >= int(chunks_total)
+
+        async def upload_chunk_async(chunk, current_upload_id):
+            chunk_data = await read_chunk_async(chunk['start'], chunk['end'])
+            chunk_input = InputFile.from_bytes(
+                chunk_data,
+                input_file.filename,
+                getattr(input_file, 'mime_type', None)
+            )
+            chunk_params = {**params, param_name: chunk_input}
+            chunk_headers = {**headers}
+            chunk_headers["content-range"] = f"bytes {chunk['start']}-{chunk['end'] - 1}/{size}"
+            if current_upload_id:
+                chunk_headers["x-{{ spec.title | caseLower }}-id"] = current_upload_id
+
+            return await self.call_async(
+                'post',
+                path,
+                chunk_headers,
+                chunk_params,
+            )
+
+        # Upload first chunk to obtain the upload ID before parallelising
+        result = await upload_chunk_async(chunks[0], upload_id_header)
+        last_result = result
+        if "$id" in result:
+            upload_id_header = result["$id"]
+
+        completed_count = chunks[0]['index'] + 1
+        uploaded_size = chunks[0]['end']
+
+        if on_progress is not None:
+            cb = on_progress({
+                "$id": result.get("$id"),
+                "progress": uploaded_size / size * 100,
+                "sizeUploaded": uploaded_size,
+                "chunksTotal": total_chunks,
+                "chunksUploaded": completed_count,
+            })
+            if inspect.isawaitable(cb):
+                await cb
+
+        semaphore = asyncio.Semaphore(8)
+
+        async def upload_remaining_chunk_async(chunk):
+            nonlocal completed_count, uploaded_size, last_result, final_result
+            async with semaphore:
+                chunk_result = await upload_chunk_async(chunk, upload_id_header)
+            async with progress_lock:
+                completed_count = completed_count + 1
+                uploaded_size = uploaded_size + (chunk['end'] - chunk['start'])
+                last_result = chunk_result
+                if is_upload_complete(chunk_result):
+                    final_result = chunk_result
+                if on_progress is not None:
+                    cb = on_progress({
+                        "$id": upload_id_header,
+                        "progress": uploaded_size / size * 100,
+                        "sizeUploaded": uploaded_size,
+                        "chunksTotal": total_chunks,
+                        "chunksUploaded": completed_count,
+                    })
+                    if inspect.isawaitable(cb):
+                        await cb
+
+        await asyncio.gather(*[upload_remaining_chunk_async(chunk) for chunk in chunks[1:]])
 
         return final_result or last_result
 

--- a/templates/python/package/services/service.py.twig
+++ b/templates/python/package/services/service.py.twig
@@ -4,56 +4,58 @@ from typing import Any, Dict, List, Optional, Union{% set hasGenericModel = fals
 
 from ..exception import AppwriteException
 from appwrite.utils.deprecated import deprecated
-{% set added = [] %}
+{% set addedEnums = [] %}
+{% set addedModels = [] %}
+{% set hasInputFile = false %}
 {% for method in service.methods %}
 {% for parameter in method.parameters.all %}
-{% if parameter.type == 'file' and parameter.type not in added %}
+{% if parameter.type == 'file' and not hasInputFile %}
 from ..input_file import InputFile
-{% set added = added|merge(['InputFile']) %}
+{% set hasInputFile = true %}
 {% endif %}
 {% if parameter.enumValues is not empty%}
-{% if parameter.enumName not in added %}
-from ..enums.{{ parameter.enumName | caseSnake }} import {{ parameter.enumName | caseUcfirst }}
-{% set added = added|merge([parameter.enumName]) %}
+{% set enumName = parameter.enumName | caseUcfirst %}
+{% if enumName not in addedEnums %}
+from ..enums.{{ parameter.enumName | caseSnake }} import {{ enumName }} as {{ enumName }}Enum
+{% set addedEnums = addedEnums|merge([enumName]) %}
 {% endif %}
 {% endif %}
 {% set modelName = parameter.model ?? parameter.array.model ?? null %}
 {% if modelName %}
-{% if modelName not in added %}
+{% if modelName not in addedModels %}
 {% if (modelName | caseUcfirst) == (service.name | caseUcfirst) %}
 from ..models.{{ modelName | caseSnake }} import {{ modelName | caseUcfirst }} as {{ modelName | caseUcfirst }}Model
 {% else %}
 from ..models.{{ modelName | caseSnake }} import {{ modelName | caseUcfirst }}
 {% endif %}
-{% set added = added|merge([modelName]) %}
+{% set addedModels = addedModels|merge([modelName]) %}
 {% endif %}
 {% endif %}
 {% endfor %}
 {% if method.responseModel and method.responseModel != 'any' %}
-{% if method.responseModel not in added %}
+{% if method.responseModel not in addedModels %}
 {% if (method.responseModel | caseUcfirst) == (service.name | caseUcfirst) %}
 from ..models.{{ method.responseModel | caseSnake }} import {{ method.responseModel | caseUcfirst }} as {{ method.responseModel | caseUcfirst }}Model
 {% else %}
 from ..models.{{ method.responseModel | caseSnake }} import {{ method.responseModel | caseUcfirst }}
 {% endif %}
-{% set added = added|merge([method.responseModel]) %}
+{% set addedModels = addedModels|merge([method.responseModel]) %}
 {% endif %}
 {% endif %}
 {% if method.responseModels is defined and method.responseModels|length > 1 %}
 {% for responseModel in method.responseModels %}
-{% if responseModel and responseModel != 'any' and responseModel not in added %}
+{% if responseModel and responseModel != 'any' and responseModel not in addedModels %}
 {% if (responseModel | caseUcfirst) == (service.name | caseUcfirst) %}
 from ..models.{{ responseModel | caseSnake }} import {{ responseModel | caseUcfirst }} as {{ responseModel | caseUcfirst }}Model
 {% else %}
 from ..models.{{ responseModel | caseSnake }} import {{ responseModel | caseUcfirst }}
 {% endif %}
-{% set added = added|merge([responseModel]) %}
+{% set addedModels = addedModels|merge([responseModel]) %}
 {% endif %}
 {% endfor %}
 {% endif %}
 {% endfor %}
 {% if hasGenericModel %}
-
 T = TypeVar('T')
 {% endif %}
 
@@ -107,7 +109,7 @@ Dict[str, Any]
 {% endset %}
     def {{ method.name | caseSnake }}(
         self{% for parameter in method.parameters.all %},
-        {{ parameter.name | escapeKeyword | caseSnake }}: {{ parameter | getServicePropertyType(service.name) | raw }}{% if not parameter.required %} = None{% endif %}{% endfor %}{% if 'multipart/form-data' in method.consumes %},
+        {{ parameter.name | escapeKeyword | caseSnake }}: {{ parameter | getServicePropertyType(service.name, spec) | raw }}{% if not parameter.required %} = None{% endif %}{% endfor %}{% if 'multipart/form-data' in method.consumes %},
         on_progress = None{% endif %}{% if isGenericResponse %},
         model_type: Type[T] = dict{% endif %}
 
@@ -128,7 +130,7 @@ Dict[str, Any]
 {% endif %}
         Parameters
         ----------
-        {% for parameter in method.parameters.all %}{{ parameter.name | escapeKeyword | caseSnake }} : {{ parameter | getServicePropertyType(service.name) | raw }}
+        {% for parameter in method.parameters.all %}{{ parameter.name | escapeKeyword | caseSnake }} : {{ parameter | getServicePropertyType(service.name, spec) | raw }}
             {% autoescape false %}{{ parameter.description | replace({"\n": "\n            "}) }}{% endautoescape %}
 
         {% endfor %}{% if 'multipart/form-data' in method.consumes %}
@@ -171,6 +173,35 @@ Dict[str, Any]
 {{ include('python/base/requests/file.twig') }}
 {% else %}
 {{ include('python/base/requests/api.twig') }}
+{% endif %}
+
+{% if method.deprecated %}
+{% if method.since and method.replaceWith %}
+    @deprecated("This API has been deprecated since {{ method.since }}. Please use `{{ method.replaceWith | caseSnakeExceptFirstDot }}` instead.")
+{% else %}
+    @deprecated("This API has been deprecated.")
+{% endif %}
+{% endif %}
+    async def {{ method.name | caseSnake }}_async(
+        self{% for parameter in method.parameters.all %},
+        {{ parameter.name | escapeKeyword | caseSnake }}: {{ parameter | getServicePropertyType(service.name, spec) | raw }}{% if not parameter.required %} = None{% endif %}{% endfor %}{% if 'multipart/form-data' in method.consumes %},
+        on_progress = None{% endif %}{% if isGenericResponse %},
+        model_type: Type[T] = dict{% endif %}
+
+    ) -> {{ returnType | trim }}:
+        """
+        Async version of :meth:`{{ method.name | caseSnake }}`.
+        """
+
+        api_path = '{{ method.path }}'
+        {%~ for security in method.securityQueries %}
+        api_path += '{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}=' + quote(str(self.client.get_config('{{ security.name | caseLower }}')), safe='')
+        {%~ endfor %}
+{{ include('python/base/params.twig') }}
+{% if 'multipart/form-data' in method.consumes %}
+{{ include('python/base/requests/file_async.twig') }}
+{% else %}
+{{ include('python/base/requests/api_async.twig') }}
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/templates/python/pyproject.toml.twig
+++ b/templates/python/pyproject.toml.twig
@@ -16,7 +16,7 @@ maintainers = [
   { name = "{{ spec.contactName }}", email = "{{ spec.contactEmail }}" }
 ]
 dependencies = [
-  "requests",
+  "httpx>=0.27",
   "pydantic>=2,<3",
 ]
 classifiers = [
@@ -34,7 +34,7 @@ classifiers = [
 
 [project.optional-dependencies]
 test = [
-  "requests_mock==1.11.0",
+  "respx",
 ]
 
 [project.urls]

--- a/templates/python/requirements.txt.twig
+++ b/templates/python/requirements.txt.twig
@@ -1,3 +1,3 @@
-requests>=2.31,<3
-requests_mock==1.12.1
+httpx>=0.27
+respx>=0.21.0
 pydantic>=2,<3

--- a/templates/python/setup.py.twig
+++ b/templates/python/setup.py.twig
@@ -20,7 +20,7 @@ setuptools.setup(
   url = '{{spec.contactURL}}',
   download_url='https://github.com/{{sdk.gitUserName}}/{{sdk.gitRepoName}}/archive/{{sdk.version}}.tar.gz',
   install_requires=[
-    'requests',
+    'httpx>=0.27',
     'pydantic>=2,<3',
   ],
   python_requires='>=3.9',

--- a/templates/python/test/services/test_service.py.twig
+++ b/templates/python/test/services/test_service.py.twig
@@ -1,5 +1,7 @@
+import asyncio
 import json
-import requests_mock
+import respx
+import httpx
 import unittest
 
 from appwrite.client import Client
@@ -14,8 +16,18 @@ class {{ service.name | caseUcfirst }}ServiceTest(unittest.TestCase):
         self.{{ service.name | caseSnake }} = {{ service.name | caseUcfirst }}(self.client)
 
 {% for method in service.methods %}
-    @requests_mock.Mocker()
-    def test_{{ method.name | caseSnake }}(self, m):
+{% set methodNameSnake = method.name | caseSnake %}
+{% set shouldSkip = false %}
+{% if method.deprecated %}
+{% for otherMethod in service.methods %}
+{% if not otherMethod.deprecated and (otherMethod.name | caseSnake) == methodNameSnake %}
+{% set shouldSkip = true %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% if not shouldSkip %}
+    @respx.mock
+    def test_{{ method.name | caseSnake }}(self):
     {%~ if method.type == 'webAuth' %}
         data = None
     {%~ elseif method.type == 'location' %}
@@ -28,13 +40,41 @@ class {{ service.name | caseUcfirst }}ServiceTest(unittest.TestCase):
         {%~ endif %}
     {%~ endif %}
         headers = {'Content-Type': {% if method.type == 'location' %}'application/octet-stream'{% else %}'application/json'{% endif %}}
-        m.request(requests_mock.ANY, requests_mock.ANY, {% if method.type == 'location' %}body=data{% else %}text=json.dumps(data){% endif %}, headers=headers)
+        respx.route().mock(return_value=httpx.Response(200, {% if method.type == 'location' %}content=bytes(data){% else %}text=json.dumps(data){% endif %}, headers=headers))
 
         response = self.{{ service.name | caseSnake }}.{{ method.name | caseSnake }}({%~ for parameter in method.parameters.all | filter((param) => param.required) ~%}
             {% if parameter.type == 'object' %}{}{% elseif parameter.type == 'array' %}[]{% elseif parameter.type == 'file' %}InputFile.from_bytes(bytearray(), "example.file"){% elseif parameter.type == 'boolean' %}True{% elseif parameter.type == 'string' %}'{% if parameter.example is not empty %}{{parameter.example | escapeDollarSign}}{% endif %}'{% elseif parameter.type == 'integer' and parameter['x-example'] is empty %}1{% elseif parameter.type == 'number' and parameter['x-example'] is empty %}1.0{% else %}{{parameter.example}}{%~ endif ~%},{%~ endfor ~%}
         )
 
-        {%~ if method.type != 'webAuth' and method.responseModel and method.responseModel != 'any' %}
+        {%~ if method.type != 'webAuth' and method.type != 'location' and method.responseModel and method.responseModel != 'any' %}
+        {%~ if spec.definitions[method.responseModel].additionalProperties %}
+        data['{{ 'data' }}'] = {}
+        {%~ endif  %}
+        self.assertEqual(response.to_dict(), data)
+        {%~ else %}
+        self.assertEqual(response, data)
+        {%~ endif  %}
+    @respx.mock
+    def test_{{ method.name | caseSnake }}_async(self):
+    {%~ if method.type == 'webAuth' %}
+        data = None
+    {%~ elseif method.type == 'location' %}
+        data = bytearray()
+    {%~ else %}
+        {%~ if method.responseModel and method.responseModel != 'any' %}
+        data = {{ method.responseModel | responseModelExample(spec) | raw }}
+        {%~ else %}
+        data = ''
+        {%~ endif %}
+    {%~ endif %}
+        headers = {'Content-Type': {% if method.type == 'location' %}'application/octet-stream'{% else %}'application/json'{% endif %}}
+        respx.route().mock(return_value=httpx.Response(200, {% if method.type == 'location' %}content=bytes(data){% else %}text=json.dumps(data){% endif %}, headers=headers))
+
+        response = asyncio.run(self.{{ service.name | caseSnake }}.{{ method.name | caseSnake }}_async({%~ for parameter in method.parameters.all | filter((param) => param.required) ~%}
+            {% if parameter.type == 'object' %}{}{% elseif parameter.type == 'array' %}[]{% elseif parameter.type == 'file' %}InputFile.from_bytes(bytearray(), "example.file"){% elseif parameter.type == 'boolean' %}True{% elseif parameter.type == 'string' %}'{% if parameter.example is not empty %}{{parameter.example | escapeDollarSign}}{% endif %}'{% elseif parameter.type == 'integer' and parameter['x-example'] is empty %}1{% elseif parameter.type == 'number' and parameter['x-example'] is empty %}1.0{% else %}{{parameter.example}}{%~ endif ~%},{%~ endfor ~%}
+        ))
+
+        {%~ if method.type != 'webAuth' and method.type != 'location' and method.responseModel and method.responseModel != 'any' %}
         {%~ if spec.definitions[method.responseModel].additionalProperties %}
         data['{{ 'data' }}'] = {}
         {%~ endif  %}
@@ -43,4 +83,5 @@ class {{ service.name | caseUcfirst }}ServiceTest(unittest.TestCase):
         self.assertEqual(response, data)
         {%~ endif  %}
 
+{% endif %}
 {% endfor %}

--- a/templates/python/test/test_client.py.twig
+++ b/templates/python/test/test_client.py.twig
@@ -130,7 +130,6 @@ class TestClientMethods(unittest.TestCase):
             client.close()
         self.assertIsNone(client._async_http_client)
 
-
     def test_sync_close_after_active_pool(self):
         """close() clears async pool reference after serving real requests."""
         import warnings
@@ -209,7 +208,6 @@ class TestClientMethods(unittest.TestCase):
             self.assertIsNone(client._async_http_client)
 
         asyncio.run(run_test())
-
 
     def test_chunked_upload_async_concurrency(self):
         async def run_test():
@@ -347,8 +345,4 @@ class TestClientMethods(unittest.TestCase):
                 warnings.simplefilter("always")
                 client._get_async_http_client()
                 self.assertTrue(any(issubclass(warn.category, ResourceWarning) for warn in w))
-
         asyncio.run(second_loop())
-
-
-

--- a/templates/python/test/test_client.py.twig
+++ b/templates/python/test/test_client.py.twig
@@ -1,0 +1,354 @@
+import asyncio
+import warnings
+import unittest
+import httpx
+import respx
+from appwrite.client import Client
+from appwrite.input_file import InputFile
+
+class TestClientMethods(unittest.TestCase):
+
+    def test_sync_context_manager(self):
+        with Client() as client:
+            http_client = client._get_http_client()
+            self.assertFalse(http_client.is_closed)
+        self.assertTrue(http_client.is_closed)
+
+    def test_async_context_manager(self):
+        async def run_test():
+            async with Client() as client:
+                async_client = client._get_async_http_client()
+                self.assertFalse(async_client.is_closed)
+            self.assertTrue(async_client.is_closed)
+
+        asyncio.run(run_test())
+
+    def test_explicit_close(self):
+        client = Client()
+        http_client = client._get_http_client()
+        self.assertFalse(http_client.is_closed)
+        client.close()
+        self.assertTrue(http_client.is_closed)
+
+    def test_explicit_aclose(self):
+        async def run_test():
+            client = Client()
+            async_client = client._get_async_http_client()
+            self.assertFalse(async_client.is_closed)
+            await client.aclose()
+            self.assertTrue(async_client.is_closed)
+
+        asyncio.run(run_test())
+
+    def test_mixed_pool_close(self):
+        client = Client()
+        sync_client = client._get_http_client()
+        async_client = client._get_async_http_client()
+        self.assertFalse(sync_client.is_closed)
+        self.assertFalse(async_client.is_closed)
+        client.close()
+        self.assertTrue(sync_client.is_closed)
+        self.assertTrue(async_client.is_closed)
+
+    def test_mixed_pool_aclose(self):
+        async def run_test():
+            client = Client()
+            sync_client = client._get_http_client()
+            async_client = client._get_async_http_client()
+            self.assertFalse(sync_client.is_closed)
+            self.assertFalse(async_client.is_closed)
+            await client.aclose()
+            self.assertTrue(sync_client.is_closed)
+            self.assertTrue(async_client.is_closed)
+
+        asyncio.run(run_test())
+
+    def test_set_self_signed_async_cleanup_no_loop(self):
+        client = Client()
+        async_client = client._get_async_http_client()
+        self.assertFalse(async_client.is_closed)
+        client.set_self_signed(True)
+        self.assertTrue(async_client.is_closed)
+
+    def test_set_self_signed_in_loop_warns(self):
+        """set_self_signed() called from the owning loop's thread emits a ResourceWarning and resets client reference.
+
+        run_coroutine_threadsafe + future.result() would deadlock (same thread drives
+        the loop); asyncio.run() raises RuntimeError for a nested loop.
+        A ResourceWarning is emitted, and the client reference is cleared so GC can reclaim it.
+        """
+        import warnings
+
+        async def run_test():
+            client = Client()
+            client._get_async_http_client()
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                client.set_self_signed(True)
+                self.assertTrue(any(issubclass(warn.category, ResourceWarning) for warn in w))
+            self.assertTrue(client._self_signed)
+            self.assertIsNone(client._async_http_client)
+
+        asyncio.run(run_test())
+
+    def test_sync_close_in_loop_warns(self):
+        """close() called from the owning loop's thread emits a ResourceWarning and resets client reference.
+
+        run_coroutine_threadsafe + future.result() would deadlock (same thread drives
+        the loop); asyncio.run() raises RuntimeError for a nested loop.
+        A ResourceWarning is emitted, and the client reference is cleared so GC can reclaim it.
+        """
+        import warnings
+
+        async def run_test():
+            client = Client()
+            client._get_async_http_client()
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                client.close()
+                self.assertTrue(any(issubclass(warn.category, ResourceWarning) for warn in w))
+            self.assertIsNone(client._async_http_client)
+
+        asyncio.run(run_test())
+
+    def test_sync_close_after_loop_exit_succeeds(self):
+        """close() called AFTER asyncio.run() exits emits ResourceWarning (or closes if no loop attached).
+
+        When the owning loop is closed/dead, asyncio.run() or loop-check emits ResourceWarning
+        and clears the reference safely for GC reclamation.
+        """
+        import warnings
+
+        client = Client()
+
+        async def setup():
+            client._get_async_http_client()
+
+        asyncio.run(setup())
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            client.close()
+        self.assertIsNone(client._async_http_client)
+
+
+    def test_sync_close_after_active_pool(self):
+        """close() clears async pool reference after serving real requests."""
+        import warnings
+
+        client = Client()
+
+        async def make_request():
+            with respx.mock() as mock:
+                mock.get(client._endpoint + "/health/version").mock(
+                    return_value=httpx.Response(200, json={"version": "test"})
+                )
+                await client.call_async(
+                    "get", "/health/version",
+                    headers={"content-type": "application/json"}
+                )
+            return client._get_async_http_client()
+
+        async_http_client = asyncio.run(make_request())
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            client.close()
+        self.assertIsNone(client._async_http_client)
+
+    def test_sync_close_from_different_thread_succeeds(self):
+        """close() called from a *different* thread than the one running the
+        owning loop can safely use run_coroutine_threadsafe -- no deadlock,
+        deterministic cleanup, since the calling thread isn't the one that
+        needs to drive the loop forward."""
+        import threading
+
+        loop_ready = threading.Event()
+        close_done = threading.Event()
+        captured = {}
+
+        def loop_thread():
+            async def keep_loop_alive():
+                client = Client()
+                captured['client'] = client
+                captured['async_client'] = client._get_async_http_client()
+                loop_ready.set()
+                while not close_done.is_set():
+                    await asyncio.sleep(0.01)
+
+            asyncio.run(keep_loop_alive())
+
+        t = threading.Thread(target=loop_thread, daemon=True)
+        t.start()
+        loop_ready.wait(timeout=5)
+
+        self.assertFalse(captured['async_client'].is_closed)
+        captured['client'].close()  # called from main thread, not the loop's thread
+        self.assertTrue(captured['async_client'].is_closed)
+
+        close_done.set()
+        t.join(timeout=5)
+
+    def test_sync_close_from_async_context_warns(self):
+        """close() called from within a running loop emits ResourceWarning and resets client reference."""
+        import warnings
+
+        async def run_test():
+            client = Client()
+            with respx.mock() as mock:
+                mock.get(client._endpoint + "/health/version").mock(
+                    return_value=httpx.Response(200, json={"version": "test"})
+                )
+                await client.call_async(
+                    "get", "/health/version",
+                    headers={"content-type": "application/json"}
+                )
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                client.close()
+                self.assertTrue(any(issubclass(warn.category, ResourceWarning) for warn in w))
+
+            self.assertIsNone(client._async_http_client)
+
+        asyncio.run(run_test())
+
+
+    def test_chunked_upload_async_concurrency(self):
+        async def run_test():
+            client = Client()
+            active_calls = 0
+            max_active_calls = 0
+            lock = asyncio.Lock()
+
+            async def mock_call_async(method, path='', headers=None, params=None, response_type='json'):
+                nonlocal active_calls, max_active_calls
+                if method == 'get':
+                    return {'chunksUploaded': 0}
+                async with lock:
+                    active_calls += 1
+                    if active_calls > max_active_calls:
+                        max_active_calls = active_calls
+                await asyncio.sleep(0.01)
+                async with lock:
+                    active_calls -= 1
+                return {'$id': 'test_id', 'chunksUploaded': 1, 'chunksTotal': 15}
+
+            client.call_async = mock_call_async
+
+            dummy_data = b'x' * (client._chunk_size * 12)
+            input_file = InputFile.from_bytes(dummy_data, 'test.bin')
+
+            await client.chunked_upload_async(
+                '/storage/files',
+                params={'file': input_file},
+                param_name='file',
+                upload_id='unique()'
+            )
+            self.assertLessEqual(max_active_calls, 8)
+            self.assertGreater(max_active_calls, 1)
+
+        asyncio.run(run_test())
+
+    def test_set_self_signed_recreates_clients(self):
+        client = Client()
+        sync_client1 = client._get_http_client()
+        async_client1 = client._get_async_http_client()
+        client.set_self_signed(True)
+        sync_client2 = client._get_http_client()
+        async_client2 = client._get_async_http_client()
+        self.assertIsNot(sync_client1, sync_client2)
+        self.assertIsNot(async_client1, async_client2)
+
+    def test_chunked_upload_sync_concurrency(self):
+        import time
+        import threading
+
+        client = Client()
+        active_calls = 0
+        max_active_calls = 0
+        lock = threading.Lock()
+
+        def mock_call(method, path='', headers=None, params=None, response_type='json'):
+            nonlocal active_calls, max_active_calls
+            if method == 'get':
+                return {'chunksUploaded': 0}
+            with lock:
+                active_calls += 1
+                if active_calls > max_active_calls:
+                    max_active_calls = active_calls
+            time.sleep(0.01)
+            with lock:
+                active_calls -= 1
+            return {'$id': 'test_id', 'chunksUploaded': 1, 'chunksTotal': 15}
+
+        client.call = mock_call
+
+        dummy_data = b'x' * (client._chunk_size * 12)
+        input_file = InputFile.from_bytes(dummy_data, 'test.bin')
+
+        client.chunked_upload(
+            '/storage/files',
+            params={'file': input_file},
+            param_name='file',
+            upload_id='unique()'
+        )
+        self.assertLessEqual(max_active_calls, 8)
+        self.assertGreater(max_active_calls, 1)
+
+    def test_multiple_asyncio_run_calls_share_client(self):
+        """Sharing a Client across multiple sequential asyncio.run() calls must succeed cleanly."""
+        client = Client()
+        c1 = None
+        c2 = None
+
+        async def run_first():
+            nonlocal c1
+            with respx.mock() as mock:
+                mock.get(client._endpoint + "/health/version").mock(
+                    return_value=httpx.Response(200, json={"version": "1.0.0"})
+                )
+                res = await client.call_async("get", "/health/version")
+                c1 = client._async_http_client
+                return res
+
+        async def run_second():
+            nonlocal c2
+            with respx.mock() as mock:
+                mock.get(client._endpoint + "/health/version").mock(
+                    return_value=httpx.Response(200, json={"version": "1.0.1"})
+                )
+                res = await client.call_async("get", "/health/version")
+                c2 = client._async_http_client
+                return res
+
+        res1 = asyncio.run(run_first())
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            res2 = asyncio.run(run_second())
+
+        self.assertEqual(res1, {"version": "1.0.0"})
+        self.assertEqual(res2, {"version": "1.0.1"})
+        self.assertIsNot(c1, c2)
+
+        client.close()
+
+    def test_loop_change_warns_when_old_pool_open(self):
+        """Switching event loops while the previous AsyncClient is still open
+        emits a ResourceWarning instead of silently orphaning the pool."""
+        import warnings
+
+        client = Client()
+
+        async def first_loop():
+            client._get_async_http_client()
+
+        asyncio.run(first_loop())
+
+        async def second_loop():
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                client._get_async_http_client()
+                self.assertTrue(any(issubclass(warn.category, ResourceWarning) for warn in w))
+
+        asyncio.run(second_loop())
+
+
+

--- a/tests/e2e/Python310Test.php
+++ b/tests/e2e/Python310Test.php
@@ -45,6 +45,16 @@ final class Python310Test extends Base
         ...Base::QUERY_HELPER_RESPONSES,
         ...Base::PERMISSION_HELPER_RESPONSES,
         ...Base::ID_HELPER_RESPONSES,
-        ...Base::OPERATOR_HELPER_RESPONSES
+        ...Base::OPERATOR_HELPER_RESPONSES,
+        ...Base::FOO_RESPONSES,
+        ...Base::BAR_RESPONSES,
+        ...Base::GENERAL_RESPONSES,
+        ...Base::UPLOAD_RESPONSES,
+        ...Base::ENUM_RESPONSES,
+        ...Base::MODEL_RESPONSES,
+        ...Base::EXCEPTION_RESPONSES,
+        Base::HEADERS_RESPONSE,
+        ...Base::OAUTH_RESPONSES,
+        'ASYNC_CLEANUP_PASSED',
     ];
 }

--- a/tests/e2e/Python311Test.php
+++ b/tests/e2e/Python311Test.php
@@ -45,6 +45,16 @@ final class Python311Test extends Base
         ...Base::QUERY_HELPER_RESPONSES,
         ...Base::PERMISSION_HELPER_RESPONSES,
         ...Base::ID_HELPER_RESPONSES,
-        ...Base::OPERATOR_HELPER_RESPONSES
+        ...Base::OPERATOR_HELPER_RESPONSES,
+        ...Base::FOO_RESPONSES,
+        ...Base::BAR_RESPONSES,
+        ...Base::GENERAL_RESPONSES,
+        ...Base::UPLOAD_RESPONSES,
+        ...Base::ENUM_RESPONSES,
+        ...Base::MODEL_RESPONSES,
+        ...Base::EXCEPTION_RESPONSES,
+        Base::HEADERS_RESPONSE,
+        ...Base::OAUTH_RESPONSES,
+        'ASYNC_CLEANUP_PASSED',
     ];
 }

--- a/tests/e2e/Python312Test.php
+++ b/tests/e2e/Python312Test.php
@@ -9,30 +9,21 @@ use Appwrite\SDK\Language\Python;
 
 final class Python312Test extends Base
 {
-    #[Override]
     protected string $sdkName = 'python';
-    #[Override]
     protected string $sdkPlatform = 'server';
-    #[Override]
     protected string $sdkLanguage = 'python';
-    #[Override]
     protected string $version = '0.0.1';
 
-    #[Override]
     protected string $language = 'python';
-    #[Override]
     protected string $class = Python::class;
-    #[Override]
     protected array $build = [
         'cp tests/e2e/languages/python/tests.py tests/e2e/sdks/python/test.py',
         'echo "" > tests/e2e/sdks/python/__init__.py',
         'docker run --rm -v $(pwd):/app -w /app --env PIP_TARGET=tests/e2e/sdks/python/vendor python:3.12-alpine pip install -r tests/e2e/sdks/python/requirements.txt --upgrade',
     ];
-    #[Override]
     protected string $command =
         'docker run --network="mockapi" --rm -v $(pwd):/app -w /app --env PIP_TARGET=tests/e2e/sdks/python/vendor --env PYTHONPATH=tests/e2e/sdks/python/vendor python:3.12-alpine python tests/e2e/sdks/python/test.py';
 
-    #[Override]
     protected array $expectedOutput = [
         ...Base::FOO_RESPONSES,
         ...Base::BAR_RESPONSES,
@@ -45,6 +36,16 @@ final class Python312Test extends Base
         ...Base::QUERY_HELPER_RESPONSES,
         ...Base::PERMISSION_HELPER_RESPONSES,
         ...Base::ID_HELPER_RESPONSES,
-        ...Base::OPERATOR_HELPER_RESPONSES
+        ...Base::OPERATOR_HELPER_RESPONSES,
+        ...Base::FOO_RESPONSES,
+        ...Base::BAR_RESPONSES,
+        ...Base::GENERAL_RESPONSES,
+        ...Base::UPLOAD_RESPONSES,
+        ...Base::ENUM_RESPONSES,
+        ...Base::MODEL_RESPONSES,
+        ...Base::EXCEPTION_RESPONSES,
+        Base::HEADERS_RESPONSE,
+        ...Base::OAUTH_RESPONSES,
+        'ASYNC_CLEANUP_PASSED',
     ];
 }

--- a/tests/e2e/Python313Test.php
+++ b/tests/e2e/Python313Test.php
@@ -45,6 +45,16 @@ final class Python313Test extends Base
         ...Base::QUERY_HELPER_RESPONSES,
         ...Base::PERMISSION_HELPER_RESPONSES,
         ...Base::ID_HELPER_RESPONSES,
-        ...Base::OPERATOR_HELPER_RESPONSES
+        ...Base::OPERATOR_HELPER_RESPONSES,
+        ...Base::FOO_RESPONSES,
+        ...Base::BAR_RESPONSES,
+        ...Base::GENERAL_RESPONSES,
+        ...Base::UPLOAD_RESPONSES,
+        ...Base::ENUM_RESPONSES,
+        ...Base::MODEL_RESPONSES,
+        ...Base::EXCEPTION_RESPONSES,
+        Base::HEADERS_RESPONSE,
+        ...Base::OAUTH_RESPONSES,
+        'ASYNC_CLEANUP_PASSED',
     ];
 }

--- a/tests/e2e/Python39Test.php
+++ b/tests/e2e/Python39Test.php
@@ -45,6 +45,16 @@ final class Python39Test extends Base
         ...Base::QUERY_HELPER_RESPONSES,
         ...Base::PERMISSION_HELPER_RESPONSES,
         ...Base::ID_HELPER_RESPONSES,
-        ...Base::OPERATOR_HELPER_RESPONSES
+        ...Base::OPERATOR_HELPER_RESPONSES,
+        ...Base::FOO_RESPONSES,
+        ...Base::BAR_RESPONSES,
+        ...Base::GENERAL_RESPONSES,
+        ...Base::UPLOAD_RESPONSES,
+        ...Base::ENUM_RESPONSES,
+        ...Base::MODEL_RESPONSES,
+        ...Base::EXCEPTION_RESPONSES,
+        Base::HEADERS_RESPONSE,
+        ...Base::OAUTH_RESPONSES,
+        'ASYNC_CLEANUP_PASSED',
     ];
 }

--- a/tests/e2e/languages/python/tests.py
+++ b/tests/e2e/languages/python/tests.py
@@ -13,6 +13,7 @@ from appwrite.enums.mock_type import MockType
 from appwrite.models.player import Player
 
 import os.path
+import asyncio
 
 client = Client()
 foo = Foo(client)
@@ -254,3 +255,115 @@ print(Operator.date_set_now())
 
 response = general.headers()
 print(response.result)
+
+# Async Foo Tests
+
+response = asyncio.run(foo.get_async('string', 123, ['string in array']))
+print(response.result)
+
+response = asyncio.run(foo.post_async('string', 123, ['string in array']))
+print(response.result)
+
+response = asyncio.run(foo.put_async('string', 123, ['string in array']))
+print(response.result)
+
+response = asyncio.run(foo.patch_async('string', 123, ['string in array']))
+print(response.result)
+
+response = asyncio.run(foo.delete_async('string', 123, ['string in array']))
+print(response.result)
+
+# Async Bar Tests
+
+response = asyncio.run(bar.get_async('string', 123, ['string in array']))
+print(response.result)
+
+response = asyncio.run(bar.post_async('string', 123, ['string in array']))
+print(response.result)
+
+response = asyncio.run(bar.put_async('string', 123, ['string in array']))
+print(response.result)
+
+response = asyncio.run(bar.patch_async('string', 123, ['string in array']))
+print(response.result)
+
+response = asyncio.run(bar.delete_async('string', 123, ['string in array']))
+print(response.result)
+
+# Async General Tests
+
+response = asyncio.run(general.redirect_async())
+print(response['result'])
+
+response = asyncio.run(general.upload_async('string', 123, ['string in array'], InputFile.from_path('./tests/resources/file.png')))
+print(response.result)
+
+response = asyncio.run(general.upload_async('string', 123, ['string in array'], InputFile.from_path('./tests/resources/large_file.mp4')))
+print(response.result)
+
+data = open('./tests/resources/file.png', 'rb').read()
+response = asyncio.run(general.upload_async('string', 123, ['string in array'], InputFile.from_bytes(data, 'file.png', 'image/png')))
+print(response.result)
+
+data = open('./tests/resources/large_file.mp4', 'rb').read()
+response = asyncio.run(general.upload_async('string', 123, ['string in array'], InputFile.from_bytes(data, 'large_file.mp4', 'video/mp4')))
+print(response.result)
+
+response = asyncio.run(general.enum_async(MockType.FIRST))
+print(response.result)
+
+# Async Request model tests
+response = asyncio.run(general.create_player_async(Player(id='player1', name='John Doe', score=100)))
+print(response.result)
+
+response = asyncio.run(general.create_players_async([
+    {'id': 'player1', 'name': 'John Doe', 'score': 100},
+    {'id': 'player2', 'name': 'Jane Doe', 'score': 200}
+]))
+print(response.result)
+
+try:
+    response = asyncio.run(general.error400_async())
+except AppwriteException as e:
+    print(e.message)
+    print(e.response)
+
+try:
+    response = asyncio.run(general.error500_async())
+except AppwriteException as e:
+    print(e.message)
+    print(e.response)
+
+try:
+    response = asyncio.run(general.error502_async())
+except AppwriteException as e:
+    print(e.message)
+    print(e.response)
+
+try:
+    client.set_endpoint("htp://cloud.appwrite.io/v1")
+except AppwriteException as e:
+    print(e.message)
+
+asyncio.run(general.empty_async())
+
+response = asyncio.run(general.headers_async())
+print(response.result)
+
+url = asyncio.run(general.oauth2_async(
+    'clientId',
+    ['test'],
+    '123456',
+    'https://localhost',
+    'https://localhost'
+))
+print(url)
+
+# Async context manager cleanup test
+async def test_async_context_manager_cleanup():
+    async with Client() as async_client:
+        async_foo = Foo(async_client)
+        await async_foo.get_async('string', 123, ['string in array'])
+    print("ASYNC_CLEANUP_PASSED" if (async_client._async_http_client is None or async_client._async_http_client.is_closed) else "ASYNC_CLEANUP_FAILED")
+
+asyncio.run(test_async_context_manager_cleanup())


### PR DESCRIPTION
**What does this PR do?**
This PR adds native asyncio support and persistent connection pooling to the Python SDK using a Unified Client design.

Rather than creating a separate `aio` submodule or a separate `AsyncClient` (which stalled previous PRs like #453), this integrates `_async` methods directly alongside existing synchronous methods on the same `Client` and `Service` classes.

**What changed:**

Unified Methods: Every service method now has an async pair (e.g. `account.get()` and `await account.get_async()`). All synchronous methods are 100% untouched and backward compatible.

Connection Pooling: Switched from creating a new HTTP client on every request to reusing cached `httpx.Client` and `httpx.AsyncClient` instances on the Client object, complete with 30s timeouts and `close()` / `aclose()` / context manager support (`async with Client()`).

Parallel Chunked Uploads: `chunked_upload_async` uses `asyncio.Semaphore(8)` + `asyncio.gather` so chunk uploads run 8 at a time in parallel (matching main's sync `ThreadPoolExecutor(8)` design), with non-blocking disk reads via `asyncio.to_thread`.

Dependencies: Migrated from `requests` to `httpx` (and `respx` for mock testing) — for both sync and async, not just the new async path. Discussed with @ChiragAgg5k: the alternative was keeping `requests` for sync and only pulling httpx in for async, but that means maintaining two HTTP libraries long term, so we went with a single unified transport instead. This is a breaking change under a major version bump — code catching `AppwriteException` (the documented pattern) is unaffected, but code catching `requests.exceptions` directly or mocking `requests` internals will need to move to httpx/respx.

Event Loop Cleanup: Closing a pooled `AsyncClient` synchronously runs into a real asyncio limitation — there's no supported way to close loop-bound transport state from a different loop once the original has stopped. Handling: if the owning loop is running in a different thread, close it for real via `run_coroutine_threadsafe`; if it's the same thread or the loop is stopped/closed, there's no safe way to close it from here, so we warn (`ResourceWarning`) and drop the reference rather than risk a broken cross-loop close. Went through this in detail with Greptile across several review rounds; it agreed this is the correct ceiling given asyncio's constraints.

**Test Plan**

Ran full test suite: all generated service unit tests passing via pytest (sync + async variants for every method, migrated to respx).

Client & Concurrency Tests: Expanded `test_client.py` covering:
- `with Client()` and `async with Client()` context managers
- Explicit `close()` and `aclose()` calls, including cross-thread closure using a real background thread + real event loop
- `Semaphore(8)` concurrency cap validation on both sync and async uploads
- Client reuse across sequential `asyncio.run()` calls, and event loop switching

E2E Tests: Added async coverage to `tests/e2e/languages/python/tests.py` (all Foo/Bar verbs, uploads, enums, models, error codes, oauth2/webAuth, headers, empty response, lifecycle cleanup) plus matching `$expectedOutput` updates across `Python39Test.php`–`Python313Test.php`. Ran for real against the mock server: **1,584 assertions passing.**

(Note: also checked whether this E2E suite would actually catch a regression of the `securityHeaders`/`securityQueries` sync-vs-async bug, since that exact bug came up a few times during review. Pulled the security headers loop out of the async template, regenerated, reran E2E — still 1,584/1,584 passing. Turns out the mock server doesn't enforce those headers, so E2E can't distinguish either way. Flagging this as a known limitation rather than a gap in what was tested — the real fix is a template-level parity check, proposed as a fast follow-up.)

CI Compatibility: Verified with Python 3.9 through 3.13.

**Related PRs and Issues**
Resolves 🚀 Feature: Native Asyncio Support for Python SDK #1456
Replaces PR Async Support in Python SDK #453

**Have you read the Contributing Guidelines on issues?**
Yes