### PR TITLE
Fix CLI endpoint errors and self-hosted console commands

### DIFF
--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -246,6 +246,24 @@ class CLI extends Node
     ];
 
     /**
+     * Methods whose endpoint only exists on Cloud, mapped to the
+     * `lib/console-fallback.ts` helper the command calls instead of the service
+     * method. The helper keeps the Cloud call and falls back to the console
+     * endpoints that self-hosted installs do serve.
+     *
+     * @var array<string, array<string, string>>
+     */
+    private const array CONSOLE_FALLBACK_METHODS = [
+        'oauth2' => [
+            'listOrganizations' => 'listOrganizationsForSession',
+            'listProjects'      => 'listProjectsForSession',
+        ],
+        'organization' => [
+            'get' => 'getOrganizationForSession',
+        ],
+    ];
+
+    /**
      * How a header-scoped service is spelled in the generated CLI.
      *
      * `service.resourceHeader` says which security scheme names the service's
@@ -325,7 +343,7 @@ class CLI extends Node
      * Emission targets for one method: the normal (possibly hidden) service
      * subcommand, plus a standalone root command when the method is aliased.
      *
-     * @return list<array{var: string, standalone: bool, hidden: bool}>
+     * @return list<array{var: string, standalone: bool, hidden: bool, implementation: string|null}>
      */
     private function getCliCommandTargets(array $method, array $service): array
     {
@@ -333,12 +351,14 @@ class CLI extends Node
         $methodName = $method['name'] ?? '';
         $commandVar = lcfirst($serviceName) . ucfirst($methodName) . 'Command';
         $isTopLevel = in_array($methodName, self::TOP_LEVEL_COMMANDS[$serviceName] ?? [], true);
+        $implementation = self::CONSOLE_FALLBACK_METHODS[$serviceName][$methodName] ?? null;
 
         $targets = [
             [
                 'var' => $commandVar,
                 'standalone' => false,
                 'hidden' => $isTopLevel,
+                'implementation' => $implementation,
             ],
         ];
 
@@ -347,10 +367,35 @@ class CLI extends Node
                 'var' => lcfirst($serviceName) . ucfirst($methodName) . 'RootCommand',
                 'standalone' => true,
                 'hidden' => false,
+                'implementation' => $implementation,
             ];
         }
 
         return $targets;
+    }
+
+    /**
+     * Console fallback helpers this service's emitted commands call, so the
+     * template imports exactly what it uses.
+     *
+     * @return list<string>
+     */
+    private function getCliFallbackHelpers(array $service): array
+    {
+        $configured = self::CONSOLE_FALLBACK_METHODS[$service['name'] ?? ''] ?? [];
+        $helpers = [];
+
+        foreach ($service['methods'] ?? [] as $method) {
+            $helper = $configured[$method['name'] ?? ''] ?? null;
+
+            if ($helper !== null && !in_array($helper, $helpers, true)) {
+                $helpers[] = $helper;
+            }
+        }
+
+        sort($helpers);
+
+        return $helpers;
     }
 
     private function hasCliQueryParam(array $service): bool
@@ -548,6 +593,16 @@ class CLI extends Node
                 'scope'         => 'copy',
                 'destination'   => 'lib/client.ts',
                 'template'      => 'cli/lib/client.ts',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'lib/errors.ts',
