### PR TITLE
fix(cli): stop logout prompting with an empty account list

### DIFF
--- a/templates/cli/lib/commands/generic.ts
+++ b/templates/cli/lib/commands/generic.ts
@@ -110,13 +110,17 @@ export const logout = new Command("logout")
       const current = globalConfig.getCurrentSession();
       const originalCurrent = current;
 
-      if (current === "" || !sessions.length) {
+      // The picker only offers sessions with an email, so count those — counting
+      // endpoint-only entries would open a checkbox with no selectable options.
+      const accounts = sessions.filter((session) => session.email);
+
+      if (current === "" || !accounts.length) {
         log(logMessages.noActiveSessions);
         return;
       }
-      if (sessions.length === 1) {
+      if (accounts.length === 1) {
         const { failed, failedIds, errors } = await logoutSessions(
-          planSessionLogout([current]),
+          planSessionLogout([accounts[0].id]),
         );
 
         if (failed > 0) {

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -266,6 +266,8 @@ abstract class Base extends TestCase
         'auth:session-has-auth:passed',
         'auth:plan-session-logout:passed',
         'auth:logout-question-choices:passed',
+        'auth:logout-skips-empty-prompt:passed',
+        'auth:logout-single-account-ignores-current-stub:passed',
         'auth:restore-current-session-fallback:passed',
         'auth:poll-device-token-success:passed',
         'auth:poll-device-token-retry:passed',

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -64,6 +64,9 @@ const {
 const { listenForBrowserOpen, loginCommand } = require("./lib/auth/login.ts");
 const { applyConfigFilters } = require("./lib/config-filters.ts");
 const { questionsLogout } = require("./lib/questions.ts");
+const { logout } = require("./lib/commands/generic.ts");
+const inquirerModule = require("inquirer");
+const inquirer = inquirerModule.default ?? inquirerModule;
 
 const extractFirstValue = (output) => {
   const firstLine =
@@ -857,6 +860,25 @@ async function runAuthChecks() {
     }
   };
 
+  // Runs fn with inquirer stubbed, returning the question sets it prompted with.
+  // Records rather than throws so a stray prompt cannot trip actionRunner's
+  // error path and exit the test process. Output is muted because the expected
+  // output is asserted positionally.
+  const recordPrompts = async (fn) => {
+    const prompts = [];
+    const original = inquirer.prompt;
+    inquirer.prompt = async (questions) => {
+      prompts.push(questions);
+      return {};
+    };
+    try {
+      await muteStdout(fn);
+    } finally {
+      inquirer.prompt = original;
+    }
+    return prompts;
+  };
+
   const deviceAuth = (overrides = {}) => ({
     expires_in: 5,
     interval: 0,
@@ -1117,6 +1139,40 @@ async function runAuthChecks() {
     assert.equal(choices[0].short, "b@c.com (current)");
     assert.equal(choices[1].name, "a@b.com - https://cloud.appwrite.io/v1");
     assert.equal(choices[1].short, "a@b.com");
+  });
+
+  // Endpoint-only entries, as left behind by `appwrite client --endpoint`.
+  await authCheck("logout-skips-empty-prompt", async () => {
+    globalConfig.clear();
+    keyringTokens.clear();
+    globalConfig.addSession("stub1", { endpoint: "https://cloud.appwrite.io/v1" });
+    globalConfig.addSession("stub2", { endpoint: "http://localhost/v1" });
+    globalConfig.setCurrentSession("stub2");
+
+    // Sessions are stored, yet the picker has nothing to offer — logout used to
+    // open a checkbox with no options and a required validator, so no answer
+    // could satisfy it.
+    assert.ok(globalConfig.getSessions().length > 0);
+    assert.deepEqual(questionsLogout[0].choices(), []);
+    assert.deepEqual(await recordPrompts(() => logout.parseAsync([], { from: "user" })), []);
+  });
+
+  await authCheck("logout-single-account-ignores-current-stub", async () => {
+    globalConfig.clear();
+    keyringTokens.clear();
+    globalConfig.addSession("stub1", { endpoint: "http://localhost/v1" });
+    globalConfig.addSession("acct1", {
+      endpoint: "https://cloud.appwrite.io/v1",
+      email: "a@b.com",
+    });
+    // The lone account is not current, so logging out the current session would
+    // revoke the wrong entry.
+    globalConfig.setCurrentSession("stub1");
+
+    assert.deepEqual(await recordPrompts(() => logout.parseAsync([], { from: "user" })), []);
+    assert.equal(globalConfig.get("acct1"), undefined);
+    assert.notEqual(globalConfig.get("stub1"), undefined);
+    assert.equal(globalConfig.getCurrentSession(), "");
   });
 
   await authCheck("restore-current-session-fallback", () => {


### PR DESCRIPTION
## What

`appwrite logout` could render a checkbox prompt with zero options and no way to answer it:

```
$ appwrite logout
? Select accounts to log out (Press <space> to select, <a> to toggle all, …)

>> Please select at least one account
```

## Why

The command branched on `globalConfig.getSessions().length`, but `questionsLogout`'s `choices()` only lists sessions that have an `email`. Endpoint-only entries counted toward the branch while contributing no choices, so `logout` took the multi-account path and opened a picker with nothing in it — and `validateRequired` meant no input could satisfy it. The only escape was Ctrl-C or editing `prefs.json` by hand.

Those entries come from `client --endpoint` (`addSession(id, { endpoint })`) and from logins killed before the token exchange completed. A `prefs.json` in this state looks like:

```json
{
    "current": "6a65d2d90037851023bb",
    "6a4e029b0029fe57a963": { "endpoint": "http://localhost/v1", "selfSigned": true },
    "6a65d2d90037851023bb": { "endpoint": "https://cloud.appwrite.io/v1" }
}
```

It is also self-perpetuating: after logging out every real account, `logout` picks the next current session with `remainingSessions.find(s => s.email) ?? remainingSessions[0]`, which falls through to one of these entries — so the next `logout` hits the empty prompt.

## How

Count the accounts the picker will actually offer:

```ts
const accounts = sessions.filter((session) => session.email);
```

The single-account path follows necessarily: `accounts.length === 1` no longer implies `current` *is* that account, so it revokes `accounts[0].id` instead of `current`. Without that, one account plus a current endpoint-only entry would revoke the wrong group and leave the real account signed in.

## Tests

Two cases in `tests/e2e/languages/cli/test.js`, registered in `Base::AUTH_LOGIC_RESPONSES`:

- `logout-skips-empty-prompt` — sessions are stored, choices are empty, and the command must not open a prompt.
- `logout-single-account-ignores-current-stub` — one account with `current` elsewhere: the account is removed, the other entry is left, `current` clears.

Both drive the real command via `logout.parseAsync`, with `inquirer.prompt` stubbed to record calls rather than throw (throwing would hit `actionRunner`'s `parseError` and exit the run). Output goes through the existing `muteStdout` helper because `Base.php` asserts expected output positionally. Verified both fail without the fix.

```
$ vendor/bin/phpunit tests/e2e/CLIBun13Test.php
OK (1 test, 2155 assertions)
```

`composer refactor:check` passes; prettier is clean on the generated `generic.ts`.

## Out of scope

Deliberately not addressed here:

- Stale endpoint-only entries are still not pruned — `client --reset` remains the only way to clear them.
- `client --endpoint` still mints a new session id per invocation instead of reusing one per endpoint, so duplicates can still accumulate.