### PR TITLE
fix(cli): preserve region for site screenshot previews

### DIFF
--- a/templates/cli/lib/commands/push.ts
+++ b/templates/cli/lib/commands/push.ts
@@ -2772,6 +2772,7 @@ export class Push {
             requiresAuth: true,
             endpointOverride:
               localConfig.getEndpoint() || globalConfig.getEndpoint(),
+            preserveRegion: true,
           });
           sitePreviewRenderer = {
             consoleClient,

--- a/templates/cli/lib/sdks.ts
+++ b/templates/cli/lib/sdks.ts
@@ -90,15 +90,19 @@ export const sdkForConsole = async ({
   requiresAuth = true,
   endpointOverride,
   organizationId,
+  preserveRegion = false,
 }: {
   requiresAuth?: boolean;
   endpointOverride?: string;
   organizationId?: string;
+  preserveRegion?: boolean;
 } = {}): Promise<Client> => {
   const client = new Client();
-  const endpoint = normalizeCloudConsoleEndpoint(
-    endpointOverride || globalConfig.getEndpoint() || DEFAULT_ENDPOINT,
-  );
+  const configuredEndpoint =
+    endpointOverride || globalConfig.getEndpoint() || DEFAULT_ENDPOINT;
+  const endpoint = preserveRegion
+    ? configuredEndpoint
+    : normalizeCloudConsoleEndpoint(configuredEndpoint);
   const isCloudEndpoint = isCloudHostname(new URL(endpoint).hostname);
   const selfSigned = globalConfig.getSelfSigned();
 

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -27,7 +27,7 @@ const {
   isAuthorizationPendingError,
   pollForDeviceToken,
 } = require("./lib/auth/oauth.ts");
-const { getValidAccessToken } = require("./lib/sdks.ts");
+const { getValidAccessToken, sdkForConsole } = require("./lib/sdks.ts");
 const {
   deleteStoredRefreshToken,
   getStoredRefreshToken,
@@ -918,7 +918,7 @@ async function runAuthChecks() {
     }
   });
 
-  await authCheck("endpoint-normalize", () => {
+  await authCheck("endpoint-normalize", async () => {
     assert.equal(
       normalizeCloudConsoleEndpoint("https://fra.cloud.appwrite.io/v1"),
       "https://cloud.appwrite.io/v1",
@@ -933,6 +933,16 @@ async function runAuthChecks() {
     );
     assert.equal(normalizeCloudConsoleEndpoint("http://localhost/v1"), "http://localhost/v1");
     assert.equal(normalizeCloudConsoleEndpoint("not a url"), "not a url");
+
+    const regionalClient = await sdkForConsole({
+      requiresAuth: false,
+      endpointOverride: "https://fra.cloud.appwrite.io/v1",
+      preserveRegion: true,
+    });
+    assert.equal(
+      regionalClient.config.endpoint,
+      "https://fra.cloud.appwrite.io/v1",
+    );
   });
 
   await authCheck("console-slug-region", () => {


### PR DESCRIPTION
## Summary

Fix CLI site screenshot previews for projects using regional Cloud endpoints.

Console clients continue to normalize to the central endpoint by default. The site preview path now opts into preserving the configured regional endpoint so Storage reads are routed to the region that holds the screenshot bytes.

Regression coverage is added as an assertion in the existing CLI endpoint-normalization test; no new test file or test infrastructure is introduced.

## Test plan

- [x] `php example.php cli`
- [x] `vendor/bin/phpunit tests/e2e/CLIBun13Test.php` — OK (1 test, 2150 assertions)
- [x] `vendor/bin/phpunit --testsuite Unit` — OK (33 tests, 125 assertions)
- [x] `composer refactor:check`
- [x] `uvx djlint templates/cli/ --lint`
- [x] `npm run build:runtime` in `examples/cli` after rebasing onto the latest `main`

The full CLI E2E run passed immediately before the clean rebase. A post-rebase rerun could not start because the local Docker daemon was offline; regeneration and the generated runtime build both passed after the rebase.
