### PR TITLE
Use compact service names in generated CLI

### DIFF
--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -640,7 +640,7 @@ class CLI extends Node
             // Command services (lib/commands/services/)
             [
                 'scope'         => 'service',
-                'destination'   => '/lib/commands/services/{{service.name | caseKebab}}.ts',
+                'destination'   => '/lib/commands/services/{{service.name | caseLower}}.ts',
                 'template'      => 'cli/lib/commands/services/services.ts.twig',
             ],
 

--- a/templates/cli/cli.ts.twig
+++ b/templates/cli/cli.ts.twig
@@ -39,7 +39,7 @@ import { migrate } from './lib/commands/generic.js';
 {% endif %}
 
 {% for service in spec.services %}
-import { {{ service.name }} } from './lib/commands/services/{{ service.name | caseKebab }}.js';
+import { {{ service.name }} } from './lib/commands/services/{{ service.name | caseLower }}.js';
 {% endfor %}
 
 const { version } = packageJson;

--- a/templates/cli/docs/example.md.twig
+++ b/templates/cli/docs/example.md.twig
@@ -13,7 +13,7 @@
 {% if query.hasPagination %}
 {% set exampleLines = exampleLines|merge(['--limit 25']) %}
 {% endif %}
-{{ language.params.executableName }} {{ service.name | caseKebab }} {{ method.name | caseKebab }}{% if exampleLines | length > 0 %} \{% endif %}
+{{ language.params.executableName }} {{ service.name | caseLower }} {{ method.name | caseKebab }}{% if exampleLines | length > 0 %} \{% endif %}
 
 {% for line in exampleLines %}
     {{ line | raw }}{% if not loop.last %} \{% endif %}

--- a/templates/cli/lib/commands/services/services.ts.twig
+++ b/templates/cli/lib/commands/services/services.ts.twig
@@ -81,7 +81,11 @@ const get{{ service.name | caseUcfirst }}Client = async (): Promise<{{ service.n
   return {{ service.name | caseCamel }}Client;
 };
 
-export const {{ service.name | caseCamel }} = new Command("{{ service.name | caseKebab }}")
+export const {{ service.name | caseCamel }} = new Command("{{ service.name | caseLower }}")
+{% if service.name == 'tablesDB' %}
+  // TODO: Move CLI alias configuration to the API spec.
+  .alias("tables-db")
+{% endif %}
 {% if service.description %}
   .description(commandDescriptions["{{ service.name | caseCamel }}"] || {{ service.description | stripMarkdown | json_encode | raw }})
 {% else %}

--- a/templates/cli/lib/parser.ts
+++ b/templates/cli/lib/parser.ts
@@ -659,7 +659,7 @@ const printQueryErrorHint = (err: Error): void => {
   }
 
   hint(
-    `For common list filters, use flags like --limit 25, --sort-desc '$createdAt', or --filter 'status=active'. Raw --queries values must be Appwrite JSON query strings, for example: ${EXECUTABLE_NAME} tables-db list-rows --queries '{"method":"limit","values":[25]}'`,
+    `For common list filters, use flags like --limit 25, --sort-desc '$createdAt', or --filter 'status=active'. Raw --queries values must be Appwrite JSON query strings, for example: ${EXECUTABLE_NAME} tablesdb list-rows --queries '{"method":"limit","values":[25]}'`,
   );
 };
 
