### PR TITLE
fix(cli): prefer in-place attribute updates over recreate

### DIFF
--- a/templates/cli/lib/commands/utils/attributes.ts
+++ b/templates/cli/lib/commands/utils/attributes.ts
@@ -1,21 +1,96 @@
 import chalk from "chalk";
 import { getDatabasesService } from "../../services.js";
-import { KeysAttributes } from "../../config.js";
-import { log, success, error, cliConfig, drawTable } from "../../parser.js";
+import { log, success, cliConfig, drawTable } from "../../parser.js";
 import { Pools } from "./pools.js";
 import inquirer from "inquirer";
 import type { Client } from "@appwrite.io/console";
 
-const changeableKeys = [
-  "status",
-  "required",
-  "xdefault",
-  "elements",
-  "min",
-  "max",
-  "default",
-  "error",
-];
+/**
+ * Per-type field rules for push diffing.
+ * - updatable: can be changed in place via update*Attribute / update*Column
+ * - recreate: require delete + recreate (no update API accepts them)
+ * Fields in neither set are ignored (server-derived or irrelevant).
+ */
+interface FieldRules {
+  updatable: string[];
+  recreate: string[];
+}
+
+const COMMON_RECREATE_KEYS = ["type", "array", "encrypt", "format"];
+
+const getAttributeFieldRules = (attribute: any): FieldRules => {
+  const type = attribute?.type;
+  const format = attribute?.format || "";
+
+  switch (type) {
+    case "string":
+      switch (format) {
+        case "enum":
+          return {
+            updatable: ["required", "default", "elements"],
+            recreate: COMMON_RECREATE_KEYS,
+          };
+        case "email":
+        case "url":
+        case "ip":
+          return {
+            updatable: ["required", "default"],
+            recreate: COMMON_RECREATE_KEYS,
+          };
+        default:
+          return {
+            updatable: ["required", "default", "size"],
+            recreate: COMMON_RECREATE_KEYS,
+          };
+      }
+    case "varchar":
+      return {
+        updatable: ["required", "default", "size"],
+        recreate: COMMON_RECREATE_KEYS,
+      };
+    case "text":
+    case "mediumtext":
+    case "longtext":
+    case "boolean":
+    case "datetime":
+    case "point":
+    case "linestring":
+    case "polygon":
+      return {
+        updatable: ["required", "default"],
+        recreate: COMMON_RECREATE_KEYS,
+      };
+    case "integer":
+    case "bigint":
+    case "double":
+      return {
+        updatable: ["required", "default", "min", "max"],
+        recreate: COMMON_RECREATE_KEYS,
+      };
+    case "relationship":
+      return {
+        updatable: ["onDelete"],
+        recreate: [
+          "type",
+          "relatedTable",
+          "relatedCollection",
+          "relationType",
+          "twoWay",
+          "twoWayKey",
+        ],
+      };
+    default:
+      return {
+        updatable: ["required", "default"],
+        recreate: COMMON_RECREATE_KEYS,
+      };
+  }
+};
+
+const INDEX_FIELD_RULES: FieldRules = {
+  updatable: [],
+  recreate: ["type", "attributes", "columns", "orders"],
+};
 
 export interface AttributeChange {
   key: string;
@@ -113,33 +188,45 @@ export class Attributes {
     local: any,
     reason: string,
     key: string,
+    immutable: boolean = false,
   ): string => {
     if (this.isEmpty(remote) && this.isEmpty(local)) {
       return reason;
     }
 
+    const suffix = immutable
+      ? " (cannot be changed in place, requires recreation)"
+      : "";
+
     if (Array.isArray(remote) && Array.isArray(local)) {
       if (JSON.stringify(remote) !== JSON.stringify(local)) {
         const bol = reason === "" ? "" : "\n";
-        reason += `${bol}${key} changed from ${chalk.red(remote)} to ${chalk.green(local)}`;
+        reason += `${bol}${key} changed from ${chalk.red(remote)} to ${chalk.green(local)}${suffix}`;
       }
     } else if (!this.isEqual(remote, local)) {
       const bol = reason === "" ? "" : "\n";
-      reason += `${bol}${key} changed from ${chalk.red(remote)} to ${chalk.green(local)}`;
+      reason += `${bol}${key} changed from ${chalk.red(remote)} to ${chalk.green(local)}${suffix}`;
     }
 
     return reason;
   };
 
+  private getFieldRules = (
+    entity: any,
+    isIndex: boolean = false,
+  ): FieldRules => (isIndex ? INDEX_FIELD_RULES : getAttributeFieldRules(entity));
+
   /**
-   * Check if attribute non-changeable fields has been changed
-   * If so return the differences as an object.
+   * Check if attribute fields have changed.
+   * When recreating=true, only immutable (recreate-forcing) fields are compared.
+   * When recreating=false, only updatable fields are compared.
    */
   private checkAttributeChanges = (
     remote: any,
     local: any,
     collection: Collection,
     recreating: boolean = true,
+    isIndex: boolean = false,
   ): AttributeChange | undefined => {
     if (local === undefined) {
       return undefined;
@@ -149,24 +236,17 @@ export class Attributes {
     const action = chalk.cyan(recreating ? "recreating" : "changing");
     let reason = "";
     const attribute = recreating ? remote : local;
+    const rules = this.getFieldRules(local, isIndex);
+    const keys = recreating ? rules.recreate : rules.updatable;
 
-    for (const key of Object.keys(remote)) {
-      if (!KeysAttributes.has(key)) {
-        continue;
-      }
-
-      if (changeableKeys.includes(key)) {
-        if (!recreating) {
-          reason = this.compareAttribute(remote[key], local[key], reason, key);
-        }
-        continue;
-      }
-
-      if (!recreating) {
-        continue;
-      }
-
-      reason = this.compareAttribute(remote[key], local[key], reason, key);
+    for (const key of keys) {
+      reason = this.compareAttribute(
+        remote[key],
+        local[key],
+        reason,
+        key,
+        recreating,
+      );
     }
 
     return reason === ""
@@ -386,11 +466,40 @@ export class Attributes {
     }
   };
 
+  private formatUpdateError = (attribute: any, err: unknown): string => {
+    const message = String(err);
+    const key = attribute?.key ?? "unknown";
+    const isResize =
+      message.includes("attribute_invalid_resize") ||
+      message.includes("column_invalid_resize") ||
+      message.includes("invalid_resize");
+
+    if (isResize) {
+      return (
+        `Failed to update "${key}": existing values exceed the new size. ` +
+        `Increase the size, shorten existing data, or recreate the attribute. ` +
+        `(${message})`
+      );
+    }
+
+    return `Failed to update "${key}": ${message}`;
+  };
+
   public updateAttribute = async (
     databaseId: string,
     collectionId: string,
     attribute: any,
   ): Promise<any> => {
+    // Indexes have no update endpoint; callers must recreate them.
+    if (
+      Array.isArray(attribute.attributes) ||
+      Array.isArray(attribute.columns)
+    ) {
+      throw new Error(
+        `Indexes cannot be updated in place (key: ${attribute.key}). Recreate the index instead.`,
+      );
+    }
+
     const databasesService = await getDatabasesService(this.client);
     switch (attribute.type) {
       case "string":
@@ -435,6 +544,7 @@ export class Attributes {
               key: attribute.key,
               required: attribute.required,
               xdefault: attribute.default,
+              size: attribute.size,
             });
         }
       case "varchar":
@@ -623,6 +733,8 @@ export class Attributes {
           attribute,
           this.attributesContains(attribute, filteredLocalAttributes),
           collection,
+          true,
+          isIndex,
         ),
       )
       .filter((attribute) => attribute !== undefined) as AttributeChange[];
@@ -633,6 +745,7 @@ export class Attributes {
           this.attributesContains(attribute, filteredLocalAttributes),
           collection,
           false,
+          isIndex,
         ),
       )
       .filter((attribute) => attribute !== undefined)
@@ -694,6 +807,33 @@ export class Attributes {
       }
     }
 
+    // Apply in-place updates first so failures abort before any deletions.
+    if (changes.length > 0) {
+      const updateResults = await Promise.allSettled(
+        changes.map((change) =>
+          this.updateAttribute(
+            collection["databaseId"],
+            collection["$id"],
+            change.attribute,
+          ),
+        ),
+      );
+
+      const failures = updateResults
+        .map((result, index) =>
+          result.status === "rejected"
+            ? this.formatUpdateError(changes[index].attribute, result.reason)
+            : null,
+        )
+        .filter((message): message is string => message !== null);
+
+      if (failures.length > 0) {
+        throw new Error(
+          `Error updating ${isIndex ? "index" : "attribute"} for ${collection["$id"]}:\n${failures.join("\n")}`,
+        );
+      }
+    }
+
     if (conflicts.length > 0) {
       changedAttributes = conflicts.map((change) => change.attribute);
       await Promise.all(
@@ -706,34 +846,18 @@ export class Attributes {
       );
     }
 
-    if (changes.length > 0) {
-      changedAttributes = changes.map((change) => change.attribute);
-      try {
-        await Promise.all(
-          changedAttributes.map((changed) =>
-            this.updateAttribute(
-              collection["databaseId"],
-              collection["$id"],
-              changed,
-            ),
-          ),
-        );
-      } catch (err) {
-        error(
-          `Error updating attribute for ${collection["$id"]}: ${String(err)}`,
-        );
-      }
-    }
-
     const deletingAttributes = deleting.map((change) => change.attribute);
     await Promise.all(
       deletingAttributes.map((attribute) =>
         this.deleteAttribute(collection, attribute, isIndex),
       ),
     );
-    const attributeKeys = deletingAttributes.map(
-      (attribute: any) => attribute.key,
-    );
+
+    // Wait for both removals and recreate-driven deletes before creating.
+    const attributeKeys = [
+      ...deletingAttributes,
+      ...conflicts.map((change) => change.attribute),
+    ].map((attribute: any) => attribute.key);
 
     if (attributeKeys.length) {
       const deleteAttributesPoolStatus =

--- a/templates/cli/lib/commands/utils/attributes.ts
+++ b/templates/cli/lib/commands/utils/attributes.ts
@@ -854,21 +854,25 @@ export class Attributes {
     );
 
     // Wait for both removals and recreate-driven deletes before creating.
-    const attributeKeys = [
+    const deletedKeys = [
       ...deletingAttributes,
       ...conflicts.map((change) => change.attribute),
     ].map((attribute: any) => attribute.key);
 
-    if (attributeKeys.length) {
-      const deleteAttributesPoolStatus =
-        await this.pools.waitForAttributeDeletion(
-          collection["databaseId"],
-          collection["$id"],
-          attributeKeys,
-        );
+    if (deletedKeys.length) {
+      const waitForDeletion = isIndex
+        ? this.pools.waitForIndexDeletion
+        : this.pools.waitForAttributeDeletion;
+      const deletePoolStatus = await waitForDeletion(
+        collection["databaseId"],
+        collection["$id"],
+        deletedKeys,
+      );
 
-      if (!deleteAttributesPoolStatus) {
-        throw new Error("Attribute deletion timed out.");
+      if (!deletePoolStatus) {
+        throw new Error(
+          `${isIndex ? "Index" : "Attribute"} deletion timed out.`,
+        );
       }
     }
 

--- a/templates/cli/lib/commands/utils/pools.ts
+++ b/templates/cli/lib/commands/utils/pools.ts
@@ -98,7 +98,7 @@ export class Pools {
   public waitForAttributeDeletion = async (
     databaseId: string,
     collectionId: string,
-    attributeKeys: any[],
+    attributeKeys: string[],
     iteration: number = 1,
   ): Promise<boolean> => {
     if (iteration > this.pollMaxDebounces) {
@@ -138,11 +138,11 @@ export class Pools {
       "attributes",
     );
 
-    const ready = attributeKeys.filter((attribute: any) =>
-      attributes.some((a: any) => a.key === attribute.key),
+    const remaining = attributeKeys.filter((key) =>
+      attributes.some((a: any) => a.key === key),
     );
 
-    if (ready.length === 0) {
+    if (remaining.length === 0) {
       return true;
     }
 
@@ -152,6 +152,64 @@ export class Pools {
       databaseId,
       collectionId,
       attributeKeys,
+      iteration + 1,
+    );
+  };
+
+  public waitForIndexDeletion = async (
+    databaseId: string,
+    collectionId: string,
+    indexKeys: string[],
+    iteration: number = 1,
+  ): Promise<boolean> => {
+    if (iteration > this.pollMaxDebounces) {
+      return false;
+    }
+
+    if (this.pollMaxDebounces === this.POLL_DEFAULT_VALUE) {
+      const steps = Math.max(1, Math.ceil(indexKeys.length / this.STEP_SIZE));
+      if (steps > 1 && iteration === 1) {
+        this.pollMaxDebounces *= steps;
+
+        log(
+          "Found a large number of indexes to be deleted. Increasing timeout to " +
+            (this.pollMaxDebounces * this.POLL_DEBOUNCE) / 1000 / 60 +
+            " minutes",
+        );
+      }
+    }
+
+    const { indexes } = await paginate(
+      async (args: any) => {
+        const databasesService = await getDatabasesService(this.client);
+        return await databasesService.listIndexes(
+          args.databaseId,
+          args.collectionId,
+          args.queries || [],
+        );
+      },
+      {
+        databaseId,
+        collectionId,
+      },
+      100,
+      "indexes",
+    );
+
+    const remaining = indexKeys.filter((key) =>
+      indexes.some((index: any) => index.key === key),
+    );
+
+    if (remaining.length === 0) {
+      return true;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, this.POLL_DEBOUNCE));
+
+    return await this.waitForIndexDeletion(
+      databaseId,
+      collectionId,
+      indexKeys,
       iteration + 1,
     );
   };

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -285,6 +285,15 @@ abstract class Base extends TestCase
         'auth:config-filters-project-header:passed',
     ];
 
+    protected const CLI_ATTRIBUTE_SYNC_RESPONSES = [
+        'attribute:in-place-updates:passed',
+        'attribute:recreates-immutable:passed',
+        'attribute:ignores-derived-fields:passed',
+        'attribute:index-columns-change:passed',
+        'attribute:update-guards:passed',
+        'attribute:resize-hard-fail:passed',
+    ];
+
     protected const CLI_LOCAL_FUNCTION_EMULATION_RESPONSES = [
         'CLI_LOCAL_FUNCTION_RUNNER_CONFIG:passed',
         'CLI_LOCAL_SOURCE_PREFLIGHT:passed',

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -290,6 +290,7 @@ abstract class Base extends TestCase
         'attribute:recreates-immutable:passed',
         'attribute:ignores-derived-fields:passed',
         'attribute:index-columns-change:passed',
+        'attribute:attribute-delete-uses-attribute-waiter:passed',
         'attribute:update-guards:passed',
         'attribute:resize-hard-fail:passed',
     ];

--- a/tests/e2e/CLIBun10Test.php
+++ b/tests/e2e/CLIBun10Test.php
@@ -50,6 +50,7 @@ final class CLIBun10Test extends Base
         ...Base::CLI_QUERY_HELPER_RESPONSES,
         ...Base::CLI_TYPEGEN_RESPONSES,
         ...Base::AUTH_LOGIC_RESPONSES,
+        ...Base::CLI_ATTRIBUTE_SYNC_RESPONSES,
     ];
 
     #[Override]

--- a/tests/e2e/CLIBun11Test.php
+++ b/tests/e2e/CLIBun11Test.php
@@ -50,6 +50,7 @@ final class CLIBun11Test extends Base
         ...Base::CLI_QUERY_HELPER_RESPONSES,
         ...Base::CLI_TYPEGEN_RESPONSES,
         ...Base::AUTH_LOGIC_RESPONSES,
+        ...Base::CLI_ATTRIBUTE_SYNC_RESPONSES,
     ];
 
     #[Override]

--- a/tests/e2e/CLIBun13Test.php
+++ b/tests/e2e/CLIBun13Test.php
@@ -50,6 +50,7 @@ final class CLIBun13Test extends Base
         ...Base::CLI_QUERY_HELPER_RESPONSES,
         ...Base::CLI_TYPEGEN_RESPONSES,
         ...Base::AUTH_LOGIC_RESPONSES,
+        ...Base::CLI_ATTRIBUTE_SYNC_RESPONSES,
     ];
 
     #[Override]

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -1600,8 +1600,18 @@ async function runAttributeSyncChecks() {
   const sync = async (remote, local, isIndex = false) => {
     const updates = [];
     const deletes = [];
+    const waiters = [];
     const helper = new Attributes(
-      { waitForAttributeDeletion: async () => true },
+      {
+        waitForAttributeDeletion: async (_db, _id, keys) => {
+          waiters.push({ type: "attribute", keys: [...keys] });
+          return true;
+        },
+        waitForIndexDeletion: async (_db, _id, keys) => {
+          waiters.push({ type: "index", keys: [...keys] });
+          return true;
+        },
+      },
       true,
     );
     helper.updateAttribute = async (_db, _id, a) => updates.push(a);
@@ -1613,7 +1623,7 @@ async function runAttributeSyncChecks() {
       collection,
       isIndex,
     );
-    return { updates, deletes, result };
+    return { updates, deletes, result, waiters };
   };
 
   await check("in-place-updates", async () => {
@@ -1735,7 +1745,7 @@ async function runAttributeSyncChecks() {
   });
 
   await check("index-columns-change", async () => {
-    const { updates, deletes, result } = await sync(
+    const { updates, deletes, result, waiters } = await sync(
       [{ key: "by_title", type: "key", columns: ["title"], orders: ["ASC"] }],
       [
         {
@@ -1751,6 +1761,17 @@ async function runAttributeSyncChecks() {
     assert.equal(deletes.length, 1);
     assert.equal(deletes[0].isIndex, true);
     assert.deepEqual(result.attributes[0].columns, ["title", "status"]);
+    // Index recreates must wait on index deletion, not listAttributes.
+    assert.deepEqual(waiters, [{ type: "index", keys: ["by_title"] }]);
+  });
+
+  await check("attribute-delete-uses-attribute-waiter", async () => {
+    const { deletes, waiters } = await sync(
+      [attr({ key: "old", type: "string", size: 16 })],
+      [],
+    );
+    assert.equal(deletes.length, 1);
+    assert.deepEqual(waiters, [{ type: "attribute", keys: ["old"] }]);
   });
 
   await check("update-guards", async () => {

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -827,6 +827,7 @@ void (async () => {
   console.log("CLI_TYPEGEN:passed");
 })()
   .then(runAuthChecks)
+  .then(runAttributeSyncChecks)
   .then(runDeploymentSymlinkChecks)
   .catch((error) => {
     throw error;
@@ -1573,6 +1574,237 @@ async function runAuthChecks() {
   restoreKeyringEntryFactory();
   if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
   else process.env.NODE_ENV = previousNodeEnv;
+}
+
+/** Push attribute sync: in-place updates vs recreate, indexes, resize hard-fail. */
+async function runAttributeSyncChecks() {
+  const { Attributes } = require("./lib/commands/utils/attributes.ts");
+  const collection = { $id: "posts", databaseId: "blog", name: "Posts" };
+  const attr = (overrides) => ({
+    required: false,
+    default: null,
+    array: false,
+    ...overrides,
+  });
+
+  const check = async (name, fn) => {
+    try {
+      await muteStdout(fn);
+      console.log(`attribute:${name}:passed`);
+    } catch (error) {
+      console.log(`attribute:${name}:failed`);
+      console.error(`attribute:${name}`, error?.message ?? error);
+    }
+  };
+
+  const sync = async (remote, local, isIndex = false) => {
+    const updates = [];
+    const deletes = [];
+    const helper = new Attributes(
+      { waitForAttributeDeletion: async () => true },
+      true,
+    );
+    helper.updateAttribute = async (_db, _id, a) => updates.push(a);
+    helper.deleteAttribute = async (_c, a, index = false) =>
+      deletes.push({ key: a.key, isIndex: index });
+    const result = await helper.attributesToCreate(
+      remote,
+      local,
+      collection,
+      isIndex,
+    );
+    return { updates, deletes, result };
+  };
+
+  await check("in-place-updates", async () => {
+    const cases = [
+      {
+        remote: [attr({ key: "title", type: "varchar", size: 50 })],
+        local: [attr({ key: "title", type: "varchar", size: 120 })],
+        expect: { updates: 1, deletes: 0 },
+      },
+      {
+        remote: [attr({ key: "slug", type: "string", size: 32 })],
+        local: [attr({ key: "slug", type: "string", size: 64 })],
+        expect: { updates: 1, deletes: 0 },
+      },
+      {
+        remote: [
+          attr({
+            key: "author",
+            type: "relationship",
+            relatedCollection: "users",
+            relationType: "manyToOne",
+            twoWay: false,
+            onDelete: "cascade",
+            side: "parent",
+          }),
+        ],
+        local: [
+          attr({
+            key: "author",
+            type: "relationship",
+            relatedCollection: "users",
+            relationType: "manyToOne",
+            twoWay: false,
+            onDelete: "restrict",
+          }),
+        ],
+        expect: { updates: 1, deletes: 0 },
+      },
+      {
+        remote: [
+          attr({
+            key: "status",
+            type: "string",
+            format: "enum",
+            elements: ["draft"],
+            default: "draft",
+          }),
+          attr({ key: "score", type: "integer", default: 0, min: 0, max: 10 }),
+        ],
+        local: [
+          attr({
+            key: "status",
+            type: "string",
+            format: "enum",
+            elements: ["draft", "live"],
+            required: true,
+          }),
+          attr({ key: "score", type: "integer", default: 1, min: 1, max: 100 }),
+        ],
+        expect: { updates: 2, deletes: 0 },
+      },
+    ];
+
+    for (const { remote, local, expect } of cases) {
+      const { updates, deletes, result } = await sync(remote, local);
+      assert.equal(updates.length, expect.updates);
+      assert.equal(deletes.length, expect.deletes);
+      assert.deepEqual(result.attributes, []);
+    }
+  });
+
+  await check("recreates-immutable", async () => {
+    const { updates, deletes, result } = await sync(
+      [
+        attr({ key: "count", type: "string", size: 16 }),
+        attr({ key: "tags", type: "string", size: 32, encrypt: false }),
+        attr({ key: "secret", type: "string", size: 64, encrypt: false }),
+      ],
+      [
+        attr({ key: "count", type: "integer" }),
+        attr({ key: "tags", type: "string", size: 32, array: true }),
+        attr({ key: "secret", type: "string", size: 64, encrypt: true }),
+      ],
+    );
+    assert.equal(updates.length, 0);
+    assert.equal(deletes.length, 3);
+    assert.equal(result.attributes.length, 3);
+  });
+
+  await check("ignores-derived-fields", async () => {
+    const { updates, deletes, result } = await sync(
+      [
+        attr({ key: "body", type: "text", size: 65535 }),
+        attr({
+          key: "author",
+          type: "relationship",
+          relatedCollection: "users",
+          relationType: "manyToOne",
+          twoWay: false,
+          onDelete: "cascade",
+          side: "parent",
+        }),
+      ],
+      [
+        attr({ key: "body", type: "text" }),
+        attr({
+          key: "author",
+          type: "relationship",
+          relatedCollection: "users",
+          relationType: "manyToOne",
+          twoWay: false,
+          onDelete: "cascade",
+        }),
+      ],
+    );
+    assert.equal(updates.length, 0);
+    assert.equal(deletes.length, 0);
+    assert.equal(result.hasChanges, false);
+  });
+
+  await check("index-columns-change", async () => {
+    const { updates, deletes, result } = await sync(
+      [{ key: "by_title", type: "key", columns: ["title"], orders: ["ASC"] }],
+      [
+        {
+          key: "by_title",
+          type: "key",
+          columns: ["title", "status"],
+          orders: ["ASC"],
+        },
+      ],
+      true,
+    );
+    assert.equal(updates.length, 0);
+    assert.equal(deletes.length, 1);
+    assert.equal(deletes[0].isIndex, true);
+    assert.deepEqual(result.attributes[0].columns, ["title", "status"]);
+  });
+
+  await check("update-guards", async () => {
+    const helper = new Attributes(
+      { waitForAttributeDeletion: async () => true },
+      true,
+    );
+    await assert.rejects(
+      () =>
+        helper.updateAttribute("blog", "posts", {
+          key: "by_title",
+          type: "key",
+          columns: ["title"],
+        }),
+      /Indexes cannot be updated in place/,
+    );
+
+    const source = fs.readFileSync(
+      path.join(process.cwd(), "lib/commands/utils/attributes.ts"),
+      "utf8",
+    );
+    const match = source.match(/updateStringAttribute\(\{([\s\S]*?)\}\)/);
+    assert.ok(match);
+    assert.match(match[1], /size:\s*attribute\.size/);
+  });
+
+  await check("resize-hard-fail", async () => {
+    const deletes = [];
+    const helper = new Attributes(
+      { waitForAttributeDeletion: async () => true },
+      true,
+    );
+    helper.updateAttribute = async () => {
+      throw new Error("attribute_invalid_resize: Resize would truncate data");
+    };
+    helper.deleteAttribute = async (_c, a) => deletes.push(a.key);
+
+    await assert.rejects(
+      () =>
+        helper.attributesToCreate(
+          [
+            attr({ key: "title", type: "varchar", size: 100 }),
+            attr({ key: "legacy", type: "string", size: 16 }),
+          ],
+          [
+            attr({ key: "title", type: "varchar", size: 10 }),
+            attr({ key: "legacy", type: "integer" }),
+          ],
+          collection,
+        ),
+      /existing values exceed the new size/,
+    );
+    assert.equal(deletes.length, 0);
+  });
 }
 
 // A function that shares code through a symlink (appwrite/sdk-for-cli#253).


### PR DESCRIPTION
## Summary

`appwrite push` previously treated almost every attribute/column field change as a **delete + recreate**, because it only considered a small flat `changeableKeys` list updatable. That caused unnecessary data loss for common edits the Appwrite API already supports in place — especially **`size`** (string/varchar) and relationship **`onDelete`**.

This PR aligns CLI push diffing with the real `update*Attribute` / `update*Column` surface:

- Prefer in-place updates when the API allows them
- Recreate only for genuinely immutable fields (`type`, `array`, `encrypt`, `format`, relationship topology)
- Ignore server-derived fields that used to trigger phantom recreates (`side`, `size` on fixed-size text types)
- Detect table index `columns` changes (previously invisible)
- Hard-fail update errors **before** any deletions, with a clear resize hint

## Problem

Before:

```ts
const changeableKeys = [
  "status", "required", "xdefault", "elements",
  "min", "max", "default", "error",
];
```

`status` / `xdefault` / `error` are not in the config schema keys compared at all, so the list effectively reduced to `required`, `default`, `min`, `max`, `elements`. Changing `size` or `onDelete` landed in `conflicts` and wiped the column.

Update failures were also swallowed:

```ts
try {
  await Promise.all(/* updates */);
} catch (err) {
  error(`Error updating attribute...`); // push continued as success
}
```

## Solution

### Per-type field rules

```ts
const getAttributeFieldRules = (attribute) => {
  switch (attribute?.type) {
    case "varchar":
      return { updatable: ["required", "default", "size"], recreate: COMMON_RECREATE_KEYS };
    case "relationship":
      return {
        updatable: ["onDelete"],
        recreate: ["type", "relatedTable", "relatedCollection", "relationType", "twoWay", "twoWayKey"],
      };
    // ...
  }
};
```

| Change | Before | After |
|--------|--------|-------|
| varchar/string `size` | recreate | **in-place update** |
| relationship `onDelete` | recreate | **in-place update** |
| enum `elements`, numeric `min`/`max`, `required`, `default` | update | update (unchanged) |
| `type` / `array` / `encrypt` / `format` | recreate | recreate |
| relationship topology (`related*`, `relationType`, `twoWay*`) | recreate | recreate |
| missing `side`, text `size` mismatch | phantom recreate | **ignored** |
| table index `columns` change | not detected | **recreate index** |

### Safer apply order

```
diff → confirm → in-place updates → delete conflicts → delete removals → wait → create
```

Updates run first via `Promise.allSettled`. Any failure (e.g. `attribute_invalid_resize`) aborts before deletes:

```ts
if (failures.length > 0) {
  throw new Error(
    `Error updating attribute for ${collection["$id"]}:\n${failures.join("\n")}`,
  );
}
```

Resize errors get an actionable hint:

> Failed to update "title": existing values exceed the new size. Increase the size, shorten existing data, or recreate the attribute.

### String update payload

`updateStringAttribute` now forwards `size` (varchar already did):

```ts
return databasesService.updateStringAttribute({
  databaseId,
  collectionId,
  key: attribute.key,
  required: attribute.required,
  xdefault: attribute.default,
  size: attribute.size,
});
```

## Tests

Added compact CLI e2e coverage in `tests/e2e/languages/cli/test.js` (`runAttributeSyncChecks`), wired into Bun 1.0/1.1/1.3 suites:

- `attribute:in-place-updates` — size / onDelete / enum / minmax
- `attribute:recreates-immutable` — type / array / encrypt
- `attribute:ignores-derived-fields` — `side`, text `size`
- `attribute:index-columns-change` — table index `columns`
- `attribute:update-guards` — index rejection + string `size` payload
- `attribute:resize-hard-fail` — failed resize deletes nothing

## Out of scope

- Column **rename** via `newKey` (still key-matched only; needs a separate design)

## Test plan

- [x] Regenerated CLI: `php example.php cli console`
- [x] Local attribute sync checks pass (all 6 tokens)
- [ ] CI: CLI Bun e2e suites (`CLIBun10/11/13`)
- [ ] Manual against a live project:
  - [ ] Grow/shrink a varchar `size` → push shows **changing**, not recreating
  - [ ] Flip relationship `onDelete` → in-place update, data preserved
  - [ ] Change enum elements / integer min-max / required / default → update
  - [ ] Change `type`, `array`, or `encrypt` → still recreates with warning
  - [ ] Change a table index `columns` list → detected and recreated
  - [ ] Shrink varchar below existing row lengths → push hard-fails, nothing deleted


Made with [Cursor](https://cursor.com)