### PR TITLE
feat(cli): promote list-organizations and list-projects to root commands

### DIFF
--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -280,15 +280,37 @@ class CLI extends Node
      * Top-level root aliases for a service, used by `cli.ts` to import and
      * register the promoted commands.
      *
+     * Only methods that survive exclusion filtering (and are therefore emitted
+     * by the service template) are returned, so `cli.ts` never imports a
+     * nonexistent export.
+     *
      * @return list<array{method: string, command: string, export: string}>
      */
     private function getCliTopLevelAliases(array $service): array
     {
         $serviceName = $service['name'] ?? '';
-        $methods = self::TOP_LEVEL_COMMANDS[$serviceName] ?? [];
+        $configured = self::TOP_LEVEL_COMMANDS[$serviceName] ?? [];
+
+        if ($configured === []) {
+            return [];
+        }
+
+        $available = [];
+        foreach ($service['methods'] ?? [] as $method) {
+            $name = $method['name'] ?? '';
+
+            if ($name !== '') {
+                $available[$name] = true;
+            }
+        }
+
         $aliases = [];
 
-        foreach ($methods as $methodName) {
+        foreach ($configured as $methodName) {
+            if (!isset($available[$methodName])) {
+                continue;
+            }
+
             $aliases[] = [
                 'method' => $methodName,
                 'command' => $this->toKebabCase($methodName),

--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -232,6 +232,20 @@ class CLI extends Node
     ];
 
     /**
+     * Methods that are also registered as top-level root commands.
+     *
+     * The service subcommand stays (hidden from help) for backwards
+     * compatibility; the root command is what `--help` advertises.
+     *
+     * TODO: Move CLI alias configuration to the API spec.
+     *
+     * @var array<string, list<string>>
+     */
+    private const array TOP_LEVEL_COMMANDS = [
+        'oauth2' => ['listOrganizations', 'listProjects'],
+    ];
+
+    /**
      * How a header-scoped service is spelled in the generated CLI.
      *
      * `service.resourceHeader` says which security scheme names the service's
@@ -260,6 +274,61 @@ class CLI extends Node
             'flag' => $this->getCliOptionName($idVar),
             'factory' => $factory,
         ];
+    }
+
+    /**
+     * Top-level root aliases for a service, used by `cli.ts` to import and
+     * register the promoted commands.
+     *
+     * @return list<array{method: string, command: string, export: string}>
+     */
+    private function getCliTopLevelAliases(array $service): array
+    {
+        $serviceName = $service['name'] ?? '';
+        $methods = self::TOP_LEVEL_COMMANDS[$serviceName] ?? [];
+        $aliases = [];
+
+        foreach ($methods as $methodName) {
+            $aliases[] = [
+                'method' => $methodName,
+                'command' => $this->toKebabCase($methodName),
+                'export' => lcfirst($serviceName) . ucfirst($methodName) . 'RootCommand',
+            ];
+        }
+
+        return $aliases;
+    }
+
+    /**
+     * Emission targets for one method: the normal (possibly hidden) service
+     * subcommand, plus a standalone root command when the method is aliased.
+     *
+     * @return list<array{var: string, standalone: bool, hidden: bool}>
+     */
+    private function getCliCommandTargets(array $method, array $service): array
+    {
+        $serviceName = $service['name'] ?? '';
+        $methodName = $method['name'] ?? '';
+        $commandVar = lcfirst($serviceName) . ucfirst($methodName) . 'Command';
+        $isTopLevel = in_array($methodName, self::TOP_LEVEL_COMMANDS[$serviceName] ?? [], true);
+
+        $targets = [
+            [
+                'var' => $commandVar,
+                'standalone' => false,
+                'hidden' => $isTopLevel,
+            ],
+        ];
+
+        if ($isTopLevel) {
+            $targets[] = [
+                'var' => lcfirst($serviceName) . ucfirst($methodName) . 'RootCommand',
+                'standalone' => true,
+                'hidden' => false,
+            ];
+        }
+
+        return $targets;
     }
 
     private function hasCliQueryParam(array $service): bool
@@ -906,6 +975,13 @@ class CLI extends Node
             new TwigFilter('hasCliQueryParam', fn (array $service): bool => $this->hasCliQueryParam($service)),
             new TwigFilter('cliServiceScope', fn (array $service): ?array => $this->getCliServiceScope($service)),
             new TwigFilter('cliQueryConfig', fn (array $method): array => $this->getCliQueryConfig($method)),
+            new TwigFilter('cliTopLevelAliases', fn (array $service): array => $this->getCliTopLevelAliases($service)),
+            new TwigFilter('cliCommandTargets', fn (array $method, array $service): array => $this->getCliCommandTargets($method, $service)),
+            new TwigFilter('cliIsTopLevelAlias', fn (array $method, array $service): bool => in_array(
+                $method['name'] ?? '',
+                self::TOP_LEVEL_COMMANDS[$service['name'] ?? ''] ?? [],
+                true,
+            )),
         ]);
     }
 

