### PR TITLE
chore(cli): bump @appwrite.io/console to 15.8.0

### DIFF
--- a/templates/cli/package.json.twig
+++ b/templates/cli/package.json.twig
@@ -51,7 +51,7 @@
     "windows-arm64": "bun build cli.ts --compile --minify --target=bun-windows-arm64 --outfile build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
-    "@appwrite.io/console": "15.7.0",
+    "@appwrite.io/console": "15.8.0",
     "@napi-rs/keyring": "^1.3.0",
     "chalk": "4.1.2",
     "chokidar": "^3.6.0",


### PR DESCRIPTION
The CLI template calls `tablesdb create`/`update` with `syncMode`, which `@appwrite.io/console@15.7.0` does not declare, so the generated CLI failed to type-check:

```
lib/commands/services/tablesdb.ts(83,108): error TS2554: Expected 1-5 arguments, but got 6.
lib/commands/services/tablesdb.ts(220,108): error TS2554: Expected 1-5 arguments, but got 6.
```

`15.8.0` is published and declares `syncMode` on both methods. Verified locally: with this pin the generated CLI completes `tsc` and all three esbuild bundles cleanly.