+                'template'      => 'cli/lib/errors.ts',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'lib/console-fallback.ts',
+                'template'      => 'cli/lib/console-fallback.ts',
             ],
             [
                 'scope'         => 'copy',
@@ -999,6 +1054,7 @@ class CLI extends Node
             new TwigFilter('cliQueryConfig', fn (array $method): array => $this->getCliQueryConfig($method)),
             new TwigFilter('cliTopLevelAliases', fn (array $service): array => $this->getCliTopLevelAliases($service)),
             new TwigFilter('cliCommandTargets', fn (array $method, array $service): array => $this->getCliCommandTargets($method, $service)),
+            new TwigFilter('cliFallbackHelpers', fn (array $service): array => $this->getCliFallbackHelpers($service)),
             new TwigFilter('cliIsTopLevelAlias', fn (array $method, array $service): bool => in_array(
                 $method['name'] ?? '',
                 self::TOP_LEVEL_COMMANDS[$service['name'] ?? ''] ?? [],

--- a/templates/cli/bun.lock.twig
+++ b/templates/cli/bun.lock.twig
@@ -524,7 +524,7 @@
 
     "jpeg-js": ["jpeg-js@0.4.4", "", {}, "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="],
 
-    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": "bin/js-yaml.js" }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
+    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": "bin/js-yaml.js" }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
 
     "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
 
@@ -710,7 +710,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "tsx": ["tsx@4.23.1", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": "dist/cli.mjs" }, "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ=="],
+    "tsx": ["tsx@4.23.4", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": "dist/cli.mjs" }, "sha512-ZiUQ8oT/KzN51mJUWPqARYqwFLFJZtGZipRkw1ynHMr9vy3eU77m5yfF3Gzm6meEg/beW+lUu3fHYgskTN2oVQ=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 

--- a/templates/cli/lib/auth/login.ts
+++ b/templates/cli/lib/auth/login.ts
@@ -30,6 +30,7 @@ import {
   removeLegacySessionsExcept,
   restoreCurrentSession,
   deleteServerSession,
+  verifyEndpoint,
 } from "./session.js";
 import { setStoredRefreshToken } from "./refresh-token.js";
 
@@ -340,7 +341,10 @@ const loginWithOAuthDevice = async ({
 }): Promise<void> => {
   const clientId = OAUTH2_CLIENT_ID;
   const oauth2 = await getOauth2Service(
-    await sdkForConsole({ requiresAuth: false, endpointOverride: configEndpoint }),
+    await sdkForConsole({
+      requiresAuth: false,
+      endpointOverride: configEndpoint,
+    }),
   );
 
   globalConfig.addSession(id, { endpoint: configEndpoint, clientId });
@@ -477,6 +481,12 @@ export const loginCommand = async ({
   }
 
   const shouldUseCloudLogin = isCloudLoginEndpoint(configEndpoint);
+
+  // Check the endpoint before anything is prompted for, so a wrong endpoint
+  // fails immediately instead of after the email and password are typed.
+  if (endpoint && !shouldUseCloudLogin) {
+    await verifyEndpoint(configEndpoint);
+  }
 
   if (shouldUseCloudLogin && (email || password || mfa || code)) {
     throw new Error(

--- a/templates/cli/lib/auth/session.ts
+++ b/templates/cli/lib/auth/session.ts
@@ -33,6 +33,55 @@ export const createLegacyConsoleClient = (
   return legacyClient;
 };
 
+/**
+ * Confirms an endpoint really is an Appwrite API root before anything is stored
+ * or prompted for. Failures carry the underlying response's code and type so
+ * error hints (e.g. a missing `/v1`) can still fire.
+ */
+export const verifyEndpoint = async (
+  endpoint: string,
+  selfSigned: boolean = globalConfig.getSelfSigned(),
+): Promise<void> => {
+  let protocol = "";
+  try {
+    protocol = new URL(endpoint).protocol;
+  } catch {
+    throw new Error(`Invalid endpoint URL: ${endpoint}`);
+  }
+
+  if (protocol !== "http:" && protocol !== "https:") {
+    throw new Error(`Invalid endpoint URL: ${endpoint}`);
+  }
+
+  let caught: { code?: number; type?: string; response?: unknown } = {};
+
+  try {
+    const response = (await createLegacyConsoleClient(
+      endpoint,
+      selfSigned,
+    ).call("GET", "/health/version")) as { version?: string };
+
+    if (response.version) {
+      return;
+    }
+  } catch (e) {
+    caught = e as { code?: number; type?: string; response?: unknown };
+  }
+
+  const failure = new Error(
+    "Invalid endpoint or your Appwrite server is not running as expected.",
+  );
+  Object.assign(
+    failure,
+    { endpoint },
+    caught.code === undefined ? {} : { code: caught.code },
+    caught.type === undefined ? {} : { type: caught.type },
+    caught.response === undefined ? {} : { response: caught.response },
+  );
+
+  throw failure;
+};
+
 export const hasAuthSession = (): boolean =>
   globalConfig.getAccessToken() !== "" || globalConfig.getCookie() !== "";
 
@@ -117,7 +166,9 @@ export const getSignedInAccounts = (): Array<{
  */
 export const isLocalOnlySession = (sessionId: string): boolean => {
   const session = getSession(sessionId);
-  return Boolean(session && !hasStoredRefreshToken(sessionId) && !session.cookie);
+  return Boolean(
+    session && !hasStoredRefreshToken(sessionId) && !session.cookie,
+  );
 };
 
 /**

--- a/templates/cli/lib/client.ts
+++ b/templates/cli/lib/client.ts
@@ -20,6 +20,7 @@ import {
   EXECUTABLE_NAME,
 } from "./constants.js";
 import { deleteStoredRefreshToken } from "./auth/refresh-token.js";
+import { describeHttpFailure } from "./errors.js";
 
 class Client {
   private endpoint: string;
@@ -144,7 +145,8 @@ class Client {
       throw new AppwriteException("Invalid endpoint URL: " + endpoint);
     }
 
-    this.endpoint = endpoint;
+    // Paths are appended verbatim, so a trailing slash would produce `//account`.
+    this.endpoint = endpoint.replace(/\/+$/, "");
     return this;
   }
 
@@ -167,6 +169,15 @@ class Client {
    */
   getHeaders(): Headers {
     return { ...this.headers };
+  }
+
+  /**
+   * Records the endpoint the failed request used, so error hints can talk about
+   * the endpoint actually called rather than the one in config.
+   */
+  private tagEndpoint<T extends Error>(exception: T): T {
+    (exception as T & { endpoint?: string }).endpoint = this.endpoint;
+    return exception;
   }
 
   async call<T = unknown>(
@@ -227,7 +238,7 @@ class Client {
         }),
       });
     } catch (error) {
-      throw new AppwriteException((error as Error).message);
+      throw this.tagEndpoint(new AppwriteException((error as Error).message));
     }
 
     if (response.status >= 400) {
@@ -235,9 +246,33 @@ class Client {
       let json: { message?: string; code?: number; type?: string } | undefined =
         undefined;
       try {
-        json = JSON.parse(text);
+        const parsed: unknown = JSON.parse(text);
+        if (parsed && typeof parsed === "object") {
+          json = parsed as { message?: string; code?: number; type?: string };
+        }
       } catch (_error) {
-        throw new AppwriteException(text, response.status, "", text);
+        json = undefined;
+      }
+
+      if (!json) {
+        // Proxies, load balancers and the console answer with HTML or plain
+        // text. Summarize it — the raw body stays on the exception for
+        // `--verbose` and `--report`.
+        const failure = describeHttpFailure(
+          response.status,
+          text,
+          response.statusText,
+          response.headers.get("content-type") ?? undefined,
+        );
+
+        throw this.tagEndpoint(
+          new AppwriteException(
+            failure.message,
+            response.status,
+            failure.type,
+            text,
+          ),
+        );
       }
 
       if (
@@ -262,19 +297,25 @@ class Client {
         /role:\s*guests/i.test(json.message);
 
       if (isUnauthorized) {
-        throw new AppwriteException(
-          `You are not authenticated. Run '${EXECUTABLE_NAME} login' to authenticate and try again.`,
-          json.code,
-          json.type,
-          text,
+        throw this.tagEndpoint(
+          new AppwriteException(
+            `You are not authenticated. Run '${EXECUTABLE_NAME} login' to authenticate and try again.`,
+            json.code,
+            json.type,
+            text,
+          ),
         );
       }
 
-      throw new AppwriteException(
-        json.message || text,
-        json.code,
-        json.type,
-        text,
+      throw this.tagEndpoint(
+        new AppwriteException(
+          json.message ||
+            describeHttpFailure(response.status, text, response.statusText)
+              .message,
+          json.code ?? response.status,
+          json.type,
+          text,
+        ),
       );
     }
 

--- a/templates/cli/lib/commands/generic.ts
+++ b/templates/cli/lib/commands/generic.ts
@@ -1,6 +1,5 @@
 import inquirer from "inquirer";
 import { Command } from "commander";
-import { Client } from "@appwrite.io/console";
 import { endpointsMatch, globalConfig, localConfig } from "../config.js";
 import { configuredOrganizationId } from "../context.js";
 import { EXECUTABLE_NAME } from "../constants.js";
@@ -29,6 +28,7 @@ import {
   logoutSessions,
   planSessionLogout,
   restoreCurrentSessionFallback,
+  verifyEndpoint,
 } from "../auth/session.js";
 
 export { loginCommand };
@@ -288,62 +288,43 @@ export const client = new Command("client")
         }
 
         if (endpoint !== undefined) {
-          try {
-            const url = new URL(endpoint);
-            if (url.protocol !== "http:" && url.protocol !== "https:") {
-              throw new Error();
-            }
+          await verifyEndpoint(
+            endpoint,
+            selfSigned || globalConfig.getSelfSigned(),
+          );
 
-            const clientInstance = new Client().setEndpoint(endpoint);
-            clientInstance.setProject("console");
-            if (selfSigned || globalConfig.getSelfSigned()) {
-              clientInstance.setSelfSigned(true);
-            }
-            const response = (await clientInstance.call(
-              "GET",
-              new URL(endpoint + "/health/version"),
-            )) as { version?: string };
-            if (!response.version) {
-              throw new Error();
-            }
+          const previous = globalConfig.getCurrentSession();
+          const match = findSessionForEndpoint(endpoint);
 
-            const previous = globalConfig.getCurrentSession();
-            const match = findSessionForEndpoint(endpoint);
-
-            if (
-              previous &&
-              endpointsMatch(getSession(previous)?.endpoint ?? "", endpoint) &&
-              (isAuthenticatedSession(previous) || !match.authenticated)
-            ) {
-              // Already on the best available session for this endpoint — keep
-              // current and refresh the stored value so regional hosts stay as
-              // requested.
-              globalConfig.setEndpoint(endpoint);
-            } else if (match.authenticated) {
-              globalConfig.setCurrentSession(match.authenticated);
-              globalConfig.setEndpoint(endpoint);
-              const email = getSession(match.authenticated)?.email;
-              if (email) {
-                log(`Using signed-in account ${email}`);
-              }
-            } else if (match.endpointOnly) {
-              globalConfig.setCurrentSession(match.endpointOnly);
-              globalConfig.setEndpoint(endpoint);
-              warnDetachedAuthenticatedSession(previous);
-            } else if (previous && !isAuthenticatedSession(previous)) {
-              // Update an existing endpoint-only stub in place.
-              globalConfig.setEndpoint(endpoint);
-            } else {
-              const id = ID.unique();
-              globalConfig.addSession(id, { endpoint });
-              globalConfig.setCurrentSession(id);
-              globalConfig.setEndpoint(endpoint);
-              warnDetachedAuthenticatedSession(previous);
+          if (
+            previous &&
+            endpointsMatch(getSession(previous)?.endpoint ?? "", endpoint) &&
+            (isAuthenticatedSession(previous) || !match.authenticated)
+          ) {
+            // Already on the best available session for this endpoint — keep
+            // current and refresh the stored value so regional hosts stay as
+            // requested.
+            globalConfig.setEndpoint(endpoint);
+          } else if (match.authenticated) {
+            globalConfig.setCurrentSession(match.authenticated);
+            globalConfig.setEndpoint(endpoint);
+            const email = getSession(match.authenticated)?.email;
+            if (email) {
+              log(`Using signed-in account ${email}`);
             }
-          } catch (_) {
-            throw new Error(
-              "Invalid endpoint or your Appwrite server is not running as expected.",
-            );
+          } else if (match.endpointOnly) {
+            globalConfig.setCurrentSession(match.endpointOnly);
+            globalConfig.setEndpoint(endpoint);
+            warnDetachedAuthenticatedSession(previous);
+          } else if (previous && !isAuthenticatedSession(previous)) {
+            // Update an existing endpoint-only stub in place.
+            globalConfig.setEndpoint(endpoint);
+          } else {
+            const id = ID.unique();
+            globalConfig.addSession(id, { endpoint });
+            globalConfig.setCurrentSession(id);
+            globalConfig.setEndpoint(endpoint);
+            warnDetachedAuthenticatedSession(previous);
           }
         }
 

--- a/templates/cli/lib/commands/services/services.ts.twig
+++ b/templates/cli/lib/commands/services/services.ts.twig
@@ -46,6 +46,10 @@ import { sdkForConsole, sdkForProject } from "../../sdks.js";
 {% else %}
 import { sdkForProject } from "../../sdks.js";
 {% endif %}
+{% set fallbackHelpers = service | cliFallbackHelpers %}
+{% if fallbackHelpers is not empty %}
+import { {{ fallbackHelpers | join(', ') }} } from "../../console-fallback.js";
+{% endif %}
 import {
   actionRunner,
   commandDescriptions,
@@ -231,6 +235,11 @@ const {{ target.var }} = {{ service.name | caseCamel }}
         const url = (await {{ clientCall }}).{{ method.name | caseCamel }}({{ argExpressions | join(', ') | raw }});
         if (url) console.log(url);
       },
+{% elseif target.implementation %}
+{# The helper resolves the scoped resource itself, so it takes the ID directly. #}
+{% set implementationArgs = (scopedFlag ? [scope.idVar] : [])|merge(argExpressions) %}
+      async ({{ actionParams }}) =>
+        parse(await {{ target.implementation }}({{ implementationArgs | join(', ') | raw }})),
 {% elseif hasParams %}
       async ({{ actionParams }}) =>
         parse(await (await {{ clientCall }}).{{ method.name | caseCamel }}({{ argExpressions | join(', ') | raw }})),

--- a/templates/cli/lib/console-fallback.ts
+++ b/templates/cli/lib/console-fallback.ts
@@ -1,0 +1,190 @@
+import { Oauth2, Organization, Teams } from "@appwrite.io/console";
+import type { Models } from "@appwrite.io/console";
+import { globalConfig } from "./config.js";
+import { DEFAULT_ENDPOINT } from "./constants.js";
+import { paginate } from "./paginate.js";
+import { sdkForConsole, sdkForConsoleWithOrganization } from "./sdks.js";
+import { getCloudBaseHostname } from "./utils.js";
+
+/**
+ * Endpoints that only exist on Cloud, and the console endpoints that stand in
+ * for them elsewhere.
+ *
+ * The OAuth2 listing endpoints resolve an access token's authorization details,
+ * so they only exist where the OAuth2 server does — Cloud. Self-hosted installs
+ * answer `general_route_not_found`, and an email/password session has no token
+ * to resolve in the first place. These helpers keep the OAuth2 call for sessions
+ * that can use it and rebuild the same response from the console endpoints
+ * (`GET /teams`, `GET /organization/projects`) for everyone else.
+ */
+
+/** Server-side defaults of the OAuth2 listing endpoints, mirrored here. */
+const DEFAULT_LIMIT = 25;
+const DEFAULT_OFFSET = 0;
+
+/** Page size used while collecting the full set to window locally. */
+const PAGE_SIZE = 100;
+
+const hasOauth2Session = (): boolean => globalConfig.getAccessToken() !== "";
+
+const isRouteMissing = (error: unknown): boolean => {
+  const failure = error as { code?: number; type?: string };
+  return failure.code === 404 || failure.type === "general_route_not_found";
+};
+
+/** Use the Cloud-only route when available, otherwise build its local result. */
+const withRouteFallback = async <T>(
+  primary: (() => Promise<T>) | undefined,
+  fallback: () => Promise<T>,
+): Promise<T> => {
+  if (primary) {
+    try {
+      return await primary();
+    } catch (error) {
+      if (!isRouteMissing(error)) {
+        throw error;
+      }
+    }
+  }
+
+  return fallback();
+};
+
+/**
+ * The OAuth2 endpoints window server-side, so `total` counts every match while
+ * the items cover one page. Windowing locally keeps that contract.
+ */
+const applyWindow = <T>(items: T[], limit?: number, offset?: number): T[] => {
+  const start = offset ?? DEFAULT_OFFSET;
+  return items.slice(start, start + (limit ?? DEFAULT_LIMIT));
+};
+
+/**
+ * Regional API endpoint for a project, matching the `endpoint` the OAuth2
+ * response carries. Regions only have their own hostname on Cloud; anywhere
+ * else every project is served from the configured endpoint.
+ */
+const endpointForRegion = (region: string): string => {
+  const endpoint = globalConfig.getEndpoint() || DEFAULT_ENDPOINT;
+
+  try {
+    const url = new URL(endpoint);
+    const base = getCloudBaseHostname(url.hostname);
+
+    if (base !== null && region !== "") {
+      return `${url.protocol}//${region}.${base}${url.pathname}`;
+    }
+  } catch {
+    // Fall through to the configured endpoint.
+  }
+
+  return endpoint;
+};
+
+/** Every organization the session can see, as teams. */
+const listAllOrganizations = async (
+  search?: string,
+): Promise<Models.Team[]> => {
+  const teams = new Teams(await sdkForConsole());
+
+  const response = await paginate<Models.Team, "teams">(
+    (args) => teams.list(args.queries as string[], search),
+    {},
+    PAGE_SIZE,
+    "teams",
+  );
+
+  return response.teams;
+};
+
+const listAllProjects = async (
+  organizationId: string,
+  search?: string,
+): Promise<Models.Project[]> => {
+  const organization = new Organization(
+    await sdkForConsole({ organizationId }),
+  );
+
+  const response = await paginate<Models.Project, "projects">(
+    (args) => organization.listProjects(args.queries as string[], search),
+    {},
+    PAGE_SIZE,
+    "projects",
+  );
+
+  return response.projects;
+};
+
+export const listProjectsForSession = async (
+  limit?: number,
+  offset?: number,
+  search?: string,
+): Promise<Models.Oauth2ProjectList> => {
+  return withRouteFallback(
+    hasOauth2Session()
+      ? async () =>
+          new Oauth2(await sdkForConsole()).listProjects(limit, offset, search)
+      : undefined,
+    async () => {
+      const projects: Models.Oauth2Project[] = [];
+
+      for (const organization of await listAllOrganizations()) {
+        for (const project of await listAllProjects(organization.$id, search)) {
+          projects.push({
+            $id: project.$id,
+            region: project.region,
+            endpoint: endpointForRegion(project.region),
+          });
+        }
+      }
+
+      return {
+        total: projects.length,
+        projects: applyWindow(projects, limit, offset),
+      };
+    },
+  );
+};
+
+export const listOrganizationsForSession = async (
+  limit?: number,
+  offset?: number,
+  search?: string,
+): Promise<Models.Oauth2OrganizationList> => {
+  return withRouteFallback(
+    hasOauth2Session()
+      ? async () =>
+          new Oauth2(await sdkForConsole()).listOrganizations(
+            limit,
+            offset,
+            search,
+          )
+      : undefined,
+    async () => {
+      const organizations = (await listAllOrganizations(search)).map(
+        ({ $id }) => ({ $id }),
+      );
+
+      return {
+        total: organizations.length,
+        organizations: applyWindow(organizations, limit, offset),
+      };
+    },
+  );
+};
+
+/**
+ * Self-hosted installs have no `/organization` — the singular organization
+ * service is Cloud-only, and an organization there is just its team. The team
+ * carries the fields the server actually knows ($id, name, timestamps, prefs);
+ * the billing fields of a Cloud organization have no equivalent to report.
+ */
+export const getOrganizationForSession = async (
+  organizationId?: string,
+): Promise<Models.Organization | Models.Team> => {
+  const client = await sdkForConsoleWithOrganization(organizationId);
+  return withRouteFallback(
+    () => new Organization(client).get(),
+    () => new Teams(client).get(client.headers["X-Appwrite-Organization"]),
+  );
+};

--- a/templates/cli/lib/errors.ts
+++ b/templates/cli/lib/errors.ts
@@ -1,0 +1,79 @@
+/** Longest server-provided snippet we print on one line. */
+const MAX_SNIPPET_LENGTH = 300;
+
+/** Snippet length used when embedding a body in a bug report URL. */
+export const MAX_REPORT_BODY_LENGTH = 500;
+
+export type HttpFailure = {
+  message: string;
+  type: string;
+};
+
+/** Whether a response is an HTML page rather than an API response. */
+export const looksLikeHtml = (body: string, contentType?: string): boolean => {
+  if (contentType?.toLowerCase().includes("text/html")) {
+    return true;
+  }
+
+  const start = body.trimStart().toLowerCase();
+  return start.startsWith("<!doctype html") || start.startsWith("<html");
+};
+
+/** Collapse untrusted server text into a printable, bounded line. */
+export const sanitizeErrorText = (
+  text: string,
+  maxLength: number = MAX_SNIPPET_LENGTH,
+): string => {
+  const collapsed = text
+    .replace(/\u001b\[[0-9;]*[a-zA-Z]/g, "")
+    .replace(/[\u0000-\u001f\u007f]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (collapsed.length <= maxLength) {
+    return collapsed;
+  }
+
+  return `${collapsed.slice(0, maxLength).trimEnd()}\u2026`;
+};
+
+const statusLabel = (status: number, statusText?: string): string => {
+  const text = statusText?.trim();
+  return text ? `HTTP ${status} ${text}` : `HTTP ${status}`;
+};
+
+/** Describe a failed non-JSON response without exposing an HTML document. */
+export const describeHttpFailure = (
+  status: number,
+  body: string,
+  statusText?: string,
+  contentType?: string,
+): HttpFailure => {
+  const label = statusLabel(status, statusText);
+  const message = looksLikeHtml(body, contentType)
+    ? ""
+    : sanitizeErrorText(body);
+
+  return {
+    message: message ? `${message} (${label})` : label,
+    type: "",
+  };
+};
+
+const formatBytes = (bytes: number): string =>
+  bytes < 1024 ? `${bytes} bytes` : `${(bytes / 1024).toFixed(1)} KB`;
+
+/** Render a response body for verbose output without flooding the terminal. */
+export const summarizeErrorBody = (body: string): string => {
+  const html = looksLikeHtml(body);
+  const summary = html ? "" : sanitizeErrorText(body);
+
+  if (!html && body.length <= MAX_SNIPPET_LENGTH) {
+    return summary;
+  }
+
+  const kind = html ? "HTML body" : "body";
+  return [`<${kind}, ${formatBytes(Buffer.byteLength(body))}>`, summary]
+    .filter(Boolean)
+    .join(" ");
+};

--- a/templates/cli/lib/hints.ts
+++ b/templates/cli/lib/hints.ts
@@ -1,5 +1,7 @@
 import type { Command } from "commander";
+import { globalConfig } from "./config.js";
 import { EXECUTABLE_NAME } from "./constants.js";
+import { looksLikeHtml } from "./errors.js";
 
 /**
  * Commands whose response carries identifiers but no detail, mapped to the
@@ -28,3 +30,54 @@ const commandPath = (command: Command): string => {
 
 export const followUpHintFor = (command: Command): string =>
   followUpHints[commandPath(command)] ?? "";
+
+const isQueryFailure = (message: string): boolean =>
+  /Invalid query(?: method)?/i.test(message) ||
+  /query[^.:\n]*syntax error|syntax error[^.:\n]*query/i.test(message);
+
+/** Endpoints without a path are missing the `/v1` the API is served under. */
+const endpointMissingApiPath = (endpoint: string): boolean => {
+  try {
+    return new URL(endpoint).pathname.replace(/\/+$/, "") === "";
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * The hints that apply to a failure. Requests made with an explicit
+ * `--endpoint` record it on the exception, so prefer that over whatever
+ * endpoint happens to be configured.
+ */
+export const errorHintsFor = (err: Error, endpoint?: string): string[] => {
+  const failure = err as Error & {
+    endpoint?: string;
+    code?: number;
+    type?: string;
+    response?: unknown;
+  };
+
+  const hints: string[] = [];
+  const requestEndpoint =
+    endpoint ?? failure.endpoint ?? globalConfig.getEndpoint();
+
+  if (isQueryFailure(failure.message ?? "")) {
+    hints.push(
+      `For common list filters, use flags like --limit 25, --sort-desc '$createdAt', or --filter 'status=active'. Raw --queries values must be Appwrite JSON query strings, for example: ${EXECUTABLE_NAME} tablesdb list-rows --queries '{"method":"limit","values":[25]}'`,
+    );
+  }
+
+  const response = typeof failure.response === "string" ? failure.response : "";
+  const routeMissing =
+    failure.code === 404 ||
+    failure.type === "general_route_not_found" ||
+    looksLikeHtml(response);
+
+  if (routeMissing && endpointMissingApiPath(requestEndpoint)) {
+    hints.push(
+      `Appwrite's API is served under /v1. Try --endpoint ${new URL(requestEndpoint).origin}/v1`,
+    );
+  }
+
+  return hints;
+};

--- a/templates/cli/lib/parser.ts
+++ b/templates/cli/lib/parser.ts
@@ -13,6 +13,12 @@ import { globalConfig } from "./config.js";
 import os from "os";
 import { Client } from "@appwrite.io/console";
 import { getErrorMessage, isCloud } from "./utils.js";
+import {
+  MAX_REPORT_BODY_LENGTH,
+  sanitizeErrorText,
+  summarizeErrorBody,
+} from "./errors.js";
+import { errorHintsFor } from "./hints.js";
 import type { CliConfig } from "./types.js";
 import {
   SDK_VERSION,
@@ -766,18 +772,10 @@ export const drawJSON = (data: unknown): void => {
   console.log(JSON.stringify(data, null, 2));
 };
 
-const isQueryError = (message: string): boolean =>
-  /Invalid query(?: method)?/i.test(message) ||
-  /query[^.:\n]*syntax error|syntax error[^.:\n]*query/i.test(message);
-
-const printQueryErrorHint = (err: Error): void => {
-  if (!isQueryError(err.message)) {
-    return;
+const printErrorHints = (err: Error): void => {
+  for (const message of errorHintsFor(err)) {
+    hint(message);
   }
-
-  hint(
-    `For common list filters, use flags like --limit 25, --sort-desc '$createdAt', or --filter 'status=active'. Raw --queries values must be Appwrite JSON query strings, for example: ${EXECUTABLE_NAME} tablesdb list-rows --queries '{"method":"limit","values":[25]}'`,
-  );
 };
 
 const ERROR_DETAIL_KEYS = ["code", "type", "response"] as const;
@@ -794,7 +792,8 @@ const formatErrorDetail = (value: unknown): string => {
         value = parsed;
       }
     } catch {
-      return text;
+      // Not JSON — summarize HTML and oversized proxy responses.
+      return summarizeErrorBody(text);
     }
   }
 
@@ -808,6 +807,42 @@ const formatErrorDetail = (value: unknown): string => {
     return String(value);
   }
 };
+
+/** Keeps a summarized message from dominating a bug report title. */
+const MAX_REPORT_TITLE_LENGTH = 120;
+
+/**
+ * Plain (uncolored, bounded) error details for a bug report body.
+ */
+const reportErrorDetails = (err: Error): string[] => {
+  const lines: string[] = [];
+
+  for (const key of ERROR_DETAIL_KEYS) {
+    if (!Object.prototype.hasOwnProperty.call(err, key)) {
+      continue;
+    }
+
+    const value = (err as unknown as Record<string, unknown>)[key];
+    const rendered =
+      typeof value === "string"
+        ? sanitizeErrorText(value, MAX_REPORT_BODY_LENGTH)
+        : String(value);
+
+    lines.push(`${key}: ${rendered}`);
+  }
+
+  return lines;
+};
+
+/**
+ * Stack frames only — the message line is rendered separately and, unlike a raw
+ * stack, frames can never carry a response body.
+ */
+const errorStackFrames = (err: Error): string[] =>
+  (err.stack ?? "")
+    .split("\n")
+    .filter((line) => line.trim().startsWith("at "))
+    .map((line) => line.trim());
 
 export const formatErrorForLog = (err: Error): string => {
   const lines = [
@@ -825,15 +860,13 @@ export const formatErrorForLog = (err: Error): string => {
     );
   }
 
-  const frames = (err.stack ?? "")
-    .split("\n")
-    .filter((line) => line.trim().startsWith("at "));
+  const frames = errorStackFrames(err);
   if (frames.length > 0) {
     lines.push(
       "",
       chalk.dim(`${ERROR_DETAIL_INDENT}Stack trace:`),
       ...frames.map((frame) =>
-        chalk.dim(`${ERROR_DETAIL_INDENT.repeat(2)}${frame.trim()}`),
+        chalk.dim(`${ERROR_DETAIL_INDENT.repeat(2)}${frame}`),
       ),
     );
   }
@@ -863,7 +896,14 @@ export const parseError = (err: Error): void => {
       const stepsToReproduce = `Running \`${EXECUTABLE_NAME} ${commandArgs.join(" ")}\``;
       const yourEnvironment = `CLI version: ${version}\nOperation System: ${os.type()}\nAppwrite version: ${appwriteVersion}\nIs Cloud: ${isCloud()}`;
 
-      const stack = "```\n" + (err.stack || err.message) + "\n```";
+      // Response bodies are summarized and frames are listed separately, so an
+      // HTML error page can never blow the issue URL past what GitHub accepts.
+      const details = [
+        `${err.name || "Error"}: ${getErrorMessage(err)}`,
+        ...reportErrorDetails(err),
+        ...errorStackFrames(err),
+      ].join("\n");
+      const stack = "```\n" + details + "\n```";
 
       const githubIssueUrl = new URL(
         "https://github.com/appwrite/appwrite/issues/new",
@@ -872,7 +912,7 @@ export const parseError = (err: Error): void => {
       githubIssueUrl.searchParams.append("template", "bug.yaml");
       githubIssueUrl.searchParams.append(
         "title",
-        `🐛 Bug Report: ${getErrorMessage(err)}`,
+        `🐛 Bug Report: ${sanitizeErrorText(getErrorMessage(err), MAX_REPORT_TITLE_LENGTH)}`,
       );
       githubIssueUrl.searchParams.append(
         "actual-behavior",
@@ -887,7 +927,7 @@ export const parseError = (err: Error): void => {
       log(
         `To report this error you can:\n - Create a support ticket in our Discord server https://appwrite.io/discord \n - Create an issue in our Github\n   ${githubIssueUrl.href}\n`,
       );
-      printQueryErrorHint(err);
+      printErrorHints(err);
 
       error("\n Stack Trace: \n");
       console.error(formatErrorForLog(err));
@@ -896,11 +936,11 @@ export const parseError = (err: Error): void => {
   } else {
     if (cliConfig.verbose) {
       console.error(formatErrorForLog(err));
-      printQueryErrorHint(err);
+      printErrorHints(err);
     } else {
       log("For detailed error pass the --verbose or --report flag");
       error(getErrorMessage(err));
-      printQueryErrorHint(err);
+      printErrorHints(err);
     }
     process.exit(1);
   }

--- a/templates/cli/lib/utils.ts
+++ b/templates/cli/lib/utils.ts
@@ -8,6 +8,11 @@ import type { Models } from "@appwrite.io/console";
 import { ProjectPolicyId } from "@appwrite.io/console";
 import { z } from "zod";
 import { globalConfig } from "./config.js";
+import {
+  describeHttpFailure,
+  looksLikeHtml,
+  sanitizeErrorText,
+} from "./errors.js";
 import { isFlagEnabled } from "./flags.js";
 import type { SettingsType } from "./commands/config.js";
 import {
@@ -138,20 +143,46 @@ export const siteRequiresBuildCommand = (site: SiteBuildConfig): boolean => {
   return !(site.framework === "other" && site.adapter === "static");
 };
 
+/** Beyond this, a message is a response body rather than a message. */
+const MAX_ERROR_MESSAGE_LENGTH = 2000;
+
+/**
+ * Turns a body that carried no usable message into a printable one. Server
+ * markup — from a proxy, or from a request that missed the API entirely — is
+ * reduced to the signal it contains instead of being printed verbatim.
+ */
+const describeErrorBody = (body: string, code?: number): string => {
+  if (looksLikeHtml(body)) {
+    return code
+      ? describeHttpFailure(code, body).message
+      : "The server returned an HTML error page.";
+  }
+
+  return sanitizeErrorText(body);
+};
+
 export const getErrorMessage = (error: unknown): string => {
   if (error instanceof Error) {
+    const code = (error as { code?: number }).code;
     const message =
       typeof error.message === "string" ? error.message.trim() : "";
+
+    // Errors raised outside our own client can carry a whole response body as
+    // their message, so summarize markup and runaway bodies before printing.
+    if (looksLikeHtml(message) || message.length > MAX_ERROR_MESSAGE_LENGTH) {
+      return describeErrorBody(message, code);
+    }
+
     if (message) {
       return message;
     }
 
     // Some error responses carry no `message` field, leaving the exception
-    // message empty. Fall back to the raw response body so users see more
-    // than a bare "✗ Error:".
+    // message empty. Fall back to the response body so users see more than a
+    // bare "✗ Error:".
     const response = (error as { response?: unknown }).response;
     if (typeof response === "string" && response.trim() !== "") {
-      return response.trim();
+      return describeErrorBody(response, code);
     }
 
     return "An unknown error occurred.";

--- a/templates/cli/package-lock.json.twig
+++ b/templates/cli/package-lock.json.twig
@@ -1925,9 +1925,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1943,9 +1940,6 @@
       "integrity": "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1963,9 +1957,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1982,9 +1973,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2000,9 +1988,6 @@
       "integrity": "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4269,9 +4254,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -5694,9 +5679,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
-      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "version": "4.23.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.4.tgz",
+      "integrity": "sha512-ZiUQ8oT/KzN51mJUWPqARYqwFLFJZtGZipRkw1ynHMr9vy3eU77m5yfF3Gzm6meEg/beW+lUu3fHYgskTN2oVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -291,6 +291,11 @@ abstract class Base extends TestCase
         'auth:context-project-precedence:passed',
     ];
 
+    protected const CLI_REGRESSION_RESPONSES = [
+        'CLI_ERROR_HANDLING:passed',
+        'CLI_CONSOLE_FALLBACKS:passed',
+    ];
+
     protected const CLI_ATTRIBUTE_SYNC_RESPONSES = [
         'attribute:in-place-updates:passed',
         'attribute:recreates-immutable:passed',

--- a/tests/e2e/CLIBun10Test.php
+++ b/tests/e2e/CLIBun10Test.php
@@ -50,6 +50,7 @@ final class CLIBun10Test extends Base
         ...Base::CLI_QUERY_HELPER_RESPONSES,
         ...Base::CLI_TYPEGEN_RESPONSES,
         ...Base::AUTH_LOGIC_RESPONSES,
+        ...Base::CLI_REGRESSION_RESPONSES,
         ...Base::CLI_ATTRIBUTE_SYNC_RESPONSES,
     ];
 

--- a/tests/e2e/CLIBun11Test.php
+++ b/tests/e2e/CLIBun11Test.php
@@ -50,6 +50,7 @@ final class CLIBun11Test extends Base
         ...Base::CLI_QUERY_HELPER_RESPONSES,
         ...Base::CLI_TYPEGEN_RESPONSES,
         ...Base::AUTH_LOGIC_RESPONSES,
+        ...Base::CLI_REGRESSION_RESPONSES,
         ...Base::CLI_ATTRIBUTE_SYNC_RESPONSES,
     ];
 

--- a/tests/e2e/CLIBun13Test.php
+++ b/tests/e2e/CLIBun13Test.php
@@ -50,6 +50,7 @@ final class CLIBun13Test extends Base
         ...Base::CLI_QUERY_HELPER_RESPONSES,
         ...Base::CLI_TYPEGEN_RESPONSES,
         ...Base::AUTH_LOGIC_RESPONSES,
+        ...Base::CLI_REGRESSION_RESPONSES,
         ...Base::CLI_ATTRIBUTE_SYNC_RESPONSES,
     ];
 

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -1275,7 +1275,6 @@ async function runAuthChecks() {
   };
 
   const withMockedHealthVersion = async (fn) => {
-    const { Client } = await import("@appwrite.io/console");
     const originalCall = Client.prototype.call;
     Client.prototype.call = async () => ({ version: "1.0.0" });
     try {

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -3,6 +3,18 @@ const fs = require("fs");
 const assert = require("node:assert/strict");
 const os = require("os");
 const path = require("path");
+
+process.env.NODE_ENV = "test";
+const sandboxHome = fs.mkdtempSync(
+  path.join(os.tmpdir(), "appwrite-cli-test-"),
+);
+os.homedir = () => sandboxHome;
+process.env.HOME = sandboxHome;
+process.env.USERPROFILE = sandboxHome;
+process.on("exit", () => {
+  fs.rmSync(sandboxHome, { recursive: true, force: true });
+});
+
 const Client = require("./lib/client.ts").default;
 const { localConfig } = require("./lib/config.ts");
 const { types } = require("./lib/commands/types.ts");
@@ -76,9 +88,24 @@ const {
   questionsClientReset,
 } = require("./lib/questions.ts");
 const { logout, client, whoami } = require("./lib/commands/generic.ts");
+const {
+  getOrganizationForSession,
+  listOrganizationsForSession,
+  listProjectsForSession,
+} = require("./lib/console-fallback.ts");
+const { formatErrorForLog } = require("./lib/parser.ts");
+const http = require("http");
 const { cliConfig } = require("./lib/parser.ts");
 const inquirerModule = require("inquirer");
 const inquirer = inquirerModule.default ?? inquirerModule;
+
+assert.ok(globalConfig.path.startsWith(sandboxHome));
+const sandboxKeyringTokens = new Map();
+setRefreshTokenEntryFactoryForTests((_service, account) => ({
+  setPassword: (password) => sandboxKeyringTokens.set(account, password),
+  getPassword: () => sandboxKeyringTokens.get(account) ?? null,
+  deletePassword: () => sandboxKeyringTokens.delete(account),
+}));
 
 const extractFirstValue = (output) => {
   const firstLine =
@@ -862,6 +889,8 @@ void (async () => {
   console.log("CLI_TYPEGEN:passed");
 })()
   .then(runAuthChecks)
+  .then(runErrorHandlingChecks)
+  .then(runConsoleFallbackChecks)
   .then(runAttributeSyncChecks)
   .then(runDeploymentSymlinkChecks)
   .catch((error) => {
@@ -2581,4 +2610,146 @@ async function runDeploymentSymlinkChecks() {
     fs.rmSync(root, { recursive: true, force: true });
     fs.rmSync(outside, { recursive: true, force: true });
   }
+}
+
+const HTML_ERROR_PAGE =
+  "<!DOCTYPE html><html><body><h1>Page not found</h1></body></html>";
+
+async function withStubServer(run) {
+  const paths = [];
+  const server = http.createServer((request, response) => {
+    paths.push(request.url);
+    response.writeHead(404, { "content-type": "text/html" });
+    response.end(HTML_ERROR_PAGE);
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const endpoint = `http://127.0.0.1:${server.address().port}`;
+
+  try {
+    await run({ endpoint, paths });
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+async function runErrorHandlingChecks() {
+  await withStubServer(async ({ endpoint, paths }) => {
+    const failure = await new Client()
+      .setEndpoint(`${endpoint}/`)
+      .call("GET", "/health/version")
+      .catch((error) => error);
+
+    assert.equal(failure.message, "HTTP 404 Not Found");
+    assert.equal(failure.response, HTML_ERROR_PAGE);
+    assert.deepEqual(paths, ["/health/version"]);
+    assert.doesNotMatch(stripAnsi(formatErrorForLog(failure)), /<!DOCTYPE/);
+  });
+
+  await withStubServer(async ({ endpoint }) => {
+    const prompts = [];
+    const originalPrompt = inquirer.prompt;
+    inquirer.prompt = async (questions) => {
+      prompts.push(questions);
+      return {};
+    };
+
+    try {
+      const failure = await muteStdout(() =>
+        loginCommand({ endpoint }).catch((error) => error),
+      );
+      assert.equal(
+        failure.message,
+        "Invalid endpoint or your Appwrite server is not running as expected.",
+      );
+      assert.deepEqual(prompts, []);
+    } finally {
+      inquirer.prompt = originalPrompt;
+    }
+  });
+
+  console.log("CLI_ERROR_HANDLING:passed");
+}
+
+async function runConsoleFallbackChecks() {
+  const { Oauth2, Organization, Teams } = await import("@appwrite.io/console");
+  const originals = {
+    listProjects: Oauth2.prototype.listProjects,
+    listOrganizations: Oauth2.prototype.listOrganizations,
+    listTeams: Teams.prototype.list,
+    getTeam: Teams.prototype.get,
+    getOrganization: Organization.prototype.get,
+    listOrganizationProjects: Organization.prototype.listProjects,
+  };
+  const calls = { oauth2: 0, team: [] };
+  const routeMissing = () => {
+    throw Object.assign(new Error("Not Found"), {
+      code: 404,
+      type: "general_route_not_found",
+    });
+  };
+
+  Oauth2.prototype.listProjects = async () => {
+    calls.oauth2++;
+    return routeMissing();
+  };
+  Oauth2.prototype.listOrganizations = async () => {
+    calls.oauth2++;
+    return routeMissing();
+  };
+  Teams.prototype.list = async () => ({
+    total: 1,
+    teams: [{ $id: "org1", name: "Self-hosted org" }],
+  });
+  Teams.prototype.get = async function (teamId) {
+    calls.team.push(teamId);
+    return { $id: teamId, name: "Self-hosted org" };
+  };
+  Organization.prototype.get = routeMissing;
+  Organization.prototype.listProjects = async () => ({
+    total: 1,
+    projects: [{ $id: "p1", region: "default", name: "Project" }],
+  });
+
+  globalConfig.clear();
+  globalConfig.addSession("session1", {
+    endpoint: "http://localhost/v1",
+    email: "test@example.com",
+    cookie: "a_session_console=stub",
+  });
+  globalConfig.setCurrentSession("session1");
+  globalConfig.setEndpoint("http://localhost/v1");
+
+  try {
+    assert.deepEqual(await listOrganizationsForSession(), {
+      total: 1,
+      organizations: [{ $id: "org1" }],
+    });
+    assert.deepEqual(await listProjectsForSession(), {
+      total: 1,
+      projects: [
+        {
+          $id: "p1",
+          region: "default",
+          endpoint: "http://localhost/v1",
+        },
+      ],
+    });
+    assert.deepEqual(await getOrganizationForSession("org1"), {
+      $id: "org1",
+      name: "Self-hosted org",
+    });
+    assert.equal(calls.oauth2, 0);
+    assert.deepEqual(calls.team, ["org1"]);
+  } finally {
+    Oauth2.prototype.listProjects = originals.listProjects;
+    Oauth2.prototype.listOrganizations = originals.listOrganizations;
+    Teams.prototype.list = originals.listTeams;
+    Teams.prototype.get = originals.getTeam;
+    Organization.prototype.get = originals.getOrganization;
+    Organization.prototype.listProjects = originals.listOrganizationProjects;
+    globalConfig.clear();
+  }
+
+  console.log("CLI_CONSOLE_FALLBACKS:passed");
 }


### PR DESCRIPTION
## What does this PR do?

This PR fixes three related CLI failure modes around custom endpoints and self-hosted Appwrite installations.

### 1. Validate and normalize endpoints before use

Explicit self-hosted login endpoints are now verified before the CLI asks for an email or password. The same verification helper is shared by `login` and `client --endpoint`, and trailing slashes are removed before request paths are appended.

```ts
if (endpoint && !shouldUseCloudLogin) {
  await verifyEndpoint(configEndpoint);
}

// Avoid requests such as https://appwrite.example/v1//account.
this.endpoint = endpoint.replace(/\/+$/, "");
```

Invalid endpoints therefore fail immediately, without storing unusable configuration or prompting for credentials that cannot be submitted.

### 2. Render concise, actionable HTTP failures

HTML error pages and oversized proxy responses are no longer printed verbatim. Non-JSON responses are converted to bounded HTTP summaries while the original response remains attached to the exception for diagnostics. Error metadata also records the endpoint that actually failed, allowing the CLI to suggest a missing `/v1` path.

```ts
const failure = describeHttpFailure(
  response.status,
  text,
  response.statusText,
  response.headers.get("content-type") ?? undefined,
);

throw this.tagEndpoint(
  new AppwriteException(failure.message, response.status, failure.type, text),
);
```

For example, an HTML 404 now renders as `HTTP 404 Not Found` instead of dumping the document, followed by an actionable hint such as:

```text
Appwrite's API is served under /v1. Try --endpoint https://appwrite.example/v1
```

Verbose output and generated GitHub report URLs use the same bounded sanitization, preventing response bodies from overwhelming the terminal or URL.

### 3. Support Cloud-only console commands on self-hosted Appwrite

The generated `list-projects`, `list-organizations`, and `organization get` commands now route through dedicated helpers. OAuth2 endpoints remain the primary path when available; missing routes fall back to the console APIs exposed by self-hosted installations.

```ts
return withRouteFallback(
  hasOauth2Session()
    ? async () => new Oauth2(await sdkForConsole()).listProjects(limit, offset, search)
    : undefined,
  async () => {
    // Rebuild the OAuth2-shaped response from teams and organization projects.
    return { total: projects.length, projects: applyWindow(projects, limit, offset) };
  },
);
```

The fallback preserves the OAuth2 response shape, pagination window, project region endpoint, and error propagation. `organization get` similarly falls back from the Cloud-only organization route to the corresponding team on self-hosted servers.

## Verification

- `php example.php cli server`
- `composer refactor:check`
- `vendor/bin/phpunit --testsuite Unit` — 33 tests, 125 assertions
- `uvx djlint templates/cli --lint` — 14 templates, no errors
- Generated CLI TypeScript declarations and ESM/CJS/CLI bundles build successfully
- Targeted ESLint passes for every changed generated TypeScript module
- Compact regression suites cover error handling and self-hosted fallbacks in the Bun 1.0, 1.1, and 1.3 E2E jobs

The Docker daemon was unavailable locally, so the three containerized Bun E2E jobs are left for CI execution.