--- a/templates/cli/cli.ts.twig
+++ b/templates/cli/cli.ts.twig
@@ -41,7 +41,7 @@ import { migrate } from './lib/commands/generic.js';
 {% endif %}
 
 {% for service in spec.services %}
-import { {{ service.name }} } from './lib/commands/services/{{ service.name | caseLower }}.js';
+import { {{ service.name }}{% for alias in service | cliTopLevelAliases %}, {{ alias.export }}{% endfor %} } from './lib/commands/services/{{ service.name | caseLower }}.js';
 {% endfor %}
 
 const { version } = packageJson;
@@ -210,6 +210,9 @@ if (process.argv.includes('-v') || process.argv.includes('--version')) {
 {% endif %}
 {% for service in spec.services %}
             .addCommand({{ service.name }})
+{% for alias in service | cliTopLevelAliases %}
+            .addCommand({{ alias.export }})
+{% endfor %}
 {% endfor %}
             .addCommand(createCompletionCommand(program))
             .addCommand(client)

--- a/templates/cli/docs/example.md.twig
+++ b/templates/cli/docs/example.md.twig
@@ -13,7 +13,11 @@
 {% if query.hasPagination %}
 {% set exampleLines = exampleLines|merge(['--limit 25']) %}
 {% endif %}
+{% if method | cliIsTopLevelAlias(service) %}
+{{ language.params.executableName }} {{ method.name | caseKebab }}{% if exampleLines | length > 0 %} \{% endif %}
+{% else %}
 {{ language.params.executableName }} {{ service.name | caseLower }} {{ method.name | caseKebab }}{% if exampleLines | length > 0 %} \{% endif %}
+{% endif %}
 
 {% for line in exampleLines %}
     {{ line | raw }}{% if not loop.last %} \{% endif %}

--- a/templates/cli/lib/commands/services/services.ts.twig
+++ b/templates/cli/lib/commands/services/services.ts.twig
@@ -139,8 +139,16 @@ export const {{ service.name | caseCamel }} = new Command("{{ service.name | cas
 {% set scopedFlag = scope and not hasScopedIdParam %}
 {% set clientCall = clientGetter ~ (scope ? '(' ~ scope.idVar ~ ')' : '()') %}
 {% set query = method | cliQueryConfig %}
-const {{ commandVar }} = {{ service.name | caseCamel }}
-  .command(`{{ commandName }}`)
+{% for target in method | cliCommandTargets(service) %}
+{% if target.standalone %}
+export const {{ target.var }} = new Command(`{{ commandName }}`)
+  .configureHelp({
+    helpWidth: process.stdout.columns || 80,
+  })
+{% else %}
+const {{ target.var }} = {{ service.name | caseCamel }}
+  .command(`{{ commandName }}`{% if target.hidden %}, { hidden: true }{% endif %})
+{% endif %}
   .description(`{{ method.description | stripMarkdown | replace({'`': '\\`'}) | raw }}`)
 {% for parameter in method.parameters.all %}
 {% set opt = getCliOption(parameter) %}
@@ -232,6 +240,7 @@ const {{ commandVar }} = {{ service.name | caseCamel }}
     ),
   );
 
+{% endfor %}
 {% if service.name == 'projects' and method.name == 'list' %}
 ({{ commandVar }} as Command & { outputFields?: string[] }).outputFields = ["name", "$id", "region", "status"];
 {% endif %}

