### PR TITLE
fix(cli): use session endpoint for token refresh

### DIFF
--- a/templates/cli/lib/auth/login.ts
+++ b/templates/cli/lib/auth/login.ts
@@ -139,7 +139,7 @@ export const getCurrentAccount = async (): Promise<Models.User | null> => {
   } catch (err) {
     if (isGuestUnauthorizedError(err)) {
       try {
-        await getValidAccessToken(globalConfig.getEndpoint(), {
+        await getValidAccessToken({
           forceRefresh: true,
         });
         const refreshedClient = await sdkForConsole();

--- a/templates/cli/lib/commands/utils/deployment.ts
+++ b/templates/cli/lib/commands/utils/deployment.ts
@@ -299,7 +299,7 @@ export async function watchDeploymentUpdates(
       headers.cookie = cookieHeader;
     }
     if (hasAccessToken) {
-      const accessToken = await getValidAccessToken(params.endpoint);
+      const accessToken = await getValidAccessToken();
       headers.authorization = `Bearer ${accessToken}`;
     }
 

--- a/templates/cli/lib/commands/utils/deployment.ts
+++ b/templates/cli/lib/commands/utils/deployment.ts
@@ -287,6 +287,7 @@ export async function watchDeploymentUpdates(
     return null;
   }
 
+  // Never attach session credentials to a different environment.
   assertSessionEndpointMatches(params.endpoint);
 
   const sessionSecret = getSessionSecret(cookieHeader);

--- a/templates/cli/lib/commands/utils/deployment.ts
+++ b/templates/cli/lib/commands/utils/deployment.ts
@@ -8,7 +8,10 @@ import { Agent, WebSocket } from "undici";
 import { Client, AppwriteException } from "@appwrite.io/console";
 import { error, warn } from "../../parser.js";
 import { globalConfig, localConfig } from "../../config.js";
-import { getValidAccessToken } from "../../sdks.js";
+import {
+  assertSessionEndpointMatches,
+  getValidAccessToken,
+} from "../../sdks.js";
 import {
   getErrorMessage,
   isPathInside,
@@ -283,6 +286,8 @@ export async function watchDeploymentUpdates(
   if (!cookieHeader && !hasAccessToken) {
     return null;
   }
+
+  assertSessionEndpointMatches(params.endpoint);
 
   const sessionSecret = getSessionSecret(cookieHeader);
   const selfSigned = globalConfig.getSelfSigned();

--- a/templates/cli/lib/sdks.ts
+++ b/templates/cli/lib/sdks.ts
@@ -21,13 +21,13 @@ import {
 } from "./auth/refresh-token.js";
 
 export const getValidAccessToken = async (
-  endpoint: string,
   options: { forceRefresh?: boolean } = {},
 ): Promise<string> => {
   const accessToken = globalConfig.getAccessToken();
   const tokenExpiry = globalConfig.getTokenExpiry();
   const clientId = globalConfig.getClientId() || OAUTH2_CLIENT_ID;
   const currentSession = globalConfig.getCurrentSession();
+  const sessionEndpoint = globalConfig.getEndpoint() || DEFAULT_ENDPOINT;
 
   if (
     !options.forceRefresh &&
@@ -53,7 +53,7 @@ export const getValidAccessToken = async (
 
   const oauth2 = new Oauth2(
     new Client()
-      .setEndpoint(normalizeCloudConsoleEndpoint(endpoint))
+      .setEndpoint(normalizeCloudConsoleEndpoint(sessionEndpoint))
       .setProject("console")
       .setSelfSigned(globalConfig.getSelfSigned()),
   );
@@ -135,7 +135,7 @@ export const sdkForConsole = async ({
 
   if (requiresAuth) {
     if (accessToken) {
-      const validAccessToken = await getValidAccessToken(endpoint);
+      const validAccessToken = await getValidAccessToken();
       client.headers["Authorization"] = `Bearer ${validAccessToken}`;
     } else if (cookie) {
       if (isCloudEndpoint) {
@@ -190,7 +190,19 @@ export const sdkForProject = async (): Promise<Client> => {
     .setLocale("en-US");
 
   if (accessToken) {
-    const validAccessToken = await getValidAccessToken(endpoint);
+    const sessionEndpoint = globalConfig.getEndpoint() || DEFAULT_ENDPOINT;
+    if (
+      isCloudEndpoint &&
+      isCloudHostname(new URL(sessionEndpoint).hostname) &&
+      normalizeCloudConsoleEndpoint(endpoint) !==
+        normalizeCloudConsoleEndpoint(sessionEndpoint)
+    ) {
+      throw new Error(
+        `Project endpoint ${endpoint} does not match the current login session endpoint ${sessionEndpoint}. Switch to an account for this environment with \`${EXECUTABLE_NAME} login --switch\`.`,
+      );
+    }
+
+    const validAccessToken = await getValidAccessToken();
     client.headers["Authorization"] = `Bearer ${validAccessToken}`;
     return client.setMode("admin");
   }

--- a/templates/cli/lib/sdks.ts
+++ b/templates/cli/lib/sdks.ts
@@ -20,14 +20,11 @@ import {
   setStoredRefreshToken,
 } from "./auth/refresh-token.js";
 
-const normalizeEndpointForComparison = (endpoint: string): string =>
-  normalizeCloudConsoleEndpoint(endpoint).replace(/\/+$/, "");
-
 export const assertSessionEndpointMatches = (endpoint: string): void => {
   const sessionEndpoint = globalConfig.getEndpoint() || DEFAULT_ENDPOINT;
   if (
-    normalizeEndpointForComparison(endpoint) !==
-    normalizeEndpointForComparison(sessionEndpoint)
+    normalizeCloudConsoleEndpoint(endpoint).replace(/\/+$/, "") !==
+    normalizeCloudConsoleEndpoint(sessionEndpoint).replace(/\/+$/, "")
   ) {
     throw new Error(
       `Endpoint ${endpoint} does not match the current login session endpoint ${sessionEndpoint}. Switch to an account for this environment with \`${EXECUTABLE_NAME} login --switch\`.`,

--- a/templates/cli/lib/sdks.ts
+++ b/templates/cli/lib/sdks.ts
@@ -20,6 +20,21 @@ import {
   setStoredRefreshToken,
 } from "./auth/refresh-token.js";
 
+const normalizeEndpointForComparison = (endpoint: string): string =>
+  normalizeCloudConsoleEndpoint(endpoint).replace(/\/+$/, "");
+
+export const assertSessionEndpointMatches = (endpoint: string): void => {
+  const sessionEndpoint = globalConfig.getEndpoint() || DEFAULT_ENDPOINT;
+  if (
+    normalizeEndpointForComparison(endpoint) !==
+    normalizeEndpointForComparison(sessionEndpoint)
+  ) {
+    throw new Error(
+      `Endpoint ${endpoint} does not match the current login session endpoint ${sessionEndpoint}. Switch to an account for this environment with \`${EXECUTABLE_NAME} login --switch\`.`,
+    );
+  }
+};
+
 export const getValidAccessToken = async (
   options: { forceRefresh?: boolean } = {},
 ): Promise<string> => {
@@ -133,6 +148,10 @@ export const sdkForConsole = async ({
     .setSelfSigned(selfSigned)
     .setLocale("en-US");
 
+  if (requiresAuth && (accessToken || cookie)) {
+    assertSessionEndpointMatches(endpoint);
+  }
+
   if (requiresAuth) {
     if (accessToken) {
       const validAccessToken = await getValidAccessToken();
@@ -189,19 +208,11 @@ export const sdkForProject = async (): Promise<Client> => {
     .setSelfSigned(selfSigned)
     .setLocale("en-US");
 
-  if (accessToken) {
-    const sessionEndpoint = globalConfig.getEndpoint() || DEFAULT_ENDPOINT;
-    if (
-      isCloudEndpoint &&
-      isCloudHostname(new URL(sessionEndpoint).hostname) &&
-      normalizeCloudConsoleEndpoint(endpoint) !==
-        normalizeCloudConsoleEndpoint(sessionEndpoint)
-    ) {
-      throw new Error(
-        `Project endpoint ${endpoint} does not match the current login session endpoint ${sessionEndpoint}. Switch to an account for this environment with \`${EXECUTABLE_NAME} login --switch\`.`,
-      );
-    }
+  if (accessToken || cookie) {
+    assertSessionEndpointMatches(endpoint);
+  }
 
+  if (accessToken) {
     const validAccessToken = await getValidAccessToken();
     client.headers["Authorization"] = `Bearer ${validAccessToken}`;
     return client.setMode("admin");

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -276,6 +276,8 @@ abstract class Base extends TestCase
         'auth:poll-device-token-default-interval:passed',
         'auth:valid-access-token-cached:passed',
         'auth:valid-access-token-missing-expiry:passed',
+        'auth:valid-access-token-session-endpoint:passed',
+        'auth:project-session-endpoint-mismatch:passed',
         'auth:oauth-login-flag:passed',
         'auth:open-browser:passed',
         'auth:config-filters-project-header:passed',

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -27,7 +27,11 @@ const {
   isAuthorizationPendingError,
   pollForDeviceToken,
 } = require("./lib/auth/oauth.ts");
-const { getValidAccessToken, sdkForConsole } = require("./lib/sdks.ts");
+const {
+  getValidAccessToken,
+  sdkForConsole,
+  sdkForProject,
+} = require("./lib/sdks.ts");
 const {
   deleteStoredRefreshToken,
   getStoredRefreshToken,
@@ -825,7 +829,7 @@ void (async () => {
   });
 
 async function runAuthChecks() {
-  const { AppwriteException } = await import("@appwrite.io/console");
+  const { AppwriteException, Oauth2 } = await import("@appwrite.io/console");
   const keyringTokens = new Map();
   const previousNodeEnv = process.env.NODE_ENV;
 
@@ -1219,7 +1223,7 @@ async function runAuthChecks() {
       tokenExpiry: Date.now() + 3600000,
     });
     globalConfig.setCurrentSession("tok1");
-    const token = await getValidAccessToken("http://localhost/v1");
+    const token = await getValidAccessToken();
     assert.equal(token, "cached-token");
   });
 
@@ -1230,8 +1234,67 @@ async function runAuthChecks() {
       accessToken: "cached-token-without-expiry",
     });
     globalConfig.setCurrentSession("tok2");
-    const token = await getValidAccessToken("http://localhost/v1");
+    const token = await getValidAccessToken();
     assert.equal(token, "cached-token-without-expiry");
+  });
+
+  await authCheck("valid-access-token-session-endpoint", async () => {
+    globalConfig.clear();
+    keyringTokens.clear();
+    globalConfig.addSession("tok3", {
+      endpoint: "https://cloud.staging.appwrite.io/v1",
+      accessToken: "expired-token",
+      tokenExpiry: Date.now() - 1000,
+    });
+    globalConfig.setCurrentSession("tok3");
+    setStoredRefreshToken("tok3", "refresh-token");
+
+    const originalCreateToken = Oauth2.prototype.createToken;
+    let refreshEndpoint = "";
+    Oauth2.prototype.createToken = async function (params) {
+      refreshEndpoint = this.client.config.endpoint;
+      assert.equal(params.grantType, "refresh_token");
+      assert.equal(params.refreshToken, "refresh-token");
+      return {
+        access_token: "refreshed-token",
+        refresh_token: "rotated-refresh-token",
+        expires_in: 3600,
+      };
+    };
+
+    try {
+      assert.equal(await getValidAccessToken(), "refreshed-token");
+    } finally {
+      Oauth2.prototype.createToken = originalCreateToken;
+    }
+
+    assert.equal(refreshEndpoint, "https://cloud.staging.appwrite.io/v1");
+    assert.equal(getStoredRefreshToken("tok3"), "rotated-refresh-token");
+  });
+
+  await authCheck("project-session-endpoint-mismatch", async () => {
+    globalConfig.clear();
+    globalConfig.addSession("tok4", {
+      endpoint: "https://cloud.staging.appwrite.io/v1",
+      accessToken: "cached-token",
+      tokenExpiry: Date.now() + 3600000,
+    });
+    globalConfig.setCurrentSession("tok4");
+
+    const originalGetEndpoint = localConfig.getEndpoint;
+    const originalGetProject = localConfig.getProject;
+    localConfig.getEndpoint = () => "https://fra.cloud.appwrite.io/v1";
+    localConfig.getProject = () => ({ projectId: "project-id" });
+
+    try {
+      await assert.rejects(
+        () => sdkForProject(),
+        /does not match the current login session endpoint/,
+      );
+    } finally {
+      localConfig.getEndpoint = originalGetEndpoint;
+      localConfig.getProject = originalGetProject;
+    }
   });
 
   await authCheck("oauth-login-flag", () => {

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -28,6 +28,7 @@ const {
   pollForDeviceToken,
 } = require("./lib/auth/oauth.ts");
 const {
+  assertSessionEndpointMatches,
   getValidAccessToken,
   sdkForConsole,
   sdkForProject,
@@ -1290,6 +1291,25 @@ async function runAuthChecks() {
       await assert.rejects(
         () => sdkForProject(),
         /does not match the current login session endpoint/,
+      );
+
+      assert.throws(
+        () => assertSessionEndpointMatches("http://localhost/v1"),
+        /does not match the current login session endpoint/,
+      );
+
+      globalConfig.addSession("tok4", {
+        endpoint: "http://localhost/v1",
+        accessToken: "cached-token",
+        tokenExpiry: Date.now() + 3600000,
+      });
+      assert.throws(
+        () =>
+          assertSessionEndpointMatches("https://cloud.staging.appwrite.io/v1"),
+        /does not match the current login session endpoint/,
+      );
+      assert.doesNotThrow(() =>
+        assertSessionEndpointMatches("http://localhost/v1/"),
       );
     } finally {
       localConfig.getEndpoint = originalGetEndpoint;


### PR DESCRIPTION
## Summary

Fix CLI OAuth refreshes so authentication credentials stay bound to the environment that issued them.

The CLI stores the active login session globally, including its console endpoint and OAuth tokens. Project commands independently select their API endpoint from the local `appwrite.config.json`. Before this change, `sdkForProject()` passed that local project endpoint into `getValidAccessToken()`.

This allowed the following configuration:

```text
active login session: https://cloud.staging.appwrite.io/v1
local project endpoint: https://fra.cloud.appwrite.io/v1
refresh destination: https://cloud.appwrite.io/v1
refresh token issuer: staging
```

Production cannot validate a refresh token signed and stored by staging, so it returns the generic OAuth response:

```text
invalid_grant: Invalid refresh token provided.
```

The error looked like an expired or corrupted refresh token even though the token itself was valid.

## Investigation results

Runtime investigation showed:

- the active CLI session belonged to staging
- the access token expired normally after its configured lifetime
- the stored refresh-token family, consent, expiry, and hash were valid
- two forced refreshes sent explicitly to staging succeeded and rotated the refresh token correctly
- the failed CLI attempts appeared on the production FRA token endpoint, while staging had no corresponding failed refresh request
- the staging token decoded with the staging signing key and failed with the production signing key, matching the server's `invalid_grant` path

This established that refresh-token rotation was working and the failure was caused by the CLI selecting the project endpoint for a session-level OAuth operation.

## Changes

- `getValidAccessToken()` no longer accepts an endpoint from its caller
- refresh requests always use the active session's stored endpoint
- console and project SDK clients validate their target before attaching an access token or legacy session cookie
- regional Cloud endpoints normalize to their central environment, so a production login remains valid for production regional project endpoints
- production, staging, self-hosted, and mixed Cloud/self-hosted environments are treated as distinct
- trailing slashes do not create false endpoint mismatches
- the deployment WebSocket validates its endpoint before attaching session credentials

The endpoint guard also addresses the security cases identified during review: a session token or cookie must never be attached to a different environment, even if refresh itself uses the correct endpoint.

## Regression coverage

The existing CLI auth e2e flow now verifies:

- an unexpired access token is still returned without refreshing
- legacy tokens without an expiry retain their existing behavior
- an expired staging session refreshes through the staging endpoint
- the refresh grant and refresh token passed to the OAuth SDK are correct
- the returned access token is persisted
- a rotated refresh token replaces the previous keyring value
- a production project with a staging session fails before authentication is attached
- Cloud-to-self-hosted and self-hosted-to-Cloud combinations fail
- equivalent self-hosted endpoints with a trailing-slash difference remain accepted

## Test plan

- [x] `php example.php cli`
- [x] `vendor/bin/phpunit tests/e2e/CLIBun13Test.php` — OK (1 test, 2153 assertions)
- [x] `vendor/bin/phpunit tests/e2e/CLIBun10Test.php` — OK (1 test, 2153 assertions)
- [x] `vendor/bin/phpunit --testsuite Unit` — OK (33 tests, 125 assertions)
- [x] Focused TypeScript compilation for the affected dependency graph
- [x] `npm run build:runtime` in `examples/cli`
- [x] ESLint on the affected generated CLI files
- [x] `composer refactor:check`
- [x] `git diff --check`

## Existing baseline failures

- `npm run build:types` in `examples/cli` reports missing dependencies from unrelated generated site fixtures; the isolated CLI e2e declaration build passes.
- `composer lint-twig` reports 44 existing errors in unrelated language templates.
