### PR TITLE
fix(cli): bump @appwrite.io/console to 15.6.0

### DIFF
--- a/templates/cli/bun.lock.twig
+++ b/templates/cli/bun.lock.twig
@@ -5,7 +5,7 @@
     "": {
       "name": "{{ language.params.npmPackage|caseDash }}",
       "dependencies": {
-        "@appwrite.io/console": "15.5.0",
+        "@appwrite.io/console": "15.6.0",
         "@napi-rs/keyring": "^1.3.0",
         "chalk": "4.1.2",
         "chokidar": "^3.6.0",
@@ -54,7 +54,7 @@
     "tmp": "^0.2.6",
   },
   "packages": {
-    "@appwrite.io/console": ["@appwrite.io/console@15.5.0", "", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-oVs0GB8aYGpdLyYY5GuS1Om5IJB49WUv3iv4Ev9E3mvbZ4KPOhJXZ5jVozBaGWMy1PuDHOHDXs3k5ANfAQBfYw=="],
+    "@appwrite.io/console": ["@appwrite.io/console@15.6.0", "", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-dSlNP01auhPeppdXEGg3mtg5nRTxqKX7H9aHsbxE/nOlJAzAGEcz9Lt/gwmY/NwzMcXrugU1+uLcXUA4Cu4XTQ=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
@@ -860,7 +860,7 @@
 
     "@jimp/types/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 

--- a/templates/cli/package-lock.json.twig
+++ b/templates/cli/package-lock.json.twig
@@ -9,7 +9,7 @@
       "version": "{{ sdk.version }}",
       "license": "{{ sdk.license }}",
       "dependencies": {
-        "@appwrite.io/console": "15.5.0",
+        "@appwrite.io/console": "15.6.0",
         "@napi-rs/keyring": "^1.3.0",
         "chalk": "4.1.2",
         "chokidar": "^3.6.0",
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@appwrite.io/console": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/@appwrite.io/console/-/console-15.5.0.tgz",
-      "integrity": "sha512-oVs0GB8aYGpdLyYY5GuS1Om5IJB49WUv3iv4Ev9E3mvbZ4KPOhJXZ5jVozBaGWMy1PuDHOHDXs3k5ANfAQBfYw==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/@appwrite.io/console/-/console-15.6.0.tgz",
+      "integrity": "sha512-dSlNP01auhPeppdXEGg3mtg5nRTxqKX7H9aHsbxE/nOlJAzAGEcz9Lt/gwmY/NwzMcXrugU1+uLcXUA4Cu4XTQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "json-bigint": "1.0.0"
@@ -4600,13 +4600,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"

--- a/templates/cli/package.json
+++ b/templates/cli/package.json
@@ -48,7 +48,7 @@
     "windows-arm64": "esbuild cli.ts --bundle --loader:.hbs=text --platform=node --target=node18 --format=esm --external:fsevents --external:terminal-image --outfile=dist/bundle-win-arm64.mjs && pkg dist/bundle-win-arm64.mjs --fallback-to-source -t node18-win-arm64 -o build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
-    "@appwrite.io/console": "15.5.0",
+    "@appwrite.io/console": "15.6.0",
     "@napi-rs/keyring": "^1.3.0",
     "chalk": "4.1.2",
     "chokidar": "^3.6.0",

--- a/templates/cli/package.json.twig
+++ b/templates/cli/package.json.twig
@@ -51,7 +51,7 @@
     "windows-arm64": "bun build cli.ts --compile --minify --target=bun-windows-arm64 --outfile build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
-    "@appwrite.io/console": "15.5.0",
+    "@appwrite.io/console": "15.6.0",
     "@napi-rs/keyring": "^1.3.0",
     "chalk": "4.1.2",
     "chokidar": "^3.6.0",


### PR DESCRIPTION
## What does this PR do?

Bumps the CLI template's `@appwrite.io/console` pin from `15.5.0` to `15.6.0`.

The generated CLI now calls methods that do not exist in `15.5.0`, so `tsc` fails on the generated output:

```
apps.ts(208):      Property 'listInstallations' does not exist on type 'Apps'
apps.ts(221/234/247): getInstallation / deleteInstallation / createInstallationToken
tablesdb.ts(308):  Property 'listOperations' does not exist on type 'TablesDB'
vcs.ts(217):       Property 'listNamespaces' does not exist on type 'Vcs'
vcs.ts(83):        Expected 1-3 arguments, but got 4   (createRepository providerNamespace)
activities.ts(50): Type 'string[]' is not assignable to parameter of type 'string'
```

`@appwrite.io/console@15.6.0` (appwrite/sdk-for-console#107) ships all of them and is published to npm as `latest`.

## Changes

- `templates/cli/package.json.twig` and `templates/cli/package.json` — pin bumped.
- `templates/cli/package-lock.json.twig` and `templates/cli/bun.lock.twig` — regenerated with `./scripts/update-lockfiles.sh cli` per AGENTS.md, not edited by hand. Twig expressions are intact in both.

## Test Plan

- `./scripts/update-lockfiles.sh cli` — both lock templates updated cleanly.
- `php example.php cli console` — regenerates without error; `examples/cli/package.json` resolves to `15.6.0`. (`examples/*` is gitignored, so this is verification only.)
- No `15.5.0` references remain under `templates/` or `examples/`.
- `composer refactor:check` — Rector clean.
- `composer lint-twig` — 44 errors both with and without this change; all pre-existing and none in the touched files.

## Related PRs and Issues

- appwrite/sdk-for-console#107 — ships the 15.6.0 methods
- appwrite/sdk-for-cli#346 — CLI 23.2.0, blocked on this bump
- appwrite/appwrite#13022 — spec fix behind the `activities.listEvents` array typing

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/sdk-generator/blob/master/CONTRIBUTING.md)?

Yes.
