### PR TITLE
feat(cli): make response output readable at a glance

### DIFF
--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -505,6 +505,11 @@ class CLI extends Node
             ],
             [
                 'scope'         => 'copy',
+                'destination'   => 'lib/hints.ts',
+                'template'      => 'cli/lib/hints.ts',
+            ],
+            [
+                'scope'         => 'copy',
                 'destination'   => 'lib/questions.ts',
                 'template'      => 'cli/lib/questions.ts',
             ],

--- a/templates/cli/cli.ts.twig
+++ b/templates/cli/cli.ts.twig
@@ -154,10 +154,14 @@ if (process.argv.includes('-v') || process.argv.includes('--version')) {
             .hook('preAction', (_thisCommand, actionCommand) => {
                 const commandConfig = actionCommand as typeof actionCommand & {
                     outputFields?: string[];
+                    followUpHint?: string;
                 };
                 cliConfig.displayFields = Array.isArray(commandConfig.outputFields)
                     ? commandConfig.outputFields
                     : [];
+                cliConfig.followUpHint = typeof commandConfig.followUpHint === 'string'
+                    ? commandConfig.followUpHint
+                    : '';
             })
             .on('option:json', () => {
                 cliConfig.json = true;

--- a/templates/cli/cli.ts.twig
+++ b/templates/cli/cli.ts.twig
@@ -11,6 +11,7 @@ import inquirer from 'inquirer';
 
 import packageJson from './package.json' with { type: 'json' };
 import { commandDescriptions, cliConfig } from './lib/parser.js';
+import { followUpHintFor } from './lib/hints.js';
 import {
     getLatestVersionForCurrentInstallation,
     compareVersions,
@@ -154,14 +155,11 @@ if (process.argv.includes('-v') || process.argv.includes('--version')) {
             .hook('preAction', (_thisCommand, actionCommand) => {
                 const commandConfig = actionCommand as typeof actionCommand & {
                     outputFields?: string[];
-                    followUpHint?: string;
                 };
                 cliConfig.displayFields = Array.isArray(commandConfig.outputFields)
                     ? commandConfig.outputFields
                     : [];
-                cliConfig.followUpHint = typeof commandConfig.followUpHint === 'string'
-                    ? commandConfig.followUpHint
-                    : '';
+                cliConfig.followUpHint = followUpHintFor(actionCommand);
             })
             .on('option:json', () => {
                 cliConfig.json = true;

--- a/templates/cli/lib/commands/services/services.ts.twig
+++ b/templates/cli/lib/commands/services/services.ts.twig
@@ -35,6 +35,11 @@ import {
 } from "../utils/query.js";
 {% endif %}
 {% set consoleOnlyMethods = service.consoleOnlyMethods | default([]) %}
+{# Commands that only return identifiers, keyed by service.method, pointed at the command that shows the full resource. #}
+{% set followUpHints = {
+  'oauth2.listProjects': 'Run `' ~ (language.params.executableName|caseLower) ~ ' project get --project-id <project-id>` to see a project\'s details.',
+  'oauth2.listOrganizations': 'Run `' ~ (language.params.executableName|caseLower) ~ ' organization get --organization-id <organization-id>` to see an organization\'s details.'
+} %}
 {# Set when the service names its target in a header instead of the path, so it takes an ID flag. #}
 {% set scope = service | cliServiceScope %}
 {% if scope %}
@@ -139,6 +144,7 @@ export const {{ service.name | caseCamel }} = new Command("{{ service.name | cas
 {% set scopedFlag = scope and not hasScopedIdParam %}
 {% set clientCall = clientGetter ~ (scope ? '(' ~ scope.idVar ~ ')' : '()') %}
 {% set query = method | cliQueryConfig %}
+{% set followUpHint = followUpHints[service.name ~ '.' ~ (method.name | caseCamel)] | default('') %}
 const {{ commandVar }} = {{ service.name | caseCamel }}
   .command(`{{ commandName }}`)
   .description(`{{ method.description | stripMarkdown | replace({'`': '\\`'}) | raw }}`)
@@ -234,6 +240,9 @@ const {{ commandVar }} = {{ service.name | caseCamel }}
 
 {% if service.name == 'projects' and method.name == 'list' %}
 ({{ commandVar }} as Command & { outputFields?: string[] }).outputFields = ["name", "$id", "region", "status"];
+{% endif %}
+{% if followUpHint %}
+({{ commandVar }} as Command & { followUpHint?: string }).followUpHint = {{ followUpHint | json_encode | raw }};
 {% endif %}
 
 {% endif %}

--- a/templates/cli/lib/commands/services/services.ts.twig
+++ b/templates/cli/lib/commands/services/services.ts.twig
@@ -35,11 +35,6 @@ import {
 } from "../utils/query.js";
 {% endif %}
 {% set consoleOnlyMethods = service.consoleOnlyMethods | default([]) %}
-{# Commands that only return identifiers, keyed by service.method, pointed at the command that shows the full resource. #}
-{% set followUpHints = {
-  'oauth2.listProjects': 'Run `' ~ (language.params.executableName|caseLower) ~ ' project get --project-id <project-id>` to see a project\'s details.',
-  'oauth2.listOrganizations': 'Run `' ~ (language.params.executableName|caseLower) ~ ' organization get --organization-id <organization-id>` to see an organization\'s details.'
-} %}
 {# Set when the service names its target in a header instead of the path, so it takes an ID flag. #}
 {% set scope = service | cliServiceScope %}
 {% if scope %}
@@ -144,7 +139,6 @@ export const {{ service.name | caseCamel }} = new Command("{{ service.name | cas
 {% set scopedFlag = scope and not hasScopedIdParam %}
 {% set clientCall = clientGetter ~ (scope ? '(' ~ scope.idVar ~ ')' : '()') %}
 {% set query = method | cliQueryConfig %}
-{% set followUpHint = followUpHints[service.name ~ '.' ~ (method.name | caseCamel)] | default('') %}
 const {{ commandVar }} = {{ service.name | caseCamel }}
   .command(`{{ commandName }}`)
   .description(`{{ method.description | stripMarkdown | replace({'`': '\\`'}) | raw }}`)
@@ -240,9 +234,6 @@ const {{ commandVar }} = {{ service.name | caseCamel }}
 
 {% if service.name == 'projects' and method.name == 'list' %}
 ({{ commandVar }} as Command & { outputFields?: string[] }).outputFields = ["name", "$id", "region", "status"];
-{% endif %}
-{% if followUpHint %}
-({{ commandVar }} as Command & { followUpHint?: string }).followUpHint = {{ followUpHint | json_encode | raw }};
 {% endif %}
 
 {% endif %}

--- a/templates/cli/lib/hints.ts
+++ b/templates/cli/lib/hints.ts
@@ -1,0 +1,27 @@
+import type { Command } from "commander";
+import { EXECUTABLE_NAME } from "./constants.js";
+
+/**
+ * Commands whose response carries identifiers but no detail, mapped to the
+ * command that shows the full resource. Keys are the command path as typed,
+ * so they can be checked against `--help` output directly.
+ */
+const followUpHints: Record<string, string> = {
+  "oauth2 list-projects": `Run \`${EXECUTABLE_NAME} project get --project-id <project-id>\` to see a project's details.`,
+  "oauth2 list-organizations": `Run \`${EXECUTABLE_NAME} organization get --organization-id <organization-id>\` to see an organization's details.`,
+};
+
+/** Command path without the executable name, e.g. `oauth2 list-projects`. */
+const commandPath = (command: Command): string => {
+  const segments: string[] = [];
+
+  for (let current: Command | null = command; current?.parent;) {
+    segments.unshift(current.name());
+    current = current.parent;
+  }
+
+  return segments.join(" ");
+};
+
+export const followUpHintFor = (command: Command): string =>
+  followUpHints[commandPath(command)] ?? "";

--- a/templates/cli/lib/parser.ts
+++ b/templates/cli/lib/parser.ts
@@ -20,7 +20,13 @@ import {
   SDK_LOGO,
   EXECUTABLE_NAME,
 } from "./constants.js";
-import { renderStructuredCollection } from "./response-config.js";
+import {
+  formatSectionField,
+  formatTimestamp,
+  humanizeSeconds,
+  renderStructuredCollection,
+  sectionFieldKeys,
+} from "./response-config.js";
 
 const cliConfig: CliConfig = {
   verbose: false,
@@ -33,6 +39,7 @@ const cliConfig: CliConfig = {
   report: false,
   reportData: {},
   displayFields: [],
+  followUpHint: "",
 };
 
 type JsonObject = Record<string, unknown>;
@@ -67,8 +74,14 @@ const toJsonObject = (value: unknown): JsonObject | null => {
   return null;
 };
 
+/**
+ * Internal bookkeeping that carries no meaning for a CLI reader, plus fields
+ * the API returns twice under two names (`billingPlanId` === `billingPlan`).
+ */
+const NORMAL_VIEW_HIDDEN_KEYS = new Set(["onboarding", "billingPlanId"]);
+
 const isNormalViewHiddenKey = (key: string): boolean =>
-  key.startsWith("$") && key !== "$id";
+  (key.startsWith("$") && key !== "$id") || NORMAL_VIEW_HIDDEN_KEYS.has(key);
 const printSpacerLine = (): void => {
   process.stdout.write(" \n");
 };
@@ -113,6 +126,17 @@ const endRender = (): void => {
       hint(message);
     }
   }
+
+  // Machine-readable output stays free of prose. Cleared once shown so commands
+  // that render more than once do not repeat themselves.
+  if (renderDepth === 0 && cliConfig.followUpHint !== "") {
+    const message = cliConfig.followUpHint;
+    cliConfig.followUpHint = "";
+
+    if (!cliConfig.json && !cliConfig.raw) {
+      hint(message);
+    }
+  }
 };
 
 const withRender = <T>(callback: () => T): T => {
@@ -134,8 +158,10 @@ const isSensitiveKey = (key: string): boolean => {
   );
 };
 
-const maskSensitiveString = (value: string): string => {
-  if (value.length <= 16) {
+const maskSensitiveString = (value: string, key: string): string => {
+  // A key or token tail helps identify which credential is in play; a password
+  // tail is just a leak, so those are masked whole.
+  if (value.length <= 16 || /password/i.test(key)) {
     return HIDDEN_VALUE;
   }
 
@@ -160,7 +186,7 @@ const maskSensitiveData = (
     }
 
     if (typeof value === "string") {
-      return maskSensitiveString(value);
+      return maskSensitiveString(value, key);
     }
 
     if (value == null) {
@@ -357,6 +383,7 @@ export const parse = (data: unknown): void => {
         drawTable([section.value as JsonObject], {
           indent: "  ",
           sectionName: section.key,
+          keyValue: true,
         });
       }
 
@@ -398,6 +425,8 @@ const truncateToVisibleWidth = (str: string, max: number): string => {
 type NamedTableOptions = {
   indent?: string;
   sectionName?: string;
+  /** Render as stacked key/value lines rather than a column table. */
+  keyValue?: boolean;
 };
 
 type EntryRenderOptions = {
@@ -442,7 +471,26 @@ const formatCellValue = (value: unknown): string => {
 
 const formatKeyValue = (key: string, value: unknown): string => {
   if (key === "status" && typeof value === "boolean") {
-    return value ? "active" : "inactive";
+    return value ? chalk.green("active") : chalk.dim("inactive");
+  }
+
+  if (typeof value === "boolean") {
+    return value ? chalk.green("true") : chalk.dim("false");
+  }
+
+  // Durations come over the wire as raw seconds, which nobody reads at a glance.
+  if (typeof value === "number" && /duration$/i.test(key)) {
+    const humanized = humanizeSeconds(value);
+    if (humanized !== "") {
+      return `${value} ${chalk.dim(`(${humanized})`)}`;
+    }
+  }
+
+  if (typeof value === "string") {
+    const timestamp = formatTimestamp(value);
+    if (timestamp !== null) {
+      return timestamp;
+    }
   }
 
   return String(value);
@@ -524,14 +572,19 @@ const drawKeyValueEntries = (
   }
 };
 
+const printWithheldFieldNote = (count: number, indent?: string): void => {
+  if (count <= 0) return;
+
+  const label = count === 1 ? "field" : "fields";
+  console.log(
+    `${indent ?? ""}${chalk.dim(`… ${count} more ${label} — pass --raw to show all`)}`,
+  );
+};
+
 const drawNamedObjectCollection = (
   rows: JsonObject[],
   options: NamedTableOptions = {},
 ): boolean => {
-  if (renderStructuredCollection(options.sectionName, rows, options)) {
-    return true;
-  }
-
   const scalarEntries = rows.map((row) => toScalarEntries(row));
   const flatScalarEntries = scalarEntries.flat();
 
@@ -589,7 +642,7 @@ export const drawTable = (
       return;
     }
 
-    const rows = applyDisplayFilter(
+    const visibleRows = applyDisplayFilter(
       data.map((item): JsonObject => {
         const maskedItem = maskSensitiveData(item, undefined, false);
         const row = toJsonObject(maskedItem) ?? {};
@@ -604,6 +657,43 @@ export const drawTable = (
       }),
     );
 
+    // An explicit --display selection wins; the reader already said what they want.
+    const allowlist =
+      cliConfig.displayFields.length > 0
+        ? undefined
+        : sectionFieldKeys(options.sectionName);
+    let withheldFields = 0;
+
+    const rows = allowlist
+      ? visibleRows.map((row) => {
+          const kept: JsonObject = {};
+
+          for (const key of allowlist) {
+            if (Object.prototype.hasOwnProperty.call(row, key)) {
+              kept[key] = formatSectionField(
+                options.sectionName,
+                key,
+                row[key],
+              );
+            }
+          }
+
+          withheldFields += Object.keys(row).length - Object.keys(kept).length;
+
+          return kept;
+        })
+      : visibleRows;
+
+    if (renderStructuredCollection(options.sectionName, rows, options)) {
+      printWithheldFieldNote(withheldFields, options.indent);
+      return;
+    }
+
+    if (options.keyValue && drawNamedObjectCollection(rows, options)) {
+      printWithheldFieldNote(withheldFields, options.indent);
+      return;
+    }
+
     // Create an object with all the keys in it
     const obj = rows.reduce((res, item) => ({ ...res, ...item }), {});
     // Get those keys as an array
@@ -616,6 +706,7 @@ export const drawTable = (
     // If too many columns, show condensed key-value output with only scalar, non-empty fields
     if (allKeys.length > MAX_COLUMNS) {
       if (drawNamedObjectCollection(rows, options)) {
+        printWithheldFieldNote(withheldFields, options.indent);
         return;
       }
 
@@ -667,6 +758,7 @@ export const drawTable = (
       table.push(rowValues);
     });
     console.log(table.toString());
+    printWithheldFieldNote(withheldFields, options.indent);
   });
 };
 

--- a/templates/cli/lib/response-config.ts
+++ b/templates/cli/lib/response-config.ts
@@ -175,8 +175,13 @@ export const humanizeSeconds = (seconds: number): string => {
   return parts.slice(0, 2).join(" ");
 };
 
+/**
+ * The offset is mandatory: ECMAScript reads an offset-less date-time as local
+ * time, so accepting one would mean labelling a local instant UTC. Values
+ * without an offset fall through and render as they arrived.
+ */
 const ISO_DATE_TIME =
-  /^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}:\d{2})(?:\.\d+)?(Z|[+-]\d{2}:\d{2})?$/;
+  /^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}:\d{2})(?:\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
 
 /** Coarsest-unit-wins tiers; approximate on purpose, this is a readability aid. */
 const RELATIVE_TIERS: Array<[string, number]> = [
@@ -214,10 +219,7 @@ export const formatTimestamp = (value: string): string | null => {
   }
 
   const [, date, time, offset] = match;
-  const zone =
-    offset == null || offset === "Z" || offset === "+00:00"
-      ? " UTC"
-      : ` ${offset}`;
+  const zone = offset === "Z" || offset === "+00:00" ? " UTC" : ` ${offset}`;
   const stamp = `${date} ${time}${zone}`;
   const parsed = new Date(value);
 

--- a/templates/cli/lib/response-config.ts
+++ b/templates/cli/lib/response-config.ts
@@ -33,6 +33,8 @@ const toTitleCase = (value: string): string =>
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
     .join(" ");
 
+const COLUMN_GAP = "  ";
+
 const padColumn = (value: string, width: number): string => {
   const valueWidth = stringWidth(value);
   if (valueWidth >= width) return value;
@@ -65,7 +67,7 @@ const renderAlignedColumns = (
       return padColumn(value, widths[columnIndex]);
     });
 
-    console.log(`${indent}${headerParts.join("  ")}`.trimEnd());
+    console.log(`${indent}${headerParts.join(COLUMN_GAP)}`.trimEnd());
   }
 
   for (let idx = 0; idx < columns[0].length; idx++) {
@@ -78,8 +80,152 @@ const renderAlignedColumns = (
       return padColumn(value, widths[columnIndex]);
     });
 
-    console.log(`${indent}${parts.join("  ")}`.trimEnd());
+    console.log(`${indent}${parts.join(COLUMN_GAP)}`.trimEnd());
   }
+};
+
+const wrapValues = (values: string[], width: number): string[] => {
+  const lines: string[] = [];
+  let current = "";
+
+  values.forEach((value, index) => {
+    const piece = index === values.length - 1 ? value : `${value},`;
+
+    if (current === "") {
+      current = piece;
+      return;
+    }
+
+    if (stringWidth(`${current} ${piece}`) > width) {
+      lines.push(current);
+      current = piece;
+      return;
+    }
+
+    current = `${current} ${piece}`;
+  });
+
+  if (current !== "") {
+    lines.push(current);
+  }
+
+  return lines;
+};
+
+/** Plan quotas are quoted in decimal units, matching how the console reads them. */
+const SIZE_UNITS = ["MB", "GB", "TB", "PB"] as const;
+type SizeUnit = (typeof SIZE_UNITS)[number];
+
+const trimTrailingZeros = (value: number): string =>
+  String(Number(value.toFixed(2)));
+
+const formatSize = (amount: number, unit: SizeUnit): string => {
+  const base = `${amount} ${unit}`;
+  let index = SIZE_UNITS.indexOf(unit);
+  let scaled = amount;
+
+  while (scaled >= 1000 && index < SIZE_UNITS.length - 1) {
+    scaled /= 1000;
+    index++;
+  }
+
+  if (SIZE_UNITS[index] === unit) {
+    return base;
+  }
+
+  return `${base} ${chalk.dim(`(${trimTrailingZeros(scaled)} ${SIZE_UNITS[index]})`)}`;
+};
+
+const compactNumber = new Intl.NumberFormat("en", {
+  notation: "compact",
+  maximumFractionDigits: 2,
+});
+
+const formatCount = (amount: number): string => {
+  if (Math.abs(amount) < 10000) {
+    return String(amount);
+  }
+
+  return `${amount} ${chalk.dim(`(${compactNumber.format(amount)})`)}`;
+};
+
+export const humanizeSeconds = (seconds: number): string => {
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return "";
+  }
+
+  const units: Array<[string, number]> = [
+    ["d", 86400],
+    ["h", 3600],
+    ["m", 60],
+    ["s", 1],
+  ];
+
+  const parts: string[] = [];
+  let remaining = Math.round(seconds);
+
+  for (const [suffix, size] of units) {
+    const amount = Math.floor(remaining / size);
+    if (amount > 0) {
+      parts.push(`${amount}${suffix}`);
+      remaining -= amount * size;
+    }
+  }
+
+  return parts.slice(0, 2).join(" ");
+};
+
+const ISO_DATE_TIME =
+  /^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}:\d{2})(?:\.\d+)?(Z|[+-]\d{2}:\d{2})?$/;
+
+/** Coarsest-unit-wins tiers; approximate on purpose, this is a readability aid. */
+const RELATIVE_TIERS: Array<[string, number]> = [
+  ["y", 31536000],
+  ["mo", 2592000],
+  ["d", 86400],
+  ["h", 3600],
+  ["m", 60],
+];
+
+const relativeTime = (date: Date): string => {
+  const deltaSeconds = (Date.now() - date.getTime()) / 1000;
+  const magnitude = Math.abs(deltaSeconds);
+
+  if (magnitude < 45) {
+    return "just now";
+  }
+
+  const [suffix, size] =
+    RELATIVE_TIERS.find(([, tierSize]) => magnitude >= tierSize) ??
+    RELATIVE_TIERS[RELATIVE_TIERS.length - 1];
+  const label = `${Math.floor(magnitude / size)}${suffix}`;
+
+  return deltaSeconds > 0 ? `${label} ago` : `in ${label}`;
+};
+
+/**
+ * Turns `2026-07-31T02:49:41.895+00:00` into `2026-07-31 02:49:41 UTC (2h ago)`.
+ * Returns null when the value is not an ISO timestamp, so callers can fall back.
+ */
+export const formatTimestamp = (value: string): string | null => {
+  const match = ISO_DATE_TIME.exec(value.trim());
+  if (!match) {
+    return null;
+  }
+
+  const [, date, time, offset] = match;
+  const zone =
+    offset == null || offset === "Z" || offset === "+00:00"
+      ? " UTC"
+      : ` ${offset}`;
+  const stamp = `${date} ${time}${zone}`;
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    return stamp;
+  }
+
+  return `${stamp} ${chalk.dim(`(${relativeTime(parsed)})`)}`;
 };
 
 const compactDate = (value: unknown): string => {
@@ -603,18 +749,171 @@ const structuredCollectionRenderers: Record<
   ]),
 };
 
+/**
+ * How a field's bare number should be annotated. Units belong to the section,
+ * not to the key: a plan's `fileSize` is megabytes, a bucket's is bytes.
+ */
+type FieldFormat =
+  /** Decimal size in the given unit, scaled up when that reads better. */
+  | { kind: "size"; unit: SizeUnit }
+  /** Large tallies get a compact magnitude hint: 3500000 (3.5M). */
+  | { kind: "count" }
+  /** A literal trailing label, e.g. `168 days`. */
+  | { kind: "label"; label: string };
+
+type SectionField = {
+  key: string;
+  format?: FieldFormat;
+};
+
+/**
+ * Embedded models that arrive with far more fields than a reader asked for.
+ * These are allowlists rather than denylists on purpose: the API keeps adding
+ * capability flags, and an allowlist stays correct without maintenance. Order
+ * here is the render order; anything absent is summarised as a footer count.
+ *
+ * Units are verified against how the console interprets the same plan fields —
+ * `bandwidth`/`storage` in GB, `fileSize` in MB.
+ */
+const sectionFields: Record<string, SectionField[]> = {
+  billingPlanDetails: [
+    { key: "$id" },
+    { key: "name" },
+    { key: "group" },
+    { key: "price" },
+    { key: "currency" },
+    { key: "trial", format: { kind: "label", label: "days" } },
+    { key: "bandwidth", format: { kind: "size", unit: "GB" } },
+    { key: "storage", format: { kind: "size", unit: "GB" } },
+    { key: "fileSize", format: { kind: "size", unit: "MB" } },
+    { key: "users", format: { kind: "count" } },
+    { key: "executions", format: { kind: "count" } },
+    { key: "GBHours", format: { kind: "label", label: "GB-hours" } },
+    { key: "databasesReads", format: { kind: "count" } },
+    { key: "databasesWrites", format: { kind: "count" } },
+    { key: "realtime", format: { kind: "count" } },
+    { key: "realtimeMessages", format: { kind: "count" } },
+    { key: "messages", format: { kind: "count" } },
+    { key: "domains", format: { kind: "count" } },
+  ],
+};
+
+export const sectionFieldKeys = (
+  sectionName: string | undefined,
+): string[] | undefined =>
+  sectionName
+    ? sectionFields[sectionName]?.map((field) => field.key)
+    : undefined;
+
+export const formatSectionField = (
+  sectionName: string | undefined,
+  key: string,
+  value: unknown,
+): unknown => {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return value;
+  }
+
+  const format = sectionName
+    ? sectionFields[sectionName]?.find((field) => field.key === key)?.format
+    : undefined;
+
+  if (!format) {
+    return value;
+  }
+
+  switch (format.kind) {
+    case "size":
+      return formatSize(value, format.unit);
+    case "count":
+      return formatCount(value);
+    case "label":
+      return `${value} ${format.label}`;
+  }
+};
+
+/**
+ * Rows that carry nothing but a name and an on/off switch — `authMethods`,
+ * `services`, `protocols` and friends. A two column table wastes a screen on
+ * them, so they collapse into wrapped enabled/disabled lists instead.
+ */
+const ToggleRowSchema = z
+  .strictObject({
+    $id: z.string().optional(),
+    name: z.string().optional(),
+    key: z.string().optional(),
+    enabled: z.boolean(),
+  })
+  .refine(
+    (row) => isPresent(row.$id) || isPresent(row.key) || isPresent(row.name),
+    { message: "Expected a toggle row with a name" },
+  );
+
+const toggleLabel = (row: JsonObject): string =>
+  compactText(
+    valueFrom(row, "$id") ?? valueFrom(row, "key") ?? valueFrom(row, "name"),
+  );
+
+const renderToggleCollection = (
+  rows: JsonObject[],
+  options: StructuredCollectionRenderOptions = {},
+): boolean => {
+  if (rows.length === 0) {
+    return false;
+  }
+
+  if (!rows.every((row) => ToggleRowSchema.safeParse(row).success)) {
+    return false;
+  }
+
+  const groups: Array<[string, string[], (value: string) => string]> = [
+    ["enabled", [], chalk.green],
+    ["disabled", [], chalk.dim],
+  ];
+
+  for (const row of rows) {
+    groups[row.enabled === true ? 0 : 1][1].push(toggleLabel(row));
+  }
+
+  const populated = groups.filter(([, labels]) => labels.length > 0);
+  const indent = options.indent ?? "";
+  const headings = populated.map(
+    ([group, labels]) => `${group} (${labels.length})`,
+  );
+  const headingWidth = Math.max(
+    ...headings.map((heading) => stringWidth(heading)),
+  );
+  const available = Math.max(
+    40,
+    (process.stdout.columns || 100) -
+      stringWidth(indent) -
+      headingWidth -
+      COLUMN_GAP.length,
+  );
+
+  populated.forEach(([, labels, paint], groupIndex) => {
+    const heading = padColumn(paint(headings[groupIndex]), headingWidth);
+
+    wrapValues(labels, available).forEach((line, lineIndex) => {
+      const prefix = lineIndex === 0 ? heading : " ".repeat(headingWidth);
+      console.log(`${indent}${prefix}${COLUMN_GAP}${line}`);
+    });
+  });
+
+  return true;
+};
+
 export const renderStructuredCollection = (
   sectionName: string | undefined,
   rows: JsonObject[],
   options: StructuredCollectionRenderOptions = {},
 ): boolean => {
-  if (!sectionName) {
-    return false;
-  }
+  const renderer = sectionName
+    ? structuredCollectionRenderers[sectionName]
+    : undefined;
 
-  const renderer = structuredCollectionRenderers[sectionName];
   if (!renderer) {
-    return false;
+    return renderToggleCollection(rows, options);
   }
 
   const allRowsMatch = rows.every(
@@ -622,7 +921,7 @@ export const renderStructuredCollection = (
   );
 
   if (!allRowsMatch) {
-    return false;
+    return renderToggleCollection(rows, options);
   }
 
   const columns = renderer.columns.map((column) =>

--- a/templates/cli/lib/types.ts
+++ b/templates/cli/lib/types.ts
@@ -60,7 +60,6 @@ export interface CliConfig {
   report: boolean;
   reportData: Record<string, unknown>;
   displayFields: string[];
-  /** Follow-up suggestion printed once after the active command's output. */
   followUpHint: string;
 }
 

--- a/templates/cli/lib/types.ts
+++ b/templates/cli/lib/types.ts
@@ -60,6 +60,8 @@ export interface CliConfig {
   report: boolean;
   reportData: Record<string, unknown>;
   displayFields: string[];
+  /** Follow-up suggestion printed once after the active command's output. */
+  followUpHint: string;
 }
 
 export interface SessionData {


### PR DESCRIPTION
## What

The CLI's human-readable output leaned almost entirely on generic table rendering. Responses were complete but hard to actually read: `project get` spent ~60 lines on three two-column `$id | enabled` tables, `organization get` spent ~70 lines listing plan capability flags nobody asked about, and machine values (raw seconds, ISO timestamps, unlabelled byte counts) were printed verbatim.

This builds on the existing `response-config.ts` mechanism — which already had per-section named renderers for `deployments`, `sessions`, `logs` etc. — and extends it with shape-aware and section-aware rendering. `--json` / `--raw` output is untouched throughout; this only affects the human view.

## Renders

### `project get` / `organization update-project`

Three `$id | enabled` tables → three lines. `authMethods`, `services`, `protocols` all match a generic **name + on/off switch** shape, so they collapse into wrapped enabled/disabled lists. Durations and timestamps gain a dim humanized hint alongside the raw value.

**Before**

```
consoleAccessedAt                            2026-07-31T05:07:16.080+00:00
oAuth2ServerAccessTokenDuration              28800
oAuth2ServerRefreshTokenDuration             31536000
smtpPassword                                 [hidden]word

authMethods (7)

  $id            │ enabled
 ────────────────┼─────────
  email-password │ true
 ────────────────┼─────────
  magic-url      │ true
 ────────────────┼─────────
  email-otp      │ true
 ────────────────┼─────────
  anonymous      │ true
 ────────────────┼─────────
  invites        │ true
 ────────────────┼─────────
  jwt            │ true
 ────────────────┼─────────
  phone          │ true

services (19)

  $id        │ enabled
 ────────────┼─────────
  account    │ true
 ────────────┼─────────
  avatars    │ true
 ────────────┼─────────
  … 17 more rows

protocols (3)

  $id       │ enabled
 ───────────┼─────────
  rest      │ true
 ───────────┼─────────
  graphql   │ true
 ───────────┼─────────
  websocket │ true
```

**After**

```
$id                                          my-new-project-id
name                                         Name Testing
teamId                                       69f822400017c6116621
region                                       fra
smtpEnabled                                  false
smtpPort                                     0
smtpPassword                                 [hidden]
pingCount                                    0
status                                       active
consoleAccessedAt                            2026-07-31 05:07:16 UTC (1h ago)
wafEnabled                                   false
oAuth2ServerEnabled                          false
oAuth2ServerAccessTokenDuration              28800 (8h)
oAuth2ServerRefreshTokenDuration             31536000 (365d)
oAuth2ServerPublicAccessTokenDuration        3600 (1h)
oAuth2ServerPublicRefreshTokenDuration       2592000 (30d)
oAuth2ServerInstallationAccessTokenDuration  3600 (1h)
oAuth2ServerConfidentialPkce                 false
oAuth2ServerUserCodeLength                   8
oAuth2ServerUserCodeFormat                   alphanumeric
oAuth2ServerDeviceCodeDuration               600 (10m)
oAuth2ServerDiscoveryUrl                     https://fra.cloud.staging.appwrite.io/oauth2/my-new-project-id/.well-known/openid-configuration

authMethods (7)
  enabled (7)  email-password, magic-url, email-otp, anonymous, invites, jwt, phone

services (19)
  enabled (18)  account, avatars, databases, tablesdb, locale, health, project, storage, teams,
                users, vcs, sites, functions, proxy, graphql, migrations, messaging, advisor
  disabled (1)  oauth2

protocols (3)
  enabled (3)  rest, graphql, websocket
♥ Hint: Sensitive values were redacted. Pass --show-secrets to display them.
```

### `organization get`

`billingPlanDetails` went from ~70 fields to 18 curated ones, in a deliberate order, with units. Quotas are annotated: decimal sizes scale up only when that reads better, and tallies over 10,000 get a compact magnitude hint.

**Before** (excerpt — 70 fields total)

```
billingPlanDetails
  $id                                tier-1
  name                               Pro
  invoiceDesc                        Your monthly recurring Pro plan.
  desc                               For pro developers and production projects that need the ability to scale.
  tag                                Most Popular
  order                              10
  bandwidth                          2000
  storage                            150
  fileSize                           5000
  users                              200000
  executions                         3500000
  emailBranding                      false
  isPublic                           true
  selfService                        true
  supportsDisposableEmailValidation  true
  supportsCanonicalEmailValidation   true
  supportsFreeEmailValidation        true
  supportsCorporateEmailValidation   true
  statementDescriptor                APPWRITE_PRO
  … 50 more like this
```

**After**

```
$id                        69f822400017c6116621
name                       Personal projects
total                      1
billingPlan                tier-1
billingStartDate           2026-05-04 00:00:00 UTC (2mo ago)
billingCurrentInvoiceDate  2026-07-12 00:00:00 UTC (19d ago)
billingNextInvoiceDate     2026-08-11 00:00:00 UTC (in 10d)
billingTrialDays           0
billingAggregationId       29a297fc985ef80af7a741d13d20c91f
billingInvoiceId           29a297fc985ef80af7a741d13d20c91f
paymentMethodId            6a04614c05ffb99b1147
status                     active
markedForDeletion          false
platform                   appwrite

billingPlanDetails
  $id               tier-1
  name              Pro
  group             pro
  price             25
  currency          USD
  trial             0 days
  bandwidth         2000 GB (2 TB)
  storage           150 GB
  fileSize          5000 MB (5 GB)
  users             200000 (200K)
  executions        3500000 (3.5M)
  GBHours           1000 GB-hours
  databasesReads    1750000 (1.75M)
  databasesWrites   750000 (750K)
  realtime          500
  realtimeMessages  6000000 (6M)
  messages          0
  domains           50
  … 57 more fields — pass --raw to show all
```

### `oauth2 list-projects` / `oauth2 list-organizations`

These return identifiers only, with no way to tell what to do next. Both now point at the command that shows the full resource.

```
oauth2 list-projects
total  2

projects (2)
  $id                  │ region │ endpoint
 ──────────────────────┼────────┼──────────────────────────────────
  6839a26e003262977966 │ fra    │ https://fra.cloud.appwrite.io/v1
 ──────────────────────┼────────┼──────────────────────────────────
  chirag-project-prod  │ sgp    │ https://sgp.cloud.appwrite.io/v1

♥ Hint: Run `appwrite project get --project-id <project-id>` to see a project's details.
```

```
oauth2 list-organizations
total  2

organizations (2)
  $id
 ──────────────────────
  67610b8ee51f147ca943
 ──────────────────────
  6a4cf8136129e72b7e52

♥ Hint: Run `appwrite organization get --organization-id <organization-id>` to see an organization's details.
```

## Implementation

### Toggle collections — shape-based, not name-based

Keyed on shape rather than a hardcoded list of section names, so it covers `authMethods` / `services` / `protocols` and anything added later. `z.strictObject` means a row carrying any extra field falls through to the normal table instead of silently hiding data.

```ts
const ToggleRowSchema = z
  .strictObject({
    $id: z.string().optional(),
    name: z.string().optional(),
    key: z.string().optional(),
    enabled: z.boolean(),
  })
  .refine(
    (row) => isPresent(row.$id) || isPresent(row.key) || isPresent(row.name),
    { message: "Expected a toggle row with a name" },
  );
```

It's dispatched as the fallback inside `renderStructuredCollection`, so named renderers keep priority:

```ts
export const renderStructuredCollection = (
  sectionName: string | undefined,
  rows: JsonObject[],
  options: StructuredCollectionRenderOptions = {},
): boolean => {
  const renderer = sectionName ? structuredCollectionRenderers[sectionName] : undefined;

  if (!renderer) {
    return renderToggleCollection(rows, options);
  }
  ...
```

### Section field config — allowlist, order and units in one place

Allowlists, not denylists: the API keeps adding `supports*` flags, and an allowlist stays correct without maintenance. The same entry carries the render order and the unit.

```ts
type FieldFormat =
  /** Decimal size in the given unit, scaled up when that reads better. */
  | { kind: "size"; unit: SizeUnit }
  /** Large tallies get a compact magnitude hint: 3500000 (3.5M). */
  | { kind: "count" }
  /** A literal trailing label, e.g. `168 days`. */
  | { kind: "label"; label: string };

const sectionFields: Record<string, SectionField[]> = {
  billingPlanDetails: [
    { key: "$id" },
    { key: "name" },
    { key: "group" },
    { key: "price" },
    { key: "currency" },
    { key: "trial", format: { kind: "label", label: "days" } },
    { key: "bandwidth", format: { kind: "size", unit: "GB" } },
    { key: "storage", format: { kind: "size", unit: "GB" } },
    { key: "fileSize", format: { kind: "size", unit: "MB" } },
    { key: "users", format: { kind: "count" } },
    ...
  ],
};
```

**Units are scoped to the section, not the key name** — this matters, because a plan's `fileSize` is megabytes while a bucket's `fileSize` is bytes. The scales were verified against how the console interprets the same fields, not inferred from the values:

- `bandwidth` / `storage` → GB, from `planComparisonBox.svelte` (`{currentPlan.bandwidth}GB bandwidth`)
- `fileSize` → MB, from `updateMaxFileSize.svelte` (`service * 1000 * 1000` → bytes, hence decimal, not binary)

Trimming is disclosed rather than silent, and `--display` bypasses the allowlist entirely:

```ts
// An explicit --display selection wins; the reader already said what they want.
const allowlist =
  cliConfig.displayFields.length > 0 ? undefined : sectionFieldKeys(options.sectionName);
```

### Value annotation

Raw value always kept, humanized form appended dim — greppable, nothing lossy.

```ts
// Durations come over the wire as raw seconds, which nobody reads at a glance.
if (typeof value === "number" && /duration$/i.test(key)) {
  const humanized = humanizeSeconds(value);
  if (humanized !== "") {
    return `${value} ${chalk.dim(`(${humanized})`)}`;
  }
}
```

Timestamps match on the ISO-8601 *shape* rather than key names, so every timestamp field across every model benefits. **An explicit offset is mandatory** — ECMAScript reads an offset-less date-time as local time, so accepting one would mean labelling a local instant UTC while deriving its age from a different one (5.5 hours apart under `Asia/Kolkata`). Values without an offset fall through and render as they arrived. Relative ages coarsen to a single unit (`just now`, `5m ago`, `2mo ago`, `7y ago`) and read correctly for future times (`in 29d`), which is what you want on `expire` / `dueAt`. Non-UTC offsets are preserved as-is rather than silently converted.

```ts
/**
 * Turns `2026-07-31T02:49:41.895+00:00` into `2026-07-31 02:49:41 UTC (2h ago)`.
 * Returns null when the value is not an ISO timestamp, so callers can fall back.
 */
export const formatTimestamp = (value: string): string | null => { ... }
```

### Follow-up hints

Declared in `lib/hints.ts` as plain source, keyed by the command path **as typed** — so keys can be checked against `--help` directly, and the type checker sees them:

```ts
const followUpHints: Record<string, string> = {
  "oauth2 list-projects": `Run \`${EXECUTABLE_NAME} project get --project-id <project-id>\` to see a project's details.`,
  "oauth2 list-organizations": `Run \`${EXECUTABLE_NAME} organization get --organization-id <organization-id>\` to see an organization's details.`,
};

/** Command path without the executable name, e.g. `oauth2 list-projects`. */
const commandPath = (command: Command): string => {
  const segments: string[] = [];

  for (let current: Command | null = command; current?.parent; ) {
    segments.unshift(current.name());
    current = current.parent;
  }

  return segments.join(" ");
};
```

Resolved at runtime in the existing `preAction` hook, one line alongside the `outputFields` handling:

```ts
cliConfig.followUpHint = followUpHintFor(actionCommand);
```

`endRender()` then prints it after all output, suppressed under `--json` / `--raw` so stdout stays parseable, and cleared once shown so a command rendering twice does not repeat itself.

An earlier revision built these in Twig. That meant hint text assembled by string concatenation, hand-escaped (the backticks silently generated broken TypeScript on the first pass), emitted as per-command metadata into every generated service file, and invisible to the type checker. Adding a hint now touches neither the generator nor any template.

## Fixes along the way

**`maskSensitiveString` leaked password tails.** `smtpPassword` rendered as `[hidden]word`, exposing the real last four characters. A token tail helps identify *which* credential is in play; a password tail is just a leak.

```ts
const maskSensitiveString = (value: string, key: string): string => {
  // A key or token tail helps identify which credential is in play; a password
  // tail is just a leak, so those are masked whole.
  if (value.length <= 16 || /password/i.test(key)) {
    return HIDDEN_VALUE;
  }
```

**Hidden noise.** `onboarding` (internal bookkeeping) and `billingPlanId` (the API returns it as an exact duplicate of `billingPlan` — the spec gives both the identical description) are dropped from the human view. `--raw` still shows everything.

**Nested single-object sections** (`billingLimits`, `billingPlanDetails`) render as key/value instead of a one-row grid.

## Deliberately not done

- **`billingAggregationId` / `billingInvoiceId` kept.** They were equal in the sample response, but they're distinct concepts upstream and are the IDs support asks for. Equal values here isn't evidence they're redundant.
- **Plan quotas that come back as `0` are printed as `0`.** I suspect 0 means "unlimited" for `messages` / `projects` / `buckets`, but `trial: 0` plainly means zero, so I didn't render an interpretation I couldn't verify for every field. Worth a follow-up with the exact field list.
- **`price` / `currency` not merged** into `$25/mo` — that asserts a billing period I haven't confirmed.

## Testing

Templates regenerated with `php example.php cli`. `tsc --noEmit` clean, Prettier clean, djLint reports 0 errors on both touched `.twig` files.

Drove `parse()` / `drawTable()` against fixtures covering:

- project model, organization model, both `oauth2 list-*` shapes
- existing named renderers (`deployments`), plain multi-column list tables, scalar arrays, nested objects, empty sections — all verified byte-identical to before
- a bucket's `fileSize: 5000` staying unannotated, proving unit scoping holds
- timestamp tiers (`just now` → `7y ago`), future dates, non-UTC offsets, non-date strings like `1.9.2`
- timestamp output byte-identical under `TZ=UTC` and `TZ=Asia/Kolkata`, with offset-less, space-separated and date-only strings all falling through untouched
- `followUpHintFor` resolving against the real generated `oauth2` command tree: hits exactly `list-projects` and `list-organizations`, all 11 siblings return `""`
- free-plan and zero/edge quota values
- `--display` bypassing the allowlist; `--json` suppressing hints and keeping stdout parseable
- 
`composer refactor:check` and `composer lint-twig` fail identically on a clean tree before this branch — both are PHP/Twig-wide pre-existing states, and this change is TypeScript plus two additive Twig blocks.