@@ -879,7 +879,7 @@ export const commandDescriptions: Record<string, string> = {
   avatars: `The avatars command aims to help you complete everyday tasks related to your app image, icons, and avatars.`,
   backups: `The backups command allows you to manage backup policies, archives, and restorations for your project.`,
   databases: `(Legacy) The databases command allows you to create structured collections of documents and query and filter lists of documents.`,
-  tablesDB: `The tables-db command allows you to create structured tables of columns and query and filter lists of rows.`,
+  tablesDB: `The tablesdb command allows you to create structured tables of columns and query and filter lists of rows.`,
   init: `The init command provides a convenient wrapper for creating and initializing projects, functions, collections, buckets, teams, messaging-topics, and skills in ${SDK_TITLE}.`,
   push: `The push command provides a convenient wrapper for pushing your functions, collections, buckets, teams, and messaging-topics.`,
   run: `The run command allows you to run the project locally to allow easy development and quick debugging.`,
@@ -905,7 +905,7 @@ export const commandDescriptions: Record<string, string> = {
   messaging: `The messaging command allows you to manage topics and targets and send messages.`,
   migrations: `The migrations command allows you to migrate data between services.`,
   notifications: `The notifications command allows you to read and manage your Appwrite Console notifications.`,
-  oauth2: `The oauth-2 command allows you to authorize apps and issue standards-based OAuth2 and OpenID Connect tokens.`,
+  oauth2: `The oauth2 command allows you to authorize apps and issue standards-based OAuth2 and OpenID Connect tokens.`,
   organization: `The organization command allows you to manage organization-level projects.`,
   organizations: `The organizations command allows you to manage organization billing, plans, invoices, and add-ons.`,
   presences: `The presences command allows you to track and manage real-time user presence in your project.`,

--- a/templates/skills/cli.md.twig
+++ b/templates/skills/cli.md.twig
@@ -441,17 +441,17 @@ appwrite push tables
 
 | Command | Description |
 |---------|-------------|
-| `appwrite tables-db list-tables --database-id <ID>` | List tables |
-| `appwrite tables-db create-table --database-id <ID>` | Create table |
-| `appwrite tables-db get-table --database-id <ID> --table-id <ID>` | Get table |
-| `appwrite tables-db update-table --database-id <ID> --table-id <ID>` | Update table |
-| `appwrite tables-db delete-table --database-id <ID> --table-id <ID>` | Delete table |
-| `appwrite tables-db list-columns --database-id <ID> --table-id <ID>` | List columns |
-| `appwrite tables-db get-column --database-id <ID> --table-id <ID> --key <KEY>` | Get column |
-| `appwrite tables-db delete-column --database-id <ID> --table-id <ID> --key <KEY>` | Delete column |
-| `appwrite tables-db list-column-indexes --database-id <ID> --table-id <ID>` | List indexes |
-| `appwrite tables-db create-column-index --database-id <ID> --table-id <ID>` | Create index |
-| `appwrite tables-db delete-column-index --database-id <ID> --table-id <ID> --key <KEY>` | Delete index |
+| `appwrite tablesdb list-tables --database-id <ID>` | List tables |
+| `appwrite tablesdb create-table --database-id <ID>` | Create table |
+| `appwrite tablesdb get-table --database-id <ID> --table-id <ID>` | Get table |
+| `appwrite tablesdb update-table --database-id <ID> --table-id <ID>` | Update table |
+| `appwrite tablesdb delete-table --database-id <ID> --table-id <ID>` | Delete table |
+| `appwrite tablesdb list-columns --database-id <ID> --table-id <ID>` | List columns |
+| `appwrite tablesdb get-column --database-id <ID> --table-id <ID> --key <KEY>` | Get column |
+| `appwrite tablesdb delete-column --database-id <ID> --table-id <ID> --key <KEY>` | Delete column |
+| `appwrite tablesdb list-column-indexes --database-id <ID> --table-id <ID>` | List indexes |
+| `appwrite tablesdb create-column-index --database-id <ID> --table-id <ID>` | Create index |
+| `appwrite tablesdb delete-column-index --database-id <ID> --table-id <ID> --key <KEY>` | Delete index |
 
 ### Column type commands
 
@@ -473,23 +473,23 @@ appwrite push tables
 | `create-enum-column` | Enum column (whitelist of accepted values) |
 | `create-relationship-column` | Relationship column |
 
-All column commands use `appwrite tables-db <command> --database-id <ID> --table-id <ID>`.
+All column commands use `appwrite tablesdb <command> --database-id <ID> --table-id <ID>`.
 
 ### Row operations
 
 ```bash
 # Create a row
-appwrite tables-db create-row \
+appwrite tablesdb create-row \
     --database-id "<DATABASE_ID>" --table-id "<TABLE_ID>" \
     --row-id 'unique()' --data '{ "title": "Hello World" }' \
     --permissions 'read("any")' 'write("team:abc")'
 
 # List rows (JSON output)
-appwrite tables-db list-rows \
+appwrite tablesdb list-rows \
     --database-id "<DATABASE_ID>" --table-id "<TABLE_ID>" --json
 
 # Get a row
-appwrite tables-db get-row \
+appwrite tablesdb get-row \
     --database-id "<DATABASE_ID>" --table-id "<TABLE_ID>" --row-id "<ROW_ID>"
 ```
 
@@ -498,7 +498,7 @@ appwrite tables-db get-row \
 Use `--where`, `--sort-asc`, `--sort-desc`, `--limit`, `--offset`, `--cursor-after`, and `--cursor-before` on list commands. Row and document list/get commands also support repeated `--select` flags.
 
 ```bash
-appwrite tables-db list-rows \
+appwrite tablesdb list-rows \
     --database-id "<DATABASE_ID>" \
     --table-id "<TABLE_ID>" \
     --where 'status=active' \
@@ -804,7 +804,7 @@ appwrite users list --json
 appwrite users list --verbose
 
 # View a row in the Console
-appwrite tables-db get-row \
+appwrite tablesdb get-row \
     --database-id "<DATABASE_ID>" \
     --table-id "<TABLE_ID>" \
     --row-id "<ROW_ID>" \


### PR DESCRIPTION
## Summary

- use compact lowercase service names for generated CLI command files, imports, commands, and examples
- expose `tablesdb` as the canonical command while retaining `tables-db` as a compatibility alias
- expose `oauth2` without adding an `oauth-2` alias
- update CLI help text and generated skills documentation to use the canonical command names
- leave a TODO to move the TablesDB alias configuration into the API spec

## Testing

- `php example.php cli`
- `php example.php skills`
- `vendor/bin/phpunit --testsuite Unit`
- `composer refactor:check`
- `uvx djlint templates/cli/cli.ts.twig templates/cli/docs/example.md.twig templates/cli/lib/commands/services/services.ts.twig --lint`
- `npm run build:cli`
- verified generated help displays `tablesdb|tables-db` and `oauth2`

## Related issue

#XXXX
