### PR TITLE
feat(cli): in-place attribute updates and previousKey renames

### DIFF
--- a/templates/cli/lib/commands/config-validations.ts
+++ b/templates/cli/lib/commands/config-validations.ts
@@ -50,6 +50,7 @@ export const validateStringSize = (data: {
 
 interface AttributeOrColumn {
   key: string;
+  previousKey?: string;
 }
 
 interface Index {
@@ -63,7 +64,8 @@ interface CollectionOrTableData {
 }
 
 /**
- * Validates duplicate keys in attributes/columns and indexes
+ * Validates duplicate keys in attributes/columns and indexes,
+ * plus previousKey rename-hint consistency.
  */
 export const validateContainerDuplicates = (
   data: CollectionOrTableData,
@@ -86,6 +88,40 @@ export const validateContainerDuplicates = (
         });
       } else {
         seenKeys.add(item.key);
+      }
+    });
+
+    // Validate previousKey rename hints
+    const seenPreviousKeys = new Set<string>();
+    items.forEach((item, index) => {
+      if (!item.previousKey) {
+        return;
+      }
+
+      if (item.previousKey === item.key) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `${itemType} '${item.key}' has previousKey equal to key. previousKey must be the old name, not the new one.`,
+          path: [itemPath, index, "previousKey"],
+        });
+      }
+
+      if (seenKeys.has(item.previousKey) && item.previousKey !== item.key) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `${itemType} '${item.key}' has previousKey '${item.previousKey}', but another ${itemType.toLowerCase()} already uses that key. Rename cannot proceed while both names exist locally.`,
+          path: [itemPath, index, "previousKey"],
+        });
+      }
+
+      if (seenPreviousKeys.has(item.previousKey)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Multiple ${itemType.toLowerCase()}s share previousKey '${item.previousKey}'. Each previousKey must be unique within a ${itemType === "Attribute" ? "collection" : "table"}.`,
+          path: [itemPath, index, "previousKey"],
+        });
+      } else {
+        seenPreviousKeys.add(item.previousKey);
       }
     });
   }

--- a/templates/cli/lib/commands/config.ts
+++ b/templates/cli/lib/commands/config.ts
@@ -248,6 +248,9 @@ const AttributeSchema = z
     attributes: z.array(z.string()).optional(),
     orders: z.array(z.string()).optional(),
     encrypt: z.boolean().optional(),
+    // Local-only hint for in-place renames via the API's newKey parameter.
+    // Cleared automatically on pull; ignored once the rename has been applied.
+    previousKey: z.string().optional(),
   })
   .strict()
   .refine(validateRequiredDefault, {
@@ -330,6 +333,9 @@ const ColumnSchema = z
     columns: z.array(z.string()).optional(),
     orders: z.array(z.string()).optional(),
     encrypt: z.boolean().optional(),
+    // Local-only hint for in-place renames via the API's newKey parameter.
+    // Cleared automatically on pull; ignored once the rename has been applied.
+    previousKey: z.string().optional(),
   })
   .strict()
   .refine(validateRequiredDefault, {

--- a/templates/cli/lib/commands/push.ts
+++ b/templates/cli/lib/commands/push.ts
@@ -2946,6 +2946,23 @@ export class Push {
           table.columns,
           table as Collection,
         );
+
+        // Server rewrites index column refs during rename; mirror that on the
+        // stale remote snapshot so the index pass does not spuriously recreate.
+        const renameMap = new Map(
+          columnsResult.renames.map((r) => [r.from, r.to]),
+        );
+        if (renameMap.size && Array.isArray(table.remoteVersion.indexes)) {
+          table.remoteVersion.indexes = table.remoteVersion.indexes.map(
+            (idx: any) => ({
+              ...idx,
+              columns: idx.columns?.map(
+                (c: string) => renameMap.get(c) ?? c,
+              ),
+            }),
+          );
+        }
+
         const indexesResult = await attributes.attributesToCreate(
           table.remoteVersion.indexes,
           table.indexes,
@@ -3128,6 +3145,25 @@ export class Push {
           collection.attributes ?? [],
           collection as Collection,
         );
+
+      // Server rewrites index attribute refs during rename; mirror that on the
+      // stale remote snapshot so the index pass does not spuriously recreate.
+      const renameMap = new Map(
+        collectionAttributesResult.renames.map((r) => [r.from, r.to]),
+      );
+      if (
+        renameMap.size &&
+        Array.isArray(collection.remoteVersion!.indexes)
+      ) {
+        collection.remoteVersion!.indexes =
+          collection.remoteVersion!.indexes.map((idx: any) => ({
+            ...idx,
+            attributes: idx.attributes?.map(
+              (a: string) => renameMap.get(a) ?? a,
+            ),
+          }));
+      }
+
       const indexesResult = await attributesHelper.attributesToCreate(
         collection.remoteVersion!.indexes,
         collection.indexes ?? [],

--- a/templates/cli/lib/commands/utils/attributes.ts
+++ b/templates/cli/lib/commands/utils/attributes.ts
@@ -197,6 +197,11 @@ export class Attributes {
     key: string,
     immutable: boolean = false,
   ): string => {
+    // Omitted local fields mean "leave remote as-is" (e.g. encrypt not in config).
+    if (local === undefined) {
+      return reason;
+    }
+
     if (this.isEmpty(remote) && this.isEmpty(local)) {
       return reason;
     }

--- a/templates/cli/lib/commands/utils/attributes.ts
+++ b/templates/cli/lib/commands/utils/attributes.ts
@@ -1,6 +1,6 @@
 import chalk from "chalk";
 import { getDatabasesService } from "../../services.js";
-import { log, success, cliConfig, drawTable } from "../../parser.js";
+import { log, warn, success, cliConfig, drawTable } from "../../parser.js";
 import { Pools } from "./pools.js";
 import inquirer from "inquirer";
 import type { Client } from "@appwrite.io/console";
@@ -97,6 +97,13 @@ export interface AttributeChange {
   attribute: any;
   reason: string;
   action: string;
+}
+
+export interface AttributeRename {
+  from: string;
+  to: string;
+  /** Remote attribute snapshot used for the update* call (key = from). */
+  attribute: any;
 }
 
 export interface Collection {
@@ -489,6 +496,7 @@ export class Attributes {
     databaseId: string,
     collectionId: string,
     attribute: any,
+    newKey?: string,
   ): Promise<any> => {
     // Indexes have no update endpoint; callers must recreate them.
     if (
@@ -511,6 +519,7 @@ export class Attributes {
               key: attribute.key,
               required: attribute.required,
               xdefault: attribute.default,
+              newKey: newKey,
             });
           case "url":
             return databasesService.updateUrlAttribute({
@@ -519,6 +528,7 @@ export class Attributes {
               key: attribute.key,
               required: attribute.required,
               xdefault: attribute.default,
+              newKey: newKey,
             });
           case "ip":
             return databasesService.updateIpAttribute({
@@ -527,6 +537,7 @@ export class Attributes {
               key: attribute.key,
               required: attribute.required,
               xdefault: attribute.default,
+              newKey: newKey,
             });
           case "enum":
             return databasesService.updateEnumAttribute({
@@ -536,6 +547,7 @@ export class Attributes {
               elements: attribute.elements,
               required: attribute.required,
               xdefault: attribute.default,
+              newKey: newKey,
             });
           default:
             return databasesService.updateStringAttribute({
@@ -545,6 +557,7 @@ export class Attributes {
               required: attribute.required,
               xdefault: attribute.default,
               size: attribute.size,
+              newKey: newKey,
             });
         }
       case "varchar":
@@ -555,6 +568,7 @@ export class Attributes {
           required: attribute.required,
           xdefault: attribute.default,
           size: attribute.size,
+          newKey: newKey,
         });
       case "text":
         return databasesService.updateTextAttribute({
@@ -563,6 +577,7 @@ export class Attributes {
           key: attribute.key,
           required: attribute.required,
           xdefault: attribute.default,
+          newKey: newKey,
         });
       case "mediumtext":
         return databasesService.updateMediumtextAttribute({
@@ -571,6 +586,7 @@ export class Attributes {
           key: attribute.key,
           required: attribute.required,
           xdefault: attribute.default,
+          newKey: newKey,
         });
       case "longtext":
         return databasesService.updateLongtextAttribute({
@@ -579,6 +595,7 @@ export class Attributes {
           key: attribute.key,
           required: attribute.required,
           xdefault: attribute.default,
+          newKey: newKey,
         });
       case "integer":
         return databasesService.updateIntegerAttribute({
@@ -589,6 +606,7 @@ export class Attributes {
           min: attribute.min,
           max: attribute.max,
           xdefault: attribute.default,
+          newKey: newKey,
         });
       case "bigint":
         return databasesService.updateBigIntAttribute({
@@ -599,6 +617,7 @@ export class Attributes {
           min: attribute.min,
           max: attribute.max,
           xdefault: attribute.default,
+          newKey: newKey,
         });
       case "double":
         return databasesService.updateFloatAttribute({
@@ -609,6 +628,7 @@ export class Attributes {
           min: attribute.min,
           max: attribute.max,
           xdefault: attribute.default,
+          newKey: newKey,
         });
       case "boolean":
         return databasesService.updateBooleanAttribute({
@@ -617,6 +637,7 @@ export class Attributes {
           key: attribute.key,
           required: attribute.required,
           xdefault: attribute.default,
+          newKey: newKey,
         });
       case "datetime":
         return databasesService.updateDatetimeAttribute({
@@ -625,6 +646,7 @@ export class Attributes {
           key: attribute.key,
           required: attribute.required,
           xdefault: attribute.default,
+          newKey: newKey,
         });
       case "relationship":
         return databasesService.updateRelationshipAttribute({
@@ -632,6 +654,7 @@ export class Attributes {
           collectionId,
           key: attribute.key,
           onDelete: attribute.onDelete,
+          newKey: newKey,
         });
       case "point":
         return databasesService.updatePointAttribute({
@@ -640,6 +663,7 @@ export class Attributes {
           key: attribute.key,
           required: attribute.required,
           xdefault: attribute.default,
+          newKey: newKey,
         });
       case "linestring":
         return databasesService.updateLineAttribute({
@@ -648,6 +672,7 @@ export class Attributes {
           key: attribute.key,
           required: attribute.required,
           xdefault: attribute.default,
+          newKey: newKey,
         });
       case "polygon":
         return databasesService.updatePolygonAttribute({
@@ -656,6 +681,7 @@ export class Attributes {
           key: attribute.key,
           required: attribute.required,
           xdefault: attribute.default,
+          newKey: newKey,
         });
       default:
         throw new Error(`Unsupported attribute type: ${attribute.type}`);
@@ -696,6 +722,67 @@ export class Attributes {
     attribute.type === "relationship" && attribute.side === "child";
 
   /**
+   * Resolve previousKey rename hints against the remote snapshot.
+   * Patches matched remote keys in place (before classification) so a pure
+   * rename does not surface as delete+add. API calls are executed later.
+   */
+  private resolveRenames = (
+    remoteAttributes: any[],
+    localAttributes: any[],
+    collection: Collection,
+  ): { renames: AttributeRename[]; renameChanges: AttributeChange[] } => {
+    const renames: AttributeRename[] = [];
+    const renameChanges: AttributeChange[] = [];
+
+    for (const local of localAttributes) {
+      if (!local.previousKey || local.previousKey === local.key) {
+        continue;
+      }
+
+      const remotePrevious = remoteAttributes.find(
+        (attr) => attr.key === local.previousKey,
+      );
+      const remoteCurrent = remoteAttributes.find(
+        (attr) => attr.key === local.key,
+      );
+
+      if (remotePrevious && !remoteCurrent) {
+        // Pending rename: patch remote key so classification matches by new name.
+        renames.push({
+          from: local.previousKey,
+          to: local.key,
+          attribute: { ...remotePrevious },
+        });
+        renameChanges.push({
+          key: `${chalk.yellow(local.key)} in ${collection.name} (${collection["$id"]})`,
+          attribute: { ...remotePrevious },
+          reason: `key renamed from ${chalk.red(local.previousKey)} to ${chalk.green(local.key)}`,
+          action: chalk.cyan("renaming"),
+        });
+        remotePrevious.key = local.key;
+        continue;
+      }
+
+      if (remoteCurrent && !remotePrevious) {
+        // Already renamed on the server; hint is stale and harmless.
+        continue;
+      }
+
+      if (!remotePrevious && !remoteCurrent) {
+        // Fresh create; ignore the hint and let the add path handle it.
+        continue;
+      }
+
+      // Both keys exist remotely — cannot rename without a collision.
+      warn(
+        `Ignoring previousKey "${local.previousKey}" for "${local.key}" in ${collection.name} (${collection["$id"]}): both keys already exist remotely. "${local.previousKey}" will be treated as a deletion if it is absent from the local config.`,
+      );
+    }
+
+    return { renames, renameChanges };
+  };
+
+  /**
    * Filter deleted and recreated attributes,
    * return list of attributes to create and whether any changes were made
    */
@@ -704,7 +791,11 @@ export class Attributes {
     localAttributes: any[],
     collection: Collection,
     isIndex: boolean = false,
-  ): Promise<{ attributes: any[]; hasChanges: boolean }> => {
+  ): Promise<{
+    attributes: any[];
+    hasChanges: boolean;
+    renames: AttributeRename[];
+  }> => {
     // Filter out child-side relationships from both local and remote attributes for comparison
     // Child-side relationships are auto-generated by Appwrite when creating two-way relationships
     // from the parent side, so we should not compare or try to create them directly
@@ -714,6 +805,16 @@ export class Attributes {
     let filteredRemoteAttributes = remoteAttributes.filter(
       (attr) => !this.isChildSideRelationship(attr),
     );
+
+    // Resolve previousKey hints before classification so renames do not
+    // appear as delete+add. Indexes have no rename API — skip entirely.
+    const { renames, renameChanges } = isIndex
+      ? { renames: [] as AttributeRename[], renameChanges: [] as AttributeChange[] }
+      : this.resolveRenames(
+          filteredRemoteAttributes,
+          filteredLocalAttributes,
+          collection,
+        );
 
     const deleting = filteredRemoteAttributes
       .filter(
@@ -755,9 +856,15 @@ export class Attributes {
       ) as AttributeChange[];
 
     let changedAttributes: any[] = [];
-    const changing = [...deleting, ...adding, ...conflicts, ...changes];
+    const changing = [
+      ...renameChanges,
+      ...deleting,
+      ...adding,
+      ...conflicts,
+      ...changes,
+    ];
     if (changing.length === 0) {
-      return { attributes: changedAttributes, hasChanges: false };
+      return { attributes: changedAttributes, hasChanges: false, renames: [] };
     }
 
     log(
@@ -803,7 +910,51 @@ export class Attributes {
       }
 
       if ((await this.getConfirmation()) !== true) {
-        return { attributes: changedAttributes, hasChanges: false };
+        return { attributes: changedAttributes, hasChanges: false, renames: [] };
+      }
+    }
+
+    // Apply renames before field updates / deletions so a failed rename
+    // never leaves data half-destroyed.
+    if (renames.length > 0) {
+      const renameResults = await Promise.allSettled(
+        renames.map((rename) =>
+          this.updateAttribute(
+            collection["databaseId"],
+            collection["$id"],
+            rename.attribute,
+            rename.to,
+          ),
+        ),
+      );
+
+      const renameFailures = renameResults
+        .map((result, index) =>
+          result.status === "rejected"
+            ? this.formatUpdateError(
+                { key: renames[index].to },
+                result.reason,
+              )
+            : null,
+        )
+        .filter((message): message is string => message !== null);
+
+      if (renameFailures.length > 0) {
+        throw new Error(
+          `Error renaming attribute for ${collection["$id"]}:\n${renameFailures.join("\n")}`,
+        );
+      }
+
+      const renameReady = await this.pools.expectAttributes(
+        collection["databaseId"],
+        collection["$id"],
+        renames.map((rename) => rename.to),
+      );
+
+      if (!renameReady) {
+        throw new Error(
+          `Attribute rename timed out waiting for keys: ${renames.map((r) => r.to).join(", ")}`,
+        );
       }
     }
 
@@ -880,7 +1031,7 @@ export class Attributes {
       (attribute) =>
         !this.attributesContains(attribute, filteredRemoteAttributes),
     );
-    return { attributes: newAttributes, hasChanges: true };
+    return { attributes: newAttributes, hasChanges: true, renames };
   };
 
   public createIndexes = async (

--- a/templates/cli/lib/parser.ts
+++ b/templates/cli/lib/parser.ts
@@ -6,6 +6,7 @@ BigInt.prototype.toJSON = function () {
 import chalk from "chalk";
 import { InvalidArgumentError } from "commander";
 import Table from "cli-table3";
+import stringWidth from "string-width";
 import packageJson from "../package.json" with { type: "json" };
 const { description } = packageJson;
 import { globalConfig } from "./config.js";
@@ -367,6 +368,33 @@ export const parse = (data: unknown): void => {
 const MAX_COL_WIDTH = 40;
 const MAX_COLUMNS = 6;
 
+/** Visible-width cap for table cells; scales with terminal size. */
+const getMaxColWidth = (): number => {
+  const columns = process.stdout.columns || 120;
+  // Leave room for Key + Action + borders; give Reason most of the rest.
+  return Math.max(MAX_COL_WIDTH, Math.min(120, Math.floor(columns * 0.5)));
+};
+
+/**
+ * Truncate by visible width so chalk ANSI codes do not eat the budget and
+ * cut off readable text while the terminal still has space.
+ */
+const truncateToVisibleWidth = (str: string, max: number): string => {
+  if (stringWidth(str) <= max) {
+    return str;
+  }
+
+  let result = "";
+  for (const char of str) {
+    const next = result + char;
+    if (stringWidth(next) > max - 1) {
+      break;
+    }
+    result = next;
+  }
+  return `${result}…`;
+};
+
 type NamedTableOptions = {
   indent?: string;
   sectionName?: string;
@@ -397,7 +425,7 @@ const formatCellValue = (value: unknown): string => {
       )
     ) {
       const joinedValue = value.map((item) => String(item)).join(", ");
-      if (joinedValue.length <= MAX_COL_WIDTH) {
+      if (stringWidth(joinedValue) <= getMaxColWidth()) {
         return joinedValue;
       }
     }
@@ -409,11 +437,7 @@ const formatCellValue = (value: unknown): string => {
     if (keys.length === 0) return "{}";
     return `{${keys.length} keys}`;
   }
-  const str = String(value);
-  if (str.length > MAX_COL_WIDTH) {
-    return str.slice(0, MAX_COL_WIDTH - 1) + "…";
-  }
-  return str;
+  return truncateToVisibleWidth(String(value), getMaxColWidth());
 };
 
 const formatKeyValue = (key: string, value: unknown): string => {
@@ -614,7 +638,8 @@ export const drawTable = (
     const table = new Table({
       head: columns.map((c) => chalk.cyan.italic.bold(c)),
       colWidths: columns.map(() => null) as (number | null)[],
-      wordWrap: false,
+      wordWrap: true,
+      wrapOnWordBoundary: true,
       chars: {
         top: " ",
         "top-mid": " ",

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -293,6 +293,14 @@ abstract class Base extends TestCase
         'attribute:attribute-delete-uses-attribute-waiter:passed',
         'attribute:update-guards:passed',
         'attribute:resize-hard-fail:passed',
+        'attribute:rename-in-place:passed',
+        'attribute:rename-already-applied:passed',
+        'attribute:rename-missing-both-creates:passed',
+        'attribute:rename-both-exist-deletes-old:passed',
+        'attribute:rename-plus-field-change:passed',
+        'attribute:rename-preserves-indexes:passed',
+        'attribute:rename-hard-fail-before-delete:passed',
+        'attribute:rename-schema-validation:passed',
     ];
 
     protected const CLI_LOCAL_FUNCTION_EMULATION_RESPONSES = [

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -289,6 +289,7 @@ abstract class Base extends TestCase
         'attribute:in-place-updates:passed',
         'attribute:recreates-immutable:passed',
         'attribute:ignores-derived-fields:passed',
+        'attribute:omitted-encrypt-not-recreate:passed',
         'attribute:index-columns-change:passed',
         'attribute:attribute-delete-uses-attribute-waiter:passed',
         'attribute:update-guards:passed',

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -1749,6 +1749,26 @@ async function runAttributeSyncChecks() {
     assert.equal(result.hasChanges, false);
   });
 
+  await check("omitted-encrypt-not-recreate", async () => {
+    // Remote has encrypt:false; local omits encrypt — must not recreate.
+    const { updates, deletes, result } = await sync(
+      [attr({ key: "title", type: "string", size: 255, encrypt: false })],
+      [attr({ key: "title", type: "string", size: 255 })],
+    );
+    assert.equal(updates.length, 0);
+    assert.equal(deletes.length, 0);
+    assert.equal(result.hasChanges, false);
+
+    // Explicit encrypt:true still forces recreate.
+    const changed = await sync(
+      [attr({ key: "title", type: "string", size: 255, encrypt: false })],
+      [attr({ key: "title", type: "string", size: 255, encrypt: true })],
+    );
+    assert.equal(changed.updates.length, 0);
+    assert.equal(changed.deletes.length, 1);
+    assert.equal(changed.result.attributes.length, 1);
+  });
+
   await check("index-columns-change", async () => {
     const { updates, deletes, result, waiters } = await sync(
       [{ key: "by_title", type: "key", columns: ["title"], orders: ["ASC"] }],

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -1611,10 +1611,15 @@ async function runAttributeSyncChecks() {
           waiters.push({ type: "index", keys: [...keys] });
           return true;
         },
+        expectAttributes: async (_db, _id, keys) => {
+          waiters.push({ type: "expect", keys: [...keys] });
+          return true;
+        },
       },
       true,
     );
-    helper.updateAttribute = async (_db, _id, a) => updates.push(a);
+    helper.updateAttribute = async (_db, _id, a, newKey) =>
+      updates.push(newKey !== undefined ? { ...a, newKey } : a);
     helper.deleteAttribute = async (_c, a, index = false) =>
       deletes.push({ key: a.key, isIndex: index });
     const result = await helper.attributesToCreate(
@@ -1825,6 +1830,282 @@ async function runAttributeSyncChecks() {
       /existing values exceed the new size/,
     );
     assert.equal(deletes.length, 0);
+  });
+
+  await check("rename-in-place", async () => {
+    const { updates, deletes, result, waiters } = await sync(
+      [attr({ key: "title", type: "string", size: 255 })],
+      [
+        attr({
+          key: "headline",
+          previousKey: "title",
+          type: "string",
+          size: 255,
+        }),
+      ],
+    );
+    assert.equal(updates.length, 1);
+    assert.equal(updates[0].key, "title");
+    assert.equal(updates[0].newKey, "headline");
+    assert.equal(deletes.length, 0);
+    assert.deepEqual(result.attributes, []);
+    assert.deepEqual(result.renames, [
+      {
+        from: "title",
+        to: "headline",
+        attribute: attr({ key: "title", type: "string", size: 255 }),
+      },
+    ]);
+    assert.deepEqual(waiters, [{ type: "expect", keys: ["headline"] }]);
+  });
+
+  await check("rename-already-applied", async () => {
+    const { updates, deletes, result } = await sync(
+      [attr({ key: "headline", type: "string", size: 255 })],
+      [
+        attr({
+          key: "headline",
+          previousKey: "title",
+          type: "string",
+          size: 255,
+        }),
+      ],
+    );
+    assert.equal(updates.length, 0);
+    assert.equal(deletes.length, 0);
+    assert.equal(result.hasChanges, false);
+    assert.deepEqual(result.renames, []);
+  });
+
+  await check("rename-missing-both-creates", async () => {
+    const { updates, deletes, result } = await sync(
+      [],
+      [
+        attr({
+          key: "headline",
+          previousKey: "title",
+          type: "string",
+          size: 255,
+        }),
+      ],
+    );
+    assert.equal(updates.length, 0);
+    assert.equal(deletes.length, 0);
+    assert.equal(result.attributes.length, 1);
+    assert.equal(result.attributes[0].key, "headline");
+    assert.deepEqual(result.renames, []);
+  });
+
+  await check("rename-both-exist-deletes-old", async () => {
+    const { updates, deletes, result } = await sync(
+      [
+        attr({ key: "title", type: "string", size: 255 }),
+        attr({ key: "headline", type: "string", size: 255 }),
+      ],
+      [
+        attr({
+          key: "headline",
+          previousKey: "title",
+          type: "string",
+          size: 255,
+        }),
+      ],
+    );
+    assert.equal(updates.length, 0);
+    assert.equal(deletes.length, 1);
+    assert.equal(deletes[0].key, "title");
+    assert.deepEqual(result.attributes, []);
+    assert.deepEqual(result.renames, []);
+  });
+
+  await check("rename-plus-field-change", async () => {
+    const { updates, deletes, result, waiters } = await sync(
+      [attr({ key: "title", type: "string", size: 50 })],
+      [
+        attr({
+          key: "headline",
+          previousKey: "title",
+          type: "string",
+          size: 120,
+        }),
+      ],
+    );
+    assert.equal(updates.length, 2);
+    assert.equal(updates[0].key, "title");
+    assert.equal(updates[0].newKey, "headline");
+    assert.equal(updates[1].key, "headline");
+    assert.equal(updates[1].size, 120);
+    assert.equal(updates[1].newKey, undefined);
+    assert.equal(deletes.length, 0);
+    assert.deepEqual(result.attributes, []);
+    assert.deepEqual(waiters, [{ type: "expect", keys: ["headline"] }]);
+  });
+
+  await check("rename-preserves-indexes", async () => {
+    const remoteColumns = [attr({ key: "title", type: "string", size: 255 })];
+    const localColumns = [
+      attr({
+        key: "headline",
+        previousKey: "title",
+        type: "string",
+        size: 255,
+      }),
+    ];
+    const { result: columnsResult } = await sync(remoteColumns, localColumns);
+    assert.equal(columnsResult.renames.length, 1);
+
+    // Mirror push.ts: rewrite remote index refs with the rename map.
+    const renameMap = new Map(
+      columnsResult.renames.map((r) => [r.from, r.to]),
+    );
+    const remoteIndexes = [
+      { key: "by_title", type: "key", columns: ["title"], orders: ["ASC"] },
+    ].map((idx) => ({
+      ...idx,
+      columns: idx.columns.map((c) => renameMap.get(c) ?? c),
+    }));
+    const localIndexes = [
+      {
+        key: "by_title",
+        type: "key",
+        columns: ["headline"],
+        orders: ["ASC"],
+      },
+    ];
+    const { updates, deletes, result } = await sync(
+      remoteIndexes,
+      localIndexes,
+      true,
+    );
+    assert.equal(updates.length, 0);
+    assert.equal(deletes.length, 0);
+    assert.equal(result.hasChanges, false);
+  });
+
+  await check("rename-hard-fail-before-delete", async () => {
+    const deletes = [];
+    const helper = new Attributes(
+      {
+        waitForAttributeDeletion: async () => true,
+        expectAttributes: async () => true,
+      },
+      true,
+    );
+    helper.updateAttribute = async (_db, _id, _a, newKey) => {
+      if (newKey) {
+        throw new Error("rename_failed: conflict");
+      }
+    };
+    helper.deleteAttribute = async (_c, a) => deletes.push(a.key);
+
+    await assert.rejects(
+      () =>
+        helper.attributesToCreate(
+          [
+            attr({ key: "title", type: "string", size: 255 }),
+            attr({ key: "legacy", type: "string", size: 16 }),
+          ],
+          [
+            attr({
+              key: "headline",
+              previousKey: "title",
+              type: "string",
+              size: 255,
+            }),
+            attr({ key: "legacy", type: "integer" }),
+          ],
+          collection,
+        ),
+      /Error renaming attribute/,
+    );
+    assert.equal(deletes.length, 0);
+  });
+
+  await check("rename-schema-validation", async () => {
+    const {
+      ColumnSchema,
+      IndexSchema,
+      TableSchema,
+    } = require("./lib/commands/config.ts");
+
+    // previousKey is allowed on columns.
+    assert.equal(
+      ColumnSchema.safeParse(
+        attr({
+          key: "headline",
+          previousKey: "title",
+          type: "string",
+          size: 255,
+        }),
+      ).success,
+      true,
+    );
+
+    // previousKey is rejected on indexes (.strict()).
+    assert.equal(
+      IndexSchema.safeParse({
+        key: "by_title",
+        type: "key",
+        attributes: ["title"],
+        previousKey: "old",
+      }).success,
+      false,
+    );
+
+    // previousKey === key is rejected.
+    const sameKey = TableSchema.safeParse({
+      $id: "posts",
+      databaseId: "blog",
+      name: "Posts",
+      columns: [
+        attr({
+          key: "title",
+          previousKey: "title",
+          type: "string",
+          size: 255,
+        }),
+      ],
+    });
+    assert.equal(sameKey.success, false);
+
+    // Collision: another column already uses previousKey as its key.
+    const collision = TableSchema.safeParse({
+      $id: "posts",
+      databaseId: "blog",
+      name: "Posts",
+      columns: [
+        attr({ key: "title", type: "string", size: 255 }),
+        attr({
+          key: "headline",
+          previousKey: "title",
+          type: "string",
+          size: 255,
+        }),
+      ],
+    });
+    assert.equal(collision.success, false);
+
+    // Duplicate previousKey across columns is rejected.
+    const duplicatePrevious = TableSchema.safeParse({
+      $id: "posts",
+      databaseId: "blog",
+      name: "Posts",
+      columns: [
+        attr({
+          key: "headline",
+          previousKey: "title",
+          type: "string",
+          size: 255,
+        }),
+        attr({
+          key: "heading",
+          previousKey: "title",
+          type: "string",
+          size: 255,
+        }),
+      ],
+    });
+    assert.equal(duplicatePrevious.success, false);
   });
 }
 


### PR DESCRIPTION
<img width="767" height="221" alt="Screenshot 2026-07-30 at 11 57 41 AM" src="https://github.com/user-attachments/assets/93451bfd-9a6a-42b2-a405-605fc8f0d519" />

## Summary

- Prefer in-place `update*Attribute` / `update*Column` calls for safe field changes (`size`, `onDelete`, `elements`, `min`/`max`, `required`, `default`) instead of destructive delete-and-recreate
- Add optional `previousKey` in `appwrite.config.json` so `appwrite push` can rename columns/attributes via the API `newKey` parameter without data loss
- Hard-fail on update/rename errors before any deletions; wait for the correct attribute/index deletion waiter; patch remote index refs after renames so indexes are not spuriously recreated

## Usage: rename a column

Edit the desired end-state `key` and add `previousKey` pointing at the remote name:

```json
{
  "tables": [
    {
      "$id": "posts",
      "databaseId": "blog",
      "name": "Posts",
      "columns": [
        {
          "key": "headline",
          "previousKey": "title",
          "type": "string",
          "size": 255,
          "required": true
        }
      ],
      "indexes": [
        {
          "key": "by_headline",
          "type": "key",
          "columns": ["headline"]
        }
      ]
    }
  ]
}
```

Then push:

```bash
appwrite push tables
```

### What you see

Instead of `deleting title` + `adding headline` (and a data-loss warning), push shows a single non-destructive row:

```
┌──────────┬──────────┬────────────────────────┐
│ Key      │ Action   │ Reason                 │
├──────────┼──────────┼────────────────────────┤
│ headline │ renaming │ key renamed from title │
└──────────┴──────────┴────────────────────────┘
```

Under the hood this calls the existing update endpoint with `newKey`:

```ts
await databasesService.updateStringAttribute({
  databaseId,
  collectionId,
  key: attribute.key,       // "title" (current remote key)
  required: attribute.required,
  xdefault: attribute.default,
  size: attribute.size,
  newKey: newKey,           // "headline"
});
```

Indexes that already list the new key locally do **not** need recreation — the server rewrites index column refs during rename, and the CLI mirrors that on the in-memory remote snapshot before the index diff.

### Lifecycle (idempotent; config is not rewritten)

| Remote state | Behavior |
|---|---|
| has `title`, not `headline` | rename via `newKey` |
| has `headline`, not `title` | no-op (stale `previousKey` is harmless) |
| has neither | plain create of `headline` |
| has both | warn; `title` follows the normal delete path |

`appwrite pull tables` clears `previousKey` automatically (full array replace + schema filter). A second push with a leftover hint prints no changes.

### Validation

Zod rejects bad hints before push:

```ts
// rejected: previousKey === key
{ "key": "title", "previousKey": "title", "type": "string", "size": 255 }

// rejected: another column already uses previousKey as its key
[
  { "key": "title", "type": "string", "size": 255 },
  { "key": "headline", "previousKey": "title", "type": "string", "size": 255 }
]

// rejected: previousKey on indexes (no rename API; .strict())
{ "key": "by_title", "type": "key", "columns": ["title"], "previousKey": "old" }
```

## Usage: in-place field updates (no rename)

Safe edits no longer recreate the attribute:

```json
{
  "key": "title",
  "type": "varchar",
  "size": 120,
  "required": false,
  "default": null
}
```

```bash
appwrite push tables
```

| Change | Action |
|---|---|
| `size`, `required`, `default`, enum `elements`, numeric `min`/`max`, relationship `onDelete` | in-place update |
| `type`, `array`, `encrypt`, relationship topology | recreate (data-loss warning) |

Failed updates (e.g. `attribute_invalid_resize`) abort **before** deletions so push cannot silently destroy data.

## Implementation notes

- Schema: optional `previousKey` on `AttributeSchema` / `ColumnSchema` only ([`templates/cli/lib/commands/config.ts`](templates/cli/lib/commands/config.ts))
- Diff pipeline: `resolveRenames` patches remote keys **before** classification, executes renames **after** confirmation and **before** field updates/deletes ([`templates/cli/lib/commands/utils/attributes.ts`](templates/cli/lib/commands/utils/attributes.ts))
- Index safety: rename map applied to `remoteVersion.indexes` between column and index `attributesToCreate` calls ([`templates/cli/lib/commands/push.ts`](templates/cli/lib/commands/push.ts))
- Per-type field rules replace the old hardcoded `changeableKeys` list

## Test plan

- [ ] `appwrite push tables` with `previousKey` renames remotely without deleting data
- [ ] Second push with the same stale `previousKey` reports no changes
- [ ] `appwrite pull tables` drops `previousKey` from config
- [ ] Rename + `size` change in one push applies rename then update
- [ ] Indexes referencing the renamed column are not recreated
- [ ] Invalid config (`previousKey === key`, collisions, index `previousKey`) fails validation
- [ ] In-place `size` / `onDelete` / enum `elements` updates do not recreate
- [ ] Immutable changes (`type`, `array`, `encrypt`) still recreate with warning
- [ ] Resize failure hard-fails with zero deletions
- [ ] CLI e2e attribute sync tokens pass (`attribute:rename-*:passed`, `attribute:in-place-updates:passed`, …)


Made with [Cursor](https://cursor.com)