### PR TITLE
fix: import FileSystem expo-file-system/legacy (react-native)

### DIFF
--- a/templates/react-native/src/services/template.ts.twig
+++ b/templates/react-native/src/services/template.ts.twig
@@ -2,7 +2,7 @@ import { Service } from '../service';
 import { {{ spec.title | caseUcfirst}}Exception, Client } from '../client';
 import type { Models } from '../models';
 import type { UploadProgress, Payload } from '../client';
-import * as FileSystem from 'expo-file-system';
+import * as FileSystem from 'expo-file-system/legacy';
 import { Platform as RNPlatform } from 'react-native';
 
 {% set added = [] %}

--- a/tests/e2e/languages/react-native/rollup.test.config.mjs
+++ b/tests/e2e/languages/react-native/rollup.test.config.mjs
@@ -22,6 +22,10 @@ export default {
             entries: [
                 { find: 'react-native', replacement: 'react-native-web' },
                 {
+                    find: 'expo-file-system/legacy',
+                    replacement: path.resolve(__dirname, 'shims/expo-file-system.js'),
+                },
+                {
                     find: 'expo-file-system',
                     replacement: path.resolve(__dirname, 'shims/expo-file-system.js'),
                 },


### PR DESCRIPTION
## 🐛 Problem & Fix

In Expo SDK 55 (`expo-file-system@55.x`), Expo moved legacy file system methods like `readAsStringAsync` and `writeAsStringAsync` to the `expo-file-system/legacy` subpath export.

Importing `readAsStringAsync` directly from top-level `expo-file-system` causes runtime crashes during chunked file uploads (> 5MB) on Expo SDK 55 applications.

This PR updates the template import in `templates/react-native/src/services/template.ts.twig` to import from `expo-file-system/legacy`, restoring compatibility for file uploads on Expo SDK 55.

Relates to appwrite/sdk-for-react-native#112
