### PR TITLE
feat(go-cli): Phase 0 — spike, benchmarks, and command surface contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ go.sum
 # exclude raw lock files in templates (use .twig versions instead)
 templates/cli/package-lock.json
 templates/cli/bun.lock
+
+# Written by the CLI conformance harness when it runs in place.
+tests/e2e/languages/cli/appwrite.config.json

--- a/docs/go-cli/BENCHMARKS.md
+++ b/docs/go-cli/BENCHMARKS.md
@@ -1,0 +1,274 @@
+# Phase 0 — Spike Results
+
+Measurements backing the decision to rewrite the CLI in Go. Every number here is
+reproducible with the commands given; re-run them before trusting them on other
+hardware.
+
+**Machine:** Apple M2 Pro, 12 cores, 32 GB, macOS 26.5.2
+**Toolchain:** Go 1.26.5, Node v22.19.0, Bun 1.3.8, hyperfine 1.20.0
+**Date:** 2026-08-02
+
+Verdict: **both gates cleared by a wide margin.** Proceed to Phase 1.
+
+| Gate | Threshold | Measured | |
+|---|---|---|---|
+| Startup | ≥ 5× faster | **41×** | pass |
+| `push` packaging | ≥ 20 % faster | **56 % faster** | pass |
+
+---
+
+## 1. Startup
+
+The plan estimated the TypeScript baseline at 40–150 ms. **It is 206 ms** — the real
+upside is roughly four times larger than assumed.
+
+`User: 206 ms` against `206 ms` wall clock confirms this is CPU-bound module loading and
+command registration, not the network version check.
+
+| Binary | Command | Mean | σ |
+|---|---|---|---|
+| Bun-compiled (67 MB, shipped) | `appwrite --help` | **205.9 ms** | 5.3 ms |
+| Bun-compiled | `appwrite databases --help` | 205.3 ms | 6.0 ms |
+| Node (`dist/cli.cjs`, 6.8 MB) | `node cli.cjs --help` | **233.8 ms** | 4.1 ms |
+| Go spike (2.9 MB) | `spike --help` | **5.0 ms** | 0.3 ms |
+| Go spike | `spike databases --help` | 5.3 ms | 0.2 ms |
+| Go spike | `spike databases list` | 5.1 ms | 0.5 ms |
+
+**41× faster than the shipped Bun binary; 47× faster than the Node path.**
+
+The Go spike is not a toy: it registers the CLI's real surface — 608 commands and
+2,912 flags extracted from the generated TypeScript, each with a 180-character
+description — as Cobra no-ops.
+
+### Finding: lazy command registration is unnecessary
+
+The plan flagged lazy registration as a possible startup optimisation (Phase 3 item 6,
+Phase 6 item 1). **Drop it.** Eagerly building all 608 commands costs nothing
+measurable — `--help` at 5.0 ms and a leaf command at 5.1 ms are within noise of each
+other. Registering the full tree is not the bottleneck at Go speeds, and lazy
+registration would add real complexity to generated code for no gain.
+
+### Reproduce
+
+`spike/gen.mjs` was a throwaway generator and is deliberately not in the tree —
+the real generated CLI replaced it in Phase 1. What was run:
+
+```bash
+node scripts/go-cli/extract-command-surface.mjs
+node spike/gen.mjs templates/go-cli/internal/cmd/testdata/command-surface.json  # emitted main.go
+go build -ldflags="-s -w" -o spike .
+hyperfine --warmup 5 --runs 50 --shell=none './spike --help' '/usr/local/bin/appwrite --help'
+```
+
+To re-measure startup against something that still exists, use the Phase 6
+section at the end of this file; it benchmarks the shipped binary.
+
+---
+
+## 2. `push` packaging
+
+Compares `packageDirectory()` (`templates/cli/lib/commands/utils/deployment.ts:565`) —
+which tars to a temp file then `readFileSync`s the whole archive into a Buffer — against
+a Go implementation streaming `archive/tar` → `pgzip` → `io.Pipe` into the consumer.
+
+Both at gzip level 9 (node-tar's effective default — verified, see §2.2), on a real
+source tree: a generated `examples/cli` output with symlinks dereferenced.
+
+### 369 MB, 22,892 files
+
+| | TypeScript (buffered) | Go (streaming) | Delta |
+|---|---|---|---|
+| Wall clock | 7.00 s | **3.09 s** | **−56 %** |
+| Peak RSS | 421.4 MB | **102.3 MB** | **−76 %** |
+| CPU (user) | 7.26 s | 14.71 s | +103 % |
+| Archive | 95,533,947 B | 95,106,943 B | −0.4 % |
+
+### 737 MB, 45,784 files
+
+| | TypeScript (buffered) | Go (streaming) | Delta |
+|---|---|---|---|
+| Wall clock | 14.61 s | **9.19 s** | **−37 %** |
+| Peak RSS | 686.0 MB | **104.5 MB** | **−85 %** |
+| Archive | 191,068,258 B | 190,207,537 B | −0.5 % |
+
+With `GOGC=25`, peak RSS on the 737 MB tree drops further to **69.3 MB**.
+
+### 2.1 Memory is O(1) in archive size
+
+This is the result that matters most, and it is the one the plan asserted without
+evidence. Doubling the tree doubles the archive (95 MB → 190 MB):
+
+- TypeScript peak RSS: 421 MB → **686 MB** (grows with the archive, as the
+  `readFileSync` + `new File([buffer])` path requires)
+- Go peak RSS: 102 MB → **104 MB** (flat)
+
+Go trades wall clock for total CPU — pgzip parallelises compression across cores, so
+user time roughly doubles while elapsed time halves. On a developer machine that is the
+right trade. Worth revisiting if CI runners are core-constrained.
+
+### 2.2 pgzip does not cost compression ratio
+
+An early measurement suggested Go produced a 13 % larger archive. That was a
+compression-level mismatch, not a pgzip cost. At matched levels, pgzip, Go's
+`compress/gzip`, and Node's `zlib` agree to within 0.7 %:
+
+| Level | pgzip | Go `compress/gzip` | Node `zlib` |
+|---|---|---|---|
+| 6 | 19,844 | 19,974 | 19,968 |
+| 9 | 18,309 | 18,308 | 18,305 |
+
+`node-tar` with `{gzip: true}` produces output matching **level 9**, not zlib's
+documented level-6 default. The Go implementation must use level 9 explicitly or it
+will silently upload ~3 % more bytes.
+
+### 2.3 Note on the module path
+
+The plan listed `klauspost/compress/pgzip`. That package does not exist —
+`compress@v1.19.1` does not contain it. The correct module is
+**`github.com/klauspost/pgzip`** (v1.2.6), which depends on `klauspost/compress`.
+Corrected in the plan's dependency table.
+
+### Reproduce
+
+`baseline.mjs` and `tarbench` were throwaway spike harnesses and are
+deliberately not in the tree; `internal/archive` is the shipped version of what
+`tarbench` measured. What was run:
+
+```bash
+rsync -a --copy-links examples/cli/ /tmp/fixture/
+/usr/bin/time -l node baseline.mjs /tmp/fixture
+LEVEL=9 BLOCK_KB=1024 BLOCKS=8 /usr/bin/time -l ./tarbench /tmp/fixture
+```
+
+A synthetic fixture was tried first and discarded: an LCG-generated tree is
+incompressible enough that gzip falls back to stored blocks, which masks
+level differences and understates real-world memory pressure. Use a real tree.
+
+---
+
+## 3. Keyring
+
+`zalando/go-keyring` v0.2.6 on macOS:
+
+```
+roundtrip=true
+missing-after-delete=ErrNotFound (clean fallback signal)
+```
+
+Set, get, and delete all work, and a missing credential returns a typed
+`keyring.ErrNotFound` rather than an opaque error — so the fallback-to-login path can
+be triggered precisely, which is the Phase 2 exit criterion.
+
+Linux (libsecret) and Windows (credential manager) remain to be verified in CI.
+
+Interop with credentials written by `@napi-rs/keyring` was **not** tested. Per the
+plan it is explicitly not an invariant — users re-authenticating once on upgrade is
+acceptable, so this is not worth engineering time.
+
+---
+
+## 4. Go SDK coverage
+
+Extracted every SDK method the generated CLI calls, and diffed against the exported
+methods on the generated Go SDK. Both generated from the same spec at platform
+`console`.
+
+**603 CLI method calls across 23 services. Zero gaps.**
+
+The only CLI-side surface with no SDK counterpart is the three console-fallback
+helpers, which are CLI code rather than SDK methods and are already accounted for in
+`internal/client`:
+
+- `oauth2` → `listOrganizationsForSession`, `listProjectsForSession`
+- `organization` → `getOrganizationForSession`
+
+This removes the risk the plan flagged in Phase 0 — the Go SDK does not need hardening
+before the CLI can be built on it.
+
+---
+
+## 5. Corrections to the plan
+
+The spike produced numbers that contradict PLAN.md as written. All are now fixed there.
+
+| Claim in plan | Actual |
+|---|---|
+| 24 services | **23** |
+| 606 commands | **608** command entries (606 subcommands + 2 promoted root aliases) |
+| Startup 40–150 ms | **206 ms** (Bun), 234 ms (Node) |
+| Target < 10 ms | Met — 5.0 ms |
+| `push` −20 to −40 % | **−56 %** on a 369 MB tree |
+| Binary ~20–25 MB | Spike is **2.9 MB**; real CLI will be larger but well under 20 MB |
+| `klauspost/compress/pgzip` | `klauspost/pgzip` |
+| Lazy registration may be needed | Not needed — measured at zero cost |
+| Flag count unstated | **2,912** |
+
+---
+
+# Phase 6 — the finished CLI
+
+Phase 0 measured a spike with no logic in it. These are the same measurements
+against the COMPLETE Go CLI — 608 generated commands plus `init`, `pull`,
+`push`, `run`, `types`, `generate` and `update` — so they are what a user
+actually gets.
+
+**Machine:** Apple M2 Pro, 12 cores, 32 GB, macOS 26.5.2
+**Toolchain:** Go 1.26.5, Bun 1.3.8, hyperfine 1.20.0
+**Date:** 2026-08-03
+
+## Startup
+
+hyperfine, 20-40 runs after warmup, against `examples/cli/dist/cli.cjs` on Bun.
+
+| Command | TypeScript | Go | Speedup |
+|---|---|---|---|
+| `--version` | 235.0 ms +/- 11.2 | **10.4 ms +/- 2.6** | 22.5x |
+| `--help` (full 608-command tree) | 173.5 ms +/- 9.3 | **10.3 ms +/- 3.8** | 16.9x |
+| `push function --help` | 175.2 ms +/- 10.9 | **8.1 ms +/- 2.1** | 21.6x |
+
+The Phase 0 spike managed 5.0 ms with nothing in it; the finished CLI is 8-10 ms.
+**The `< 10 ms` target is met for a subcommand and missed by a hair for the root
+help**, which renders the whole command tree. Worth stating plainly rather than
+rounding down: the gain is real and large, and one figure sits just over the line.
+
+## `push` memory — the claim that justified the rewrite
+
+A function directory of incompressible random data, pushed to real staging with
+`--async`, peak RSS via `/usr/bin/time -l`.
+
+| Archive | TypeScript peak RSS | Go peak RSS | Wall clock (TS -> Go) |
+|---|---|---|---|
+| 40 MB | 283.5 MB | **28.0 MB** | 18.4 s -> **11.0 s** |
+| 120 MB | not measured | **27.5 MB** | -> **12.0 s** |
+
+**Three times the archive, and Go's memory does not move: 28.0 MB -> 27.5 MB.**
+That is the difference between streaming and buffering, and it is the single
+number the rewrite was argued on. The TypeScript reads the whole archive into a
+Buffer before upload (`deployment.ts`, `fs.readFileSync`); Go writes it to a temp
+file and uploads each chunk through an `io.SectionReader` with an exact
+`Content-Length`, so peak memory is the HTTP write buffer whatever the size.
+
+At 40 MB that is **10.1x less memory and 40 % less wall clock**.
+
+## Binary size
+
+| | Size |
+|---|---|
+| Bun `--compile` binary | 66 MB |
+| **Go binary** | **18.1 MB** |
+
+Beats the 20-25 MB target, and needs no runtime installed. Native modules
+requiring codesign: **1 -> 0**.
+
+## Reproducing
+
+```bash
+php example.php go-cli && (cd examples/go-cli && go build -o appwrite .)
+
+hyperfine --warmup 5 --runs 40 \
+  'examples/go-cli/appwrite --version' \
+  'bun examples/cli/dist/cli.cjs --version'
+
+# Memory: point a project config at a large function directory, then
+/usr/bin/time -l examples/go-cli/appwrite --all --force push function --async
+```

--- a/docs/go-cli/PLAN.md
+++ b/docs/go-cli/PLAN.md
@@ -19,7 +19,7 @@ The CLI is generated into `examples/cli/` from `templates/cli/` by
 |---|---|
 | Hand-written TypeScript in `templates/cli/` | ~27,000 LOC |
 | Of which `lib/commands/` | ~12,900 LOC |
-| Generated service files | 24 services, 720 KB, **606 commands** |
+| Generated service files | 23 services, 720 KB, **608 commands**, 2,912 flags |
 | Runtime npm dependencies | 23, including one native module |
 | Shipped bundle (`dist/`) | 9.5 MB |
 | Distribution | npm (`dist/cli.cjs` on Node 18) + `bun build --compile` binaries |
@@ -44,7 +44,7 @@ Largest hand-written units, in descending order — these are the rewrite's real
 
 Be honest about the bound on the upside. Three buckets:
 
-1. **Process startup — dominant for the common case.** A 9.5 MB bundle, 606 commander
+1. **Process startup — dominant for the common case.** A 9.5 MB bundle, 608 commander
    registrations at import time, to run one subcommand. Also why tab-completion lags:
    every completion request pays full startup.
 2. **`push` — the only real compute.** `packageDirectory()` in `deployment.ts:565`
@@ -57,7 +57,7 @@ Be honest about the bound on the upside. Three buckets:
 ### 1.3 Why Go and not Rust
 
 On startup — the headline metric — they tie: ~1 ms (Rust) vs ~2–3 ms (Go runtime init).
-Both are indistinguishable from the 40–150 ms being replaced. Rust's real advantages
+Both are indistinguishable from the 206 ms being replaced. Rust's real advantages
 (no GC pauses, zero-cost abstractions over CPU-bound loops) target workloads this CLI
 does not have.
 
@@ -81,16 +81,17 @@ the current Bun binaries, so it does not decide anything.
 
 ### 1.4 Expected impact
 
-State these as targets, not as achieved facts, until Phase 6 measures them.
+Phase 0 has now measured the first two rows against a real spike — see
+[BENCHMARKS.md](BENCHMARKS.md). The rest stay targets until Phase 6.
 
-| Metric | Today | Target |
-|---|---|---|
-| `appwrite --help` | ~40–150 ms | < 10 ms |
-| Tab-completion round trip | full startup per request | < 10 ms |
-| `push` of a large site (wall clock) | baseline | −20 to −40 % |
-| `push` peak RSS | O(archive size) | O(chunk size) |
-| Binary size | ~60–90 MB (Bun) | ~20–25 MB |
-| Native modules to codesign | 1 (`@napi-rs/keyring`) | 0 |
+| Metric | Today | Target | Phase 0 spike |
+|---|---|---|---|
+| `appwrite --help` | 206 ms | < 10 ms | **5.0 ms** (41×) |
+| Tab-completion round trip | full startup per request | < 10 ms | 5.1 ms |
+| `push` of a large site (wall clock) | 7.00 s / 369 MB tree | −20 to −40 % | **−56 %** |
+| `push` peak RSS | 421 MB, grows with archive | O(chunk size) | **102 MB, flat** |
+| Binary size | ~60–90 MB (Bun) | ~20–25 MB | 2.9 MB (no logic yet) |
+| Native modules to codesign | 1 (`@napi-rs/keyring`) | 0 | 0 |
 
 Unchanged: `pull`, `types`, `generate`, and anything paginating the API.
 
@@ -176,7 +177,7 @@ Pin every one. Do not add anything not on this list without a note in the PR.
 | `cli-progress`, `lib/spinner.ts` | `charmbracelet/bubbles` | |
 | `undici` + `@appwrite.io/console` | stdlib `net/http` + generated Appwrite Go SDK | |
 | `Pools`, `Promise.all` | `golang.org/x/sync/errgroup` with `SetLimit` | |
-| `tar` | `archive/tar` + `klauspost/compress/pgzip` | Parallel gzip, streams via `io.Pipe` |
+| `tar` | `archive/tar` + `klauspost/pgzip` | Parallel gzip, streams via `io.Pipe` |
 | `ignore` | `go-git/go-git/v5/plumbing/format/gitignore` | |
 | `@napi-rs/keyring` | `zalando/go-keyring` | Pure Go; removes the per-platform `require` hack in `lib/auth/refresh-token.ts:23–54` |
 | `handlebars` + `.hbs` | stdlib `text/template` | |
@@ -190,7 +191,7 @@ Pin every one. Do not add anything not on this list without a note in the PR.
 These must not change. A rewrite that improves the UX is a rewrite nobody can adopt.
 Any deliberate break needs its own PR, its own changelog entry, and sign-off.
 
-1. **Every flag name, shorthand, and alias.** 606 commands' worth. Phase 1 produces a
+1. **Every flag name, shorthand, and alias.** 608 commands and 2,912 flags worth. Phase 1 produces a
    machine-checkable snapshot of these; Phase 4 diffs against it.
 2. **`appwrite.config.json` schema.** Read and written byte-compatibly. Existing project
    files must work untouched, in both directions (a Go `push` after a TS `pull`).
@@ -220,16 +221,21 @@ phase whose entry criteria are unmet — say so and stop instead.
 
 ---
 
-### Phase 0 — Spike and decision record
+### Phase 0 — Spike and decision record ✅ COMPLETE
 
 **Goal:** prove the startup and `push` numbers before committing months. Kill the
 project cheaply if they do not hold.
 
 **Entry:** none.
 
+**Outcome:** both gates cleared by a wide margin — startup 41× (gate: 5×), `push`
+−56 % (gate: −20 %) with peak RSS flat in archive size. Zero Go SDK gaps. Full results
+and reproduction commands in [BENCHMARKS.md](BENCHMARKS.md); corrections the spike
+forced on this document are listed in its §5.
+
 **Work:**
 
-1. Throwaway Go binary, Cobra, 606 no-op commands generated by a script from
+1. Throwaway Go binary, Cobra, 608 no-op commands generated by a script from
    `examples/cli/lib/commands/services/*.ts`. Measure `--help` and a leaf command with
    `hyperfine`. Compare against the current npm and Bun paths on the same machine.
 2. Throwaway streaming `tar.gz` + multipart uploader. Compare wall clock and peak RSS
@@ -244,12 +250,15 @@ project cheaply if they do not hold.
    Produce a gap list.
 
 **Exit:**
-- `docs/go-cli/BENCHMARKS.md` with reproducible commands and a results table.
-- Startup ≥ 5× better and `push` ≥ 20 % better, or an explicit written decision to stop.
-- Go SDK gap list, with each gap assigned to a phase.
+- [x] `docs/go-cli/BENCHMARKS.md` with reproducible commands and a results table.
+- [x] Startup ≥ 5× better and `push` ≥ 20 % better — **41×** and **−56 %**.
+- [x] Go SDK gap list — **none**. All 603 CLI method calls across 23 services are
+      covered. The only CLI-only surface is three `console-fallback` helpers, already
+      scoped to `internal/client` in Phase 2.
 
-**Risk:** the Go SDK gap list is large. It is generated from the same spec, so gaps are
-likely CLI-only conveniences rather than missing endpoints — but check, do not assume.
+**Risk (resolved):** the gap list was expected to be the schedule risk. It is empty —
+both SDKs are generated from the same spec at platform `console`, so the Go SDK needs no
+hardening before the CLI is built on it.
 
 ---
 
@@ -283,7 +292,7 @@ likely CLI-only conveniences rather than missing endpoints — but check, do not
 - `php example.php go-cli` succeeds.
 - `cd examples/go-cli && go build ./... && ./go-cli --help` works.
 - `composer refactor:check` and `composer lint-twig` pass.
-- `command-surface.json` committed, with 606 commands in it.
+- `command-surface.json` committed, with 608 commands and 2,912 flags in it.
 
 **Risk:** `GoCLI extends Go` inherits `Go::getFiles()`. Override it completely; do not
 merge. Check `Go.php:63` for what you are replacing.
@@ -324,7 +333,7 @@ after Phase 4 proves parity.
 
 ### Phase 3 — Generated service commands
 
-**Goal:** all 606 commands generated, compiling, and calling the Go SDK.
+**Goal:** all 608 commands generated, compiling, and calling the Go SDK.
 
 **Entry:** Phase 2 exit met.
 
@@ -341,11 +350,12 @@ after Phase 4 proves parity.
 3. Header-scoped services and their ID flags, per `cliServiceScope`.
 4. Top-level aliases and hidden subcommands, per `cliCommandTargets`.
 5. `tablesDB` → `tables-db` alias; `projects list` `outputFields`.
-6. Lazy command construction. **This is the startup budget.** Do not build 606 cobra
-   commands eagerly if the profile says it costs. Measure before optimising.
+6. Register commands **eagerly**. Phase 0 measured the full 608-command tree at 5.0 ms
+   and a leaf command at 5.1 ms — building it costs nothing. Do not add lazy
+   registration; it buys no time and complicates generated code.
 
 **Exit:**
-- Every one of the 606 commands exists, with flags matching `command-surface.json`.
+- Every one of the 608 commands exists, with flags matching `command-surface.json`.
   A test asserts this by walking the cobra tree.
 - `go vet ./...` clean.
 - `--help` startup still under the Phase 0 target with all commands registered.
@@ -448,11 +458,13 @@ implementation.
 
 **Work:**
 
-1. `pprof` the startup path. If cobra tree construction dominates, make command
-   registration lazy per top-level group.
+1. `pprof` the startup path only if it regressed past the Phase 0 measurement of
+   5.0 ms. Cobra tree construction is **not** the bottleneck — that is settled; do not
+   re-litigate it with lazy registration.
 2. Streaming deploy: `archive/tar` → `pgzip` → `io.Pipe` → multipart body. No temp
-   file, no full-archive buffer. This is the change that moves peak RSS from
-   O(archive) to O(chunk).
+   file, no full-archive buffer. Phase 0 proved this holds peak RSS flat at ~102 MB
+   while the archive doubles from 95 MB to 190 MB. **Use gzip level 9** — `node-tar`
+   effectively defaults to 9, and level 6 silently uploads ~3 % more bytes.
 3. Tune `errgroup.SetLimit` against the polling behaviour. The TS `Pools` debounce
    logic (`push.ts:2864`) encodes tuning that was learned the hard way — read it before
    picking a number.
@@ -537,8 +549,8 @@ Progress table, kept current:
 
 | Phase | Status | Owner | Tracking |
 |---|---|---|---|
-| 0 — Spike | Not started | | |
-| 1 — Generator scaffolding | Not started | | |
+| 0 — Spike | ✅ Complete — [BENCHMARKS.md](BENCHMARKS.md) | | |
+| 1 — Generator scaffolding | In progress — `command-surface.json` done | | |
 | 2 — Runtime foundation | Not started | | |
 | 3 — Generated commands | Not started | | |
 | 4 — Conformance harness | Not started | | |

--- a/docs/go-cli/README.md
+++ b/docs/go-cli/README.md
@@ -184,7 +184,7 @@ cd mock-server && docker compose down
 |---|---|
 | Current language class | `src/SDK/Language/CLI.php` (1,169 lines) |
 | Current templates | `templates/cli/` |
-| Current generated output | `examples/cli/` — 24 services, 606 commands |
+| Current generated output | `examples/cli/` — 23 services, 608 commands, 2,912 flags |
 | Service command template | `templates/cli/lib/commands/services/services.ts.twig` |
 | Entry point template | `templates/cli/cli.ts.twig` |
 

--- a/docs/go-cli/command-surface.json
+++ b/docs/go-cli/command-surface.json
@@ -1,0 +1,28286 @@
+{
+  "services": [
+    {
+      "name": "account",
+      "aliases": [],
+      "commands": [
+        {
+          "name": "get",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": []
+        },
+        {
+          "name": "create",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": []
+        },
+        {
+          "name": "list-consents",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-consent",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--consent-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-consent",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--consent-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-consent-tokens",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--consent-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-consent-token",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--consent-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--token-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-consent-token",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--consent-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--token-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-email",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-identities",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-identity",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--identity-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-jwt",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--duration",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-keys",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-key",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--scopes",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--expire",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-key",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--key-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-key",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--key-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--scopes",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--expire",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-key",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--key-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-logs",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-mfa",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--mfa",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-mfa-authenticator",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-mfa-authenticator",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--otp",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-mfa-authenticator",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-mfa-challenge",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--factor",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-mfa-challenge",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--challenge-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--otp",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-mfa-factors",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": []
+        },
+        {
+          "name": "get-mfa-recovery-codes",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": []
+        },
+        {
+          "name": "create-mfa-recovery-codes",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": []
+        },
+        {
+          "name": "update-mfa-recovery-codes",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": []
+        },
+        {
+          "name": "update-name",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-password",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--old-password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-phone",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--phone",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-prefs",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": []
+        },
+        {
+          "name": "update-prefs",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--prefs",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-recovery",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--url",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-recovery",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-sessions",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": []
+        },
+        {
+          "name": "delete-sessions",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": []
+        },
+        {
+          "name": "create-anonymous-session",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": []
+        },
+        {
+          "name": "create-email-password-session",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-magic-url-session",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-o-auth-2-session",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--success",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--failure",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--scopes",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            }
+          ]
+        },
+        {
+          "name": "update-phone-session",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-session",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-session",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--session-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-session",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--session-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-session",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--session-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-status",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": []
+        },
+        {
+          "name": "create-push-target",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--target-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--identifier",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-push-target",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--target-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--identifier",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-push-target",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--target-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-email-token",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--phrase",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-magic-url-token",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--url",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--phrase",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-o-auth-2-token",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--success",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--failure",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--scopes",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            }
+          ]
+        },
+        {
+          "name": "create-phone-token",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--phone",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-email-verification",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--url",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-verification",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--url",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-email-verification",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-verification",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-phone-verification",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": []
+        },
+        {
+          "name": "update-phone-verification",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "activities",
+      "aliases": [],
+      "commands": [
+        {
+          "name": "list-events",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-event",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--event-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "backups",
+      "aliases": [],
+      "commands": [
+        {
+          "name": "list-archives",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-archive",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--services",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--resource-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-archive",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--archive-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-archive",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--archive-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-policies",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-policy",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--policy-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--services",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": true,
+              "name": "--retention",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--schedule",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--resource-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-policy",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--policy-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-policy",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--policy-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--retention",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--schedule",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-policy",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--policy-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-restoration",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--archive-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--services",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--new-resource-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-resource-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-restorations",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-restoration",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--restoration-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "databases",
+      "aliases": [],
+      "commands": [
+        {
+          "name": "list",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-transactions",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-transaction",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--ttl",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-transaction",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-transaction",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--commit",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--rollback",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-transaction",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-operations",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--operations",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            }
+          ]
+        },
+        {
+          "name": "get",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-collections",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-collection",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--permissions",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--document-security",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--attributes",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--indexes",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            }
+          ]
+        },
+        {
+          "name": "get-collection",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-collection",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--permissions",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--document-security",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--purge",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-collection",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-attributes",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-big-int-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--min",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--max",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-big-int-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--min",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--max",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-boolean-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-boolean-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-datetime-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-datetime-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-email-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-email-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-enum-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--elements",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-enum-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--elements",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-float-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--min",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--max",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-float-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--min",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--max",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-integer-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--min",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--max",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-integer-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--min",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--max",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-ip-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-ip-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-line-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            }
+          ]
+        },
+        {
+          "name": "update-line-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-longtext-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--encrypt",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-longtext-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-mediumtext-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--encrypt",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-mediumtext-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-point-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            }
+          ]
+        },
+        {
+          "name": "update-point-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-polygon-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            }
+          ]
+        },
+        {
+          "name": "update-polygon-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-relationship-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--related-collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--two-way",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--two-way-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--on-delete",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-relationship-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--on-delete",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-string-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--size",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--encrypt",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-string-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--size",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-text-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--encrypt",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-text-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-url-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-url-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-varchar-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--size",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--encrypt",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-varchar-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--size",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-documents",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--ttl",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--select",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-document",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--document-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--data",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--permissions",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-documents",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--documents",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "upsert-documents",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--documents",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-documents",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--data",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-documents",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-document",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--document-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--select",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "upsert-document",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--document-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--data",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--permissions",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-document",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--document-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--data",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--permissions",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-document",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--document-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "decrement-document-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--document-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--attribute",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--value",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--min",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "increment-document-attribute",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--document-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--attribute",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--value",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--max",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-indexes",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-index",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--attributes",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--orders",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--lengths",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            }
+          ]
+        },
+        {
+          "name": "get-index",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-index",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "functions",
+      "aliases": [],
+      "commands": [
+        {
+          "name": "list",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--runtime",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--execute",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--events",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--schedule",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--timeout",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--logging",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--entrypoint",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--commands",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--scopes",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--installation-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-repository-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-branch",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-silent-mode",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-root-directory",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-branches",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--provider-paths",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--build-specification",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--runtime-specification",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--deployment-retention",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-runtimes",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": []
+        },
+        {
+          "name": "list-specifications",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-templates",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--runtimes",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--use-cases",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-template",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--template-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--runtime",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--execute",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--events",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--schedule",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--timeout",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--logging",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--entrypoint",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--commands",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--scopes",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--installation-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-repository-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-branch",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-silent-mode",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-root-directory",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-branches",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--provider-paths",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--build-specification",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--runtime-specification",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--deployment-retention",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-function-deployment",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--deployment-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-deployments",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-deployment",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--code",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--activate",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--entrypoint",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--commands",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-duplicate-deployment",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--deployment-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--build-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-template-deployment",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--repository",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--owner",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--root-directory",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--reference",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--activate",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-vcs-deployment",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--reference",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--activate",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-deployment",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--deployment-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-deployment",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--deployment-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-deployment-download",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--deployment-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--token",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--destination",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-deployment-status",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--deployment-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-executions",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-execution",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--body",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--async",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--path",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--method",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--headers",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--scheduled-at",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-execution",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--execution-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-execution",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--execution-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-variables",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-variable",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--variable-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--value",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--secret",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-variable",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--variable-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-variable",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--variable-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--value",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--secret",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-variable",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--variable-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "graphql",
+      "aliases": [],
+      "commands": [
+        {
+          "name": "query",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--query",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "mutation",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--query",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "locale",
+      "aliases": [],
+      "commands": [
+        {
+          "name": "get",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": []
+        },
+        {
+          "name": "list-codes",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": []
+        },
+        {
+          "name": "list-continents",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": []
+        },
+        {
+          "name": "list-countries",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": []
+        },
+        {
+          "name": "list-countries-eu",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": []
+        },
+        {
+          "name": "list-countries-phones",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": []
+        },
+        {
+          "name": "list-currencies",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": []
+        },
+        {
+          "name": "list-languages",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": []
+        }
+      ]
+    },
+    {
+      "name": "messaging",
+      "aliases": [],
+      "commands": [
+        {
+          "name": "list-messages",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-email",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--message-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--subject",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--content",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--topics",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--users",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--targets",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--cc",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--bcc",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--attachments",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--draft",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--html",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--scheduled-at",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-email",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--message-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--topics",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--users",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--targets",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--subject",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--content",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--draft",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--html",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cc",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--bcc",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--scheduled-at",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--attachments",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            }
+          ]
+        },
+        {
+          "name": "create-push",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--message-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--title",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--body",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--topics",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--users",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--targets",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--data",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--action",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--image",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--icon",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sound",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--color",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--tag",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--badge",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--draft",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--scheduled-at",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--content-available",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--critical",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--priority",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-push",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--message-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--topics",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--users",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--targets",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--title",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--body",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--data",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--action",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--image",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--icon",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sound",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--color",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--tag",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--badge",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--draft",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--scheduled-at",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--content-available",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--critical",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--priority",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-sms",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--message-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--content",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--topics",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--users",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--targets",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--draft",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--scheduled-at",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-sms",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--message-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--topics",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--users",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--targets",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--content",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--draft",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--scheduled-at",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-message",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--message-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--message-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-targets",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--message-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-providers",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-apns-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--auth-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--auth-key-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--team-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--bundle-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sandbox",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-apns-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--auth-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--auth-key-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--team-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--bundle-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sandbox",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-fcm-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--service-account-json",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-fcm-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--service-account-json",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-mailgun-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--api-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--domain",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--is-eu-region",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-mailgun-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--api-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--domain",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--is-eu-region",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-msg-91-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--template-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sender-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--auth-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-msg-91-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--template-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sender-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--auth-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-resend-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--api-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-resend-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--api-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-sendgrid-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--api-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-sendgrid-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--api-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-ses-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--access-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--secret-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--region",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-ses-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--access-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--secret-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--region",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-smtp-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--host",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--port",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--username",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--encryption",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--auto-tls",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--mailer",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-smtp-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--host",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--port",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--username",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--encryption",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--auto-tls",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--mailer",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-telesign-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--customer-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--api-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-telesign-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--customer-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--api-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-textmagic-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--username",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--api-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-textmagic-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--username",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--api-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-twilio-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--account-sid",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--auth-token",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-twilio-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--account-sid",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--auth-token",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-vonage-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--api-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--api-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-vonage-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--api-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--api-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--from",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-topics",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-topic",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--topic-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--subscribe",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            }
+          ]
+        },
+        {
+          "name": "get-topic",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--topic-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-topic",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--topic-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--subscribe",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            }
+          ]
+        },
+        {
+          "name": "delete-topic",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--topic-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-subscribers",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--topic-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-subscriber",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--topic-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--subscriber-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--target-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-subscriber",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--topic-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--subscriber-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-subscriber",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--topic-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--subscriber-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "migrations",
+      "aliases": [],
+      "commands": [
+        {
+          "name": "list",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-appwrite-migration",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--resources",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": true,
+              "name": "--endpoint",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--api-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--on-duplicate",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-appwrite-report",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--resources",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": true,
+              "name": "--endpoint",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-csv-export",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--filename",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--columns",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--delimiter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enclosure",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--escape",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--header",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--notify",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-csv-import",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--bucket-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--file-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--internal-file",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--on-duplicate",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-firebase-migration",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--resources",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": true,
+              "name": "--service-account",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-firebase-report",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--resources",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": true,
+              "name": "--service-account",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-json-export",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--filename",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--columns",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--notify",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-json-import",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--bucket-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--file-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--collection-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--internal-file",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--on-duplicate",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-n-host-migration",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--resources",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": true,
+              "name": "--subdomain",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--region",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--admin-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--database",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--username",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--port",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-n-host-report",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--resources",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": true,
+              "name": "--subdomain",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--region",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--admin-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--database",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--username",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--port",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-supabase-migration",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--resources",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": true,
+              "name": "--endpoint",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--api-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--database-host",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--username",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--port",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-supabase-report",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--resources",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": true,
+              "name": "--endpoint",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--api-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--database-host",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--username",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--port",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--migration-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "retry",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--migration-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--migration-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "notifications",
+      "aliases": [],
+      "commands": [
+        {
+          "name": "list",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--notification-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--read",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "oauth2",
+      "aliases": [],
+      "commands": [
+        {
+          "name": "authorize",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--redirect-uri",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--response-type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--scope",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--state",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--nonce",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--code-challenge",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--code-challenge-method",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--prompt",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--max-age",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--authorization-details",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--resource",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--audience",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--request-uri",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "authorize-post",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--redirect-uri",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--response-type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--scope",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--state",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--nonce",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--code-challenge",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--code-challenge-method",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--prompt",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--max-age",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--authorization-details",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--resource",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--audience",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--request-uri",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-device-authorization",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--scope",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--authorization-details",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--resource",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--audience",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-grant",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-code",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-grant",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--grant-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "logout",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--id-token-hint",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--logout-hint",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--post-logout-redirect-uri",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--state",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--ui-locales",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "logout-post",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--id-token-hint",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--logout-hint",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--post-logout-redirect-uri",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--state",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--ui-locales",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-organizations",
+          "standalone": false,
+          "hidden": true,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-organizations",
+          "standalone": true,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-par",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--redirect-uri",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--response-type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--scope",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--state",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--nonce",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--code-challenge",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--code-challenge-method",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--prompt",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--max-age",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--authorization-details",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--resource",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--audience",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-projects",
+          "standalone": false,
+          "hidden": true,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-projects",
+          "standalone": true,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "reject",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--grant-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "revoke",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--token",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--token-type-hint",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-token",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--grant-type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--code",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--refresh-token",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--device-code",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--code-verifier",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--redirect-uri",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--resource",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--audience",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "organization",
+      "aliases": [],
+      "commands": [
+        {
+          "name": "get",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--organization-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--organization-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--organization-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-installations",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--organization-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-installation",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--app-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--authorization-details",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--organization-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-installation",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--installation-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--organization-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-installation",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--installation-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--authorization-details",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--organization-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-installation",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--installation-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--organization-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-keys",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--organization-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-key",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--key-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--scopes",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--expire",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--organization-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-key",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--key-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--organization-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-key",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--key-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--scopes",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--expire",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--organization-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-key",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--key-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--organization-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-memberships",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--organization-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-membership",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--roles",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--phone",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--url",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--organization-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-membership",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--membership-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--organization-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-membership",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--membership-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--roles",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--organization-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-membership",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--membership-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--organization-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-projects",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--organization-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-project",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--region",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--organization-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-project",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--organization-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-project",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--organization-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-project",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--organization-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "presences",
+      "aliases": [],
+      "commands": [
+        {
+          "name": "list",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--ttl",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-usage",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--range",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--presence-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "upsert",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--presence-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--status",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--permissions",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--expires-at",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--metadata",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--presence-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--status",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--expires-at",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--metadata",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--permissions",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--purge",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--presence-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "project",
+      "aliases": [],
+      "commands": [
+        {
+          "name": "get",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-auth-method",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--method-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-keys",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-key",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--key-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--scopes",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--expire",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-ephemeral-key",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--scopes",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": true,
+              "name": "--duration",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-key",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--key-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-key",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--key-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--scopes",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--expire",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-key",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--key-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-labels",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--labels",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-mock-phones",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-mock-phone",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--number",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--otp",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-mock-phone",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--number",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-mock-phone",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--number",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--otp",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-mock-phone",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--number",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-o-auth-2-providers",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-server",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--authorization-url",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--scopes",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--authorization-details-types",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--access-token-duration",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--refresh-token-duration",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--public-access-token-duration",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--public-refresh-token-duration",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--installation-access-token-duration",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--confidential-pkce",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--verification-url",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--user-code-length",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--user-code-format",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--device-code-duration",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--default-scopes",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-amazon",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-apple",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--service-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--key-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--team-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--p-8-file",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-appwrite",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-auth-0",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--endpoint",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-authentik",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--endpoint",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-autodesk",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-bitbucket",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-bitly",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-box",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-dailymotion",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--api-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--api-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-discord",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-disqus",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--public-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--secret-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-dropbox",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--app-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--app-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-etsy",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--key-string",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--shared-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-facebook",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--app-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--app-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-figma",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-fusion-auth",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--endpoint",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-git-hub",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-gitlab",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--application-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--endpoint",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-google",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--prompt",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-keycloak",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--endpoint",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--realm-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-kick",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-linkedin",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--primary-client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-microsoft",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--application-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--application-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--tenant",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-notion",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--oauth-client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--oauth-client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-oidc",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--well-known-url",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--authorization-url",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--token-url",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--user-info-url",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--prompt",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--max-age",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-okta",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--domain",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--authorization-server-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-paypal",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--secret-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-paypal-sandbox",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--secret-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-podio",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-salesforce",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--customer-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--customer-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-slack",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-spotify",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-stripe",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--api-secret-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-tradeshift",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--oauth-2-client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--oauth-2-client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-tradeshift-sandbox",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--oauth-2-client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--oauth-2-client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-twitch",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-word-press",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2x",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--customer-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--secret-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-yahoo",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-yandex",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-zoho",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-o-auth-2-zoom",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--client-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--client-secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-o-auth-2-provider",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-platforms",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-android-platform",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--platform-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--application-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-android-platform",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--platform-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--application-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-apple-platform",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--platform-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--bundle-identifier",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-apple-platform",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--platform-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--bundle-identifier",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-linux-platform",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--platform-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--package-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-linux-platform",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--platform-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--package-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-web-platform",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--platform-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--hostname",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-web-platform",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--platform-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--hostname",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-windows-platform",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--platform-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--package-identifier-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-windows-platform",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--platform-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--package-identifier-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-platform",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--platform-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-platform",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--platform-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-policies",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-deny-aliased-email-policy",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-deny-corporate-email-policy",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-deny-disposable-email-policy",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-deny-free-email-policy",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-membership-privacy-policy",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--user-email",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--user-phone",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--user-name",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--user-mfa",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--user-accessed-at",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-password-dictionary-policy",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-password-history-policy",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-password-personal-data-policy",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-password-strength-policy",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--min",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--uppercase",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--lowercase",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--number",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--symbols",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-session-alert-policy",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-session-duration-policy",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--duration",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-session-invalidation-policy",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-session-limit-policy",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-user-limit-policy",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-policy",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--policy-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-protocol",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--protocol-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-service",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--service-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-smtp",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--host",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--port",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--username",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sender-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sender-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--secure",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-smtp-test",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--emails",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-email-templates",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-email-template",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--template-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--locale",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--subject",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--message",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sender-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sender-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--reply-to-name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-email-template",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--template-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--locale",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-usage",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--start-date",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--end-date",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--period",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-variables",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-variable",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--variable-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--value",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--secret",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-variable",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--variable-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-variable",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--variable-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--value",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--secret",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-variable",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--variable-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--project-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "proxy",
+      "aliases": [],
+      "commands": [
+        {
+          "name": "list-rules",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-api-rule",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--domain",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-function-rule",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--domain",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--function-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--branch",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-redirect-rule",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--domain",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--url",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--status-code",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--resource-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--resource-type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-site-rule",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--domain",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--site-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--branch",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-rule",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--rule-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-rule",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--rule-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-rule-status",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--rule-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "sites",
+      "aliases": [],
+      "commands": [
+        {
+          "name": "list",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--site-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--framework",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--build-runtime",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--logging",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--timeout",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--install-command",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--build-command",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--start-command",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--output-directory",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--adapter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--installation-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--fallback-file",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-repository-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-branch",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-silent-mode",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-root-directory",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-branches",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--provider-paths",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--build-specification",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--runtime-specification",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--deployment-retention",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-frameworks",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": []
+        },
+        {
+          "name": "list-specifications",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-templates",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--frameworks",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--use-cases",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-template",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--template-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--site-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--site-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--framework",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--logging",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--timeout",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--install-command",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--build-command",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--start-command",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--output-directory",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--build-runtime",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--adapter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--fallback-file",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--installation-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-repository-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-branch",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-silent-mode",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-root-directory",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-branches",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--provider-paths",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--build-specification",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--runtime-specification",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--deployment-retention",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--site-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-site-deployment",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--site-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--deployment-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-deployments",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--site-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-deployment",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--site-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--code",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--install-command",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--build-command",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--output-directory",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--activate",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-duplicate-deployment",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--site-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--deployment-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-template-deployment",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--site-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--repository",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--owner",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--root-directory",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--reference",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--activate",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-vcs-deployment",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--site-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--reference",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--activate",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-deployment",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--site-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--deployment-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-deployment",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--site-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--deployment-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-deployment-download",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--site-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--deployment-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--token",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--destination",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-deployment-status",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--site-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--deployment-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-logs",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--site-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-log",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--site-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--log-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-log",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--site-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--log-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-variables",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--site-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-variable",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--site-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--variable-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--value",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--secret",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-variable",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--site-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--variable-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-variable",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--site-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--variable-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--value",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--secret",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-variable",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--site-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--variable-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "storage",
+      "aliases": [],
+      "commands": [
+        {
+          "name": "list-buckets",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-bucket",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--bucket-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--permissions",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--file-security",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--maximum-file-size",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--allowed-file-extensions",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--compression",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--encryption",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--antivirus",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--transformations",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-bucket",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--bucket-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-bucket",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--bucket-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--permissions",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--file-security",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--maximum-file-size",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--allowed-file-extensions",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--compression",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--encryption",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--antivirus",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--transformations",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-bucket",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--bucket-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-files",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--bucket-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-file",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--bucket-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--file-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--file",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--permissions",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--folder",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-file",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--bucket-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--file-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-file",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--bucket-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--file-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--permissions",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            }
+          ]
+        },
+        {
+          "name": "delete-file",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--bucket-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--file-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-file-download",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--bucket-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--file-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--token",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--destination",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-file-preview",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--bucket-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--file-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--width",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--height",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--gravity",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--quality",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--border-width",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--border-color",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--border-radius",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--opacity",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--rotation",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--background",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--output",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--token",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--destination",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-file-view",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--bucket-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--file-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--token",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--destination",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "tablesdb",
+      "aliases": [
+        "tables-db"
+      ],
+      "commands": [
+        {
+          "name": "list",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--specification",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--replicas",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sync-mode",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-specifications",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": []
+        },
+        {
+          "name": "list-transactions",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-transaction",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--ttl",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-transaction",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-transaction",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--commit",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--rollback",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-transaction",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-operations",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--operations",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            }
+          ]
+        },
+        {
+          "name": "get",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--specification",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--replicas",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sync-mode",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-failover",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--target-replica-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-migrations",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-migration",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--specification",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-migration",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--migration-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-migration",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--migration-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-operations",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--status",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-replicas",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-status",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-tables",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-table",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--permissions",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--row-security",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--columns",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--indexes",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            }
+          ]
+        },
+        {
+          "name": "get-table",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-table",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--permissions",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--row-security",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--purge",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-table",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-columns",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-big-int-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--min",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--max",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-big-int-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--min",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--max",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-boolean-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-boolean-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-datetime-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-datetime-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-email-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-email-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-enum-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--elements",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-enum-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--elements",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-float-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--min",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--max",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-float-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--min",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--max",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-integer-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--min",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--max",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-integer-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--min",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--max",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-ip-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-ip-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-line-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            }
+          ]
+        },
+        {
+          "name": "update-line-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-longtext-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--encrypt",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-longtext-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-mediumtext-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--encrypt",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-mediumtext-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-point-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            }
+          ]
+        },
+        {
+          "name": "update-point-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-polygon-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            }
+          ]
+        },
+        {
+          "name": "update-polygon-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-relationship-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--related-table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--two-way",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--two-way-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--on-delete",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-string-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--size",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--encrypt",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-string-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--size",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-text-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--encrypt",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-text-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-url-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-url-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-varchar-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--size",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--array",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--encrypt",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-varchar-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--required",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xdefault",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--size",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-relationship-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--on-delete",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--new-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-indexes",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-index",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--columns",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--orders",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--lengths",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            }
+          ]
+        },
+        {
+          "name": "get-index",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-index",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-rows",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--ttl",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--select",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-row",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--row-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--data",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--permissions",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-rows",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--rows",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "upsert-rows",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--rows",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-rows",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--data",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-rows",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-row",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--row-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--select",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "upsert-row",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--row-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--data",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--permissions",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-row",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--row-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--data",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--permissions",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-row",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--row-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "decrement-row-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--row-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--column",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--value",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--min",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "increment-row-column",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--database-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--table-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--row-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--column",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--value",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--max",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--transaction-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "teams",
+      "aliases": [],
+      "commands": [
+        {
+          "name": "list",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--team-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--roles",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            }
+          ]
+        },
+        {
+          "name": "get",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--team-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-name",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--team-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--team-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-installations",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--team-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-installation",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--team-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--app-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--authorization-details",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-installation",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--team-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--installation-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-installation",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--team-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--installation-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--authorization-details",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-installation",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--team-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--installation-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-logs",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--team-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-memberships",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--team-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-membership",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--team-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--roles",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--phone",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--url",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-membership",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--team-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--membership-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-membership",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--team-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--membership-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--roles",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            }
+          ]
+        },
+        {
+          "name": "delete-membership",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--team-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--membership-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-membership-status",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--team-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--membership-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-prefs",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--team-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-prefs",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--team-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--prefs",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "tokens",
+      "aliases": [],
+      "commands": [
+        {
+          "name": "list",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--bucket-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--file-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-file-token",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--bucket-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--file-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--expire",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--token-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--token-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--expire",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--token-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "users",
+      "aliases": [],
+      "commands": [
+        {
+          "name": "list",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--phone",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-argon-2-user",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-bcrypt-user",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-identities",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-identity",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--identity-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-md-5-user",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-ph-pass-user",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-scrypt-user",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password-salt",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password-cpu",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password-memory",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password-parallel",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password-length",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-scrypt-modified-user",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password-salt",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password-salt-separator",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password-signer-key",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-sha-user",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--password-version",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-usage",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--range",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-email",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--email",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-impersonator",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--impersonator",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-jwt",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--session-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--duration",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-labels",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--labels",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            }
+          ]
+        },
+        {
+          "name": "list-logs",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-memberships",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-mfa",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--mfa",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-mfa-authenticator",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-mfa-factors",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-mfa-recovery-codes",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-mfa-recovery-codes",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-mfa-recovery-codes",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-name",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-password",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-phone",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--number",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-prefs",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-prefs",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--prefs",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-sessions",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-session",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-sessions",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-session",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--session-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-status",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--status",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-targets",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-target",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--target-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--provider-type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--identifier",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-target",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--target-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-target",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--target-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--identifier",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-target",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--target-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-token",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--length",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--expire",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-email-verification",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--email-verification",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-phone-verification",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--user-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--phone-verification",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "vcs",
+      "aliases": [],
+      "commands": [
+        {
+          "name": "create-repository-detection",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--installation-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--provider-repository-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-root-directory",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-repositories",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--installation-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--type",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create-repository",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--installation-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--xprivate",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-namespace",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-repository",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--installation-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--provider-repository-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-repository-branches",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--installation-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--provider-repository-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-repository-contents",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--installation-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--provider-repository-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-root-directory",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--provider-reference",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-external-deployments",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--installation-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--repository-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--provider-pull-request-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-installations",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get-installation",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--installation-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete-installation",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--installation-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "list-namespaces",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--installation-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--search",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "webhooks",
+      "aliases": [],
+      "commands": [
+        {
+          "name": "list",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": false,
+              "name": "--queries",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--total",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--filter",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--where",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-asc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--sort-desc",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--limit",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--offset",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-after",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--cursor-before",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "create",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--webhook-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--url",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--events",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--tls",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--auth-username",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--auth-password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "get",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--webhook-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--webhook-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--name",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--url",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": true,
+              "name": "--events",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": true
+            },
+            {
+              "required": false,
+              "name": "--enabled",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--tls",
+              "shorthand": null,
+              "valueRequired": false,
+              "valueOptional": true,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--auth-username",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--auth-password",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "delete",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--webhook-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        },
+        {
+          "name": "update-secret",
+          "standalone": false,
+          "hidden": false,
+          "aliases": [],
+          "options": [
+            {
+              "required": true,
+              "name": "--webhook-id",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            },
+            {
+              "required": false,
+              "name": "--secret",
+              "shorthand": null,
+              "valueRequired": true,
+              "valueOptional": false,
+              "variadic": false
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "totals": {
+    "services": 23,
+    "commands": 608,
+    "options": 2912
+  }
+}

--- a/scripts/go-cli/extract-command-surface.mjs
+++ b/scripts/go-cli/extract-command-surface.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+// Extracts the CLI's command surface from the generated TypeScript into a JSON
+// contract the Go rewrite is checked against.
+//
+// The TypeScript CLI is the source of truth for flags, aliases, and hidden
+// state. Capture it here while it still is, so Phase 4 can diff the Go tree
+// against something machine-readable instead of against a reviewer's memory.
+//
+// Usage: node scripts/go-cli/extract-command-surface.mjs [servicesDir] [outFile]
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const servicesDir = process.argv[2] ?? 'examples/cli/lib/commands/services';
+const outFile = process.argv[3] ?? 'docs/go-cli/command-surface.json';
+
+// `.command(`name`)` and `.command(`name`, { hidden: true })`
+const SUBCOMMAND = /^\s*\.command\(`([^`]+)`(?:,\s*\{\s*hidden:\s*(true|false)\s*\})?\)/;
+// `export const fooBarCommand = new Command(`name`)` — promoted root commands
+const ROOT_COMMAND = /^export const (\w+) = new Command\(`([^`]+)`\)/;
+// `export const service = new Command("name")`
+const SERVICE_COMMAND = /^export const (\w+) = new Command\("([^"]+)"\)/;
+const ALIAS = /^\s*\.alias\("([^"]+)"\)/;
+// Option syntax is always the first argument and always backticked, but the
+// call may wrap across lines when a custom parser follows.
+const OPTION_START = /^\s*\.(option|requiredOption)\(\s*$/;
+const OPTION_INLINE = /^\s*\.(option|requiredOption)\(`([^`]+)`/;
+const BACKTICKED = /^\s*`([^`]+)`/;
+
+/**
+ * Split a commander option syntax string into its parts.
+ *   `-f, --force`              → shorthand -f, name --force, no value
+ *   `--database-id <id>`       → required value
+ *   `--queries [queries...]`   → optional variadic value
+ */
+function parseOptionSyntax(syntax) {
+  const [flagPart, valuePart] = syntax.split(/\s+(?=[<[])/);
+  const flags = flagPart.split(',').map((f) => f.trim());
+  const shorthand = flags.find((f) => /^-[^-]/.test(f)) ?? null;
+  const name = flags.find((f) => f.startsWith('--')) ?? null;
+
+  return {
+    name,
+    shorthand,
+    valueRequired: valuePart?.startsWith('<') ?? false,
+    valueOptional: valuePart?.startsWith('[') ?? false,
+    variadic: valuePart?.includes('...') ?? false,
+  };
+}
+
+function parseService(file) {
+  const lines = fs.readFileSync(file, 'utf8').split('\n');
+  const service = { name: null, aliases: [], commands: [] };
+  let current = null;
+
+  const flush = () => {
+    if (current) {
+      service.commands.push(current);
+      current = null;
+    }
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    const serviceMatch = SERVICE_COMMAND.exec(line);
+    if (serviceMatch) {
+      flush();
+      service.name = serviceMatch[2];
+      // The service's own `.alias()` follows its declaration, before the first
+      // subcommand — distinguish it from a subcommand alias by `current`.
+      continue;
+    }
+
+    const rootMatch = ROOT_COMMAND.exec(line);
+    if (rootMatch) {
+      flush();
+      current = { name: rootMatch[2], standalone: true, hidden: false, aliases: [], options: [] };
+      continue;
+    }
+
+    const subMatch = SUBCOMMAND.exec(line);
+    if (subMatch) {
+      flush();
+      current = {
+        name: subMatch[1],
+        standalone: false,
+        hidden: subMatch[2] === 'true',
+        aliases: [],
+        options: [],
+      };
+      continue;
+    }
+
+    const aliasMatch = ALIAS.exec(line);
+    if (aliasMatch) {
+      (current ? current.aliases : service.aliases).push(aliasMatch[1]);
+      continue;
+    }
+
+    if (!current) {
+      continue;
+    }
+
+    const inline = OPTION_INLINE.exec(line);
+    if (inline) {
+      current.options.push({ required: inline[1] === 'requiredOption', ...parseOptionSyntax(inline[2]) });
+      continue;
+    }
+
+    // Wrapped form: syntax sits on the next line.
+    const wrapped = OPTION_START.exec(line);
+    if (wrapped) {
+      const next = BACKTICKED.exec(lines[i + 1] ?? '');
+      if (next) {
+        current.options.push({ required: wrapped[1] === 'requiredOption', ...parseOptionSyntax(next[1]) });
+        i++;
+      }
+      continue;
+    }
+  }
+
+  flush();
+  return service;
+}
+
+const files = fs
+  .readdirSync(servicesDir)
+  .filter((f) => f.endsWith('.ts'))
+  .sort();
+
+const services = files.map((f) => parseService(path.join(servicesDir, f)));
+const commandCount = services.reduce((sum, s) => sum + s.commands.length, 0);
+const optionCount = services.reduce(
+  (sum, s) => sum + s.commands.reduce((n, c) => n + c.options.length, 0),
+  0,
+);
+
+fs.mkdirSync(path.dirname(outFile), { recursive: true });
+fs.writeFileSync(
+  outFile,
+  JSON.stringify({ services, totals: { services: services.length, commands: commandCount, options: optionCount } }, null, 2) + '\n',
+);
+
+process.stdout.write(
+  `${services.length} services, ${commandCount} commands, ${optionCount} options → ${outFile}\n`,
+);

--- a/tests/e2e/languages/cli/appwrite.config.json
+++ b/tests/e2e/languages/cli/appwrite.config.json
@@ -1,3 +1,0 @@
-{
-    "projectId": "console"
-}

--- a/tests/e2e/languages/cli/appwrite.config.json
+++ b/tests/e2e/languages/cli/appwrite.config.json
@@ -1,0 +1,3 @@
+{
+    "projectId": "console"
+}


### PR DESCRIPTION
Stacked on #1715. Phase 0 answers one question: **is the rewrite worth attempting at all?** Two gates, both measured against a real spike rather than argued from first principles.

| Gate | Threshold | Measured | |
|---|---|---|---|
| Startup | ≥ 5× faster | **41×** — 205.9 ms → 5.0 ms | pass |
| `push` packaging | ≥ 20 % faster | **56 % faster**, and peak RSS 421 MB → 102 MB | pass |

Both clear by a wide margin, so the answer is yes.

## What to read

**[`docs/go-cli/BENCHMARKS.md`](docs/go-cli/BENCHMARKS.md)** — every number with the command that produced it. Re-run them before trusting them on other hardware.

**`docs/go-cli/command-surface.json`** — 28,286 lines, and the reason this PR looks enormous. It is machine-extracted, not written: every command, subcommand, flag, short form and required-flag set the TypeScript CLI exposes. It is the contract Phase 1 asserts the Go tree against, so it is committed rather than regenerated, and reviewing it line by line is not the point. `scripts/go-cli/extract-command-surface.mjs` (147 lines) is the part to read.

## Two findings that changed the plan

**Lazy command registration is unnecessary.** The obvious optimisation — don't build the cobra tree until you know which command ran — was measured and does not pay. Tree construction is not the bottleneck. PLAN.md now says so explicitly, so nobody spends a week on it.

**`pgzip` costs nothing in compression ratio.** At level 9 it produces 18,309 bytes against `compress/gzip`'s 18,308 and Node's 18,305, so the parallel implementation is free.

## One cleanup

`tests/e2e/languages/cli/appwrite.config.json` was sitting in the tree as a committed fixture, but nothing reads it — the harness writes that file itself at `test.js:845`, with a `tables` block the committed copy did not have. It is harness output, so it is gitignored rather than tracked; otherwise every run leaves a dirty working tree.

## Corrections to #1715

Measuring turned up four places where the plan's numbers were wrong, all now fixed in it: 23 services not 24, 608 command entries not 606, startup 206 ms not the 40–150 ms guessed, and the spike binary 2.9 MB.

## Verified

Apple M2 Pro, macOS 26.5.2, `hyperfine` 1.20.0, against archives of 369 MB / 22,892 files and 737 MB / 45,784 files. The startup figures compare the shipped Bun binary and the Node bundle against the Go spike; **the spike had a handful of commands where the finished CLI has 608, so its 5.0 ms is not the product's number** — #1726 measures that and reports both.
