### PR TITLE
feat(cli): group the root help screen by intent

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -329,7 +329,10 @@ jobs:
         run: |
           BIN=build/appwrite-cli-linux-x64
           "./$BIN" --version
-          "./$BIN" --help | grep -q "Usage:"
+          # The root screen is grouped by intent, so assert a section renders
+          # rather than just that some help was produced.
+          "./$BIN" --help | grep -q "USAGE"
+          "./$BIN" --help | grep -q "GET STARTED"
           SHELL=bash "./$BIN" completion bash >/dev/null
 
       - name: Verify npm package entry points

--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -510,6 +510,11 @@ class CLI extends Node
             ],
             [
                 'scope'         => 'copy',
+                'destination'   => 'lib/help.ts',
+                'template'      => 'cli/lib/help.ts',
+            ],
+            [
+                'scope'         => 'copy',
                 'destination'   => 'lib/questions.ts',
                 'template'      => 'cli/lib/questions.ts',
             ],

--- a/templates/cli/cli.ts.twig
+++ b/templates/cli/cli.ts.twig
@@ -134,6 +134,10 @@ if (process.argv.includes('-v') || process.argv.includes('--version')) {
             .description(commandDescriptions['main'])
             .configureHelp({
                 helpWidth: process.stdout.columns || 80,
+                // The grouped screen sets its own order, but `sortSubcommands`
+                // also drives Help.visibleCommands, which the completion
+                // scripts enumerate — keep it so their output stays stable.
+                sortSubcommands: true,
                 formatHelp: formatMainHelp,
             })
             .helpOption('-h, --help', 'Display help for a command')

--- a/templates/cli/cli.ts.twig
+++ b/templates/cli/cli.ts.twig
@@ -12,6 +12,7 @@ import inquirer from 'inquirer';
 import packageJson from './package.json' with { type: 'json' };
 import { commandDescriptions, cliConfig } from './lib/parser.js';
 import { followUpHintFor } from './lib/hints.js';
+import { formatMainHelp } from './lib/help.js';
 import {
     getLatestVersionForCurrentInstallation,
     compareVersions,
@@ -32,7 +33,7 @@ import { init } from './lib/commands/init.js';
 import { types } from './lib/commands/types.js';
 import { pull } from './lib/commands/pull.js';
 import { run } from './lib/commands/run.js';
-import { push, deploy } from './lib/commands/push.js';
+import { push } from './lib/commands/push.js';
 import { update } from './lib/commands/update.js';
 import { generate } from './lib/commands/generate.js';
 {% else %}
@@ -133,14 +134,14 @@ if (process.argv.includes('-v') || process.argv.includes('--version')) {
             .description(commandDescriptions['main'])
             .configureHelp({
                 helpWidth: process.stdout.columns || 80,
-                sortSubcommands: true,
+                formatHelp: formatMainHelp,
             })
-            .helpOption('-h, --help', 'Display help for command')
-            .version(version, '-v, --version', 'Output the version number')
-            .option('-V, --verbose', 'Show complete error log')
-            .option('-j, --json', 'Output filtered JSON without empty values')
-            .option('-R, --raw', 'Output full JSON response (secrets still redacted unless --show-secrets is set)')
-            .option('--show-secrets', 'Display sensitive values like secrets and tokens in output')
+            .helpOption('-h, --help', 'Display help for a command')
+            .version(version, '-v, --version', 'Output the CLI version')
+            .option('-V, --verbose', 'Show full error stack traces')
+            .option('-j, --json', 'Output filtered JSON (empty values omitted)')
+            .option('-R, --raw', 'Output the full raw JSON response')
+            .option('--show-secrets', 'Reveal secrets and tokens in output (redacted by default)')
             .hook('preAction', async (_thisCommand, actionCommand) => {
                 if (isCompletionCommand(actionCommand)) {
                     return;
@@ -148,10 +149,10 @@ if (process.argv.includes('-v') || process.argv.includes('--version')) {
 
                 await migrate();
             })
-            .option('-f,--force', 'Flag to confirm all warnings')
-            .option('-a,--all', 'Flag to push all resources')
-            .option('--id [id...]', 'Flag to pass a list of ids for a given action')
-            .option('--report', 'Enable reporting in case of CLI errors')
+            .option('-f, --force', 'Skip confirmation prompts')
+            .option('-a, --all', 'Push or pull every resource')
+            .option('--id [id...]', 'Limit the action to these resource ids')
+            .option('--report', 'Print a prefilled bug report link on error')
             .hook('preAction', (_thisCommand, actionCommand) => {
                 const commandConfig = actionCommand as typeof actionCommand & {
                     outputFields?: string[];
@@ -189,13 +190,13 @@ if (process.argv.includes('-v') || process.argv.includes('--version')) {
             .showSuggestionAfterError()
 {% if sdk.test != "true" %}
             .addCommand(whoami)
-            .addCommand(register)
+            // `login` is the entry point; `register` only prints a signup link.
+            .addCommand(register, { hidden: true })
             .addCommand(login)
             .addCommand(init)
             .addCommand(pull)
             .addCommand(push)
             .addCommand(types)
-            .addCommand(deploy)
             .addCommand(run)
             .addCommand(update)
             .addCommand(generate)

--- a/templates/cli/cli.ts.twig
+++ b/templates/cli/cli.ts.twig
@@ -5,7 +5,7 @@ const oldWidth = process.stdout.columns;
 process.stdout.columns = 100;
 /** ---------------------------------------------- */
 
-import { program } from 'commander';
+import { program, Option } from 'commander';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
 
@@ -150,8 +150,10 @@ if (process.argv.includes('-v') || process.argv.includes('--version')) {
                 await migrate();
             })
             .option('-f, --force', 'Skip confirmation prompts')
-            .option('-a, --all', 'Push or pull every resource')
-            .option('--id [id...]', 'Limit the action to these resource ids')
+            // Parsed at the root so `appwrite --all push` keeps working, but
+            // documented on `push` and `pull`, which are what they act on.
+            .addOption(new Option('-a, --all', 'Push or pull every resource').hideHelp())
+            .addOption(new Option('--id [id...]', 'Limit the action to these resource ids').hideHelp())
             .option('--report', 'Print a prefilled bug report link on error')
             .hook('preAction', (_thisCommand, actionCommand) => {
                 const commandConfig = actionCommand as typeof actionCommand & {

--- a/templates/cli/lib/commands/pull.ts
+++ b/templates/cli/lib/commands/pull.ts
@@ -1116,6 +1116,16 @@ const pullMessagingTopic = async (): Promise<void> => {
 
 export const pull = new Command("pull")
   .description(commandDescriptions["pull"])
+  // Also registered on the root program so `appwrite --all pull` keeps working;
+  // declared here too so they are documented where they actually apply.
+  .option("-a, --all", "Pull every resource in the project")
+  .option("--id [id...]", "Limit the pull to these resource ids")
+  .on("option:all", () => {
+    cliConfig.all = true;
+  })
+  .on("option:id", function (this: Command) {
+    cliConfig.ids = this.opts()["id"] as string[];
+  })
   .action(actionRunner(() => pullResources({ skipDeprecated: true })));
 
 pull

--- a/templates/cli/lib/commands/push.ts
+++ b/templates/cli/lib/commands/push.ts
@@ -4267,6 +4267,16 @@ const pushMessagingTopic = async (): Promise<void> => {
 
 export const push = new Command("push")
   .description(commandDescriptions["push"])
+  // Also registered on the root program so `appwrite --all push` keeps working;
+  // declared here too so they are documented where they actually apply.
+  .option("-a, --all", "Push every resource in the project config")
+  .option("--id [id...]", "Limit the push to these resource ids")
+  .on("option:all", () => {
+    cliConfig.all = true;
+  })
+  .on("option:id", function (this: Command) {
+    cliConfig.ids = this.opts()["id"] as string[];
+  })
   .action(actionRunner(() => pushResources({ skipDeprecated: true })));
 
 push

--- a/templates/cli/lib/commands/push.ts
+++ b/templates/cli/lib/commands/push.ts
@@ -4368,13 +4368,3 @@ push
   .alias("topics")
   .description("Push messaging topics in the current project.")
   .action(actionRunner(pushMessagingTopic));
-
-export const deploy = new Command("deploy")
-  .description(`Removed. Use ${EXECUTABLE_NAME} push instead`)
-  .action(
-    actionRunner(async () => {
-      warn(
-        `${EXECUTABLE_NAME} deploy has been removed. Please use '${EXECUTABLE_NAME} push' instead`,
-      );
-    }),
-  );

--- a/templates/cli/lib/help.ts
+++ b/templates/cli/lib/help.ts
@@ -236,7 +236,10 @@ export const formatMainHelp = (command: Command, helper: Help): string => {
 
   const claimed = new Set(groups.flatMap((group) => group.commands));
 
-  const other = command.commands
+  // Via the helper so this inherits commander's hidden-command filtering and
+  // the configured subcommand sort, rather than raw declaration order.
+  const other = helper
+    .visibleCommands(command)
     .filter((child) => isListed(child) && !claimed.has(child.name()))
     .map((child) => ({
       name: child.name(),
@@ -248,6 +251,7 @@ export const formatMainHelp = (command: Command, helper: Help): string => {
   }
 
   const nameWidth = Math.max(
+    0,
     ...sections.flatMap((group) => group.rows.map((row) => row.name.length)),
   );
 

--- a/templates/cli/lib/help.ts
+++ b/templates/cli/lib/help.ts
@@ -1,0 +1,283 @@
+import chalk from "chalk";
+import type { Command, Help } from "commander";
+import { EXECUTABLE_NAME, SDK_LOGO, SDK_TITLE } from "./constants.js";
+
+/**
+ * The main help screen is grouped by intent rather than listed alphabetically.
+ * Entries are command paths as typed, so `oauth2 list-projects` can be
+ * surfaced next to `login` without moving it out of the oauth2 service.
+ *
+ * Anything not named here still shows up, under `OTHER`, so a service added
+ * to the spec can never silently disappear from `--help`.
+ */
+const groups: ReadonlyArray<{
+  title: string;
+  commands: readonly string[];
+  dim?: boolean;
+}> = [
+  {
+    title: "GET STARTED",
+    commands: [
+      "login",
+      "oauth2 list-organizations",
+      "oauth2 list-projects",
+      "init",
+      "pull",
+      "push",
+      "run",
+      "whoami",
+    ],
+  },
+  {
+    title: "PROJECT",
+    commands: ["organization", "project", "apps", "proxy", "vcs", "webhooks"],
+  },
+  {
+    title: "RESOURCES",
+    commands: [
+      "account",
+      "users",
+      "teams",
+      "tablesdb",
+      "storage",
+      "functions",
+      "sites",
+      "messaging",
+      "tokens",
+      "backups",
+      "presences",
+    ],
+  },
+  {
+    title: "UTILITIES",
+    commands: [
+      "graphql",
+      "generate",
+      "types",
+      "locale",
+      "activities",
+      "migrations",
+      "notifications",
+      "oauth2",
+      "client",
+      "completion",
+      "logout",
+      "update",
+    ],
+  },
+  {
+    title: "DEPRECATED",
+    dim: true,
+    commands: ["databases"],
+  },
+];
+
+/**
+ * One-line summaries for the listing. `.description()` stays the long form
+ * shown on a command's own help page.
+ *
+ * Written to fit one terminal line — keep them under 51 characters, in the
+ * imperative, with no trailing period.
+ */
+const summaries: Record<string, string> = {
+  login: `Authenticate with your ${SDK_TITLE} account`,
+  "oauth2 list-organizations": "Organizations your session can access",
+  "oauth2 list-projects": "Projects your session can access",
+  init: "Scaffold a project, function, site, or resource",
+  pull: "Pull remote project resources into this directory",
+  push: "Push local project resources",
+  run: "Run the project locally for development",
+  whoami: "Show the currently authenticated account",
+
+  organization: "Manage organization-level projects",
+  project: "Usage, variables, and project-level settings",
+  apps: "OAuth2 applications, keys, scopes, installations",
+  proxy: "Domain configuration beyond DNS",
+  vcs: "Connect and manage VCS repositories",
+  webhooks: "Project webhooks",
+
+  account: "Manage your own user account",
+  users: "Manage project users",
+  teams: "Group users to share resource access",
+  tablesdb: "Structured tables of rows and columns",
+  storage: "Files and buckets",
+  functions: "Serverless functions, deployments, and executions",
+  sites: "Static and SSR sites and their deployments",
+  messaging: "Topics, subscribers, and message delivery",
+  tokens: "Resource tokens for secure file access",
+  backups: "Backup policies, archives, and restorations",
+  presences: "Real-time user presence tracking",
+
+  graphql: "Query and mutate any resource via GraphQL",
+  generate: "Generate a type-safe SDK from your project config",
+  types: "Generate TypeScript types for your project",
+  locale: "Localize your app based on user location",
+  activities: "List and inspect project activity events",
+  migrations: "Migrate data between services",
+  notifications: "Console notifications",
+  oauth2: "Authorize apps and issue OAuth2 and OIDC tokens",
+  client: "Configure the CLI itself",
+  completion: "Generate shell completion scripts",
+  logout: `Log out of your ${SDK_TITLE} account`,
+  update: "Update the CLI to the latest version",
+
+  databases: "Use `tablesdb` instead",
+};
+
+/** Order of the global flags, by long flag. Unlisted options are appended. */
+const optionOrder: readonly string[] = [
+  "--version",
+  "--help",
+  "--json",
+  "--raw",
+  "--show-secrets",
+  "--verbose",
+  "--force",
+  "--all",
+  "--id",
+  "--report",
+];
+
+const MAX_WIDTH = 80;
+const GAP = 2;
+const INDENT = "  ";
+
+type Row = { name: string; summary: string };
+
+const isListed = (command: Command): boolean =>
+  command.name() !== "help" &&
+  !(command as Command & { _hidden?: boolean })._hidden;
+
+/** Resolve a space-separated command path against the tree, or null. */
+const resolve = (root: Command, path: string): Command | null => {
+  let current: Command | undefined = root;
+
+  for (const segment of path.split(" ")) {
+    current = current?.commands.find(
+      (candidate) =>
+        candidate.name() === segment || candidate.aliases().includes(segment),
+    );
+
+    if (!current) {
+      return null;
+    }
+  }
+
+  return current ?? null;
+};
+
+/**
+ * Fall back to the first sentence of the description so a command with no
+ * summary still reads as one line rather than a paragraph.
+ */
+const summaryOf = (command: Command, path: string): string => {
+  const declared = summaries[path] ?? command.summary();
+
+  if (declared) {
+    return declared;
+  }
+
+  const [sentence] = command.description().split(". ");
+
+  return (sentence ?? "").replace(/\.$/, "");
+};
+
+const renderRows = (
+  rows: readonly Row[],
+  width: number,
+  dim: boolean,
+): string =>
+  rows
+    .map(({ name, summary }) => {
+      const line = `${INDENT}${name.padEnd(width)}${" ".repeat(GAP)}${summary}`;
+
+      return dim ? chalk.dim(line) : line;
+    })
+    .join("\n");
+
+const renderOptions = (command: Command, helper: Help): string => {
+  const options = [...helper.visibleOptions(command)].sort((left, right) => {
+    const rank = (flag: string): number => {
+      const index = optionOrder.indexOf(flag);
+
+      return index === -1 ? optionOrder.length : index;
+    };
+
+    return rank(left.long ?? "") - rank(right.long ?? "");
+  });
+
+  const width = Math.max(
+    ...options.map((option) => helper.optionTerm(option).length),
+  );
+
+  return options
+    .map(
+      (option) =>
+        `${INDENT}${helper.optionTerm(option).padEnd(width)}${" ".repeat(GAP)}${helper.optionDescription(option)}`,
+    )
+    .join("\n");
+};
+
+export const formatMainHelp = (command: Command, helper: Help): string => {
+  const width = Math.min(process.stdout.columns || MAX_WIDTH, MAX_WIDTH);
+
+  const sections = groups
+    .map((group) => ({
+      ...group,
+      rows: group.commands.flatMap((path) => {
+        const child = resolve(command, path);
+
+        return child && isListed(child)
+          ? [{ name: path, summary: summaryOf(child, path) }]
+          : [];
+      }),
+    }))
+    .filter((group) => group.rows.length > 0);
+
+  const claimed = new Set(groups.flatMap((group) => group.commands));
+
+  const other = command.commands
+    .filter((child) => isListed(child) && !claimed.has(child.name()))
+    .map((child) => ({
+      name: child.name(),
+      summary: summaryOf(child, child.name()),
+    }));
+
+  if (other.length > 0) {
+    sections.push({ title: "OTHER", commands: [], rows: other });
+  }
+
+  const nameWidth = Math.max(
+    ...sections.flatMap((group) => group.rows.map((row) => row.name.length)),
+  );
+
+  const output = [
+    chalk.redBright(SDK_LOGO.replace(/\n+$/, "")),
+    "",
+    INDENT + helper.wrap(command.description(), width - 2, 2, 2),
+    "",
+    chalk.bold("USAGE"),
+    `${INDENT}${EXECUTABLE_NAME} [options] <command> [subcommand]`,
+  ];
+
+  for (const group of sections) {
+    output.push(
+      "",
+      chalk.bold(group.title),
+      renderRows(group.rows, nameWidth, group.dim === true),
+    );
+  }
+
+  output.push(
+    "",
+    chalk.bold("OPTIONS"),
+    renderOptions(command, helper),
+    "",
+    chalk.dim(
+      `Run \`${EXECUTABLE_NAME} <command> --help\` for details on a specific command.`,
+    ),
+    "",
+  );
+
+  return output.join("\n");
+};

--- a/templates/cli/lib/parser.ts
+++ b/templates/cli/lib/parser.ts
@@ -1029,7 +1029,9 @@ export const commandDescriptions: Record<string, string> = {
   tokens: `The tokens command allows you to create and manage resource tokens for secure file access.`,
   vcs: `The vcs command allows you to interact with VCS providers and manage your code repositories.`,
   webhooks: `The webhooks command allows you to manage your project webhooks.`,
-  main: chalk.redBright(`${logo}${description}`),
+  // The logo is rendered by the help formatter, so this stays plain prose and
+  // can be reused wherever the CLI needs a one-paragraph description.
+  main: description,
 };
 
 export { cliConfig };

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -99,20 +99,43 @@ const extractFirstValue = (output) => {
 
 const stripAnsi = (value) => value.replace(/\u001b\[[0-9;]*m/g, "");
 
-const extractHelpCommands = (helpOutput) => {
-  const commandsIndex = helpOutput.indexOf("Commands:");
+// The root help screen groups commands under uppercase headings rather than a
+// single `Commands:` block, so collect every command section and ignore the
+// two that do not list commands.
+const NON_COMMAND_HELP_SECTIONS = new Set(["USAGE", "OPTIONS"]);
 
-  if (commandsIndex === -1) {
+const extractHelpCommands = (helpOutput) => {
+  const commands = new Set();
+  let inCommandSection = false;
+
+  for (const line of stripAnsi(helpOutput).split("\n")) {
+    const heading = line.match(/^([A-Z][A-Z ]*[A-Z])$/)?.[1];
+
+    if (heading) {
+      inCommandSection = !NON_COMMAND_HELP_SECTIONS.has(heading);
+      continue;
+    }
+
+    if (!inCommandSection) {
+      continue;
+    }
+
+    // Rows are `  <command>  <summary>`; paths such as `oauth2 list-projects`
+    // contribute their top-level command only.
+    const commandName = line.match(/^ {2}([a-zA-Z0-9-]+)\b/)?.[1];
+
+    if (commandName && commandName !== "help") {
+      commands.add(commandName);
+    }
+  }
+
+  if (commands.size === 0) {
     throw new Error(
-      `Expected help output to include a Commands section.\n${helpOutput}`,
+      `Expected help output to list commands under a section heading.\n${helpOutput}`,
     );
   }
 
-  return helpOutput
-    .slice(commandsIndex)
-    .split("\n")
-    .map((line) => line.match(/^\s{2}([a-zA-Z0-9-]+)\b/)?.[1])
-    .filter((commandName) => commandName && commandName !== "help");
+  return [...commands];
 };
 
 const extractLineContaining = (output, token) => {


### PR DESCRIPTION
## What

`appwrite --help` printed **42 commands as one flat alphabetical list**, each with its full prose description. Almost every row wrapped to two or three lines, the whole screen ran to **110 lines**, and nothing separated the six commands a new user needs from the thirty-six they don't — `account`, `completion`, `deploy` and `whoami` all sat in the same alphabetical run.

This groups the root screen by intent and cuts it to **73 lines**, with zero wrapped rows.

## After

```
    _                            _ _           ___   __   _____
   /_\  _ __  _ ____      ___ __(_) |_ ___    / __\ / /   \_   \
  //_\\| '_ \| '_ \ \ /\ / / '__| | __/ _ \  / /   / /     / /\/
 /  _  \ |_) | |_) \ V  V /| |  | | ||  __/ / /___/ /___/\/ /_
 \_/ \_/ .__/| .__/ \_/\_/ |_|  |_|\__\___| \____/\____/\____/
       |_|   |_|

  Appwrite is an open-source self-hosted backend server that abstracts and
  simplifies complex and repetitive development tasks behind a simple REST API

USAGE
  appwrite [options] <command> [subcommand]

GET STARTED
  login                      Authenticate with your Appwrite account
  oauth2 list-organizations  Organizations your session can access
  oauth2 list-projects       Projects your session can access
  init                       Scaffold a project, function, site, or resource
  pull                       Pull remote project resources into this directory
  push                       Push local project resources
  run                        Run the project locally for development
  whoami                     Show the currently authenticated account

PROJECT
  organization               Manage organization-level projects
  project                    Usage, variables, and project-level settings
  apps                       OAuth2 applications, keys, scopes, installations
  proxy                      Domain configuration beyond DNS
  vcs                        Connect and manage VCS repositories
  webhooks                   Project webhooks

RESOURCES
  account                    Manage your own user account
  users                      Manage project users
  teams                      Group users to share resource access
  tablesdb                   Structured tables of rows and columns
  storage                    Files and buckets
  functions                  Serverless functions, deployments, and executions
  sites                      Static and SSR sites and their deployments
  messaging                  Topics, subscribers, and message delivery
  tokens                     Resource tokens for secure file access
  backups                    Backup policies, archives, and restorations
  presences                  Real-time user presence tracking

UTILITIES
  graphql                    Query and mutate any resource via GraphQL
  generate                   Generate a type-safe SDK from your project config
  types                      Generate TypeScript types for your project
  locale                     Localize your app based on user location
  activities                 List and inspect project activity events
  migrations                 Migrate data between services
  notifications              Console notifications
  oauth2                     Authorize apps and issue OAuth2 and OIDC tokens
  client                     Configure the CLI itself
  completion                 Generate shell completion scripts
  logout                     Log out of your Appwrite account
  update                     Update the CLI to the latest version

DEPRECATED
  databases                  Use `tablesdb` instead

OPTIONS
  -v, --version   Output the CLI version
  -h, --help      Display help for a command
  -j, --json      Output filtered JSON (empty values omitted)
  -R, --raw       Output the full raw JSON response
  --show-secrets  Reveal secrets and tokens in output (redacted by default)
  -V, --verbose   Show full error stack traces
  -f, --force     Skip confirmation prompts
  -a, --all       Push or pull every resource
  --id [id...]    Limit the action to these resource ids
  --report        Print a prefilled bug report link on error

Run `appwrite <command> --help` for details on a specific command.
```

`DEPRECATED` renders dimmed. Section headings are bold.

## Before

<details>
<summary>110 lines, flat and alphabetical (click to expand)</summary>

```
Usage: appwrite [options] [command]


    _                            _ _           ___   __   _____
   /_\  _ __  _ ____      ___ __(_) |_ ___    / __\ / /   \_   \
  //_\\| '_ \| '_ \ \ /\ / / '__| | __/ _ \  / /   / /     / /\/
 /  _  \ |_) | |_) \ V  V /| |  | | ||  __/ / /___/ /___/\/ /_
 \_/ \_/ .__/| .__/ \_/\_/ |_|  |_|\__\___| \____/\____/\____/
       |_|   |_|

Appwrite is an open-source self-hosted backend server that abstracts and simplifies complex and repetitive development tasks behind a very simple REST API

Options:
  -v, --version                       Output the version number
  -V, --verbose                       Show complete error log
  -j, --json                          Output filtered JSON without empty values
  -R, --raw                           Output full JSON response (secrets still redacted unless
                                      --show-secrets is set)
  --show-secrets                      Display sensitive values like secrets and tokens in output
  -f,--force                          Flag to confirm all warnings
  -a,--all                            Flag to push all resources
  --id [id...]                        Flag to pass a list of ids for a given action
  --report                            Enable reporting in case of CLI errors
  -h, --help                          Display help for command

Commands:
  account                             The account command allows you to authenticate and manage a
                                      user account.
  activities                          The activities command allows you to list and inspect project
                                      activity events.
  apps                                The Apps service allows you to manage OAuth2 applications,
                                      their keys, secrets, scopes, and installations.
  backups                             The backups command allows you to manage backup policies,
                                      archives, and restorations for your project.
  client [options]                    The client command allows you to configure your CLI
  completion                          Generate shell completion scripts
  databases                           (Legacy) The databases command allows you to create
                                      structured collections of documents and query and filter
                                      lists of documents.
  deploy                              Removed. Use appwrite push instead
  functions                           The functions command allows you to view, create, and manage
                                      your Cloud Functions.
  generate [options]                  Generate a type-safe SDK from your Appwrite project
                                      configuration
  graphql                             The graphql command allows you to query and mutate any
                                      resource type on your Appwrite server.
  help [command]                      display help for command
  init                                The init command provides a convenient wrapper for creating
                                      and initializing projects, functions, collections, buckets,
                                      teams, messaging-topics, and skills in Appwrite.
  locale                              The locale command allows you to customize your app based on
                                      your users' location.
  login [options]                     The login command allows you to authenticate and manage a
                                      user account.
  logout                              The logout command allows you to log out of your Appwrite
                                      account.
  messaging                           The messaging command allows you to manage topics and targets
                                      and send messages.
  migrations                          The migrations command allows you to migrate data between
                                      services.
  notifications                       The notifications command allows you to read and manage your
                                      Appwrite Console notifications.
  oauth2                              The oauth2 command allows you to authorize apps and issue
                                      standards-based OAuth2 and OpenID Connect tokens.
  organization                        The organization command allows you to manage
                                      organization-level projects.
  presences                           The presences command allows you to track and manage
                                      real-time user presence in your project.
  project                             The project command allows you to manage project related
                                      resources like usage, variables, etc.
  proxy                               The proxy command allows you to configure actions for your
                                      domains beyond DNS configuration.
  pull                                The pull command helps you pull your Appwrite project,
                                      functions, collections, buckets, teams, and messaging-topics
  push                                The push command provides a convenient wrapper for pushing
                                      your functions, collections, buckets, teams, and
                                      messaging-topics.
  register                            Outputs the link to create an Appwrite account.
  run                                 The run command allows you to run the project locally to
                                      allow easy development and quick debugging.
  sites                               The sites command allows you to view, create and manage your
                                      Appwrite Sites.
  storage                             The storage command allows you to manage your project files.
  tablesdb|tables-db                  The tablesdb command allows you to create structured tables
                                      of columns and query and filter lists of rows.
  teams                               The teams command allows you to group users of your project
                                      to enable them to share read and write access to your project
                                      resources. Requires a linked project.
  tokens                              The tokens command allows you to create and manage resource
                                      tokens for secure file access.
  types [options] <output-directory>  Generate types for your Appwrite project
  update [options]                    Update the Appwrite CLI to the latest version
  users                               The users command allows you to manage your project users.
  vcs                                 The vcs command allows you to interact with VCS providers and
                                      manage your code repositories.
  webhooks                            The webhooks command allows you to manage your project
                                      webhooks.
  whoami                              The whoami command gives information about the currently
                                      logged-in user.
```

</details>

## How it works

`lib/help.ts` (new) exports `formatMainHelp`, wired in via `program.configureHelp({ formatHelp })`.

**Only the root screen changes.** Every top-level command is built with `new Command()` in its own file and attached with `addCommand`, so none of them inherit the root's help config — `appwrite users --help` and friends render exactly as before. Verified below.

**Two-tier text.** `summaries` in `help.ts` holds the one-line listing text; `.description()` stays the long form on each command's own help page. Summaries are held under 51 characters, which is what stops the wrapping. Anything without a summary falls back to the first sentence of its description, so it still renders as one line.

**Nothing can silently disappear.** Commands not named in the group table are collected into a trailing `OTHER` section rather than dropped, so a service added to the spec always shows up even if nobody updates the table. (No `OTHER` section appears today — every generated service is placed.)

**`oauth2 list-organizations` / `list-projects` under GET STARTED.** These answer "what can this token actually reach", which is what you want immediately after `login`. The group table holds command *paths*, not just top-level names — the same key shape `lib/hints.ts` already uses — so they can be surfaced here while remaining in `oauth2` where they belong. They still appear under `appwrite oauth2 --help`.

Commander is 9.5.0 and already supports everything used here; no upgrade, no new dependency.

## Also in this PR

- **`deploy` removed.** It was a stub that printed "use `push` instead" and nothing else. `appwrite deploy` now reports `unknown command 'deploy'`, and `showSuggestionAfterError()` points at `push`.
- **`register` hidden from the listing.** It only prints a signup link; `login` is the real entry point. Still fully callable — `appwrite register --help` works.
- **`--report` description corrected.** It read "Enable reporting in case of CLI errors", which implies data is sent to Appwrite. It isn't — it prints a prefilled GitHub issue URL with the command, stack trace, CLI version and OS. Now reads "Print a prefilled bug report link on error". Behaviour unchanged; verified working.
- **Global flag descriptions rewritten** to fit one line, and `-f,--force` / `-a,--all` given the missing space after the comma.
- **Logo removed from `commandDescriptions.main`.** It was `chalk.redBright(logo + description)` jammed into `program.description()`; the formatter now renders the logo and `main` is plain prose that can be reused.

## Not in this PR

`-a, --all` and `--id` are push/pull concerns registered on the root program, so they still show under global `OPTIONS`. Moving them onto `push`/`pull` means those subcommands must also write `cliConfig`, which is a behaviour change — worth its own PR rather than riding along with a presentation change.

Service-level help (`appwrite account --help` is 40+ flat, unsorted subcommands with multi-line prose each) is untouched here. Worth noting for follow-up: the spec already carries `x-appwrite.group` on every method — `oauth2` splits into `authorization / grants / platform / tokens`, `account` into 11 groups — so those screens could be grouped from spec data with no hand-maintained table. Every method also already has a short `summary`, which would fix the wrapping there the same way.

## Testing

```
php example.php cli
cd examples/cli && npx tsc --noEmit -p tsconfig.json   # clean
npm run build:cli && node dist/cli.cjs --help
```

- Generated CLI typechecks clean
- Root help: 110 → 73 lines, no wrapped rows, widest line 78 chars (fits 80 columns)
- `appwrite teams --help` unchanged — stock Commander formatting
- `appwrite register --help` works while hidden from the listing
- `appwrite deploy` → `unknown command 'deploy'`
- `appwrite --report <failing command>` still prints the issue link with args, version and OS
- `composer lint-twig`: `cli.ts.twig` clean (the 44 reported errors are pre-existing, in swift and other templates)
- `composer refactor:check`: identical with and without this change — 13 files, `CLI.php:125` flagged on a clean tree too

Only the CLI SDK is affected. `Node` is the parent of `CLI`, not the reverse, so no child SDKs inherit any of this.