--- a/templates/cli/lib/help.ts
+++ b/templates/cli/lib/help.ts
@@ -4,8 +4,8 @@ import { EXECUTABLE_NAME, SDK_LOGO, SDK_TITLE } from "./constants.js";
 
 /**
  * The main help screen is grouped by intent rather than listed alphabetically.
- * Entries are command paths as typed, so `oauth2 list-projects` can be
- * surfaced next to `login` without moving it out of the oauth2 service.
+ * Entries are command paths as typed, so a root alias such as
+ * `list-projects` can sit next to `login` in GET STARTED.
  *
  * Anything not named here still shows up, under `OTHER`, so a service added
  * to the spec can never silently disappear from `--help`.
@@ -19,8 +19,8 @@ const groups: ReadonlyArray<{
     title: "GET STARTED",
     commands: [
       "login",
-      "oauth2 list-organizations",
-      "oauth2 list-projects",
+      "list-organizations",
+      "list-projects",
       "init",
       "pull",
       "push",
@@ -81,8 +81,8 @@ const groups: ReadonlyArray<{
  */
 const summaries: Record<string, string> = {
   login: `Authenticate with your ${SDK_TITLE} account`,
-  "oauth2 list-organizations": "Organizations your session can access",
-  "oauth2 list-projects": "Projects your session can access",
+  "list-organizations": "Organizations your session can access",
+  "list-projects": "Projects your session can access",
   init: "Scaffold a project, function, site, or resource",
   pull: "Pull remote project resources into this directory",
   push: "Push local project resources",

--- a/templates/cli/lib/hints.ts
+++ b/templates/cli/lib/hints.ts
@@ -7,11 +7,14 @@ import { EXECUTABLE_NAME } from "./constants.js";
  * so they can be checked against `--help` output directly.
  */
 const followUpHints: Record<string, string> = {
+  "list-projects": `Run \`${EXECUTABLE_NAME} project get --project-id <project-id>\` to see a project's details.`,
+  "list-organizations": `Run \`${EXECUTABLE_NAME} organization get --organization-id <organization-id>\` to see an organization's details.`,
+  // Hidden oauth2 paths kept so the legacy invocations still get a hint.
   "oauth2 list-projects": `Run \`${EXECUTABLE_NAME} project get --project-id <project-id>\` to see a project's details.`,
   "oauth2 list-organizations": `Run \`${EXECUTABLE_NAME} organization get --organization-id <organization-id>\` to see an organization's details.`,
 };
 
-/** Command path without the executable name, e.g. `oauth2 list-projects`. */
+/** Command path without the executable name, e.g. `list-projects`. */
 const commandPath = (command: Command): string => {
   const segments: string[] = [];
 

--- a/templates/cli/lib/parser.ts
+++ b/templates/cli/lib/parser.ts
@@ -1022,7 +1022,7 @@ export const commandDescriptions: Record<string, string> = {
   messaging: `The messaging command allows you to manage topics and targets and send messages.`,
   migrations: `The migrations command allows you to migrate data between services.`,
   notifications: `The notifications command allows you to read and manage your Appwrite Console notifications.`,
-  oauth2: `The oauth2 command allows you to authorize apps and issue standards-based OAuth2 and OpenID Connect tokens. The 'list-organizations' and 'list-projects' commands are console-level and report the organizations and projects your current session can access.`,
+  oauth2: `The oauth2 command allows you to authorize apps and issue standards-based OAuth2 and OpenID Connect tokens.`,
   organization: `The organization command allows you to manage organization-level projects.`,
   organizations: `The organizations command allows you to manage organization billing, plans, invoices, and add-ons.`,
   presences: `The presences command allows you to track and manage real-time user presence in your project.`,


### PR DESCRIPTION
## Summary

- Promote `oauth2 list-organizations` / `oauth2 list-projects` to root-level `list-organizations` / `list-projects` so GET STARTED reads more naturally for new users.
- Keep the nested `oauth2 …` invocations working for backwards compatibility, but hide them from `oauth2 --help`.
- Leave the `oauth2` service itself listed under UTILITIES.

Commander cannot attach one `Command` in two places with different visibility, so the generator emits aliased methods twice: a hidden service subcommand plus a standalone root command registered on `program`.

## User-facing change

**Before**

```text
GET STARTED
  login                      Authenticate with your Appwrite account
  oauth2 list-organizations  Organizations your session can access
  oauth2 list-projects       Projects your session can access
  init                       ...
```

**After**

```text
GET STARTED
  login               Authenticate with your Appwrite account
  list-organizations  Organizations your session can access
  list-projects       Projects your session can access
  init                ...
```

Users can now run:

```bash
appwrite list-organizations
appwrite list-projects
```

Legacy paths still work:

```bash
appwrite oauth2 list-organizations
appwrite oauth2 list-projects
```

## How it works

### 1. Alias config (`CLI.php`)

```php
private const array TOP_LEVEL_COMMANDS = [
    'oauth2' => ['listOrganizations', 'listProjects'],
];
```

Twig filters:
- `cliTopLevelAliases` — exports to import/register from `cli.ts`
- `cliCommandTargets` — one or two emission targets per method
- `cliIsTopLevelAlias` — docs examples use the promoted form

### 2. Dual emission (`services.ts.twig`)

```twig
{% for target in method | cliCommandTargets(service) %}
{% if target.standalone %}
export const {{ target.var }} = new Command(`{{ commandName }}`)
  .configureHelp({ helpWidth: process.stdout.columns || 80 })
{% else %}
const {{ target.var }} = {{ service.name | caseCamel }}
  .command(`{{ commandName }}`{% if target.hidden %}, { hidden: true }{% endif %})
{% endif %}
  .description(...)
  {# options + action unchanged #}
{% endfor %}
```

Generated shape for `list-projects`:

```ts
const oauth2ListProjectsCommand = oauth2
  .command(`list-projects`, { hidden: true })
  .description(`...`)
  .action(/* same handler */);

export const oauth2ListProjectsRootCommand = new Command(`list-projects`)
  .configureHelp({ helpWidth: process.stdout.columns || 80 })
  .description(`...`)
  .action(/* same handler */);
```

### 3. Root registration (`cli.ts.twig`)

```twig
import { {{ service.name }}{% for alias in service | cliTopLevelAliases %}, {{ alias.export }}{% endfor %} } from '...';
...
.addCommand({{ service.name }})
{% for alias in service | cliTopLevelAliases %}
.addCommand({{ alias.export }})
{% endfor %}
```

### 4. Help / hints / docs

- [`templates/cli/lib/help.ts`](templates/cli/lib/help.ts) — GET STARTED + summaries use the short names
- [`templates/cli/lib/hints.ts`](templates/cli/lib/hints.ts) — follow-up hints for both root and legacy paths
- [`templates/cli/lib/parser.ts`](templates/cli/lib/parser.ts) — oauth2 description no longer points users at the nested form
- [`templates/cli/docs/example.md.twig`](templates/cli/docs/example.md.twig) — published examples show `appwrite list-projects`

## Test plan

Built locally with:

```bash
php example.php cli
cd examples/cli && npm run build:cli
```

Exercised against a live Cloud session from `~/.appwrite/prefs.json`:

- [x] `appwrite --help` — GET STARTED shows `list-organizations` / `list-projects`; `oauth2` remains under UTILITIES
- [x] `appwrite oauth2 --help` — `list-*` **not** listed
- [x] `appwrite whoami` — session auth OK
- [x] `appwrite list-organizations` — returned 2 orgs + follow-up hint
- [x] `appwrite list-projects` — returned 5 projects + follow-up hint
- [x] `appwrite oauth2 list-organizations` / `oauth2 list-projects` — still resolve (legacy)
- [x] Root vs legacy `--json` digests match for both commands
- [x] `--limit 1` works on both root commands
- [x] `composer refactor:check` — pass
- [x] `vendor/bin/phpunit --testsuite Unit` — 33 tests pass
- [x] Twig lint on touched templates — clean

### Live run excerpts

```text
$ appwrite list-organizations
total  2
organizations (2)
  $id
  67610b8ee51f147ca943
  6a4cf8136129e72b7e52
♥ Hint: Run `appwrite organization get --organization-id <organization-id>` ...

$ appwrite list-projects
total  5
projects (5)
  $id                      │ region │ endpoint
  6839a26e003262977966     │ fra    │ https://fra.cloud.appwrite.io/v1
  ...
♥ Hint: Run `appwrite project get --project-id <project-id>` ...

$ # root vs legacy JSON parity
PASS: root and legacy list-projects JSON match
PASS: root and legacy list-organizations JSON match
```

## Notes

- Shell completions follow `visibleCommands`, so root `list-*` gain completion and the hidden oauth2 subcommands lose theirs (intentional).
- The e2e CLI fixture has no `oauth2` service, so that suite is unaffected; unresolved GET STARTED entries are skipped by design.

Made with [Cursor](https://cursor.com)