### PR TITLE
chore(cli): pin @appwrite.io/console 15.7.0

### DIFF
--- a/templates/cli/bun.lock.twig
+++ b/templates/cli/bun.lock.twig
@@ -5,7 +5,7 @@
     "": {
       "name": "{{ language.params.npmPackage|caseDash }}",
       "dependencies": {
-        "@appwrite.io/console": "15.6.0",
+        "@appwrite.io/console": "15.7.0",
         "@napi-rs/keyring": "^1.3.0",
         "chalk": "4.1.2",
         "chokidar": "^3.6.0",
@@ -54,7 +54,7 @@
     "tmp": "^0.2.6",
   },
   "packages": {
-    "@appwrite.io/console": ["@appwrite.io/console@15.6.0", "", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-dSlNP01auhPeppdXEGg3mtg5nRTxqKX7H9aHsbxE/nOlJAzAGEcz9Lt/gwmY/NwzMcXrugU1+uLcXUA4Cu4XTQ=="],
+    "@appwrite.io/console": ["@appwrite.io/console@15.7.0", "", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-43FVjVbqdedkoiMrAKCFpEnAhBb7YruW9fHqUJ/uvzMT2yg8g8cx+s5b0gkmiC276URALa5BzkYUBoTLw/Dnsw=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 

--- a/templates/cli/package-lock.json.twig
+++ b/templates/cli/package-lock.json.twig
@@ -9,7 +9,7 @@
       "version": "{{ sdk.version }}",
       "license": "{{ sdk.license }}",
       "dependencies": {
-        "@appwrite.io/console": "15.6.0",
+        "@appwrite.io/console": "15.7.0",
         "@napi-rs/keyring": "^1.3.0",
         "chalk": "4.1.2",
         "chokidar": "^3.6.0",
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@appwrite.io/console": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/@appwrite.io/console/-/console-15.6.0.tgz",
-      "integrity": "sha512-dSlNP01auhPeppdXEGg3mtg5nRTxqKX7H9aHsbxE/nOlJAzAGEcz9Lt/gwmY/NwzMcXrugU1+uLcXUA4Cu4XTQ==",
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/@appwrite.io/console/-/console-15.7.0.tgz",
+      "integrity": "sha512-43FVjVbqdedkoiMrAKCFpEnAhBb7YruW9fHqUJ/uvzMT2yg8g8cx+s5b0gkmiC276URALa5BzkYUBoTLw/Dnsw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "json-bigint": "1.0.0"

--- a/templates/cli/package.json.twig
+++ b/templates/cli/package.json.twig
@@ -51,7 +51,7 @@
     "windows-arm64": "bun build cli.ts --compile --minify --target=bun-windows-arm64 --outfile build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
-    "@appwrite.io/console": "15.6.0",
+    "@appwrite.io/console": "15.7.0",
     "@napi-rs/keyring": "^1.3.0",
     "chalk": "4.1.2",
     "chokidar": "^3.6.0",


### PR DESCRIPTION
The CLI template generates calls that pass `specification` to `tablesDB.update()`, `documentsDB.update()`, and `vectorsDB.update()`, and `folder` to `storage.createFile()`. Those parameters land in console SDK 15.7.0, so the previous `15.6.0` pin failed `tsc` with:

```
lib/commands/services/tablesdb.ts(218,98): error TS2554: Expected 1-4 arguments, but got 5.
```

Bumps the pin in `package.json.twig` and updates the matching entries in `package-lock.json.twig` and `bun.lock.twig` (version, resolved URL, integrity). Console 15.7.0 has the same single dependency (`json-bigint@1.0.0`), so the rest of the dependency graph is unchanged.

Verified against a generated CLI: `npm ci` and `bun install --frozen-lockfile` both resolve console 15.7.0, and `npm run build` (tsc + esbuild) passes.

Unblocks the CLI 24.0.0 release.