### PR TITLE
refactor(cli): make OAuth2 the only Cloud login flow

### DIFF
--- a/templates/cli/lib/auth/login.ts
+++ b/templates/cli/lib/auth/login.ts
@@ -13,7 +13,6 @@ import {
   isRegionalCloudEndpoint,
   openBrowser,
 } from "../utils.js";
-import { isFlagEnabled } from "../flags.js";
 import ID from "../id.js";
 import {
   questionsListFactors,
@@ -476,8 +475,13 @@ export const loginCommand = async ({
   const configEndpoint = normalizeCloudConsoleEndpoint(
     (endpoint ?? globalConfig.getEndpoint()) || DEFAULT_ENDPOINT,
   );
-  const shouldUseCloudLogin =
-    isFlagEnabled("oauthLogin") && isCloudLoginEndpoint(configEndpoint);
+  const shouldUseCloudLogin = isCloudLoginEndpoint(configEndpoint);
+
+  if (shouldUseCloudLogin && (email || password || mfa || code)) {
+    throw new Error(
+      `Cloud sign-in happens in your browser. Run '${EXECUTABLE_NAME} login' without --email, --password, --mfa or --code — those options are for self-hosted instances.`,
+    );
+  }
 
   let oldCurrent = globalConfig.getCurrentSession();
 
@@ -493,7 +497,7 @@ export const loginCommand = async ({
 
     if (account) {
       if (
-        isFlagEnabled("oauthLogin") &&
+        shouldUseCloudLogin &&
         !globalConfig.getAccessToken() &&
         globalConfig.getCookie()
       ) {

--- a/templates/cli/lib/commands/generic.ts
+++ b/templates/cli/lib/commands/generic.ts
@@ -81,13 +81,13 @@ export const register = new Command("register")
 
 export const login = new Command("login")
   .description(commandDescriptions["login"])
-  .option(`--email [email]`, `Email`)
-  .option(`--password [password]`, `Password`)
+  .option(`--email [email]`, `Email, for self hosted instances`)
+  .option(`--password [password]`, `Password, for self hosted instances`)
   .option(
     `--mfa [factor]`,
-    `Factor used for MFA. Must be one of: email, phone, totp, recoveryCode`,
+    `Factor used for MFA on self hosted instances. Must be one of: email, phone, totp, recoveryCode`,
   )
-  .option(`--code [code]`, `Code used for MFA`)
+  .option(`--code [code]`, `Code used for MFA on self hosted instances`)
   .option(
     `--endpoint [endpoint]`,
     `Appwrite endpoint for self hosted instances`,

--- a/templates/cli/lib/flags.ts
+++ b/templates/cli/lib/flags.ts
@@ -6,8 +6,6 @@
  * and read it anywhere with isFlagEnabled("<name>").
  */
 const FLAG_ENV_VARS = {
-  // Browser-based OAuth2 device login for Cloud (otherwise email/password).
-  oauthLogin: "APPWRITE_CLI_OAUTH_LOGIN",
   // Treat localhost/loopback endpoints as Cloud for OAuth login testing.
   devCloudLogin: "APPWRITE_CLI_DEV_CLOUD_LOGIN",
 } as const;

--- a/templates/cli/lib/sdks.ts
+++ b/templates/cli/lib/sdks.ts
@@ -14,7 +14,6 @@ import {
 } from "./constants.js";
 import { warn } from "./parser.js";
 import { isCloudHostname } from "./utils.js";
-import { isFlagEnabled } from "./flags.js";
 import {
   getStoredRefreshToken,
   setStoredRefreshToken,
@@ -87,8 +86,7 @@ export const getValidAccessToken = async (
 let legacySessionWarningShown = false;
 
 const warnLegacySession = (): void => {
-  // Only nudge toward OAuth login when the feature is enabled.
-  if (legacySessionWarningShown || !isFlagEnabled("oauthLogin")) {
+  if (legacySessionWarningShown) {
     return;
   }
 

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -278,7 +278,7 @@ abstract class Base extends TestCase
         'auth:valid-access-token-missing-expiry:passed',
         'auth:valid-access-token-session-endpoint:passed',
         'auth:project-session-endpoint-mismatch:passed',
-        'auth:oauth-login-flag:passed',
+        'auth:cloud-login-rejects-credentials:passed',
         'auth:open-browser:passed',
         'auth:config-filters-project-header:passed',
     ];

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -61,7 +61,7 @@ const {
   normalizeCloudConsoleEndpoint,
   globalConfig,
 } = require("./lib/config.ts");
-const { listenForBrowserOpen } = require("./lib/auth/login.ts");
+const { listenForBrowserOpen, loginCommand } = require("./lib/auth/login.ts");
 const { applyConfigFilters } = require("./lib/config-filters.ts");
 const { questionsLogout } = require("./lib/questions.ts");
 
@@ -1317,16 +1317,30 @@ async function runAuthChecks() {
     }
   });
 
-  await authCheck("oauth-login-flag", () => {
-    const prev = process.env.APPWRITE_CLI_OAUTH_LOGIN;
-    delete process.env.APPWRITE_CLI_OAUTH_LOGIN;
+  await authCheck("cloud-login-rejects-credentials", async () => {
+    const prev = process.env.APPWRITE_CLI_DEV_CLOUD_LOGIN;
+    delete process.env.APPWRITE_CLI_DEV_CLOUD_LOGIN;
     try {
-      assert.equal(isFlagEnabled("oauthLogin"), false);
-      process.env.APPWRITE_CLI_OAUTH_LOGIN = "1";
-      assert.equal(isFlagEnabled("oauthLogin"), true);
+      for (const options of [
+        { email: "user@example.com", password: "password" },
+        { mfa: "totp" },
+        { code: "123456" },
+      ]) {
+        await assert.rejects(
+          () =>
+            loginCommand({
+              endpoint: "https://cloud.appwrite.io/v1",
+              ...options,
+            }),
+          /Cloud sign-in happens in your browser/,
+        );
+      }
+
+      // Self-hosted endpoints keep the email/password flow.
+      assert.equal(isCloudLoginEndpoint("http://localhost/v1"), false);
     } finally {
-      if (prev === undefined) delete process.env.APPWRITE_CLI_OAUTH_LOGIN;
-      else process.env.APPWRITE_CLI_OAUTH_LOGIN = prev;
+      if (prev === undefined) delete process.env.APPWRITE_CLI_DEV_CLOUD_LOGIN;
+      else process.env.APPWRITE_CLI_DEV_CLOUD_LOGIN = prev;
     }
   });
 


### PR DESCRIPTION
## What

Cloud sign-in now always uses the browser-based OAuth2 device flow, and `APPWRITE_CLI_OAUTH_LOGIN` is gone. Self-hosted instances keep email/password exactly as they are today.

Before this change, `login` picked its flow like so:

```ts
const shouldUseCloudLogin =
  isFlagEnabled("oauthLogin") && isCloudLoginEndpoint(configEndpoint);
```

With the flag unset — the default for every user — Cloud sign-in fell through to `POST /account/sessions/email`. The device flow shipped but nobody reached it without opting in. The gate is now just the endpoint check.

## Why

Cloud is the environment where a terminal password prompt is least appropriate. It sidesteps the console's own sign-in path (social providers, MFA enrollment, passkeys) and asks users to type a Cloud password into a CLI. The device flow already exists, already stores refresh tokens in the OS keyring, and already handles MFA in the browser where it belongs — it only needed to become the default.

Self-hosted keeps email/password deliberately. Many self-hosted instances predate the `/oauth2/device_authorization` and `/oauth2/token` endpoints, and an API key is not a substitute: it can't reach console-only commands like `push settings`. Removing the password path there would strand those users.

## Changes

| File | Change |
|---|---|
| `templates/cli/lib/auth/login.ts` | `shouldUseCloudLogin` reduces to `isCloudLoginEndpoint(configEndpoint)`. New guard rejects `--email`/`--password`/`--mfa`/`--code` against Cloud instead of silently ignoring them. The legacy-cookie nudge now keys off `shouldUseCloudLogin`. |
| `templates/cli/lib/flags.ts` | Removed `oauthLogin` / `APPWRITE_CLI_OAUTH_LOGIN`. `devCloudLogin` stays — it still drives localhost-as-Cloud testing. |
| `templates/cli/lib/sdks.ts` | `warnLegacySession()` no longer gated on the flag. Both call sites are already inside `if (isCloudEndpoint)`. |
| `templates/cli/lib/commands/generic.ts` | Help text marks the four credential options as self-hosted-only. |
| `tests/e2e/languages/cli/test.js`, `tests/e2e/Base.php` | Replaced the `oauth-login-flag` check with `cloud-login-rejects-credentials`. |

Two details worth a reviewer's eye:

**The legacy-cookie warning had to move with the gate.** `login.ts` and `sdks.ts` both nudge cookie-session users toward `login --new`. That message was flag-gated; making it unconditional would have shown it to self-hosted users, whose cookie session is not legacy and who have no OAuth alternative. In `login.ts` it now keys off `shouldUseCloudLogin`; in `sdks.ts` the two call sites were already inside `if (isCloudEndpoint)`, so dropping the flag check there is sufficient.

**Credential options now fail loudly.** Previously `login --email x --password y` against Cloud with the flag on ignored both options and silently opened a browser. Now:

```
Cloud sign-in happens in your browser. Run 'appwrite login' without
--email, --password, --mfa or --code — those options are for self-hosted instances.
```

The throw happens before any config mutation or network call.

## Compatibility

- **Existing cookie sessions keep working.** Nothing was removed from `config.ts`, `client.ts`, `session.ts`, or the cookie branches in `sdkForConsole`/`sdkForProject`. Upgrading logs nobody out; `logout` still revokes cookie sessions server-side.
- **`APPWRITE_CLI_OAUTH_LOGIN` becomes a no-op.** Anyone who set it to `1` in CI already gets this behavior. Anyone who set it to `0` expecting to disable the browser flow on Cloud no longer can — the only intentional break, and it's covered by a test.
- **Self-hosted is untouched**, including MFA via `--mfa`/`--code`.

## Testing

### Generator and static checks

- `php example.php cli` regenerates cleanly; `examples/cli/` reflects all four template edits
- `tsc --noEmit` and `eslint` on the changed files: clean
- `composer refactor:check`: OK
- Unit suite: 33 tests, 125 assertions, OK
- `vendor/bin/phpunit tests/e2e/CLIBun13Test.php`: OK, 2153 assertions, including the new `auth:cloud-login-rejects-credentials:passed`

`composer lint-twig` reports 44 pre-existing djLint errors, all in `templates/swift/` and `templates/dart/`. This PR touches no `.twig` files.

### Compiled binary against live Cloud

Built the real distributable — `php example.php cli` → `bun install` → `bun run mac-arm64` → `examples/cli/build/appwrite-cli-darwin-arm64` (bun-compiled, 66 MB) — and ran it against live production and staging sessions using an isolated `HOME` with a copy of `prefs.json`. **19/19 passed.**

| Check | production | staging |
|---|---|---|
| `whoami` resolves account via refresh token | PASS | PASS |
| `whoami` reports the right endpoint | PASS | PASS |
| `login` with a valid session short-circuits | PASS | PASS |
| `--email`/`--password` rejected | PASS | PASS |
| `--mfa` rejected | PASS | PASS |
| `--code` rejected | PASS | PASS |
| `login --new` opens device flow with **no env var set** | PASS | PASS |
| Device flow targets the right console host | PASS | PASS |

Plus:

| Check | Result |
|---|---|
| Self-hosted endpoint not caught by the Cloud guard | PASS |
| Self-hosted still attempts the email/password endpoint | PASS |
| `APPWRITE_CLI_OAUTH_LOGIN=0` no longer disables OAuth on Cloud | PASS |

What this establishes beyond the unit-level tests:

- Both Cloud endpoints print the device code and `…/console/oauth2/device?user_code=…` with **no environment variable set** — the behavior that previously required `APPWRITE_CLI_OAUTH_LOGIN=1`. Staging correctly resolves to `cloud.staging.appwrite.io`, not production, so the endpoint-derived console host still holds.
- `APPWRITE_CLI_OAUTH_LOGIN=0` does not suppress the guard, confirming the flag is genuinely removed rather than defaulted on.
- The self-hosted case (`http://localhost:9520/v1`) skips the guard and goes down the email/password path, failing only with `Unable to connect` because nothing listens on that port — that failure mode *is* the evidence the network call was attempted.
- `whoami` refreshed expired access tokens against both environments, so OAuth session refresh works in the `bun --compile` binary, where the keyring is loaded through a per-platform literal `require`.

`login --help` after the change:

```
  --email [email]        Email, for self hosted instances
  --password [password]  Password, for self hosted instances
  --mfa [factor]         Factor used for MFA on self hosted instances. Must be
                         one of: email, phone, totp, recoveryCode
  --code [code]          Code used for MFA on self hosted instances
  --endpoint [endpoint]  Appwrite endpoint for self hosted instances
  --switch               Switch to another signed-in account
  --new                  Sign in to another account
```

### Not covered

Approving a device authorization end-to-end needs a human in a browser, so the tests stop at "the code and URL are correct and polling starts". `pollForDeviceToken` success, retry, timeout, slow-down and error paths are covered by the existing e2e auth checks.
