### PR TITLE
feat(cli): render compact deployment summaries

### DIFF
--- a/templates/cli/lib/response-config.ts
+++ b/templates/cli/lib/response-config.ts
@@ -107,6 +107,62 @@ const compactAmount = (value: unknown): string => {
   return "—";
 };
 
+const compactBytes = (value: unknown): string => {
+  const bytes =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim() !== ""
+        ? Number(value)
+        : Number.NaN;
+
+  if (!Number.isFinite(bytes) || bytes < 0) {
+    return "—";
+  }
+
+  if (bytes < 1024) {
+    return `${Math.round(bytes)} B`;
+  }
+
+  const units = ["KB", "MB", "GB", "TB"];
+  let amount = bytes / 1024;
+  let unitIndex = 0;
+
+  while (amount >= 1024 && unitIndex < units.length - 1) {
+    amount /= 1024;
+    unitIndex++;
+  }
+
+  return `${amount.toFixed(1).replace(/\.0$/, "")} ${units[unitIndex]}`;
+};
+
+const compactDuration = (value: unknown): string => {
+  const duration =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim() !== ""
+        ? Number(value)
+        : Number.NaN;
+
+  if (!Number.isFinite(duration) || duration < 0) {
+    return "—";
+  }
+
+  const totalSeconds = Math.round(duration);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+
+  return `${seconds}s`;
+};
+
 const isPresent = (value: unknown): boolean => {
   if (value == null) return false;
   if (typeof value === "string") return value.trim() !== "";
@@ -228,6 +284,17 @@ const RuntimeSummarySchema = createSummarySchema(
   "Expected a runtime summary row",
 );
 
+const DeploymentSummarySchema = z
+  .object({
+    $id: z.string(),
+    status: z.string(),
+    type: z.string().nullable().optional(),
+    activate: z.boolean().optional(),
+    totalSize: z.union([z.string(), z.number()]).nullable().optional(),
+    buildDuration: z.union([z.string(), z.number()]).nullable().optional(),
+  })
+  .passthrough();
+
 const paymentMethodLabel = (row: JsonObject): string => {
   const brand = valueFrom<string>(row, "brand") ?? "";
   const last4 = valueFrom<string>(row, "last4") ?? "";
@@ -291,10 +358,56 @@ const runtimeLabel = (row: JsonObject): string => {
   return `${runtimeName} ${version}`;
 };
 
+const deploymentStatus = (row: JsonObject): string => {
+  const status = compactText(valueFrom(row, "status"), "unknown");
+
+  switch (status.toLowerCase()) {
+    case "ready":
+      return chalk.green(status);
+    case "failed":
+      return chalk.red(status);
+    case "waiting":
+    case "processing":
+    case "building":
+      return chalk.yellow(status);
+    case "canceled":
+      return chalk.dim(status);
+    default:
+      return status;
+  }
+};
+
 const structuredCollectionRenderers: Record<
   string,
   StructuredCollectionRenderer
 > = {
+  deployments: createColumnRenderer(DeploymentSummarySchema, [
+    {
+      header: "deployment",
+      value: (row, context) =>
+        indexedLabel(compactText(valueFrom(row, "$id")), context),
+    },
+    {
+      header: "status",
+      value: (row) => deploymentStatus(row),
+    },
+    {
+      header: "type",
+      value: (row) => compactText(valueFrom(row, "type")),
+    },
+    {
+      header: "auto-activate",
+      value: (row) => (row.activate === true ? "yes" : "no"),
+    },
+    {
+      header: "size",
+      value: (row) => compactBytes(valueFrom(row, "totalSize")),
+    },
+    {
+      header: "build",
+      value: (row) => compactDuration(valueFrom(row, "buildDuration")),
+    },
+  ]),
   runtimes: createColumnRenderer(RuntimeSummarySchema, [
     {
       header: "runtime",

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -288,8 +288,9 @@ abstract class Base extends TestCase
 
     protected const HEADERS_RESPONSE = '__HEADERS_RESPONSE__';
 
-    protected const CLI_RUNTIME_RENDERING_RESPONSES = [
+    protected const CLI_RESPONSE_RENDERING_RESPONSES = [
         'CLI_RUNTIME_RENDERING:passed',
+        'CLI_DEPLOYMENT_RENDERING:passed',
     ];
 
     protected const CLI_QUERY_HELPER_RESPONSES = [

--- a/tests/e2e/CLIBun10Test.php
+++ b/tests/e2e/CLIBun10Test.php
@@ -46,7 +46,7 @@ final class CLIBun10Test extends Base
         ...Base::CLI_HEADERS_RESPONSES,
         ...Base::CLI_FUNCTION_RESPONSES,
         ...Base::CLI_LOCAL_FUNCTION_EMULATION_RESPONSES,
-        ...Base::CLI_RUNTIME_RENDERING_RESPONSES,
+        ...Base::CLI_RESPONSE_RENDERING_RESPONSES,
         ...Base::CLI_QUERY_HELPER_RESPONSES,
         ...Base::CLI_TYPEGEN_RESPONSES,
         ...Base::AUTH_LOGIC_RESPONSES,

--- a/tests/e2e/CLIBun11Test.php
+++ b/tests/e2e/CLIBun11Test.php
@@ -46,7 +46,7 @@ final class CLIBun11Test extends Base
         ...Base::CLI_HEADERS_RESPONSES,
         ...Base::CLI_FUNCTION_RESPONSES,
         ...Base::CLI_LOCAL_FUNCTION_EMULATION_RESPONSES,
-        ...Base::CLI_RUNTIME_RENDERING_RESPONSES,
+        ...Base::CLI_RESPONSE_RENDERING_RESPONSES,
         ...Base::CLI_QUERY_HELPER_RESPONSES,
         ...Base::CLI_TYPEGEN_RESPONSES,
         ...Base::AUTH_LOGIC_RESPONSES,

--- a/tests/e2e/CLIBun13Test.php
+++ b/tests/e2e/CLIBun13Test.php
@@ -46,7 +46,7 @@ final class CLIBun13Test extends Base
         ...Base::CLI_HEADERS_RESPONSES,
         ...Base::CLI_FUNCTION_RESPONSES,
         ...Base::CLI_LOCAL_FUNCTION_EMULATION_RESPONSES,
-        ...Base::CLI_RUNTIME_RENDERING_RESPONSES,
+        ...Base::CLI_RESPONSE_RENDERING_RESPONSES,
         ...Base::CLI_QUERY_HELPER_RESPONSES,
         ...Base::CLI_TYPEGEN_RESPONSES,
         ...Base::AUTH_LOGIC_RESPONSES,

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -549,6 +549,98 @@ for (const forbiddenToken of [
 
 console.log("CLI_RUNTIME_RENDERING:passed");
 
+const deploymentRenderingOutput = captureStdoutSync(() =>
+  parse({
+    total: 3,
+    deployments: [
+      {
+        $id: "6a65e0ff00d45cdb1e36",
+        type: "manual",
+        resourceId: "layby",
+        resourceType: "sites",
+        sourceSize: 7507,
+        buildSize: 0,
+        totalSize: 7507,
+        activate: false,
+        status: "failed",
+        buildLogs: "Build failed with exit code -1.",
+        buildDuration: 904,
+      },
+      {
+        $id: "6a66c7381a16bff498d3",
+        type: "cli",
+        resourceId: "layby",
+        resourceType: "sites",
+        sourceSize: 10471,
+        buildSize: 20480,
+        totalSize: 30951,
+        activate: false,
+        status: "ready",
+        buildLogs: "Build finished.",
+        buildDuration: 14,
+      },
+      {
+        $id: "6a67091aeafb8c211d5e",
+        type: "cli",
+        resourceId: "layby",
+        resourceType: "sites",
+        sourceSize: 67782,
+        buildSize: 77824,
+        totalSize: 145606,
+        activate: true,
+        status: "ready",
+        buildLogs: "Build finished.",
+        buildDuration: 16,
+      },
+    ],
+  }),
+)
+  .split("\n")
+  .map((line) => line.replace(/\s+$/g, ""))
+  .join("\n");
+
+for (const expectedToken of [
+  "total  3",
+  "deployments (3)",
+  "deployment",
+  "status",
+  "type",
+  "auto-activate",
+  "size",
+  "build",
+  "[1] 6a65e0ff00d45cdb1e36",
+  "failed",
+  "7.3 KB",
+  "15m 4s",
+  "[3] 6a67091aeafb8c211d5e",
+  "142.2 KB",
+  "yes",
+]) {
+  if (!deploymentRenderingOutput.includes(expectedToken)) {
+    throw new Error(
+      `Expected deployment rendering to include ${JSON.stringify(expectedToken)}.\n${deploymentRenderingOutput}`,
+    );
+  }
+}
+
+for (const forbiddenToken of [
+  "resourceId",
+  "resourceType",
+  "sourceSize",
+  "buildSize",
+  "totalSize",
+  "buildLogs",
+  "Build failed with exit code -1.",
+]) {
+  if (deploymentRenderingOutput.includes(forbiddenToken)) {
+    throw new Error(
+      `Expected deployment rendering to omit ${JSON.stringify(forbiddenToken)}.\n${deploymentRenderingOutput}`,
+    );
+  }
+}
+
+console.log("CLI_DEPLOYMENT_RENDERING:passed");
+
 output = execFileSync(
   "bun",
   [


### PR DESCRIPTION
## Summary

Improves the default output for function and site deployment lists.

- renders one compact, aligned row per deployment
- keeps the full deployment ID copyable
- color-codes deployment status
- formats total size and build duration for humans
- labels `activate` as `auto-activate` to reflect its API semantics
- omits build logs, screenshot IDs, and redundant resource fields from the normal list view

Detailed responses remain available through `get-deployment`, `--json`, and `--raw`.

## Approach

Adds a schema-validated `deployments` renderer to the existing structured response configuration. This applies to both Functions and Sites because they share the deployment response model.

The renderer is intentionally permissive about optional fields and unknown status strings. If a response does not match the expected deployment shape, the parser falls back to its existing generic output.

## Before and after

The generic renderer currently expands every deployment into a multi-line record. Build logs make even a small page difficult to scan. For example, this abridged response already consumes more than 30 lines for only two deployments:

### Before

```console
$ appwrite sites list-deployments --site-id layby
total  12

deployments (12)
  [1]
    $id            6a65e0ff00d45cdb1e36
    type           manual
    resourceId     layby
    resourceType   sites
    sourceSize     7507
    buildSize      0
    totalSize      7507
    activate       false
    status         failed
    buildLogs
Build failed with exit code -1.
    buildDuration  904

  [3]
    $id            6a66c7381a16bff498d3
    type           cli
    resourceId     layby
    resourceType   sites
    sourceSize     10471
    buildSize      20480
    totalSize      30951
    activate       false
    status         ready
    buildLogs      [02:49:30] [open-runtimes] Build cache miss.
[02:49:30] [open-runtimes] Environment preparation started.
[02:49:30] [open-runtimes] Build finished.
[02:49:45] [appwrite] Deployment finished.
    buildDuration  14

  ... repeated for every deployment ...
```

### After

The same command produces one row per deployment:

```console
$ appwrite sites list-deployments --site-id layby
total  12

deployments (12)
  deployment                 status  type    auto-activate  size      build
  [1]  6a65e0ff00d45cdb1e36  failed  manual  no             7.3 KB    15m 4s
  [2]  6a65e3bceb21eeb3b885  failed  manual  no             7.3 KB    15m 3s
  [3]  6a66c7381a16bff498d3  ready   cli     no             30.2 KB   14s
  [4]  6a66c902d395a7df2a4d  ready   manual  no             30.2 KB   14s
  ...
  [12] 6a67091aeafb8c211d5e  ready   cli     yes            142.2 KB  16s
```

The summary keeps the fields needed to identify and compare deployments while making the raw values easier to read:

- `totalSize: 7507` becomes `7.3 KB`
- `buildDuration: 904` becomes `15m 4s`
- `activate: true` becomes `auto-activate: yes`; it does not incorrectly imply that the deployment is currently active
- deployment IDs remain complete and copyable
- statuses remain textual and gain terminal colors: green for ready, red for failed, yellow for in-progress states, and dimmed for canceled

Users can still inspect logs and source/build size details with a single-deployment command or machine-readable output:

```console
appwrite sites get-deployment \
  --site-id layby \
  --deployment-id 6a65e0ff00d45cdb1e36

appwrite sites list-deployments --site-id layby --json
appwrite sites list-deployments --site-id layby --raw
```

## Test plan

- [x] Regenerated the CLI SDK with `php example.php cli`
- [x] Verified the generated response configuration matches the template
- [x] `npm run build:types`
- [x] ESLint on the changed generated response configuration
- [x] `vendor/bin/phpunit --testsuite Unit` — 33 tests, 125 assertions
- [x] `composer refactor:check`
- [x] `vendor/bin/phpunit tests/e2e/CLIBun13Test.php` — 1 test, 2151 assertions
- [x] Added CLI e2e coverage for compact deployment fields, human-readable formatting, and omitted verbose fields

## Existing baseline failures

- Repository-wide `npm run lint` reports 1,231 existing generated-code errors outside this change.
- `composer lint-twig` reports 44 existing errors in unrelated language templates.
