### PR TITLE
feat(go-cli): Phase 2 — runtime foundation (config, auth, output, client)

### DIFF
--- a/docs/go-cli/PLAN.md
+++ b/docs/go-cli/PLAN.md
@@ -564,7 +564,7 @@ Progress table, kept current:
 |---|---|---|---|
 | 0 — Spike | ✅ Complete — [BENCHMARKS.md](BENCHMARKS.md) | | |
 | 1 — Generator scaffolding | ✅ Complete — surface matches TS exactly (608/608) | | |
-| 2 — Runtime foundation | 🔄 In progress — config, redaction, client, session done | | |
+| 2 — Runtime foundation | 🔄 In progress — config, jsonx, redaction, JSON output, client, auth, session | #1718 |
 | 3 — Generated commands | Not started | | |
 | 4 — Conformance harness | Not started | | |
 | 5 — Stateful commands | Not started | | |

--- a/docs/go-cli/PLAN.md
+++ b/docs/go-cli/PLAN.md
@@ -564,7 +564,7 @@ Progress table, kept current:
 |---|---|---|---|
 | 0 — Spike | ✅ Complete — [BENCHMARKS.md](BENCHMARKS.md) | | |
 | 1 — Generator scaffolding | ✅ Complete — surface matches TS exactly (608/608) | | |
-| 2 — Runtime foundation | Not started | | |
+| 2 — Runtime foundation | 🔄 In progress — config, redaction, client, session done | | |
 | 3 — Generated commands | Not started | | |
 | 4 — Conformance harness | Not started | | |
 | 5 — Stateful commands | Not started | | |

--- a/docs/go-cli/PLAN.md
+++ b/docs/go-cli/PLAN.md
@@ -312,7 +312,7 @@ merge. Check `Go.php:63` for what you are replacing.
 
 ---
 
-### Phase 2 — Runtime foundation
+### Phase 2 — Runtime foundation ✅ COMPLETE
 
 **Goal:** the non-generated core, with unit tests. No service commands, no stateful
 commands.
@@ -564,7 +564,7 @@ Progress table, kept current:
 |---|---|---|---|
 | 0 — Spike | ✅ Complete — [BENCHMARKS.md](BENCHMARKS.md) | | |
 | 1 — Generator scaffolding | ✅ Complete — surface matches TS exactly (608/608) | | |
-| 2 — Runtime foundation | 🔄 In progress — config (global+local, both byte-identical), jsonx, redaction, JSON output, client, auth, session | #1718 |
+| 2 — Runtime foundation | ✅ Complete — exit criteria met; `response-config.ts` formatting and `internal/prompt` deferred | #1718 |
 | 3 — Generated commands | Not started | | |
 | 4 — Conformance harness | Not started | | |
 | 5 — Stateful commands | Not started | | |

--- a/docs/go-cli/PLAN.md
+++ b/docs/go-cli/PLAN.md
@@ -564,7 +564,7 @@ Progress table, kept current:
 |---|---|---|---|
 | 0 — Spike | ✅ Complete — [BENCHMARKS.md](BENCHMARKS.md) | | |
 | 1 — Generator scaffolding | ✅ Complete — surface matches TS exactly (608/608) | | |
-| 2 — Runtime foundation | 🔄 In progress — config, jsonx, redaction, JSON output, client, auth, session | #1718 |
+| 2 — Runtime foundation | 🔄 In progress — config (global+local, both byte-identical), jsonx, redaction, JSON output, client, auth, session | #1718 |
 | 3 — Generated commands | Not started | | |
 | 4 — Conformance harness | Not started | | |
 | 5 — Stateful commands | Not started | | |

--- a/docs/go-cli/README.md
+++ b/docs/go-cli/README.md
@@ -302,6 +302,11 @@ Ranked by how often they will bite you.
 
 **Your change did nothing.** No `getFiles()` entry. Check `GoCLI::getFiles()`.
 
+**You removed a `getFiles()` entry but the file is still there.** Generation writes
+files; it never deletes them. `examples/` keeps the old output, and the build fails with
+a redeclaration error that points at code you thought was gone. Delete the stale file
+from `examples/go-cli/` by hand, or regenerate into a clean directory.
+
 **Your Twig syntax appears literally in the output.** The file is `'scope' => 'copy'`.
 Change the scope or remove the variable.
 

--- a/example.php
+++ b/example.php
@@ -316,7 +316,6 @@ try {
     // Go CLI (rewrite in progress -- see docs/go-cli/PLAN.md)
     if (!$requestedSdk || $requestedSdk === 'go-cli') {
         $language = new GoCLI();
-        $language->setModulePath('github.com/appwrite/appwrite-cli-go');
         $language->setExecutableName('appwrite');
 
         $sdk = new SDK($language, buildSpec($specFormat, $spec));

--- a/src/SDK/Language/GoCLI.php
+++ b/src/SDK/Language/GoCLI.php
@@ -352,6 +352,21 @@ class GoCLI extends Go
                 'template'      => 'go-cli/internal/cmd/login.go',
             ],
             [
+                'scope'         => 'copy',
+                'destination'   => 'internal/output/filter.go',
+                'template'      => 'go-cli/internal/output/filter.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/output/filter_test.go',
+                'template'      => 'go-cli/internal/output/filter_test.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/output/render.go',
+                'template'      => 'go-cli/internal/output/render.go',
+            ],
+            [
                 'scope'         => 'default',
                 'destination'   => 'internal/cmd/services/register.go',
                 'template'      => 'go-cli/internal/cmd/services/register.go.twig',

--- a/src/SDK/Language/GoCLI.php
+++ b/src/SDK/Language/GoCLI.php
@@ -23,11 +23,22 @@ class GoCLI extends Go
     use CliCommandSurface;
 
     /**
+     * Go module path the CLI is published under.
+     *
+     * A constant rather than a settable param: Go has no relative imports, so
+     * this string is baked into every import in the runtime packages. Those
+     * files are `copy` scope -- plain Go that can be edited, vetted and tested
+     * in place -- which is only safe while the path cannot change underneath
+     * them.
+     */
+    public const string MODULE_PATH = 'github.com/appwrite/appwrite-cli-go';
+
+    /**
      * @var array
      */
     #[Override]
     protected $params = [
-        'modulePath' => 'github.com/appwrite/appwrite-cli-go',
+        'modulePath' => self::MODULE_PATH,
         'executableName' => 'appwrite',
         'homebrewTapOwner' => 'appwrite',
         'homebrewTapName' => 'appwrite',
@@ -38,16 +49,6 @@ class GoCLI extends Go
     public function getName(): string
     {
         return 'GoCLI';
-    }
-
-    /**
-     * Go module path the generated CLI is published under.
-     */
-    public function setModulePath(string $modulePath): self
-    {
-        $this->setParam('modulePath', $modulePath);
-
-        return $this;
     }
 
     /**
@@ -254,6 +255,41 @@ class GoCLI extends Go
                 'scope'         => 'default',
                 'destination'   => 'internal/cmd/root.go',
                 'template'      => 'go-cli/internal/cmd/root.go.twig',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/config/ordered.go',
+                'template'      => 'go-cli/internal/config/ordered.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/config/global.go',
+                'template'      => 'go-cli/internal/config/global.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/config/config_test.go',
+                'template'      => 'go-cli/internal/config/config_test.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/output/redact.go',
+                'template'      => 'go-cli/internal/output/redact.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/output/redact_test.go',
+                'template'      => 'go-cli/internal/output/redact_test.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/client/client.go',
+                'template'      => 'go-cli/internal/client/client.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/cmd/session.go',
+                'template'      => 'go-cli/internal/cmd/session.go',
             ],
             [
                 'scope'         => 'default',

--- a/src/SDK/Language/GoCLI.php
+++ b/src/SDK/Language/GoCLI.php
@@ -353,6 +353,11 @@ class GoCLI extends Go
             ],
             [
                 'scope'         => 'copy',
+                'destination'   => 'internal/cmd/login_test.go',
+                'template'      => 'go-cli/internal/cmd/login_test.go',
+            ],
+            [
+                'scope'         => 'copy',
                 'destination'   => 'internal/output/filter.go',
                 'template'      => 'go-cli/internal/output/filter.go',
             ],

--- a/src/SDK/Language/GoCLI.php
+++ b/src/SDK/Language/GoCLI.php
@@ -327,6 +327,16 @@ class GoCLI extends Go
                 'template'      => 'go-cli/internal/output/json_test.go',
             ],
             [
+                'scope'         => 'copy',
+                'destination'   => 'internal/config/local.go',
+                'template'      => 'go-cli/internal/config/local.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/config/local_test.go',
+                'template'      => 'go-cli/internal/config/local_test.go',
+            ],
+            [
                 'scope'         => 'default',
                 'destination'   => 'internal/cmd/services/register.go',
                 'template'      => 'go-cli/internal/cmd/services/register.go.twig',

--- a/src/SDK/Language/GoCLI.php
+++ b/src/SDK/Language/GoCLI.php
@@ -337,6 +337,21 @@ class GoCLI extends Go
                 'template'      => 'go-cli/internal/config/local_test.go',
             ],
             [
+                'scope'         => 'copy',
+                'destination'   => 'internal/auth/device.go',
+                'template'      => 'go-cli/internal/auth/device.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/auth/device_test.go',
+                'template'      => 'go-cli/internal/auth/device_test.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/cmd/login.go',
+                'template'      => 'go-cli/internal/cmd/login.go',
+            ],
+            [
                 'scope'         => 'default',
                 'destination'   => 'internal/cmd/services/register.go',
                 'template'      => 'go-cli/internal/cmd/services/register.go.twig',

--- a/src/SDK/Language/GoCLI.php
+++ b/src/SDK/Language/GoCLI.php
@@ -292,6 +292,21 @@ class GoCLI extends Go
                 'template'      => 'go-cli/internal/cmd/session.go',
             ],
             [
+                'scope'         => 'copy',
+                'destination'   => 'internal/auth/keyring.go',
+                'template'      => 'go-cli/internal/auth/keyring.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/auth/refresh.go',
+                'template'      => 'go-cli/internal/auth/refresh.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/auth/refresh_test.go',
+                'template'      => 'go-cli/internal/auth/refresh_test.go',
+            ],
+            [
                 'scope'         => 'default',
                 'destination'   => 'internal/cmd/services/register.go',
                 'template'      => 'go-cli/internal/cmd/services/register.go.twig',

--- a/src/SDK/Language/GoCLI.php
+++ b/src/SDK/Language/GoCLI.php
@@ -258,11 +258,6 @@ class GoCLI extends Go
             ],
             [
                 'scope'         => 'copy',
-                'destination'   => 'internal/config/ordered.go',
-                'template'      => 'go-cli/internal/config/ordered.go',
-            ],
-            [
-                'scope'         => 'copy',
                 'destination'   => 'internal/config/global.go',
                 'template'      => 'go-cli/internal/config/global.go',
             ],
@@ -305,6 +300,31 @@ class GoCLI extends Go
                 'scope'         => 'copy',
                 'destination'   => 'internal/auth/refresh_test.go',
                 'template'      => 'go-cli/internal/auth/refresh_test.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/jsonx/object.go',
+                'template'      => 'go-cli/internal/jsonx/object.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/jsonx/object_test.go',
+                'template'      => 'go-cli/internal/jsonx/object_test.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/config/json.go',
+                'template'      => 'go-cli/internal/config/json.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/output/json.go',
+                'template'      => 'go-cli/internal/output/json.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/output/json_test.go',
+                'template'      => 'go-cli/internal/output/json_test.go',
             ],
             [
                 'scope'         => 'default',

--- a/templates/go-cli/README.md.twig
+++ b/templates/go-cli/README.md.twig
@@ -17,6 +17,7 @@ idempotent, so formatting is a build step rather than a template concern.
 
 ```bash
 gofmt -w .
+go mod tidy
 go build -ldflags="-s -w" -o {{ language.params.executableName }} .
 ./{{ language.params.executableName }} --help
 ```

--- a/templates/go-cli/go.mod.twig
+++ b/templates/go-cli/go.mod.twig
@@ -6,6 +6,7 @@ go 1.24
 // indirect set and refresh go.sum -- go.mod is regenerated from this template,
 // so anything added by hand to the generated file is lost on the next run.
 require (
+	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
 	github.com/zalando/go-keyring v0.2.6

--- a/templates/go-cli/go.mod.twig
+++ b/templates/go-cli/go.mod.twig
@@ -2,7 +2,11 @@ module {{ language.params.modulePath }}
 
 go 1.24
 
+// Direct dependencies only. Run `go mod tidy` after generation to resolve the
+// indirect set and refresh go.sum -- go.mod is regenerated from this template,
+// so anything added by hand to the generated file is lost on the next run.
 require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
+	github.com/zalando/go-keyring v0.2.6
 )

--- a/templates/go-cli/internal/auth/device.go
+++ b/templates/go-cli/internal/auth/device.go
@@ -1,0 +1,266 @@
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/appwrite/appwrite-cli-go/internal/client"
+	"github.com/appwrite/appwrite-cli-go/internal/config"
+)
+
+// Ports the device-code half of templates/cli/lib/auth/oauth.ts and
+// lib/auth/login.ts -- RFC 8628 device authorization.
+
+// OAuth2Scopes are the scopes the CLI requests.
+//
+// Ports OAUTH2_SCOPES (templates/cli/lib/constants.ts:34).
+const OAuth2Scopes = "openid email profile all"
+
+// defaultPollInterval is used when the server omits one.
+//
+// RFC 8628 section 3.5. The TypeScript guards against a missing interval
+// becoming NaN and busy-polling the endpoint; the Go equivalent is guarding
+// against zero.
+const defaultPollInterval = 5 * time.Second
+
+// slowDownIncrement is how much a `slow_down` response adds to the interval.
+const slowDownIncrement = 5 * time.Second
+
+// ErrDeviceAuthorizationExpired means the user did not approve in time.
+var ErrDeviceAuthorizationExpired = errors.New("device authorization expired before it was approved")
+
+// DeviceAuthorization is the server's response to a device authorization
+// request.
+type DeviceAuthorization struct {
+	DeviceCode              string      `json:"device_code"`
+	UserCode                string      `json:"user_code"`
+	VerificationURI         string      `json:"verification_uri"`
+	VerificationURIComplete string      `json:"verification_uri_complete"`
+	ExpiresIn               json.Number `json:"expires_in"`
+	Interval                json.Number `json:"interval"`
+}
+
+// VerificationURL is the URL to show the user, preferring the one that embeds
+// the code so they do not have to type it.
+func (d DeviceAuthorization) VerificationURL() string {
+	if d.VerificationURIComplete != "" {
+		return d.VerificationURIComplete
+	}
+
+	return d.VerificationURI
+}
+
+// PollInterval is how long to wait between token requests.
+func (d DeviceAuthorization) PollInterval() time.Duration {
+	seconds, err := d.Interval.Int64()
+	if err != nil || seconds <= 0 {
+		return defaultPollInterval
+	}
+
+	return time.Duration(seconds) * time.Second
+}
+
+// Lifetime is how long the authorization is valid for.
+//
+// An explicit zero means already expired and is honoured as such -- the
+// TypeScript computes `Date.now() + expires_in * 1000` directly, so a zero
+// there ends the loop immediately. Only a missing or unparseable value falls
+// back to a default, which stops a malformed response becoming an instant
+// failure.
+func (d DeviceAuthorization) Lifetime() time.Duration {
+	seconds, err := d.ExpiresIn.Int64()
+	if err != nil {
+		return 10 * time.Minute
+	}
+	if seconds < 0 {
+		return 0
+	}
+
+	return time.Duration(seconds) * time.Second
+}
+
+// DeviceFlow runs RFC 8628 device authorization against one endpoint.
+type DeviceFlow struct {
+	Endpoint   string
+	ClientID   string
+	SDKVersion string
+
+	// Sleep and Now are injectable so the poll loop is testable without
+	// waiting real seconds.
+	Sleep func(time.Duration)
+	Now   func() time.Time
+}
+
+// NewDeviceFlow wires a device flow against an endpoint.
+func NewDeviceFlow(endpoint, sdkVersion string) *DeviceFlow {
+	return &DeviceFlow{
+		Endpoint:   config.NormalizeCloudConsoleEndpoint(endpoint),
+		ClientID:   DefaultClientID,
+		SDKVersion: sdkVersion,
+		Sleep:      time.Sleep,
+		Now:        time.Now,
+	}
+}
+
+func (f *DeviceFlow) api() *client.Client {
+	return client.New(f.Endpoint, f.SDKVersion).SetProject(config.ProjectConsole)
+}
+
+// Authorize requests a device code and user code.
+func (f *DeviceFlow) Authorize() (DeviceAuthorization, error) {
+	var authorization DeviceAuthorization
+	err := f.api().Call("POST",
+		"/oauth2/"+config.ProjectConsole+"/device_authorization",
+		map[string]any{
+			"client_id": f.ClientID,
+			"scope":     OAuth2Scopes,
+		},
+		&authorization)
+
+	return authorization, err
+}
+
+// Poll requests a token until the user approves, the authorization expires, or
+// the server returns a real error.
+//
+// Returns ErrDeviceAuthorizationExpired when the window closes. Pending and
+// empty-body responses are retried; `slow_down` additionally widens the
+// interval per RFC 8628 section 3.5.
+func (f *DeviceFlow) Poll(authorization DeviceAuthorization) (*TokenSet, error) {
+	interval := authorization.PollInterval()
+	deadline := f.now().Add(authorization.Lifetime())
+
+	for f.now().Before(deadline) {
+		f.sleep(interval)
+
+		var token tokenResponse
+		err := f.api().Call("POST", "/oauth2/"+config.ProjectConsole+"/token", map[string]any{
+			"grant_type":  "urn:ietf:params:oauth:grant-type:device_code",
+			"device_code": authorization.DeviceCode,
+			"client_id":   f.ClientID,
+		}, &token)
+
+		if err == nil && token.AccessToken != "" {
+			expiresIn, _ := token.ExpiresIn.Int64()
+
+			return &TokenSet{
+				AccessToken:  token.AccessToken,
+				RefreshToken: token.RefreshToken,
+				IDToken:      token.IDToken,
+				ExpiresAt:    f.now().Add(time.Duration(expiresIn) * time.Second),
+			}, nil
+		}
+		if err == nil {
+			// A 2xx with no token is not something the spec describes; treat it
+			// like a pending response rather than looping instantly.
+			continue
+		}
+
+		if isSlowDown(err) {
+			interval += slowDownIncrement
+
+			continue
+		}
+		if isAuthorizationPending(err) {
+			continue
+		}
+
+		return nil, err
+	}
+
+	return nil, ErrDeviceAuthorizationExpired
+}
+
+// TokenSet is a completed device authorization.
+type TokenSet struct {
+	AccessToken  string
+	RefreshToken string
+	IDToken      string
+	ExpiresAt    time.Time
+}
+
+func (f *DeviceFlow) sleep(duration time.Duration) {
+	if f.Sleep == nil {
+		time.Sleep(duration)
+
+		return
+	}
+	f.Sleep(duration)
+}
+
+func (f *DeviceFlow) now() time.Time {
+	if f.Now == nil {
+		return time.Now()
+	}
+
+	return f.Now()
+}
+
+// matchesOAuthError reports whether an API error carries an OAuth error code.
+//
+// The code can arrive as the error type or the message depending on how the
+// endpoint failed, so both are checked -- ports matchesOAuthError().
+func matchesOAuthError(err error, code string) bool {
+	var apiError *client.APIError
+	if !errors.As(err, &apiError) {
+		return false
+	}
+
+	return apiError.Type == code ||
+		apiError.Message == code ||
+		strings.Contains(apiError.Message, code)
+}
+
+func isSlowDown(err error) bool {
+	return matchesOAuthError(err, "slow_down")
+}
+
+// isAuthorizationPending reports whether polling should continue.
+//
+// An empty error body -- a 400 with no type and no message -- is treated as
+// pending rather than fatal. Ports isEmptyDevicePollError(): aborting the whole
+// login because one poll came back blank would be a worse failure than one more
+// round trip.
+func isAuthorizationPending(err error) bool {
+	if matchesOAuthError(err, "authorization_pending") || matchesOAuthError(err, "slow_down") {
+		return true
+	}
+
+	var apiError *client.APIError
+	if !errors.As(err, &apiError) {
+		return false
+	}
+
+	return strings.TrimSpace(apiError.Type) == "" && strings.TrimSpace(apiError.Message) == ""
+}
+
+// DecodeIDToken pulls the profile claims out of an OIDC ID token.
+//
+// The signature is not verified: the token arrived over TLS from the endpoint
+// the user just authenticated against, and it is used only to label the stored
+// session. Ports decodeIdToken().
+func DecodeIDToken(idToken string) (email, name, subject string) {
+	parts := strings.Split(idToken, ".")
+	if len(parts) < 2 {
+		return "", "", ""
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", "", ""
+	}
+
+	var claims struct {
+		Email   string `json:"email"`
+		Name    string `json:"name"`
+		Subject string `json:"sub"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", "", ""
+	}
+
+	return claims.Email, claims.Name, claims.Subject
+}

--- a/templates/go-cli/internal/auth/device_test.go
+++ b/templates/go-cli/internal/auth/device_test.go
@@ -1,0 +1,226 @@
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// deviceServer stands in for the token endpoint, replying with the queued
+// responses in order.
+func deviceServer(t *testing.T, responses []func(w http.ResponseWriter)) (*httptest.Server, *int) {
+	t.Helper()
+
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		index := calls
+		calls++
+		if index >= len(responses) {
+			t.Errorf("unexpected extra poll %d", index)
+
+			return
+		}
+		responses[index](w)
+	}))
+	t.Cleanup(server.Close)
+
+	return server, &calls
+}
+
+func pendingResponse(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusBadRequest)
+	_ = json.NewEncoder(w).Encode(map[string]any{"type": "authorization_pending"})
+}
+
+func slowDownResponse(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusBadRequest)
+	_ = json.NewEncoder(w).Encode(map[string]any{"type": "slow_down"})
+}
+
+func tokenGrantedResponse(w http.ResponseWriter) {
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"access_token":  "granted",
+		"refresh_token": "refresh",
+		"expires_in":    3600,
+	})
+}
+
+func newTestFlow(t *testing.T, endpoint string) (*DeviceFlow, *[]time.Duration) {
+	t.Helper()
+
+	slept := []time.Duration{}
+	flow := NewDeviceFlow(endpoint, "0.0.1")
+	flow.Sleep = func(d time.Duration) { slept = append(slept, d) }
+	flow.Now = func() time.Time { return fixedNow }
+
+	return flow, &slept
+}
+
+func testAuthorization() DeviceAuthorization {
+	return DeviceAuthorization{
+		DeviceCode: "device-code",
+		UserCode:   "ABCD-EFGH",
+		ExpiresIn:  json.Number("600"),
+		Interval:   json.Number("5"),
+	}
+}
+
+// Polling continues through pending responses and stops on the granted token.
+func TestPollSucceedsAfterPendingResponses(t *testing.T) {
+	server, calls := deviceServer(t, []func(http.ResponseWriter){
+		pendingResponse, pendingResponse, tokenGrantedResponse,
+	})
+
+	flow, slept := newTestFlow(t, server.URL)
+	token, err := flow.Poll(testAuthorization())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token.AccessToken != "granted" {
+		t.Errorf("access token = %q", token.AccessToken)
+	}
+	if *calls != 3 {
+		t.Errorf("polls = %d, want 3", *calls)
+	}
+	for _, interval := range *slept {
+		if interval != 5*time.Second {
+			t.Errorf("poll interval = %s, want 5s", interval)
+		}
+	}
+}
+
+// RFC 8628 section 3.5: `slow_down` widens the interval by five seconds, and
+// the widened interval persists for subsequent polls.
+func TestPollWidensIntervalOnSlowDown(t *testing.T) {
+	server, _ := deviceServer(t, []func(http.ResponseWriter){
+		slowDownResponse, pendingResponse, tokenGrantedResponse,
+	})
+
+	flow, slept := newTestFlow(t, server.URL)
+	if _, err := flow.Poll(testAuthorization()); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []time.Duration{5 * time.Second, 10 * time.Second, 10 * time.Second}
+	if len(*slept) != len(want) {
+		t.Fatalf("slept = %v, want %v", *slept, want)
+	}
+	for i, interval := range *slept {
+		if interval != want[i] {
+			t.Errorf("poll %d slept %s, want %s", i, interval, want[i])
+		}
+	}
+}
+
+// An empty error body -- a 400 with no type and no message -- is transient.
+// Aborting the whole login on one blank response is a worse failure than one
+// more round trip.
+func TestPollTreatsEmptyErrorBodyAsPending(t *testing.T) {
+	empty := func(w http.ResponseWriter) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{}`))
+	}
+
+	server, calls := deviceServer(t, []func(http.ResponseWriter){empty, tokenGrantedResponse})
+
+	flow, _ := newTestFlow(t, server.URL)
+	if _, err := flow.Poll(testAuthorization()); err != nil {
+		t.Fatal(err)
+	}
+	if *calls != 2 {
+		t.Errorf("polls = %d, want 2", *calls)
+	}
+}
+
+// A real error -- access_denied -- must abort rather than spin until the
+// authorization expires.
+func TestPollAbortsOnRealError(t *testing.T) {
+	denied := func(w http.ResponseWriter) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{"type": "access_denied"})
+	}
+
+	server, calls := deviceServer(t, []func(http.ResponseWriter){denied})
+
+	flow, _ := newTestFlow(t, server.URL)
+	if _, err := flow.Poll(testAuthorization()); err == nil {
+		t.Fatal("expected an error")
+	}
+	if *calls != 1 {
+		t.Errorf("polls = %d, want 1", *calls)
+	}
+}
+
+// When the window closes the caller gets a distinguishable error rather than a
+// nil token.
+func TestPollExpires(t *testing.T) {
+	server, _ := deviceServer(t, []func(http.ResponseWriter){})
+
+	flow, _ := newTestFlow(t, server.URL)
+	authorization := testAuthorization()
+	authorization.ExpiresIn = json.Number("0")
+
+	if _, err := flow.Poll(authorization); err != ErrDeviceAuthorizationExpired {
+		t.Errorf("err = %v, want ErrDeviceAuthorizationExpired", err)
+	}
+}
+
+// A server that omits the interval must not produce a busy loop.
+func TestPollIntervalDefaultsWhenMissing(t *testing.T) {
+	authorization := DeviceAuthorization{}
+	if got := authorization.PollInterval(); got != defaultPollInterval {
+		t.Errorf("interval = %s, want %s", got, defaultPollInterval)
+	}
+
+	authorization.Interval = json.Number("0")
+	if got := authorization.PollInterval(); got != defaultPollInterval {
+		t.Errorf("zero interval = %s, want %s", got, defaultPollInterval)
+	}
+}
+
+// The URL with the code embedded is preferred so the user does not retype it.
+func TestVerificationURLPrefersCompleteForm(t *testing.T) {
+	authorization := DeviceAuthorization{
+		VerificationURI:         "https://example.com/device",
+		VerificationURIComplete: "https://example.com/device?code=ABCD",
+	}
+	if got := authorization.VerificationURL(); got != authorization.VerificationURIComplete {
+		t.Errorf("URL = %q, want the complete form", got)
+	}
+
+	authorization.VerificationURIComplete = ""
+	if got := authorization.VerificationURL(); got != authorization.VerificationURI {
+		t.Errorf("URL = %q, want the plain form", got)
+	}
+}
+
+func TestDecodeIDToken(t *testing.T) {
+	claims := map[string]any{"email": "a@b.c", "name": "Test User", "sub": "user-1"}
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idToken := "header." + base64.RawURLEncoding.EncodeToString(payload) + ".signature"
+
+	email, name, subject := DecodeIDToken(idToken)
+	if email != "a@b.c" || name != "Test User" || subject != "user-1" {
+		t.Errorf("claims = %q, %q, %q", email, name, subject)
+	}
+}
+
+// A malformed token must return empty claims rather than panic -- it is only
+// used to label the stored session, so it is never worth failing a login over.
+func TestDecodeIDTokenToleratesGarbage(t *testing.T) {
+	for _, idToken := range []string{"", "onlyonepart", "a.!!!notbase64!!!.c", "a.e30.c"} {
+		email, name, subject := DecodeIDToken(idToken)
+		if idToken == "a.e30.c" {
+			continue // valid but empty claims
+		}
+		if email != "" || name != "" || subject != "" {
+			t.Errorf("DecodeIDToken(%q) = %q, %q, %q, want empty", idToken, email, name, subject)
+		}
+	}
+}

--- a/templates/go-cli/internal/auth/keyring.go
+++ b/templates/go-cli/internal/auth/keyring.go
@@ -1,0 +1,95 @@
+package auth
+
+import (
+	"github.com/appwrite/appwrite-cli-go/internal/config"
+	"github.com/zalando/go-keyring"
+)
+
+// Ports templates/cli/lib/auth/refresh-token.ts.
+
+// refreshTokenService is the keyring service refresh tokens are filed under.
+//
+// Matches the TypeScript CLI's `${EXECUTABLE_NAME}-oauth-refresh-token` exactly.
+// Interop is not an invariant -- docs/go-cli/PLAN.md §3 says re-authenticating
+// once on upgrade is acceptable -- but matching costs nothing and spares users
+// a login if the platform keyring cooperates.
+const refreshTokenService = "appwrite-oauth-refresh-token"
+
+// prefsRefreshTokenKey is where a refresh token lands when no keyring is
+// available.
+const prefsRefreshTokenKey = config.PreferenceRefreshToken
+
+// TokenStore reads and writes refresh tokens, preferring the OS keyring and
+// falling back to the preferences file.
+//
+// The fallback is not a convenience: headless Linux and CI containers have no
+// secret service, and a CLI that refuses to hold a session there is a CLI that
+// cannot be scripted. The TypeScript CLI makes the same trade.
+type TokenStore struct {
+	Global *config.Global
+}
+
+// Refresh returns the stored refresh token for a session, or "" when there is
+// none.
+//
+// Keyring errors are swallowed rather than surfaced: an unavailable keyring is
+// indistinguishable from an absent entry as far as the caller is concerned, and
+// both mean "fall back to prefs".
+func (s *TokenStore) Refresh(sessionID string) string {
+	if sessionID == "" {
+		return ""
+	}
+
+	if token, err := keyring.Get(refreshTokenService, sessionID); err == nil && token != "" {
+		return token
+	}
+
+	session := s.Global.SessionData(sessionID)
+	if session == nil {
+		return ""
+	}
+
+	return session.GetString(prefsRefreshTokenKey)
+}
+
+// SetRefresh stores a refresh token, preferring the keyring.
+//
+// On success the prefs copy is removed, so a token never lingers in plaintext
+// after the keyring starts working. On failure it is written to prefs instead.
+func (s *TokenStore) SetRefresh(sessionID, token string) error {
+	if sessionID == "" {
+		return nil
+	}
+	if token == "" {
+		return s.DeleteRefresh(sessionID)
+	}
+
+	if err := keyring.Set(refreshTokenService, sessionID, token); err == nil {
+		s.clearPrefsToken(sessionID)
+
+		return s.Global.Write()
+	}
+
+	if session := s.Global.SessionData(sessionID); session != nil {
+		session.Set(prefsRefreshTokenKey, token)
+	}
+
+	return s.Global.Write()
+}
+
+// DeleteRefresh removes a refresh token from both stores.
+//
+// A missing or unavailable keyring must not block local cleanup, so the keyring
+// error is ignored and the prefs copy is removed regardless.
+func (s *TokenStore) DeleteRefresh(sessionID string) error {
+	_ = keyring.Delete(refreshTokenService, sessionID)
+	s.clearPrefsToken(sessionID)
+
+	return s.Global.Write()
+}
+
+func (s *TokenStore) clearPrefsToken(sessionID string) {
+	if session := s.Global.SessionData(sessionID); session != nil {
+		session.Delete(prefsRefreshTokenKey)
+	}
+}

--- a/templates/go-cli/internal/auth/refresh.go
+++ b/templates/go-cli/internal/auth/refresh.go
@@ -1,0 +1,146 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"strconv"
+	"time"
+
+	"github.com/appwrite/appwrite-cli-go/internal/client"
+	"github.com/appwrite/appwrite-cli-go/internal/config"
+)
+
+// Ports getValidAccessToken() from templates/cli/lib/sdks.ts:33.
+
+// DefaultClientID is the OAuth2 client the CLI identifies as.
+const DefaultClientID = "appwrite-cli"
+
+// refreshSkew is how far before expiry a token is treated as stale.
+//
+// A token that expires during the request it authenticates is a confusing
+// failure, so renew a minute early. Matches the TypeScript `60_000`.
+const refreshSkew = 60 * time.Second
+
+// ErrSessionExpired is returned when no usable credential remains.
+var ErrSessionExpired = errors.New("session expired. Run `appwrite login` to create a new session")
+
+// tokenResponse is the subset of the OAuth2 token payload the CLI uses.
+type tokenResponse struct {
+	AccessToken  string      `json:"access_token"`
+	RefreshToken string      `json:"refresh_token"`
+	ExpiresIn    json.Number `json:"expires_in"`
+}
+
+// Authenticator resolves a usable access token for the active session.
+type Authenticator struct {
+	Global     *config.Global
+	Store      *TokenStore
+	SDKVersion string
+
+	// Now is injectable so expiry logic is testable without sleeping.
+	Now func() time.Time
+}
+
+// NewAuthenticator wires an authenticator over the given preferences.
+func NewAuthenticator(global *config.Global, sdkVersion string) *Authenticator {
+	return &Authenticator{
+		Global:     global,
+		Store:      &TokenStore{Global: global},
+		SDKVersion: sdkVersion,
+		Now:        time.Now,
+	}
+}
+
+func (a *Authenticator) now() time.Time {
+	if a.Now == nil {
+		return time.Now()
+	}
+
+	return a.Now()
+}
+
+// AccessToken returns a valid access token, refreshing it when necessary.
+//
+// forceRefresh renews even a token that still looks valid, which the caller
+// uses after the API rejects one.
+func (a *Authenticator) AccessToken(forceRefresh bool) (string, error) {
+	session := a.Global.Current()
+	if session == nil {
+		return "", ErrSessionExpired
+	}
+
+	accessToken := session.GetString(config.PreferenceAccessToken)
+	expiry := session.GetInt64(config.PreferenceTokenExpiry)
+	sessionID := a.Global.CurrentSessionID()
+
+	deadline := a.now().Add(refreshSkew).UnixMilli()
+	if !forceRefresh && accessToken != "" && expiry > deadline {
+		return accessToken, nil
+	}
+
+	refreshToken := a.Store.Refresh(sessionID)
+
+	// An expiry of zero means the token came from a flow that does not report
+	// one. Without a refresh token there is nothing better to do than use it and
+	// let the API decide.
+	if accessToken != "" && expiry == 0 && refreshToken == "" {
+		return accessToken, nil
+	}
+
+	if refreshToken == "" {
+		return "", ErrSessionExpired
+	}
+
+	return a.refresh(session, sessionID, refreshToken)
+}
+
+func (a *Authenticator) refresh(session *config.Object, sessionID, refreshToken string) (string, error) {
+	endpoint := session.GetString(config.PreferenceEndpoint)
+	if endpoint == "" {
+		endpoint = config.DefaultEndpoint
+	}
+
+	clientID := session.GetString(config.PreferenceClientID)
+	if clientID == "" {
+		clientID = DefaultClientID
+	}
+
+	// The token endpoint is served by the console project and is not regional,
+	// so the endpoint is normalised before use.
+	api := client.New(config.NormalizeCloudConsoleEndpoint(endpoint), a.SDKVersion).
+		SetProject(config.ProjectConsole)
+
+	var token tokenResponse
+	err := api.Call("POST", "/oauth2/"+config.ProjectConsole+"/token", map[string]any{
+		"grant_type":    "refresh_token",
+		"refresh_token": refreshToken,
+		"client_id":     clientID,
+	}, &token)
+	if err != nil {
+		return "", err
+	}
+	if token.AccessToken == "" {
+		return "", ErrSessionExpired
+	}
+
+	expiresIn, _ := token.ExpiresIn.Int64()
+	session.Set(config.PreferenceAccessToken, token.AccessToken)
+	newExpiry := a.now().Add(time.Duration(expiresIn) * time.Second).UnixMilli()
+	// json.Number so the timestamp is written as an integer literal rather than
+	// in scientific notation, matching how the TypeScript CLI stores it.
+	session.Set(config.PreferenceTokenExpiry, json.Number(strconv.FormatInt(newExpiry, 10)))
+
+	// The server may rotate the refresh token; when it does, the old one stops
+	// working, so persisting the new one is not optional.
+	if token.RefreshToken != "" {
+		if err := a.Store.SetRefresh(sessionID, token.RefreshToken); err != nil {
+			return "", err
+		}
+	}
+
+	if err := a.Global.Write(); err != nil {
+		return "", err
+	}
+
+	return token.AccessToken, nil
+}

--- a/templates/go-cli/internal/auth/refresh.go
+++ b/templates/go-cli/internal/auth/refresh.go
@@ -28,6 +28,7 @@ var ErrSessionExpired = errors.New("session expired. Run `appwrite login` to cre
 type tokenResponse struct {
 	AccessToken  string      `json:"access_token"`
 	RefreshToken string      `json:"refresh_token"`
+	IDToken      string      `json:"id_token"`
 	ExpiresIn    json.Number `json:"expires_in"`
 }
 

--- a/templates/go-cli/internal/auth/refresh_test.go
+++ b/templates/go-cli/internal/auth/refresh_test.go
@@ -1,0 +1,243 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/appwrite/appwrite-cli-go/internal/config"
+)
+
+// fixedNow keeps expiry arithmetic deterministic.
+var fixedNow = time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+
+// newTestGlobal writes a prefs file with one session and returns it loaded.
+func newTestGlobal(t *testing.T, endpoint string, expiry int64, accessToken string) *config.Global {
+	t.Helper()
+
+	prefs := map[string]any{
+		"current": "session-1",
+		"session-1": map[string]any{
+			"endpoint":    endpoint,
+			"accessToken": accessToken,
+			"tokenExpiry": expiry,
+			"email":       "someone@example.com",
+		},
+	}
+	encoded, err := json.Marshal(prefs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(t.TempDir(), "prefs.json")
+	if err := os.WriteFile(path, encoded, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	return config.LoadGlobal(path)
+}
+
+// A token comfortably inside its lifetime must be returned untouched -- no
+// network call, no rewrite of the config.
+func TestAccessTokenReturnsValidTokenWithoutRefreshing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected refresh request to %s", r.URL.Path)
+	}))
+	defer server.Close()
+
+	expiry := fixedNow.Add(time.Hour).UnixMilli()
+	global := newTestGlobal(t, server.URL, expiry, "still-good")
+
+	authenticator := NewAuthenticator(global, "0.0.1")
+	authenticator.Now = func() time.Time { return fixedNow }
+
+	token, err := authenticator.AccessToken(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "still-good" {
+		t.Errorf("token = %q, want %q", token, "still-good")
+	}
+}
+
+// A token inside the skew window is treated as stale: it would otherwise expire
+// mid-request.
+func TestAccessTokenRefreshesInsideSkewWindow(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body["grant_type"] != "refresh_token" {
+			t.Errorf("grant_type = %v", body["grant_type"])
+		}
+		if body["refresh_token"] != "stored-refresh" {
+			t.Errorf("refresh_token = %v", body["refresh_token"])
+		}
+		if body["client_id"] != DefaultClientID {
+			t.Errorf("client_id = %v", body["client_id"])
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "fresh-token",
+			"expires_in":   3600,
+		})
+	}))
+	defer server.Close()
+
+	// Expires in 30s: still valid, but inside the 60s skew.
+	expiry := fixedNow.Add(30 * time.Second).UnixMilli()
+	global := newTestGlobal(t, server.URL, expiry, "about-to-expire")
+	seedPrefsRefreshToken(t, global, "session-1", "stored-refresh")
+
+	authenticator := NewAuthenticator(global, "0.0.1")
+	authenticator.Now = func() time.Time { return fixedNow }
+
+	token, err := authenticator.AccessToken(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "fresh-token" {
+		t.Errorf("token = %q, want %q", token, "fresh-token")
+	}
+	if requests != 1 {
+		t.Errorf("refresh requests = %d, want 1", requests)
+	}
+
+	// The new token and its expiry must be persisted, or every command refreshes.
+	reloaded := config.LoadGlobal(global.Path())
+	session := reloaded.Current()
+	if got := session.GetString(config.PreferenceAccessToken); got != "fresh-token" {
+		t.Errorf("persisted access token = %q", got)
+	}
+	wantExpiry := fixedNow.Add(3600 * time.Second).UnixMilli()
+	if got := session.GetInt64(config.PreferenceTokenExpiry); got != wantExpiry {
+		t.Errorf("persisted expiry = %d, want %d", got, wantExpiry)
+	}
+}
+
+// The server may rotate the refresh token. Failing to persist the new one would
+// leave the CLI holding a token that no longer works.
+func TestAccessTokenPersistsRotatedRefreshToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "fresh-token",
+			"refresh_token": "rotated-refresh",
+			"expires_in":    3600,
+		})
+	}))
+	defer server.Close()
+
+	global := newTestGlobal(t, server.URL, 0, "expired")
+	seedPrefsRefreshToken(t, global, "session-1", "stored-refresh")
+
+	authenticator := NewAuthenticator(global, "0.0.1")
+	authenticator.Now = func() time.Time { return fixedNow }
+
+	// Whichever backend SetRefresh lands on -- the keyring where one exists,
+	// prefs otherwise -- Refresh must read the rotated value back.
+	t.Cleanup(func() { _ = authenticator.Store.DeleteRefresh("session-1") })
+
+	if _, err := authenticator.AccessToken(true); err != nil {
+		t.Fatal(err)
+	}
+
+	if stored := authenticator.Store.Refresh("session-1"); stored != "rotated-refresh" {
+		t.Errorf("stored refresh token = %q, want %q", stored, "rotated-refresh")
+	}
+}
+
+// No refresh token and an expired access token is an unrecoverable state; the
+// user has to log in again, and the message must say so.
+func TestAccessTokenWithoutRefreshTokenFailsCleanly(t *testing.T) {
+	global := newTestGlobal(t, "https://cloud.appwrite.io/v1",
+		fixedNow.Add(-time.Hour).UnixMilli(), "expired")
+
+	authenticator := NewAuthenticator(global, "0.0.1")
+	authenticator.Now = func() time.Time { return fixedNow }
+
+	_, err := authenticator.AccessToken(false)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if err != ErrSessionExpired {
+		t.Errorf("err = %v, want ErrSessionExpired", err)
+	}
+}
+
+// An expiry of zero means the issuing flow reported none. With no refresh token
+// available, the access token is used as-is rather than rejected outright.
+func TestAccessTokenWithZeroExpiryAndNoRefreshTokenIsUsedAsIs(t *testing.T) {
+	global := newTestGlobal(t, "https://cloud.appwrite.io/v1", 0, "no-expiry-token")
+
+	authenticator := NewAuthenticator(global, "0.0.1")
+	authenticator.Now = func() time.Time { return fixedNow }
+
+	token, err := authenticator.AccessToken(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "no-expiry-token" {
+		t.Errorf("token = %q", token)
+	}
+}
+
+func TestAccessTokenWithoutSessionFails(t *testing.T) {
+	global := config.LoadGlobal(filepath.Join(t.TempDir(), "absent.json"))
+
+	if _, err := NewAuthenticator(global, "0.0.1").AccessToken(false); err != ErrSessionExpired {
+		t.Errorf("err = %v, want ErrSessionExpired", err)
+	}
+}
+
+// seedPrefsRefreshToken writes a refresh token into the prefs fallback, which
+// is the path headless environments without a keyring take.
+func seedPrefsRefreshToken(t *testing.T, global *config.Global, sessionID, token string) {
+	t.Helper()
+
+	session := global.SessionData(sessionID)
+	if session == nil {
+		t.Fatalf("session %q not found", sessionID)
+	}
+	session.Set(config.PreferenceRefreshToken, token)
+	if err := global.Write(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Timestamps must be written as integer literals; scientific notation would not
+// parse back as an integer.
+func TestRefreshWritesIntegerTimestamp(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "fresh-token",
+			"expires_in":   3600,
+		})
+	}))
+	defer server.Close()
+
+	global := newTestGlobal(t, server.URL, 0, "expired")
+	seedPrefsRefreshToken(t, global, "session-1", "stored-refresh")
+
+	authenticator := NewAuthenticator(global, "0.0.1")
+	authenticator.Now = func() time.Time { return fixedNow }
+	if _, err := authenticator.AccessToken(true); err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := os.ReadFile(global.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := strconv.FormatInt(fixedNow.Add(3600*time.Second).UnixMilli(), 10)
+	if !strings.Contains(string(raw), want) {
+		t.Errorf("expiry %s not written as an integer literal:\n%s", want, raw)
+	}
+}

--- a/templates/go-cli/internal/client/client.go
+++ b/templates/go-cli/internal/client/client.go
@@ -1,0 +1,171 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// Ports templates/cli/lib/client.ts.
+
+// ResponseFormat pins the API response shape the CLI is written against.
+//
+// Hard-coded in the TypeScript client too (client.ts:40). It tracks the API
+// version the CLI was generated for, not the CLI's own version, so it must not
+// be wired to sdk.version.
+const ResponseFormat = "1.8.1"
+
+// Header names. The API is case-insensitive, but these match the TypeScript
+// spelling so the two CLIs are directly comparable on the wire.
+const (
+	headerProject      = "X-Appwrite-Project"
+	headerKey          = "X-Appwrite-Key"
+	headerJWT          = "X-Appwrite-JWT"
+	headerLocale       = "X-Appwrite-Locale"
+	headerMode         = "X-Appwrite-Mode"
+	headerOrganization = "X-Appwrite-Organization"
+	headerFormat       = "X-Appwrite-Response-Format"
+)
+
+// Client is a thin HTTP client for the Appwrite API.
+type Client struct {
+	Endpoint   string
+	HTTP       *http.Client
+	headers    map[string]string
+	cookie     string
+	SDKVersion string
+}
+
+// New returns a client with the headers every request carries.
+func New(endpoint, sdkVersion string) *Client {
+	return &Client{
+		Endpoint:   strings.TrimRight(endpoint, "/"),
+		HTTP:       &http.Client{Timeout: 60 * time.Second},
+		SDKVersion: sdkVersion,
+		headers: map[string]string{
+			"content-type":   "application/json",
+			headerFormat:     ResponseFormat,
+			"x-sdk-name":     "Command Line",
+			"x-sdk-platform": "console",
+			"x-sdk-language": "cli",
+			"x-sdk-version":  sdkVersion,
+			"user-agent": fmt.Sprintf("AppwriteCLI/%s (%s; %s)",
+				sdkVersion, runtime.GOOS, runtime.GOARCH),
+		},
+	}
+}
+
+// SetHeader sets one header.
+func (c *Client) SetHeader(name, value string) *Client {
+	c.headers[name] = value
+
+	return c
+}
+
+// SetProject sets the project the request acts on.
+func (c *Client) SetProject(project string) *Client { return c.SetHeader(headerProject, project) }
+
+// SetKey authenticates with an API key.
+func (c *Client) SetKey(key string) *Client { return c.SetHeader(headerKey, key) }
+
+// SetJWT authenticates with a JWT.
+func (c *Client) SetJWT(jwt string) *Client { return c.SetHeader(headerJWT, jwt) }
+
+// SetLocale sets the response locale.
+func (c *Client) SetLocale(locale string) *Client { return c.SetHeader(headerLocale, locale) }
+
+// SetMode selects admin or default scope resolution.
+func (c *Client) SetMode(mode string) *Client { return c.SetHeader(headerMode, mode) }
+
+// SetOrganization names the organization for endpoints that take no ID in the
+// path.
+func (c *Client) SetOrganization(id string) *Client { return c.SetHeader(headerOrganization, id) }
+
+// SetBearer authenticates with an OAuth2 access token.
+func (c *Client) SetBearer(token string) *Client {
+	return c.SetHeader("Authorization", "Bearer "+token)
+}
+
+// SetCookie authenticates with a legacy session cookie.
+func (c *Client) SetCookie(cookie string) *Client {
+	c.cookie = cookie
+
+	return c
+}
+
+// APIError is a non-2xx response from the API.
+type APIError struct {
+	Status  int
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Type    string `json:"type"`
+}
+
+func (e *APIError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+
+	return fmt.Sprintf("request failed with status %d", e.Status)
+}
+
+// Call performs a request and decodes the JSON response into out.
+//
+// out may be nil for endpoints whose body is not needed. Numbers decode as
+// json.Number so large integers survive, matching the json-bigint parsing the
+// TypeScript CLI uses.
+func (c *Client) Call(method, path string, body any, out any) error {
+	var reader io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		reader = bytes.NewReader(encoded)
+	}
+
+	request, err := http.NewRequest(method, c.Endpoint+path, reader)
+	if err != nil {
+		return err
+	}
+	for name, value := range c.headers {
+		request.Header.Set(name, value)
+	}
+	if c.cookie != "" {
+		request.Header.Set("Cookie", c.cookie)
+	}
+
+	response, err := c.HTTP.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	payload, err := io.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		apiError := &APIError{Status: response.StatusCode}
+		// A non-JSON error body (a proxy error page, say) leaves Message empty
+		// and Error() falls back to the status line.
+		_ = json.Unmarshal(payload, apiError)
+
+		return apiError
+	}
+
+	if out == nil {
+		return nil
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.UseNumber()
+
+	return decoder.Decode(out)
+}

--- a/templates/go-cli/internal/cmd/login.go
+++ b/templates/go-cli/internal/cmd/login.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"time"
+
+	"github.com/appwrite/appwrite-cli-go/internal/auth"
+	"github.com/appwrite/appwrite-cli-go/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// Ports the device-code path of templates/cli/lib/auth/login.ts.
+
+func newLoginCommand() *cobra.Command {
+	var endpoint string
+
+	command := &cobra.Command{
+		Use:   "login",
+		Short: "Sign in to an Appwrite endpoint",
+		RunE: func(command *cobra.Command, args []string) error {
+			global, err := preferences()
+			if err != nil {
+				return err
+			}
+
+			if endpoint == "" {
+				endpoint = config.DefaultEndpoint
+			}
+
+			flow := auth.NewDeviceFlow(endpoint, Version)
+			authorization, err := flow.Authorize()
+			if err != nil {
+				return err
+			}
+
+			url := authorization.VerificationURL()
+			command.Printf("\nTo sign in, confirm the code below in your browser:\n\n")
+			command.Printf("  Code: %s\n", authorization.UserCode)
+			command.Printf("  URL:  %s\n\n", url)
+			openBrowser(url)
+
+			token, err := flow.Poll(authorization)
+			if err != nil {
+				return err
+			}
+
+			email, name, subject := auth.DecodeIDToken(token.IDToken)
+			sessionID := subject
+			if sessionID == "" {
+				// Without a subject claim there is nothing stable to key the
+				// session on, so fall back to the login time. Two logins to the
+				// same account would then create two entries rather than
+				// overwrite one, which is noisy but not wrong.
+				sessionID = strconv.FormatInt(time.Now().UnixMilli(), 10)
+			}
+
+			session := config.NewObject()
+			// Key order matches what the TypeScript CLI writes, so a prefs.json
+			// touched by both binaries does not churn.
+			session.Set(config.PreferenceEndpoint, endpoint)
+			session.Set(config.PreferenceClientID, auth.DefaultClientID)
+			session.Set(config.PreferenceAccessToken, token.AccessToken)
+			// json.Number so the timestamp is written as an integer literal, not a
+			// float in scientific notation.
+			session.Set(config.PreferenceTokenExpiry,
+				json.Number(strconv.FormatInt(token.ExpiresAt.UnixMilli(), 10)))
+			if email != "" {
+				session.Set(config.PreferenceEmail, email)
+			}
+			global.AddSession(sessionID, session)
+
+			if err := global.Write(); err != nil {
+				return err
+			}
+
+			// Written after the session exists: the store needs the entry to
+			// fall back to prefs when no keyring is available.
+			if token.RefreshToken != "" {
+				store := &auth.TokenStore{Global: global}
+				if err := store.SetRefresh(sessionID, token.RefreshToken); err != nil {
+					return err
+				}
+			}
+
+			who := email
+			if who == "" {
+				who = name
+			}
+			command.Printf("Signed in as %s on %s\n", who, endpoint)
+
+			return nil
+		},
+	}
+	command.Flags().StringVar(&endpoint, "endpoint", "",
+		"Appwrite endpoint to sign in to. Defaults to "+config.DefaultEndpoint+".")
+
+	return command
+}
+
+// openBrowser is best-effort: a headless or locked-down environment simply
+// leaves the user to open the printed URL themselves, which is why the error is
+// discarded rather than surfaced.
+func openBrowser(url string) {
+	var command string
+	var args []string
+
+	switch runtime.GOOS {
+	case "darwin":
+		command, args = "open", []string{url}
+	case "windows":
+		command, args = "rundll32", []string{"url.dll,FileProtocolHandler", url}
+	default:
+		command, args = "xdg-open", []string{url}
+	}
+
+	_ = exec.Command(command, args...).Start()
+}

--- a/templates/go-cli/internal/cmd/login.go
+++ b/templates/go-cli/internal/cmd/login.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/appwrite/appwrite-cli-go/internal/auth"
@@ -108,6 +109,12 @@ func newLoginCommand() *cobra.Command {
 // account you are already signed in to. Composing the two keeps the
 // deduplication and drops the collision. The key is internal, so its spelling
 // is free.
+//
+// The WHOLE endpoint goes into the key, not just its host. Two self-hosted
+// instances can share a host and differ only by scheme or base path -- one
+// reverse-proxied at /staging/v1 and another at /prod/v1, or an http and an https
+// URL for the same box during a migration -- and reducing them to the host would
+// reintroduce exactly the collision this function exists to remove.
 func cloudSessionID(endpoint, subject string) string {
 	if subject == "" {
 		// No subject claim leaves nothing stable to key on, so fall back to the
@@ -116,12 +123,25 @@ func cloudSessionID(endpoint, subject string) string {
 		return strconv.FormatInt(time.Now().UnixMilli(), 10)
 	}
 
-	host := endpoint
-	if parsed, err := url.Parse(endpoint); err == nil && parsed.Host != "" {
-		host = parsed.Host
-	}
+	return subject + "@" + canonicalEndpoint(endpoint)
+}
 
-	return subject + "@" + host
+// canonicalEndpoint reduces an endpoint to one spelling per instance, so the same
+// instance keys to the same session however it was typed.
+//
+// Hostnames are case-insensitive and a trailing slash is not meaningful; paths
+// are case-sensitive, so only the host is folded.
+func canonicalEndpoint(endpoint string) string {
+	trimmed := strings.TrimRight(endpoint, "/")
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Host == "" {
+		return trimmed
+	}
+	parsed.Host = strings.ToLower(parsed.Host)
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+
+	return parsed.String()
 }
 
 // openBrowser is best-effort: a headless or locked-down environment simply

--- a/templates/go-cli/internal/cmd/login.go
+++ b/templates/go-cli/internal/cmd/login.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"net/url"
 	"os/exec"
 	"runtime"
 	"strconv"
@@ -48,14 +49,7 @@ func newLoginCommand() *cobra.Command {
 			}
 
 			email, name, subject := auth.DecodeIDToken(token.IDToken)
-			sessionID := subject
-			if sessionID == "" {
-				// Without a subject claim there is nothing stable to key the
-				// session on, so fall back to the login time. Two logins to the
-				// same account would then create two entries rather than
-				// overwrite one, which is noisy but not wrong.
-				sessionID = strconv.FormatInt(time.Now().UnixMilli(), 10)
-			}
+			sessionID := cloudSessionID(endpoint, subject)
 
 			session := config.NewObject()
 			// Key order matches what the TypeScript CLI writes, so a prefs.json
@@ -98,6 +92,36 @@ func newLoginCommand() *cobra.Command {
 		"Appwrite endpoint to sign in to. Defaults to "+config.DefaultEndpoint+".")
 
 	return command
+}
+
+// cloudSessionID keys a browser-flow session on the endpoint as well as the
+// account.
+//
+// The subject alone is not unique. Every `*.appwrite.io` host takes this flow,
+// and a staging deployment seeded from a production dump hands out the very
+// same account IDs, so keying on the subject alone lets a second sign-in
+// overwrite the first endpoint's session -- and, because the same string names
+// the keyring entry, its refresh token with it.
+//
+// The TypeScript avoids this by keying on `ID.unique()` (login.ts:548), which
+// is collision-free but accumulates a fresh entry every time you sign in to an
+// account you are already signed in to. Composing the two keeps the
+// deduplication and drops the collision. The key is internal, so its spelling
+// is free.
+func cloudSessionID(endpoint, subject string) string {
+	if subject == "" {
+		// No subject claim leaves nothing stable to key on, so fall back to the
+		// sign-in time. Repeated sign-ins then accumulate entries rather than
+		// overwrite one, which is noisy but never wrong.
+		return strconv.FormatInt(time.Now().UnixMilli(), 10)
+	}
+
+	host := endpoint
+	if parsed, err := url.Parse(endpoint); err == nil && parsed.Host != "" {
+		host = parsed.Host
+	}
+
+	return subject + "@" + host
 }
 
 // openBrowser is best-effort: a headless or locked-down environment simply

--- a/templates/go-cli/internal/cmd/login_test.go
+++ b/templates/go-cli/internal/cmd/login_test.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// Every `*.appwrite.io` host takes the browser flow, and a staging deployment
+// seeded from a production dump hands out the same account IDs. Keying a
+// session on the subject alone let the second sign-in overwrite the first
+// endpoint's session -- and its keyring refresh token, which shares the key.
+func TestCloudSessionIDSeparatesEndpointsSharingASubject(t *testing.T) {
+	production := cloudSessionID("https://cloud.appwrite.io/v1", "68a1b2c3d4e5f6")
+	staging := cloudSessionID("https://stage.appwrite.io/v1", "68a1b2c3d4e5f6")
+
+	if production == staging {
+		t.Errorf("both endpoints keyed to %q, so one sign-in overwrites the other", production)
+	}
+}
+
+// Signing in again to an account already signed in on the same endpoint has to
+// land on the existing entry rather than accumulate a new one each time.
+func TestCloudSessionIDIsStableForOneAccountAndEndpoint(t *testing.T) {
+	first := cloudSessionID("https://cloud.appwrite.io/v1", "68a1b2c3d4e5f6")
+	second := cloudSessionID("https://cloud.appwrite.io/v1", "68a1b2c3d4e5f6")
+
+	if first != second {
+		t.Errorf("%q then %q, want one stable key per account and endpoint", first, second)
+	}
+}
+
+// No subject claim leaves nothing stable to key on. The fallback still has to
+// produce a usable key rather than one that starts at the separator.
+func TestCloudSessionIDFallsBackWithoutASubject(t *testing.T) {
+	id := cloudSessionID("https://cloud.appwrite.io/v1", "")
+
+	if id == "" || strings.HasPrefix(id, "@") {
+		t.Errorf("id = %q, want a usable fallback key", id)
+	}
+}

--- a/templates/go-cli/internal/cmd/login_test.go
+++ b/templates/go-cli/internal/cmd/login_test.go
@@ -29,6 +29,41 @@ func TestCloudSessionIDIsStableForOneAccountAndEndpoint(t *testing.T) {
 	}
 }
 
+// Two self-hosted instances can share a host and differ only by scheme or base
+// path -- one reverse-proxied at /staging/v1 and another at /prod/v1, or an http
+// and an https URL for the same box during a migration. Keying on the host alone
+// collapsed those onto one session.
+func TestCloudSessionIDSeparatesEndpointsSharingAHost(t *testing.T) {
+	for _, pair := range [][2]string{
+		{"http://appwrite.example/v1", "https://appwrite.example/v1"},
+		{"https://appwrite.example/staging/v1", "https://appwrite.example/prod/v1"},
+		{"https://appwrite.example:8080/v1", "https://appwrite.example:9090/v1"},
+	} {
+		first := cloudSessionID(pair[0], "68a1b2c3d4e5f6")
+		second := cloudSessionID(pair[1], "68a1b2c3d4e5f6")
+
+		if first == second {
+			t.Errorf("%s and %s both keyed to %q", pair[0], pair[1], first)
+		}
+	}
+}
+
+// The same instance typed differently must still be one session, or a trailing
+// slash would strand the credentials of the session it already has.
+func TestCloudSessionIDIgnoresSpellingOfTheSameEndpoint(t *testing.T) {
+	for _, pair := range [][2]string{
+		{"https://cloud.appwrite.io/v1", "https://cloud.appwrite.io/v1/"},
+		{"https://Cloud.Appwrite.IO/v1", "https://cloud.appwrite.io/v1"},
+	} {
+		first := cloudSessionID(pair[0], "68a1b2c3d4e5f6")
+		second := cloudSessionID(pair[1], "68a1b2c3d4e5f6")
+
+		if first != second {
+			t.Errorf("%s keyed to %q but %s keyed to %q", pair[0], first, pair[1], second)
+		}
+	}
+}
+
 // No subject claim leaves nothing stable to key on. The fallback still has to
 // produce a usable key rather than one that starts at the separator.
 func TestCloudSessionIDFallsBackWithoutASubject(t *testing.T) {

--- a/templates/go-cli/internal/cmd/root.go.twig
+++ b/templates/go-cli/internal/cmd/root.go.twig
@@ -9,6 +9,9 @@ import (
 // Version is stamped at build time with -ldflags.
 var Version = "{{ sdk.version }}"
 
+// ExecutableName is the binary name, and the directory preferences live under.
+const ExecutableName = "{{ language.params.executableName }}"
+
 // NewRootCommand builds the full command tree.
 //
 // Registration is deliberately eager. Phase 0 measured the complete tree at
@@ -26,6 +29,7 @@ func NewRootCommand() *cobra.Command {
 	}
 
 	services.Register(root)
+	registerSessionCommands(root)
 
 	return root
 }

--- a/templates/go-cli/internal/cmd/session.go
+++ b/templates/go-cli/internal/cmd/session.go
@@ -176,5 +176,6 @@ func newLogoutCommand() *cobra.Command {
 func registerSessionCommands(root *cobra.Command) {
 	root.AddCommand(newWhoamiCommand())
 	root.AddCommand(newSessionsCommand())
+	root.AddCommand(newLoginCommand())
 	root.AddCommand(newLogoutCommand())
 }

--- a/templates/go-cli/internal/cmd/session.go
+++ b/templates/go-cli/internal/cmd/session.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 
+	"github.com/appwrite/appwrite-cli-go/internal/auth"
 	"github.com/appwrite/appwrite-cli-go/internal/client"
 	"github.com/appwrite/appwrite-cli-go/internal/config"
 	"github.com/spf13/cobra"
@@ -26,9 +27,8 @@ func preferences() (*config.Global, error) {
 
 // consoleClient builds a client authenticated against the console project.
 //
-// Ports sdkForConsole(). Token refresh is deliberately not implemented here --
-// that arrives with internal/auth in the rest of Phase 2; until then an expired
-// token surfaces as a normal API error rather than being silently renewed.
+// Ports sdkForConsole(). The access token is refreshed first when it is expired
+// or within a minute of expiring.
 func consoleClient() (*client.Client, *config.Global, error) {
 	global, err := preferences()
 	if err != nil {
@@ -49,12 +49,16 @@ func consoleClient() (*client.Client, *config.Global, error) {
 		SetProject(config.ProjectConsole).
 		SetLocale("en-US")
 
-	accessToken := session.GetString(config.PreferenceAccessToken)
+	hasAccessToken := session.GetString(config.PreferenceAccessToken) != ""
 	cookie := session.GetString(config.PreferenceCookie)
 
 	switch {
-	case accessToken != "":
-		api.SetBearer(accessToken)
+	case hasAccessToken:
+		token, err := auth.NewAuthenticator(global, Version).AccessToken(false)
+		if err != nil {
+			return nil, nil, err
+		}
+		api.SetBearer(token)
 	case cookie != "":
 		api.SetCookie(cookie)
 	default:
@@ -122,8 +126,55 @@ func newSessionsCommand() *cobra.Command {
 	}
 }
 
+func newLogoutCommand() *cobra.Command {
+	var all bool
+
+	command := &cobra.Command{
+		Use:   "logout",
+		Short: "Sign out and remove the stored session",
+		RunE: func(command *cobra.Command, args []string) error {
+			global, err := preferences()
+			if err != nil {
+				return err
+			}
+
+			targets := []string{global.CurrentSessionID()}
+			if all {
+				targets = global.SessionIDs()
+			}
+			if len(targets) == 0 || targets[0] == "" {
+				command.Println("No active session.")
+
+				return nil
+			}
+
+			// Clear the refresh token before removing the session entry:
+			// DeleteRefresh needs the session to still exist to drop the prefs
+			// fallback copy.
+			store := &auth.TokenStore{Global: global}
+			for _, id := range targets {
+				if err := store.DeleteRefresh(id); err != nil {
+					return err
+				}
+				global.DeleteSession(id)
+			}
+			if err := global.Write(); err != nil {
+				return err
+			}
+
+			command.Printf("Signed out of %d session(s).\n", len(targets))
+
+			return nil
+		},
+	}
+	command.Flags().BoolVar(&all, "all", false, "Sign out of every stored session.")
+
+	return command
+}
+
 // registerSessionCommands attaches the commands that do not come from the spec.
 func registerSessionCommands(root *cobra.Command) {
 	root.AddCommand(newWhoamiCommand())
 	root.AddCommand(newSessionsCommand())
+	root.AddCommand(newLogoutCommand())
 }

--- a/templates/go-cli/internal/cmd/session.go
+++ b/templates/go-cli/internal/cmd/session.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"errors"
+
+	"github.com/appwrite/appwrite-cli-go/internal/client"
+	"github.com/appwrite/appwrite-cli-go/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// Ports the session half of templates/cli/lib/sdks.ts and the `whoami` command
+// in templates/cli/lib/commands/generic.ts.
+
+// ErrNotLoggedIn is returned when a command needs a session and none is stored.
+var ErrNotLoggedIn = errors.New("no active session. Run `" + ExecutableName + " login` to sign in")
+
+// preferences loads the user's global preferences.
+func preferences() (*config.Global, error) {
+	path, err := config.GlobalPath(ExecutableName)
+	if err != nil {
+		return nil, err
+	}
+
+	return config.LoadGlobal(path), nil
+}
+
+// consoleClient builds a client authenticated against the console project.
+//
+// Ports sdkForConsole(). Token refresh is deliberately not implemented here --
+// that arrives with internal/auth in the rest of Phase 2; until then an expired
+// token surfaces as a normal API error rather than being silently renewed.
+func consoleClient() (*client.Client, *config.Global, error) {
+	global, err := preferences()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	session := global.Current()
+	if session == nil {
+		return nil, nil, ErrNotLoggedIn
+	}
+
+	endpoint := session.GetString(config.PreferenceEndpoint)
+	if endpoint == "" {
+		return nil, nil, ErrNotLoggedIn
+	}
+
+	api := client.New(endpoint, Version).
+		SetProject(config.ProjectConsole).
+		SetLocale("en-US")
+
+	accessToken := session.GetString(config.PreferenceAccessToken)
+	cookie := session.GetString(config.PreferenceCookie)
+
+	switch {
+	case accessToken != "":
+		api.SetBearer(accessToken)
+	case cookie != "":
+		api.SetCookie(cookie)
+	default:
+		return nil, nil, ErrNotLoggedIn
+	}
+
+	return api, global, nil
+}
+
+func newWhoamiCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "whoami",
+		Short: "Show the account the CLI is currently signed in as",
+		RunE: func(command *cobra.Command, args []string) error {
+			api, global, err := consoleClient()
+			if err != nil {
+				return err
+			}
+
+			var account map[string]any
+			if err := api.Call("GET", "/account", nil, &account); err != nil {
+				return err
+			}
+
+			session := global.Current()
+			command.Printf("Endpoint : %s\n", session.GetString(config.PreferenceEndpoint))
+			command.Printf("Email    : %v\n", account["email"])
+			command.Printf("Name     : %v\n", account["name"])
+			command.Printf("ID       : %v\n", account["$id"])
+
+			return nil
+		},
+	}
+}
+
+func newSessionsCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "sessions",
+		Short: "List the sessions stored in the CLI preferences",
+		RunE: func(command *cobra.Command, args []string) error {
+			global, err := preferences()
+			if err != nil {
+				return err
+			}
+
+			ids := global.SessionIDs()
+			if len(ids) == 0 {
+				command.Println("No stored sessions.")
+
+				return nil
+			}
+
+			current := global.CurrentSessionID()
+			for _, id := range ids {
+				session, _ := global.Session(id)
+				marker := " "
+				if id == current {
+					marker = "*"
+				}
+				command.Printf("%s %s  %s  %s\n", marker, id, session.Email, session.Endpoint)
+			}
+
+			return nil
+		},
+	}
+}
+
+// registerSessionCommands attaches the commands that do not come from the spec.
+func registerSessionCommands(root *cobra.Command) {
+	root.AddCommand(newWhoamiCommand())
+	root.AddCommand(newSessionsCommand())
+}

--- a/templates/go-cli/internal/config/config_test.go
+++ b/templates/go-cli/internal/config/config_test.go
@@ -1,0 +1,198 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A real prefs.json, shaped exactly as the TypeScript CLI writes one. Key order
+// here is the order the TS CLI produces, which is what the round-trip test
+// pins.
+const realPrefs = `{
+    "current": "6a6f6194001a17532db8",
+    "6a6f6194001a17532db8": {
+        "endpoint": "https://cloud.staging.appwrite.io/v1",
+        "clientId": "appwrite-cli",
+        "accessToken": "header.payload.signature",
+        "tokenExpiry": 1785687988066,
+        "email": "someone@example.com",
+        "cookie": "a_session_console=deleted"
+    }
+}`
+
+// Invariant 2 and 6: reading a config and writing it back must not change the
+// bytes. Go maps marshal with sorted keys, so a naive port would silently
+// reorder every user's file on first write.
+func TestGlobalRoundTripIsByteIdentical(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "prefs.json")
+	if err := os.WriteFile(path, []byte(realPrefs), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	global := LoadGlobal(path)
+	if err := global.Write(); err != nil {
+		t.Fatal(err)
+	}
+
+	written, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(written) != realPrefs {
+		t.Errorf("round-trip changed the file.\n--- want ---\n%s\n--- got ---\n%s", realPrefs, written)
+	}
+}
+
+// A millisecond timestamp exceeds float64's exact integer range in the general
+// case; json.Number keeps every digit.
+func TestGlobalPreservesLargeIntegers(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "prefs.json")
+	if err := os.WriteFile(path, []byte(realPrefs), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	global := LoadGlobal(path)
+	session := global.Current()
+	if session == nil {
+		t.Fatal("no current session")
+	}
+
+	if got := session.GetInt64(PreferenceTokenExpiry); got != 1785687988066 {
+		t.Errorf("tokenExpiry = %d, want 1785687988066", got)
+	}
+}
+
+// Overwriting an existing key must not move it to the end -- that is what keeps
+// a rewritten config diff-free.
+func TestSetPreservesKeyPosition(t *testing.T) {
+	object := NewObject()
+	object.Set("a", "1")
+	object.Set("b", "2")
+	object.Set("c", "3")
+	object.Set("a", "changed")
+
+	keys := object.Keys()
+	want := []string{"a", "b", "c"}
+	for i := range want {
+		if keys[i] != want[i] {
+			t.Fatalf("keys = %v, want %v", keys, want)
+		}
+	}
+}
+
+func TestGlobalSessionsIgnoreSettingKeys(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "prefs.json")
+	if err := os.WriteFile(path, []byte(realPrefs), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	global := LoadGlobal(path)
+	ids := global.SessionIDs()
+	if len(ids) != 1 || ids[0] != "6a6f6194001a17532db8" {
+		t.Errorf("SessionIDs() = %v, want one session ID", ids)
+	}
+
+	session, ok := global.Session(ids[0])
+	if !ok {
+		t.Fatal("session not found")
+	}
+	if session.Email != "someone@example.com" {
+		t.Errorf("email = %q", session.Email)
+	}
+	if session.Endpoint != "https://cloud.staging.appwrite.io/v1" {
+		t.Errorf("endpoint = %q", session.Endpoint)
+	}
+}
+
+// Deleting the active session must move `current`, never leave it dangling.
+func TestDeleteCurrentSessionRepointsCurrent(t *testing.T) {
+	global := &Global{path: filepath.Join(t.TempDir(), "prefs.json"), data: NewObject()}
+
+	first, second := NewObject(), NewObject()
+	first.Set(PreferenceEmail, "a@example.com")
+	second.Set(PreferenceEmail, "b@example.com")
+	global.AddSession("one", first)
+	global.AddSession("two", second)
+
+	global.DeleteSession("two")
+
+	if got := global.CurrentSessionID(); got != "one" {
+		t.Errorf("current = %q, want %q", got, "one")
+	}
+
+	global.DeleteSession("one")
+	if got := global.CurrentSessionID(); got != "" {
+		t.Errorf("current = %q, want empty after deleting the last session", got)
+	}
+}
+
+func TestNormalizeCloudConsoleEndpoint(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"https://cloud.appwrite.io/v1", "https://cloud.appwrite.io/v1"},
+		{"https://fra.cloud.appwrite.io/v1", "https://cloud.appwrite.io/v1"},
+		{"https://syd.cloud.staging.appwrite.io/v1", "https://cloud.staging.appwrite.io/v1"},
+		// Self-hosted endpoints pass through untouched.
+		{"https://appwrite.example.com/v1", "https://appwrite.example.com/v1"},
+		// Not a known region code, so not Cloud -- must not be normalised, or a
+		// session stored for real Cloud could be selected for this host.
+		{"https://evil.cloud.appwrite.io/v1", "https://evil.cloud.appwrite.io/v1"},
+		// Multi-label prefixes are not regions either.
+		{"https://a.b.cloud.appwrite.io/v1", "https://a.b.cloud.appwrite.io/v1"},
+		{"not a url", "not a url"},
+	}
+
+	for _, tc := range cases {
+		if got := NormalizeCloudConsoleEndpoint(tc.in); got != tc.want {
+			t.Errorf("NormalizeCloudConsoleEndpoint(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestEndpointsMatch(t *testing.T) {
+	if !EndpointsMatch("https://fra.cloud.appwrite.io/v1", "https://cloud.appwrite.io/v1/") {
+		t.Error("regional and base Cloud endpoints should match")
+	}
+	if EndpointsMatch("https://cloud.appwrite.io/v1", "https://appwrite.example.com/v1") {
+		t.Error("Cloud and self-hosted endpoints should not match")
+	}
+	if EndpointsMatch("https://evil.cloud.appwrite.io/v1", "https://cloud.appwrite.io/v1") {
+		t.Error("an unknown subdomain must not match Cloud")
+	}
+}
+
+// A missing or corrupt file must yield empty preferences, not an error -- a
+// broken prefs.json should never block `login`.
+func TestLoadGlobalToleratesMissingAndCorruptFiles(t *testing.T) {
+	missing := LoadGlobal(filepath.Join(t.TempDir(), "absent.json"))
+	if missing.CurrentSessionID() != "" || len(missing.SessionIDs()) != 0 {
+		t.Error("missing file should produce empty preferences")
+	}
+
+	path := filepath.Join(t.TempDir(), "prefs.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	corrupt := LoadGlobal(path)
+	if corrupt.CurrentSessionID() != "" {
+		t.Error("corrupt file should produce empty preferences")
+	}
+}
+
+func TestWriteCreatesPrivateFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "prefs.json")
+	global := LoadGlobal(path)
+	global.SetCurrentSessionID("abc")
+	if err := global.Write(); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("prefs.json mode = %o, want 600 -- it holds access tokens", perm)
+	}
+}

--- a/templates/go-cli/internal/config/config_test.go
+++ b/templates/go-cli/internal/config/config_test.go
@@ -64,24 +64,6 @@ func TestGlobalPreservesLargeIntegers(t *testing.T) {
 	}
 }
 
-// Overwriting an existing key must not move it to the end -- that is what keeps
-// a rewritten config diff-free.
-func TestSetPreservesKeyPosition(t *testing.T) {
-	object := NewObject()
-	object.Set("a", "1")
-	object.Set("b", "2")
-	object.Set("c", "3")
-	object.Set("a", "changed")
-
-	keys := object.Keys()
-	want := []string{"a", "b", "c"}
-	for i := range want {
-		if keys[i] != want[i] {
-			t.Fatalf("keys = %v, want %v", keys, want)
-		}
-	}
-}
-
 func TestGlobalSessionsIgnoreSettingKeys(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "prefs.json")
 	if err := os.WriteFile(path, []byte(realPrefs), 0o600); err != nil {

--- a/templates/go-cli/internal/config/global.go
+++ b/templates/go-cli/internal/config/global.go
@@ -27,6 +27,11 @@ const (
 	PreferenceClientID     = "clientId"
 )
 
+// DefaultEndpoint is used when a session records none.
+//
+// Ports DEFAULT_ENDPOINT from templates/cli/lib/constants.ts:30.
+const DefaultEndpoint = "https://cloud.appwrite.io/v1"
+
 const (
 	ModeAdmin      = "admin"
 	ModeDefault    = "default"
@@ -151,6 +156,16 @@ func (g *Global) Session(id string) (Session, bool) {
 		Endpoint: entry.GetString(PreferenceEndpoint),
 		Email:    entry.GetString(PreferenceEmail),
 	}, true
+}
+
+// SessionData returns the raw stored values for one session, or nil when the
+// session does not exist.
+func (g *Global) SessionData(id string) *Object {
+	if id == "" {
+		return nil
+	}
+
+	return g.data.GetObject(id)
 }
 
 // Current returns the active session's stored values.

--- a/templates/go-cli/internal/config/global.go
+++ b/templates/go-cli/internal/config/global.go
@@ -1,0 +1,285 @@
+package config
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Ports templates/cli/lib/config.ts -- the `Config` base class and `Global`.
+
+// Preference keys stored in prefs.json. Names match the TypeScript CLI exactly:
+// the same file is read and written by both binaries during the migration.
+const (
+	PreferenceCurrent      = "current"
+	PreferenceEndpoint     = "endpoint"
+	PreferenceEmail        = "email"
+	PreferenceSelfSigned   = "selfSigned"
+	PreferenceCookie       = "cookie"
+	PreferenceProject      = "project"
+	PreferenceKey          = "key"
+	PreferenceLocale       = "locale"
+	PreferenceMode         = "mode"
+	PreferenceAccessToken  = "accessToken"
+	PreferenceRefreshToken = "refreshToken"
+	PreferenceTokenExpiry  = "tokenExpiry"
+	PreferenceClientID     = "clientId"
+)
+
+const (
+	ModeAdmin      = "admin"
+	ModeDefault    = "default"
+	ProjectConsole = "console"
+)
+
+// ignoredAttributes are top-level keys in prefs.json that are settings rather
+// than sessions. Everything else at the top level is a session ID.
+//
+// Ports Global.IGNORE_ATTRIBUTES.
+var ignoredAttributes = map[string]bool{
+	PreferenceCurrent:      true,
+	PreferenceSelfSigned:   true,
+	PreferenceEndpoint:     true,
+	PreferenceCookie:       true,
+	PreferenceProject:      true,
+	PreferenceKey:          true,
+	PreferenceLocale:       true,
+	PreferenceMode:         true,
+	PreferenceAccessToken:  true,
+	PreferenceRefreshToken: true,
+	PreferenceTokenExpiry:  true,
+	PreferenceClientID:     true,
+}
+
+// Global is the user-level preferences file, `~/.appwrite/prefs.json`.
+type Global struct {
+	path string
+	data *Object
+}
+
+// Session is one stored login.
+type Session struct {
+	ID       string
+	Endpoint string
+	Email    string
+}
+
+// GlobalPath returns the default preferences path for the current user.
+func GlobalPath(executableName string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(home, "."+executableName, "prefs.json"), nil
+}
+
+// LoadGlobal reads the preferences file. A missing or unparseable file yields
+// empty preferences rather than an error, matching the TypeScript `read()`,
+// which swallows failures so a corrupt file never blocks `login`.
+func LoadGlobal(path string) *Global {
+	global := &Global{path: path, data: NewObject()}
+
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return global
+	}
+
+	parsed := NewObject()
+	if err := parsed.UnmarshalJSON(contents); err != nil {
+		return global
+	}
+	global.data = parsed
+
+	return global
+}
+
+// Path returns the file backing these preferences.
+func (g *Global) Path() string {
+	return g.path
+}
+
+// Write persists preferences, creating the directory if needed.
+//
+// 0600 on the file and 0700 on the directory: this holds access and refresh
+// tokens.
+func (g *Global) Write() error {
+	if err := os.MkdirAll(filepath.Dir(g.path), 0o700); err != nil {
+		return err
+	}
+
+	encoded, err := Marshal(g.data)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(g.path, encoded, 0o600)
+}
+
+// CurrentSessionID returns the active session ID, or "" if none is set.
+func (g *Global) CurrentSessionID() string {
+	return g.data.GetString(PreferenceCurrent)
+}
+
+// SetCurrentSessionID marks a session active.
+func (g *Global) SetCurrentSessionID(id string) {
+	g.data.Set(PreferenceCurrent, id)
+}
+
+// SessionIDs lists stored session IDs in file order.
+func (g *Global) SessionIDs() []string {
+	ids := []string{}
+	for _, key := range g.data.Keys() {
+		if !ignoredAttributes[key] {
+			ids = append(ids, key)
+		}
+	}
+
+	return ids
+}
+
+// Session returns one stored session.
+func (g *Global) Session(id string) (Session, bool) {
+	entry := g.data.GetObject(id)
+	if entry == nil {
+		return Session{}, false
+	}
+
+	return Session{
+		ID:       id,
+		Endpoint: entry.GetString(PreferenceEndpoint),
+		Email:    entry.GetString(PreferenceEmail),
+	}, true
+}
+
+// Current returns the active session's stored values.
+func (g *Global) Current() *Object {
+	id := g.CurrentSessionID()
+	if id == "" {
+		return nil
+	}
+
+	return g.data.GetObject(id)
+}
+
+// CurrentValue reads one field from the active session.
+func (g *Global) CurrentValue(key string) string {
+	current := g.Current()
+	if current == nil {
+		return ""
+	}
+
+	return current.GetString(key)
+}
+
+// SetCurrentValue writes one field on the active session, creating the session
+// entry if it does not exist yet.
+func (g *Global) SetCurrentValue(key string, value any) {
+	id := g.CurrentSessionID()
+	if id == "" {
+		return
+	}
+	current := g.data.GetObject(id)
+	if current == nil {
+		current = NewObject()
+		g.data.Set(id, current)
+	}
+	current.Set(key, value)
+}
+
+// AddSession stores a session and makes it current.
+func (g *Global) AddSession(id string, values *Object) {
+	g.data.Set(id, values)
+	g.SetCurrentSessionID(id)
+}
+
+// DeleteSession removes a session. When it was the active one, the `current`
+// pointer is moved to another session if any remain, so the file is never left
+// pointing at a session that no longer exists.
+func (g *Global) DeleteSession(id string) {
+	g.data.Delete(id)
+
+	if g.CurrentSessionID() != id {
+		return
+	}
+
+	remaining := g.SessionIDs()
+	if len(remaining) == 0 {
+		g.data.Delete(PreferenceCurrent)
+
+		return
+	}
+	g.SetCurrentSessionID(remaining[0])
+}
+
+// TODO: Derive this list from the regions in the API spec.
+//
+// Ports CLOUD_REGION_CODES and CLOUD_BASE_HOSTNAMES from
+// templates/cli/lib/utils.ts:449.
+var (
+	cloudRegionCodes = map[string]bool{
+		"fra": true, "nyc": true, "syd": true, "sfo": true, "sgp": true, "tor": true,
+	}
+	cloudBaseHostnames = map[string]bool{
+		"cloud.appwrite.io":         true,
+		"cloud.staging.appwrite.io": true,
+	}
+)
+
+// baseCloudHostname strips a regional prefix such as `fra.` from a Cloud
+// hostname, returning "" when the host is not Appwrite Cloud.
+//
+// Only a single label is stripped, and only when it is a known region code.
+// Matching on suffix alone would treat any `*.cloud.appwrite.io` host as Cloud,
+// including one an attacker controls, and normalising it would let a session
+// stored for real Cloud be selected for that endpoint.
+//
+// Ports getCloudBaseHostname(). JavaScript's URL parser lower-cases hostnames
+// and Go's does not, hence the explicit fold.
+func baseCloudHostname(hostname string) string {
+	hostname = strings.ToLower(hostname)
+	if cloudBaseHostnames[hostname] {
+		return hostname
+	}
+
+	region, base, found := strings.Cut(hostname, ".")
+	if !found {
+		return ""
+	}
+	if cloudBaseHostnames[base] && cloudRegionCodes[region] {
+		return base
+	}
+
+	return ""
+}
+
+// NormalizeCloudConsoleEndpoint collapses a regional Cloud endpoint onto its
+// base host, leaving self-hosted endpoints untouched.
+//
+// Ports normalizeCloudConsoleEndpoint().
+func NormalizeCloudConsoleEndpoint(endpoint string) string {
+	parsed, err := url.Parse(endpoint)
+	if err != nil || parsed.Hostname() == "" {
+		return endpoint
+	}
+
+	base := baseCloudHostname(parsed.Hostname())
+	if base == "" {
+		return endpoint
+	}
+
+	return "https://" + base + "/v1"
+}
+
+// EndpointsMatch compares two endpoints for session matching, normalising
+// regional Cloud hosts and ignoring trailing slashes.
+//
+// Ports endpointsMatch().
+func EndpointsMatch(a, b string) bool {
+	trim := func(value string) string {
+		return strings.TrimRight(NormalizeCloudConsoleEndpoint(value), "/")
+	}
+
+	return trim(a) == trim(b)
+}

--- a/templates/go-cli/internal/config/json.go
+++ b/templates/go-cli/internal/config/json.go
@@ -1,0 +1,14 @@
+package config
+
+import "github.com/appwrite/appwrite-cli-go/internal/jsonx"
+
+// Object and Marshal live in internal/jsonx because internal/output needs them
+// too, and an output package importing config for a JSON primitive would be
+// the wrong dependency. Aliased here so config's own callers keep one import.
+type Object = jsonx.Object
+
+// NewObject returns an empty ordered object.
+func NewObject() *Object { return jsonx.NewObject() }
+
+// Marshal renders a value the way the TypeScript CLI writes config files.
+func Marshal(value any) ([]byte, error) { return jsonx.Marshal(value) }

--- a/templates/go-cli/internal/config/local.go
+++ b/templates/go-cli/internal/config/local.go
@@ -176,12 +176,18 @@ func (l *Local) resolveIncludePath(resource, includePath string) (string, error)
 	if err != nil {
 		return "", err
 	}
+	// Both sides are resolved, not just the include. A project directory is
+	// often reached through a symlink -- macOS puts temp directories behind one,
+	// and so does any checkout under a symlinked home -- and comparing a
+	// resolved include against an unresolved root would read every ordinary
+	// include as an escape.
+	root = resolveSymlinks(root)
 
 	resolved := filepath.Join(root, includePath)
 	if filepath.IsAbs(includePath) {
 		resolved = includePath
 	}
-	resolved = filepath.Clean(resolved)
+	resolved = resolveSymlinks(filepath.Clean(resolved))
 
 	relative, err := filepath.Rel(root, resolved)
 	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
@@ -190,6 +196,31 @@ func (l *Local) resolveIncludePath(resource, includePath string) (string, error)
 	}
 
 	return resolved, nil
+}
+
+// resolveSymlinks resolves path as far as it exists on disk.
+//
+// Comparing cleaned path strings is not containment: a link named
+// `functions.json` sitting in the project can point anywhere, and both the read
+// and the write that follow would go to the target rather than to the project.
+//
+// filepath.EvalSymlinks fails outright when the leaf does not exist, which is
+// the ordinary case for an include being written for the first time, so the
+// deepest existing ancestor is resolved and the missing tail rejoined onto it.
+func resolveSymlinks(path string) string {
+	tail := ""
+	for current := path; ; {
+		if resolved, err := filepath.EvalSymlinks(current); err == nil {
+			return filepath.Join(resolved, tail)
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			return path
+		}
+		tail = filepath.Join(filepath.Base(current), tail)
+		current = parent
+	}
 }
 
 // Write persists the config, splitting `includes` back out, dropping empty

--- a/templates/go-cli/internal/config/local.go
+++ b/templates/go-cli/internal/config/local.go
@@ -1,0 +1,302 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/appwrite/appwrite-cli-go/internal/jsonx"
+)
+
+// Ports the `Local` half of templates/cli/lib/config.ts -- appwrite.config.json.
+//
+// docs/go-cli/PLAN.md invariant 2: this file lives in user repositories and is
+// code-reviewed, so reading and rewriting it must not change a byte that the
+// user did not ask to change.
+
+// LocalFileName is the project config the CLI reads from the working directory.
+const LocalFileName = "appwrite.config.json"
+
+// configKeyOrder is the order top-level keys are written in.
+//
+// Ports CONFIG_KEY_ORDER (templates/cli/lib/config.ts:83). Without it every
+// write would reorder the file according to whatever order the data happened to
+// be built in, producing a diff on every command that touches the config.
+var configKeyOrder = []string{
+	"organizationId",
+	"projectId",
+	"projectName",
+	"endpoint",
+	"includes",
+	"settings",
+	"functions",
+	"sites",
+	"databases",
+	"collections",
+	"tablesDB",
+	"tables",
+	"buckets",
+	"teams",
+	"webhooks",
+	"topics",
+	"messages",
+}
+
+// resourceKeys are the top-level arrays that can be split into their own files
+// and that are dropped from the root document when empty.
+//
+// Ports CONFIG_RESOURCE_KEYS (templates/cli/lib/constants.ts:37).
+var resourceKeys = []string{
+	"databases",
+	"functions",
+	"topics",
+	"messages",
+	"sites",
+	"buckets",
+	"tablesDB",
+	"tables",
+	"teams",
+	"webhooks",
+	"collections",
+}
+
+func isResourceKey(key string) bool {
+	for _, resource := range resourceKeys {
+		if resource == key {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Local is a project's appwrite.config.json.
+//
+// Data holds the document as read, with any `includes` resources merged in, so
+// callers see one config regardless of how it is split on disk. Write puts the
+// split back.
+type Local struct {
+	path     string
+	Data     *jsonx.Object
+	includes map[string]string
+}
+
+// LocalPath returns the config path for a directory.
+func LocalPath(directory string) string {
+	return filepath.Join(directory, LocalFileName)
+}
+
+// LoadLocal reads a project config, resolving `includes`.
+//
+// Unlike the global preferences, a malformed project config is an error rather
+// than an empty document: silently treating a typo'd config as absent would let
+// `push` deploy nothing and report success.
+func LoadLocal(path string) (*Local, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	root := jsonx.NewObject()
+	if err := root.UnmarshalJSON(contents); err != nil {
+		return nil, fmt.Errorf("failed to read config file %q: %w", path, err)
+	}
+
+	local := &Local{path: path, Data: root, includes: map[string]string{}}
+	if err := local.resolveIncludes(); err != nil {
+		return nil, err
+	}
+
+	return local, nil
+}
+
+// Path returns the file backing this config.
+func (l *Local) Path() string {
+	return l.path
+}
+
+// Includes reports which resources are stored in separate files.
+func (l *Local) Includes() map[string]string {
+	copied := make(map[string]string, len(l.includes))
+	for resource, path := range l.includes {
+		copied[resource] = path
+	}
+
+	return copied
+}
+
+// resolveIncludes replaces the `includes` map with the resource arrays it
+// points at, so callers see a single merged document.
+func (l *Local) resolveIncludes() error {
+	includes := l.Data.GetObject("includes")
+	if includes == nil {
+		return nil
+	}
+
+	for _, resource := range includes.Keys() {
+		includePath := includes.GetString(resource)
+		if includePath == "" {
+			continue
+		}
+
+		resolved, err := l.resolveIncludePath(resource, includePath)
+		if err != nil {
+			return err
+		}
+		l.includes[resource] = includePath
+
+		contents, err := os.ReadFile(resolved)
+		if err != nil {
+			return fmt.Errorf("failed to read included config %q: %w", includePath, err)
+		}
+
+		decoded, err := jsonx.DecodeValue(contents)
+		if err != nil {
+			return fmt.Errorf("failed to read included config %q: %w", includePath, err)
+		}
+		items, ok := decoded.([]any)
+		if !ok {
+			return fmt.Errorf("config resource %q must be an array", resource)
+		}
+		l.Data.Set(resource, items)
+	}
+
+	return nil
+}
+
+// resolveIncludePath resolves an include relative to the config file and
+// refuses to escape the project directory.
+//
+// Ports assertIncludePathInsideProject(). A config that points at
+// `../../.ssh/id_rsa` would otherwise have that file overwritten on the next
+// write.
+func (l *Local) resolveIncludePath(resource, includePath string) (string, error) {
+	root, err := filepath.Abs(filepath.Dir(l.path))
+	if err != nil {
+		return "", err
+	}
+
+	resolved := filepath.Join(root, includePath)
+	if filepath.IsAbs(includePath) {
+		resolved = includePath
+	}
+	resolved = filepath.Clean(resolved)
+
+	relative, err := filepath.Rel(root, resolved)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("config include for %q must stay inside the project directory: %s",
+			resource, includePath)
+	}
+
+	return resolved, nil
+}
+
+// Write persists the config, splitting `includes` back out, dropping empty
+// resource arrays and restoring the canonical key order.
+//
+// Ports writeResolvedLocalConfig().
+func (l *Local) Write() error {
+	root := jsonx.NewObject()
+	for _, key := range l.Data.Keys() {
+		value, _ := l.Data.Get(key)
+		root.Set(key, value)
+	}
+
+	// Split included resources back into their own files and drop them from the
+	// root document.
+	for resource, includePath := range l.includes {
+		items, _ := root.Get(resource)
+		if items == nil {
+			items = []any{}
+		}
+		list, ok := items.([]any)
+		if !ok {
+			return fmt.Errorf("config resource %q must be an array", resource)
+		}
+
+		resolved, err := l.resolveIncludePath(resource, includePath)
+		if err != nil {
+			return err
+		}
+		if err := writeJSONFile(resolved, list); err != nil {
+			return err
+		}
+		root.Delete(resource)
+	}
+
+	if len(l.includes) > 0 {
+		includes := jsonx.NewObject()
+		// Written in configKeyOrder's resource order so the includes map itself
+		// is stable rather than following Go's map iteration.
+		for _, resource := range resourceKeys {
+			if path, ok := l.includes[resource]; ok {
+				includes.Set(resource, path)
+			}
+		}
+		root.Set("includes", includes)
+	} else {
+		root.Delete("includes")
+	}
+
+	return writeJSONFile(l.path, orderConfigKeys(pruneEmptyResourceArrays(root)))
+}
+
+// pruneEmptyResourceArrays drops resource keys whose array is empty.
+//
+// Ports pruneEmptyTopLevelResourceArrays(). An empty array and an absent key
+// mean the same thing to the CLI, and writing `"teams": []` into a config the
+// user never gave teams to is noise in their diff.
+func pruneEmptyResourceArrays(data *jsonx.Object) *jsonx.Object {
+	pruned := jsonx.NewObject()
+	for _, key := range data.Keys() {
+		value, _ := data.Get(key)
+		if isResourceKey(key) {
+			if list, ok := value.([]any); ok && len(list) == 0 {
+				continue
+			}
+		}
+		pruned.Set(key, value)
+	}
+
+	return pruned
+}
+
+// orderConfigKeys emits known keys in canonical order, then anything else in
+// its existing order.
+//
+// Ports orderConfigKeys(). Unknown keys are preserved rather than dropped: a
+// newer CLI may have written a field this build does not know about, and losing
+// it on the next write would be data loss.
+func orderConfigKeys(data *jsonx.Object) *jsonx.Object {
+	ordered := jsonx.NewObject()
+
+	for _, key := range configKeyOrder {
+		if value, ok := data.Get(key); ok {
+			ordered.Set(key, value)
+		}
+	}
+	for _, key := range data.Keys() {
+		if !ordered.Has(key) {
+			value, _ := data.Get(key)
+			ordered.Set(key, value)
+		}
+	}
+
+	return ordered
+}
+
+// writeJSONFile writes a config document the way the TypeScript CLI does:
+// four-space indentation, mode 0600.
+func writeJSONFile(path string, data any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+
+	encoded, err := Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, encoded, 0o600)
+}

--- a/templates/go-cli/internal/config/local_test.go
+++ b/templates/go-cli/internal/config/local_test.go
@@ -1,0 +1,338 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// realConfig is a project config in the exact shape and key order the
+// TypeScript CLI writes: CONFIG_KEY_ORDER at the top level, four-space
+// indentation, no trailing newline.
+//
+// It deliberately includes a URL with an ampersand and a `>` in a description.
+// Go's JSON encoder escapes both by default, which would rewrite a user's file
+// on the next save.
+const realConfig = `{
+    "projectId": "68f2a1b4c5d6e7f80912",
+    "projectName": "Acme Storefront",
+    "endpoint": "https://cloud.staging.appwrite.io/v1",
+    "settings": {
+        "services": {
+            "account": true
+        }
+    },
+    "functions": [
+        {
+            "$id": "checkout",
+            "name": "Checkout handler",
+            "runtime": "node-22",
+            "execute": [
+                "any"
+            ],
+            "events": [],
+            "schedule": "",
+            "timeout": 15,
+            "path": "functions/checkout",
+            "entrypoint": "src/main.js",
+            "commands": "npm install",
+            "specification": "s-0.5vcpu-512mb"
+        }
+    ],
+    "databases": [
+        {
+            "$id": "main",
+            "name": "Main",
+            "enabled": true
+        }
+    ],
+    "collections": [
+        {
+            "$id": "orders",
+            "databaseId": "main",
+            "name": "Orders",
+            "enabled": true,
+            "documentSecurity": false,
+            "$permissions": [
+                "read(\"any\")"
+            ],
+            "attributes": [
+                {
+                    "key": "callbackUrl",
+                    "type": "string",
+                    "required": false,
+                    "array": false,
+                    "size": 2048,
+                    "default": "https://acme.test/cb?a=1&b=2"
+                },
+                {
+                    "key": "note",
+                    "type": "string",
+                    "required": false,
+                    "array": false,
+                    "size": 255,
+                    "default": "qty > 1"
+                }
+            ],
+            "indexes": []
+        }
+    ],
+    "buckets": [
+        {
+            "$id": "invoices",
+            "name": "Invoices",
+            "enabled": true,
+            "maximumFileSize": 30000000
+        }
+    ],
+    "teams": [
+        {
+            "$id": "staff",
+            "name": "Staff"
+        }
+    ]
+}`
+
+func writeConfig(t *testing.T, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), LocalFileName)
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	return path
+}
+
+// Invariant 2. This file is code-reviewed in user repositories, so a read
+// followed by a write must not change a byte.
+func TestLocalRoundTripIsByteIdentical(t *testing.T) {
+	path := writeConfig(t, realConfig)
+
+	local, err := LoadLocal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := local.Write(); err != nil {
+		t.Fatal(err)
+	}
+
+	written, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(written) != realConfig {
+		t.Errorf("round-trip changed the file.\n--- want ---\n%s\n--- got ---\n%s", realConfig, written)
+	}
+}
+
+// The characters Go's encoder escapes by default. A regression here silently
+// rewrites URLs and descriptions in a user's committed config.
+func TestLocalRoundTripPreservesHTMLCharacters(t *testing.T) {
+	path := writeConfig(t, realConfig)
+
+	local, err := LoadLocal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := local.Write(); err != nil {
+		t.Fatal(err)
+	}
+
+	written, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, literal := range []string{"https://acme.test/cb?a=1&b=2", "qty > 1"} {
+		if !strings.Contains(string(written), literal) {
+			t.Errorf("literal %q was rewritten:\n%s", literal, written)
+		}
+	}
+	// Go's encoder writes these by default; JSON.stringify never does.
+	for _, escape := range []string{`\u0026`, `\u003e`, `\u003c`} {
+		if strings.Contains(string(written), escape) {
+			t.Errorf("output contains the escape %s, which the TypeScript CLI never writes:\n%s",
+				escape, written)
+		}
+	}
+}
+
+// Keys written out of order must come back in canonical order, and unknown keys
+// must survive -- a newer CLI may have written a field this build has no name
+// for, and dropping it on the next write is data loss.
+func TestOrderConfigKeys(t *testing.T) {
+	const scrambled = `{
+    "buckets": [
+        {
+            "$id": "b"
+        }
+    ],
+    "futureField": "keep me",
+    "projectName": "Acme",
+    "projectId": "abc",
+    "organizationId": "org"
+}`
+
+	path := writeConfig(t, scrambled)
+	local, err := LoadLocal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := local.Write(); err != nil {
+		t.Fatal(err)
+	}
+
+	written, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{`"organizationId"`, `"projectId"`, `"projectName"`, `"buckets"`, `"futureField"`}
+	previous := -1
+	for _, key := range want {
+		index := strings.Index(string(written), key)
+		if index < 0 {
+			t.Fatalf("%s missing from output:\n%s", key, written)
+		}
+		if index < previous {
+			t.Errorf("%s is out of canonical order:\n%s", key, written)
+		}
+		previous = index
+	}
+}
+
+// An empty resource array and an absent key mean the same thing, and writing
+// `"teams": []` into a config the user never gave teams to is diff noise.
+func TestEmptyResourceArraysArePruned(t *testing.T) {
+	path := writeConfig(t, `{
+    "projectId": "abc",
+    "teams": [],
+    "functions": []
+}`)
+
+	local, err := LoadLocal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := local.Write(); err != nil {
+		t.Fatal(err)
+	}
+
+	written, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(written), "teams") || strings.Contains(string(written), "functions") {
+		t.Errorf("empty resource arrays were not pruned:\n%s", written)
+	}
+}
+
+// A split config must stay split: inlining the resources back into the root
+// would silently reorganise the user's repository layout.
+func TestIncludesRoundTripStaySplit(t *testing.T) {
+	directory := t.TempDir()
+	path := filepath.Join(directory, LocalFileName)
+
+	const root = `{
+    "projectId": "abc",
+    "includes": {
+        "functions": "config/functions.json"
+    }
+}`
+	const functions = `[
+    {
+        "$id": "checkout",
+        "name": "Checkout"
+    }
+]`
+
+	if err := os.WriteFile(path, []byte(root), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(directory, "config"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	functionsPath := filepath.Join(directory, "config", "functions.json")
+	if err := os.WriteFile(functionsPath, []byte(functions), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	local, err := LoadLocal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Callers see one merged document regardless of the on-disk split.
+	if _, ok := local.Data.Get("functions"); !ok {
+		t.Fatal("included functions were not merged into the config")
+	}
+
+	if err := local.Write(); err != nil {
+		t.Fatal(err)
+	}
+
+	writtenRoot, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(writtenRoot), "checkout") {
+		t.Errorf("included resource was inlined into the root config:\n%s", writtenRoot)
+	}
+	if !strings.Contains(string(writtenRoot), `"includes"`) {
+		t.Errorf("includes map was dropped:\n%s", writtenRoot)
+	}
+
+	writtenFunctions, err := os.ReadFile(functionsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(writtenFunctions) != functions {
+		t.Errorf("included file changed.\n--- want ---\n%s\n--- got ---\n%s", functions, writtenFunctions)
+	}
+}
+
+// An include pointing outside the project would let a config overwrite an
+// arbitrary file on the next write.
+func TestIncludesCannotEscapeTheProjectDirectory(t *testing.T) {
+	path := writeConfig(t, `{
+    "projectId": "abc",
+    "includes": {
+        "functions": "../../escape.json"
+    }
+}`)
+
+	if _, err := LoadLocal(path); err == nil {
+		t.Fatal("expected an error for an include outside the project directory")
+	}
+}
+
+// A malformed project config is an error, not an empty document: treating a
+// typo'd config as absent would let `push` deploy nothing and report success.
+func TestLoadLocalRejectsMalformedConfig(t *testing.T) {
+	path := writeConfig(t, "{not json")
+
+	if _, err := LoadLocal(path); err == nil {
+		t.Fatal("expected an error for a malformed config")
+	}
+}
+
+func TestLocalWriteIsPrivate(t *testing.T) {
+	path := writeConfig(t, `{"projectId":"abc"}`)
+
+	local, err := LoadLocal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := local.Write(); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("config mode = %o, want 600", perm)
+	}
+}

--- a/templates/go-cli/internal/config/local_test.go
+++ b/templates/go-cli/internal/config/local_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -304,6 +305,97 @@ func TestIncludesCannotEscapeTheProjectDirectory(t *testing.T) {
 
 	if _, err := LoadLocal(path); err == nil {
 		t.Fatal("expected an error for an include outside the project directory")
+	}
+}
+
+// The containment check compared cleaned path strings, which a symlink does not
+// have to agree with. An include that is lexically inside the project but
+// resolves outside it passed, and the next write followed the link and replaced
+// whatever it pointed at.
+func TestIncludesCannotEscapeThroughASymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating a symlink on Windows needs privileges the test runner may not have")
+	}
+
+	project := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.json")
+	// A valid resource array, so nothing rejects it on the way in and the only
+	// thing standing between the config and this file is the containment check.
+	const sensitive = `[{"do":"not touch"}]`
+	if err := os.WriteFile(outside, []byte(sensitive), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Lexically "functions.json", inside the project. Actually the file above.
+	if err := os.Symlink(outside, filepath.Join(project, "functions.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(project, LocalFileName)
+	if err := os.WriteFile(path, []byte(`{
+    "projectId": "abc",
+    "includes": {
+        "functions": "functions.json"
+    }
+}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	local, err := LoadLocal(path)
+	if err == nil {
+		// Whatever the config holds is what a write sends to the include, so
+		// give it something unmistakable.
+		local.Data.Set("functions", []any{"overwritten"})
+		err = local.Write()
+	}
+
+	survived, readErr := os.ReadFile(outside)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(survived) != sensitive {
+		t.Errorf("the file outside the project was rewritten to %q", survived)
+	}
+	if err == nil {
+		t.Error("an include resolving outside the project was accepted")
+	}
+}
+
+// The project directory itself is often reached through a symlink -- macOS puts
+// temp directories behind one -- so resolving includes must not turn an
+// ordinary include into an escape.
+func TestIncludesResolveInsideASymlinkedProject(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating a symlink on Windows needs privileges the test runner may not have")
+	}
+
+	real := filepath.Join(t.TempDir(), "project")
+	if err := os.Mkdir(real, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(t.TempDir(), "linked")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(real, "functions.json"), []byte(`[]`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(real, LocalFileName), []byte(`{
+    "projectId": "abc",
+    "includes": {
+        "functions": "functions.json"
+    }
+}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	local, err := LoadLocal(filepath.Join(link, LocalFileName))
+	if err != nil {
+		t.Fatalf("an include inside a symlinked project was rejected: %v", err)
+	}
+	if err := local.Write(); err != nil {
+		t.Fatalf("writing an include inside a symlinked project failed: %v", err)
 	}
 }
 

--- a/templates/go-cli/internal/config/ordered.go
+++ b/templates/go-cli/internal/config/ordered.go
@@ -1,0 +1,274 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Object is a JSON object that remembers the order its keys were read in.
+//
+// Go's map[string]any marshals keys sorted; JavaScript preserves insertion
+// order. The TypeScript CLI reads a config, mutates a field and writes the
+// whole document back, so a Go port backed by a plain map would silently
+// reorder every key in every user's appwrite.config.json the first time it
+// wrote one. That file lives in user repositories and gets code-reviewed, so
+// the churn would be real and blamed on us.
+//
+// Numbers are kept as json.Number rather than float64 for the same reason the
+// TypeScript CLI uses json-bigint: float64 cannot hold a millisecond timestamp
+// past 2^53 without losing digits, and `tokenExpiry` is exactly that.
+type Object struct {
+	keys   []string
+	values map[string]any
+}
+
+// NewObject returns an empty ordered object.
+func NewObject() *Object {
+	return &Object{values: map[string]any{}}
+}
+
+// Keys returns the keys in their original order.
+func (o *Object) Keys() []string {
+	if o == nil {
+		return nil
+	}
+
+	return append([]string(nil), o.keys...)
+}
+
+// Get returns the value stored under key.
+func (o *Object) Get(key string) (any, bool) {
+	if o == nil {
+		return nil, false
+	}
+	value, ok := o.values[key]
+
+	return value, ok
+}
+
+// GetString returns a string value, or "" when absent or another type.
+func (o *Object) GetString(key string) string {
+	value, ok := o.Get(key)
+	if !ok {
+		return ""
+	}
+	if s, ok := value.(string); ok {
+		return s
+	}
+
+	return ""
+}
+
+// GetObject returns a nested object, or nil when absent or another type.
+func (o *Object) GetObject(key string) *Object {
+	value, ok := o.Get(key)
+	if !ok {
+		return nil
+	}
+	if nested, ok := value.(*Object); ok {
+		return nested
+	}
+
+	return nil
+}
+
+// GetInt64 returns an integer value, or 0 when absent or not a number.
+func (o *Object) GetInt64(key string) int64 {
+	value, ok := o.Get(key)
+	if !ok {
+		return 0
+	}
+	number, ok := value.(json.Number)
+	if !ok {
+		return 0
+	}
+	parsed, err := number.Int64()
+	if err != nil {
+		return 0
+	}
+
+	return parsed
+}
+
+// Set stores a value, appending the key if it is new and leaving its position
+// untouched if it already exists. Overwriting must not move a key: that is what
+// keeps a rewritten config diff-free.
+func (o *Object) Set(key string, value any) {
+	if o.values == nil {
+		o.values = map[string]any{}
+	}
+	if _, exists := o.values[key]; !exists {
+		o.keys = append(o.keys, key)
+	}
+	o.values[key] = value
+}
+
+// Delete removes a key, preserving the order of the rest.
+func (o *Object) Delete(key string) {
+	if o == nil {
+		return
+	}
+	if _, exists := o.values[key]; !exists {
+		return
+	}
+	delete(o.values, key)
+	for i, existing := range o.keys {
+		if existing == key {
+			o.keys = append(o.keys[:i], o.keys[i+1:]...)
+			break
+		}
+	}
+}
+
+// Has reports whether key is present.
+func (o *Object) Has(key string) bool {
+	if o == nil {
+		return false
+	}
+	_, ok := o.values[key]
+
+	return ok
+}
+
+// Len returns the number of keys.
+func (o *Object) Len() int {
+	if o == nil {
+		return 0
+	}
+
+	return len(o.keys)
+}
+
+// UnmarshalJSON decodes an object while recording key order.
+func (o *Object) UnmarshalJSON(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	if delim, ok := token.(json.Delim); !ok || delim != '{' {
+		return fmt.Errorf("config: expected object, got %v", token)
+	}
+
+	o.keys = nil
+	o.values = map[string]any{}
+
+	return o.decodeInto(decoder)
+}
+
+func (o *Object) decodeInto(decoder *json.Decoder) error {
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		key, ok := token.(string)
+		if !ok {
+			return fmt.Errorf("config: expected object key, got %v", token)
+		}
+
+		value, err := decodeValue(decoder)
+		if err != nil {
+			return err
+		}
+		o.Set(key, value)
+	}
+
+	// Consume the closing brace.
+	if _, err := decoder.Token(); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+func decodeValue(decoder *json.Decoder) (any, error) {
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	delim, isDelim := token.(json.Delim)
+	if !isDelim {
+		return token, nil
+	}
+
+	switch delim {
+	case '{':
+		nested := NewObject()
+		if err := nested.decodeInto(decoder); err != nil {
+			return nil, err
+		}
+
+		return nested, nil
+	case '[':
+		items := []any{}
+		for decoder.More() {
+			item, err := decodeValue(decoder)
+			if err != nil {
+				return nil, err
+			}
+			items = append(items, item)
+		}
+		if _, err := decoder.Token(); err != nil {
+			return nil, err
+		}
+
+		return items, nil
+	}
+
+	return nil, fmt.Errorf("config: unexpected delimiter %v", delim)
+}
+
+// MarshalJSON re-encodes the object in its recorded key order.
+func (o *Object) MarshalJSON() ([]byte, error) {
+	if o == nil {
+		return []byte("null"), nil
+	}
+
+	var buffer bytes.Buffer
+	buffer.WriteByte('{')
+	for i, key := range o.keys {
+		if i > 0 {
+			buffer.WriteByte(',')
+		}
+		encoded, err := json.Marshal(key)
+		if err != nil {
+			return nil, err
+		}
+		buffer.Write(encoded)
+		buffer.WriteByte(':')
+
+		encoded, err = json.Marshal(o.values[key])
+		if err != nil {
+			return nil, err
+		}
+		buffer.Write(encoded)
+	}
+	buffer.WriteByte('}')
+
+	return buffer.Bytes(), nil
+}
+
+// Marshal renders the object the way the TypeScript CLI writes config files:
+// four-space indentation, no HTML escaping, and a trailing newline left off.
+//
+// json.Encoder escapes <, > and & by default, which would rewrite any URL or
+// description containing them. JSON.stringify does not, so neither does this.
+func Marshal(value any) ([]byte, error) {
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "    ")
+
+	if err := encoder.Encode(value); err != nil {
+		return nil, err
+	}
+
+	return []byte(strings.TrimRight(buffer.String(), "\n")), nil
+}

--- a/templates/go-cli/internal/jsonx/object.go
+++ b/templates/go-cli/internal/jsonx/object.go
@@ -1,4 +1,4 @@
-package config
+package jsonx
 
 import (
 	"bytes"
@@ -8,6 +8,8 @@ import (
 	"strings"
 )
 
+// Package jsonx provides JSON handling shared by config and output.
+//
 // Object is a JSON object that remembers the order its keys were read in.
 //
 // Go's map[string]any marshals keys sorted; JavaScript preserves insertion
@@ -152,7 +154,7 @@ func (o *Object) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if delim, ok := token.(json.Delim); !ok || delim != '{' {
-		return fmt.Errorf("config: expected object, got %v", token)
+		return fmt.Errorf("jsonx: expected object, got %v", token)
 	}
 
 	o.keys = nil
@@ -169,7 +171,7 @@ func (o *Object) decodeInto(decoder *json.Decoder) error {
 		}
 		key, ok := token.(string)
 		if !ok {
-			return fmt.Errorf("config: expected object key, got %v", token)
+			return fmt.Errorf("jsonx: expected object key, got %v", token)
 		}
 
 		value, err := decodeValue(decoder)
@@ -222,7 +224,7 @@ func decodeValue(decoder *json.Decoder) (any, error) {
 		return items, nil
 	}
 
-	return nil, fmt.Errorf("config: unexpected delimiter %v", delim)
+	return nil, fmt.Errorf("jsonx: unexpected delimiter %v", delim)
 }
 
 // MarshalJSON re-encodes the object in its recorded key order.
@@ -237,14 +239,14 @@ func (o *Object) MarshalJSON() ([]byte, error) {
 		if i > 0 {
 			buffer.WriteByte(',')
 		}
-		encoded, err := json.Marshal(key)
+		encoded, err := marshalUnescaped(key)
 		if err != nil {
 			return nil, err
 		}
 		buffer.Write(encoded)
 		buffer.WriteByte(':')
 
-		encoded, err = json.Marshal(o.values[key])
+		encoded, err = marshalUnescaped(o.values[key])
 		if err != nil {
 			return nil, err
 		}
@@ -253,6 +255,29 @@ func (o *Object) MarshalJSON() ([]byte, error) {
 	buffer.WriteByte('}')
 
 	return buffer.Bytes(), nil
+}
+
+// marshalUnescaped encodes a value without Go's HTML escaping.
+//
+// json.Marshal always escapes <, > and & to \u003c and friends, and there is no
+// option to turn that off -- only json.Encoder has one. Nested values have to
+// go through an encoder too, because the outer encoder's SetEscapeHTML(false)
+// does not reach inside a custom MarshalJSON's output: it is copied through
+// compact(), which does not undo escapes already written.
+//
+// Without this, any URL with a query string comes out as `?a=1\u0026b=2` --
+// valid JSON, but not the bytes JSON.stringify produces, which breaks
+// invariant 4 and rewrites URLs in config files.
+func marshalUnescaped(value any) ([]byte, error) {
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+
+	if err := encoder.Encode(value); err != nil {
+		return nil, err
+	}
+
+	return bytes.TrimRight(buffer.Bytes(), "\n"), nil
 }
 
 // Marshal renders the object the way the TypeScript CLI writes config files:

--- a/templates/go-cli/internal/jsonx/object.go
+++ b/templates/go-cli/internal/jsonx/object.go
@@ -280,6 +280,33 @@ func marshalUnescaped(value any) ([]byte, error) {
 	return bytes.TrimRight(buffer.Bytes(), "\n"), nil
 }
 
+// DecodeValue parses any JSON document, preserving object key order and keeping
+// numbers as json.Number.
+//
+// Use this rather than json.Unmarshal into an any: that produces map[string]any
+// for objects, which re-emits keys sorted, and float64 for numbers, which loses
+// digits past 2^53.
+func DecodeValue(payload []byte) (any, error) {
+	trimmed := bytes.TrimSpace(payload)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+
+	if trimmed[0] == '{' {
+		object := NewObject()
+		if err := object.UnmarshalJSON(trimmed); err != nil {
+			return nil, err
+		}
+
+		return object, nil
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(trimmed))
+	decoder.UseNumber()
+
+	return decodeValue(decoder)
+}
+
 // Marshal renders the object the way the TypeScript CLI writes config files:
 // four-space indentation, no HTML escaping, and a trailing newline left off.
 //

--- a/templates/go-cli/internal/jsonx/object_test.go
+++ b/templates/go-cli/internal/jsonx/object_test.go
@@ -1,0 +1,66 @@
+package jsonx
+
+import "testing"
+
+// Overwriting an existing key must not move it to the end -- that is what keeps
+// a rewritten config diff-free.
+func TestSetPreservesKeyPosition(t *testing.T) {
+	object := NewObject()
+	object.Set("a", "1")
+	object.Set("b", "2")
+	object.Set("c", "3")
+	object.Set("a", "changed")
+
+	keys := object.Keys()
+	want := []string{"a", "b", "c"}
+	for i := range want {
+		if keys[i] != want[i] {
+			t.Fatalf("keys = %v, want %v", keys, want)
+		}
+	}
+}
+
+// Nested objects and arrays must round-trip in order too, not just the root.
+func TestRoundTripPreservesNestedOrder(t *testing.T) {
+	const document = `{"z":1,"a":{"y":2,"b":[{"w":3,"c":4}]}}`
+
+	object := NewObject()
+	if err := object.UnmarshalJSON([]byte(document)); err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := object.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(encoded) != document {
+		t.Errorf("round-trip = %s, want %s", encoded, document)
+	}
+}
+
+// JSON.stringify does not escape <, > or &; neither may Marshal, or any URL or
+// description containing them would be rewritten.
+func TestMarshalDoesNotEscapeHTML(t *testing.T) {
+	object := NewObject()
+	object.Set("url", "https://example.com/?a=1&b=2")
+	object.Set("html", "<b>bold</b>")
+
+	encoded, err := Marshal(object)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"&b=2", "<b>bold</b>"} {
+		if !contains(string(encoded), want) {
+			t.Errorf("%s missing from output:\n%s", want, encoded)
+		}
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+
+	return false
+}

--- a/templates/go-cli/internal/output/filter.go
+++ b/templates/go-cli/internal/output/filter.go
@@ -1,0 +1,154 @@
+package output
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/appwrite/appwrite-cli-go/internal/jsonx"
+)
+
+// Ports the field-selection half of templates/cli/lib/parser.ts.
+//
+// FilterData decides what --json shows, so it is part of invariant 4 rather
+// than cosmetic.
+
+// normalViewHiddenKeys are dropped from the human-readable view.
+//
+// Internal bookkeeping that carries no meaning for a CLI reader, plus fields
+// the API returns twice under two names (`billingPlanId` === `billingPlan`).
+//
+// Ports NORMAL_VIEW_HIDDEN_KEYS (templates/cli/lib/parser.ts:84).
+var normalViewHiddenKeys = map[string]bool{
+	"onboarding":    true,
+	"billingPlanId": true,
+}
+
+// IsNormalViewHiddenKey reports whether a field is hidden from the table view.
+//
+// `$`-prefixed keys are Appwrite's internal metadata and are hidden, except
+// `$id`, which is the one a user actually needs.
+func IsNormalViewHiddenKey(key string) bool {
+	if strings.HasPrefix(key, "$") && key != "$id" {
+		return true
+	}
+
+	return normalViewHiddenKeys[key]
+}
+
+// FilterObject flattens one object for display: scalars survive, nested objects
+// and blank strings are dropped.
+//
+// Ports filterObject().
+func FilterObject(object *jsonx.Object) *jsonx.Object {
+	result := jsonx.NewObject()
+
+	for _, key := range object.Keys() {
+		value, _ := object.Get(key)
+		if value == nil {
+			continue
+		}
+		if number, ok := value.(json.Number); ok {
+			result.Set(key, number.String())
+
+			continue
+		}
+		switch typed := value.(type) {
+		case *jsonx.Object, []any:
+			_ = typed
+
+			continue
+		case string:
+			if strings.TrimSpace(typed) == "" {
+				continue
+			}
+		}
+		result.Set(key, value)
+	}
+
+	return result
+}
+
+// FilterData prepares a response for --json.
+//
+// Scalars survive. Arrays survive with their object elements flattened by
+// FilterObject. Nested objects, nulls and blank strings are dropped. Numbers
+// become strings, which looks odd but is what the TypeScript does: json-bigint
+// yields BigNumber instances and `String(value)` is how they are rendered.
+//
+// Ports filterData().
+func FilterData(data *jsonx.Object) *jsonx.Object {
+	result := jsonx.NewObject()
+
+	for _, key := range data.Keys() {
+		value, _ := data.Get(key)
+		if value == nil {
+			continue
+		}
+
+		if number, ok := value.(json.Number); ok {
+			result.Set(key, number.String())
+
+			continue
+		}
+
+		switch typed := value.(type) {
+		case []any:
+			items := make([]any, 0, len(typed))
+			for _, item := range typed {
+				if number, ok := item.(json.Number); ok {
+					items = append(items, number.String())
+
+					continue
+				}
+				if object, ok := item.(*jsonx.Object); ok {
+					items = append(items, FilterObject(object))
+
+					continue
+				}
+				items = append(items, item)
+			}
+			result.Set(key, items)
+		case *jsonx.Object:
+			continue
+		case string:
+			if strings.TrimSpace(typed) == "" {
+				continue
+			}
+			result.Set(key, typed)
+		default:
+			result.Set(key, value)
+		}
+	}
+
+	return result
+}
+
+// ApplyDisplayFields narrows rows to the fields named by --display-field.
+//
+// A row that has none of the requested fields is returned whole rather than
+// blank: showing nothing would look like the row does not exist.
+//
+// Ports applyDisplayFilter().
+func ApplyDisplayFields(rows []*jsonx.Object, fields []string) []*jsonx.Object {
+	if len(fields) == 0 {
+		return rows
+	}
+
+	filtered := make([]*jsonx.Object, 0, len(rows))
+	for _, row := range rows {
+		narrowed := jsonx.NewObject()
+		for _, field := range fields {
+			if value, ok := row.Get(field); ok {
+				narrowed.Set(field, value)
+			}
+		}
+		if narrowed.Len() == 0 {
+			filtered = append(filtered, row)
+
+			continue
+		}
+		filtered = append(filtered, narrowed)
+	}
+
+	return filtered
+}

--- a/templates/go-cli/internal/output/filter_test.go
+++ b/templates/go-cli/internal/output/filter_test.go
@@ -1,0 +1,131 @@
+package output
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/appwrite/appwrite-cli-go/internal/jsonx"
+)
+
+func decode(t *testing.T, document string) *jsonx.Object {
+	t.Helper()
+
+	object := jsonx.NewObject()
+	if err := object.UnmarshalJSON([]byte(document)); err != nil {
+		t.Fatal(err)
+	}
+
+	return object
+}
+
+func render(t *testing.T, value any) string {
+	t.Helper()
+
+	var buffer bytes.Buffer
+	if err := RenderJSON(&buffer, value); err != nil {
+		t.Fatal(err)
+	}
+
+	return buffer.String()
+}
+
+func TestIsNormalViewHiddenKey(t *testing.T) {
+	hidden := []string{"$createdAt", "$updatedAt", "$permissions", "onboarding", "billingPlanId"}
+	for _, key := range hidden {
+		if !IsNormalViewHiddenKey(key) {
+			t.Errorf("IsNormalViewHiddenKey(%q) = false, want true", key)
+		}
+	}
+
+	// $id is the one internal field a user actually needs.
+	visible := []string{"$id", "name", "email", "billingPlan"}
+	for _, key := range visible {
+		if IsNormalViewHiddenKey(key) {
+			t.Errorf("IsNormalViewHiddenKey(%q) = true, want false", key)
+		}
+	}
+}
+
+// Ports filterData()'s decision table: nulls, nested objects and blank strings
+// are dropped; numbers become strings; arrays keep their elements with objects
+// flattened.
+func TestFilterData(t *testing.T) {
+	input := decode(t, `{
+		"name": "proj",
+		"blank": "   ",
+		"missing": null,
+		"count": 42,
+		"nested": {"a": 1},
+		"rows": [
+			{"id": "1", "nested": {"b": 2}, "blank": "", "n": 7},
+			"scalar",
+			9
+		]
+	}`)
+
+	got := render(t, FilterData(input))
+	want := `{
+  "name": "proj",
+  "count": "42",
+  "rows": [
+    {
+      "id": "1",
+      "n": "7"
+    },
+    "scalar",
+    "9"
+  ]
+}
+`
+
+	if got != want {
+		t.Errorf("FilterData output.\n--- want ---\n%s\n--- got ---\n%s", want, got)
+	}
+}
+
+// Field order must survive filtering, or --json consumers see fields move.
+func TestFilterDataPreservesOrder(t *testing.T) {
+	input := decode(t, `{"z":"1","a":"2","m":"3"}`)
+
+	keys := FilterData(input).Keys()
+	want := []string{"z", "a", "m"}
+	for i := range want {
+		if keys[i] != want[i] {
+			t.Fatalf("keys = %v, want %v", keys, want)
+		}
+	}
+}
+
+func TestApplyDisplayFields(t *testing.T) {
+	rows := []*jsonx.Object{
+		decode(t, `{"$id":"1","name":"a","region":"fra"}`),
+		decode(t, `{"$id":"2","name":"b","region":"nyc"}`),
+	}
+
+	narrowed := ApplyDisplayFields(rows, []string{"name", "$id"})
+	if got := narrowed[0].Keys(); len(got) != 2 || got[0] != "name" || got[1] != "$id" {
+		t.Errorf("keys = %v, want [name $id] in the requested order", got)
+	}
+}
+
+// A row with none of the requested fields comes back whole: showing nothing
+// would look like the row does not exist.
+func TestApplyDisplayFieldsKeepsRowsWithNoMatch(t *testing.T) {
+	rows := []*jsonx.Object{decode(t, `{"other":"value"}`)}
+
+	narrowed := ApplyDisplayFields(rows, []string{"name"})
+	if narrowed[0].Len() != 1 {
+		t.Errorf("row was blanked instead of preserved: %v", narrowed[0].Keys())
+	}
+	if _, ok := narrowed[0].Get("other"); !ok {
+		t.Error("original field was lost")
+	}
+}
+
+func TestApplyDisplayFieldsIsIdentityWithoutFields(t *testing.T) {
+	rows := []*jsonx.Object{decode(t, `{"a":"1"}`)}
+
+	if got := ApplyDisplayFields(rows, nil); len(got) != 1 || got[0] != rows[0] {
+		t.Error("no display fields should return the rows untouched")
+	}
+}

--- a/templates/go-cli/internal/output/json.go
+++ b/templates/go-cli/internal/output/json.go
@@ -1,0 +1,92 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"strings"
+
+	"github.com/appwrite/appwrite-cli-go/internal/jsonx"
+)
+
+// Ports the --json and --raw output paths from templates/cli/lib/parser.ts.
+//
+// docs/go-cli/PLAN.md lists this as invariant 4: these two modes are scripted
+// against, so the bytes must match the TypeScript CLI's exactly.
+
+// Mode selects how a response is rendered.
+type Mode int
+
+const (
+	// ModeTable is the default human-readable rendering.
+	ModeTable Mode = iota
+	// ModeJSON emits filtered JSON (--json).
+	ModeJSON
+	// ModeRaw emits the unfiltered response as JSON (--raw).
+	ModeRaw
+)
+
+// Renderer writes command results.
+type Renderer struct {
+	Mode        Mode
+	ShowSecrets bool
+	Writer      io.Writer
+}
+
+// RenderJSON writes a value as JSON.stringify(value, null, 2) does.
+//
+// Two details make this byte-compatible rather than merely valid:
+//
+//   - Two-space indentation, not the four the config files use.
+//   - No HTML escaping. Go's encoder rewrites <, > and & to < and friends;
+//     JSON.stringify does not, so any URL with a query string would differ.
+//
+// Key order comes from jsonx.Object, which preserves the order the API sent.
+func RenderJSON(writer io.Writer, value any) error {
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+
+	if err := encoder.Encode(value); err != nil {
+		return err
+	}
+
+	// Encode appends a newline, which is what console.log does too.
+	_, err := writer.Write(buffer.Bytes())
+
+	return err
+}
+
+// DecodeOrdered parses a response body preserving key order and large integers.
+//
+// Responses must go through this rather than encoding/json's default
+// map[string]any: a map would re-emit keys sorted, which --json consumers would
+// see as the field order changing between the two CLIs.
+func DecodeOrdered(payload []byte) (any, error) {
+	trimmed := strings.TrimSpace(string(payload))
+	if trimmed == "" {
+		return nil, nil
+	}
+
+	// Only objects carry key order worth preserving; arrays and scalars decode
+	// normally, with UseNumber so integers keep their digits.
+	if strings.HasPrefix(trimmed, "{") {
+		object := jsonx.NewObject()
+		if err := object.UnmarshalJSON([]byte(trimmed)); err != nil {
+			return nil, err
+		}
+
+		return object, nil
+	}
+
+	decoder := json.NewDecoder(strings.NewReader(trimmed))
+	decoder.UseNumber()
+
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+
+	return value, nil
+}

--- a/templates/go-cli/internal/output/json_test.go
+++ b/templates/go-cli/internal/output/json_test.go
@@ -1,0 +1,145 @@
+package output
+
+import (
+	"bytes"
+	"testing"
+)
+
+// nodeBaseline is the exact output of the TypeScript CLI's drawJSON() for the
+// document below -- captured from `JSON.stringify(value, null, 2)`, which is
+// what parser.ts:772 calls.
+//
+// docs/go-cli/PLAN.md invariant 4: --json and --raw are scripted against, so
+// this has to match byte for byte. The interesting parts are the ampersand in
+// the URL, which Go's encoder escapes by default and JSON.stringify does not,
+// and the field order, which a Go map would sort.
+const nodeBaseline = `{
+  "name": "proj",
+  "url": "https://x.io/?a=1&b=2",
+  "nested": {
+    "apiKey": "standard_0123456789abcdefghij"
+  },
+  "list": [
+    {
+      "secret": "short"
+    },
+    1,
+    null,
+    true
+  ]
+}
+`
+
+const sourceDocument = `{"name":"proj","url":"https://x.io/?a=1&b=2","nested":{"apiKey":"standard_0123456789abcdefghij"},"list":[{"secret":"short"},1,null,true]}`
+
+func TestRenderJSONMatchesNodeByteForByte(t *testing.T) {
+	value, err := DecodeOrdered([]byte(sourceDocument))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buffer bytes.Buffer
+	if err := RenderJSON(&buffer, value); err != nil {
+		t.Fatal(err)
+	}
+
+	if buffer.String() != nodeBaseline {
+		t.Errorf("output differs from JSON.stringify(value, null, 2).\n--- want ---\n%s\n--- got ---\n%s",
+			nodeBaseline, buffer.String())
+	}
+}
+
+// The ampersand case on its own, because it is the one a reviewer is most
+// likely to "fix" by dropping SetEscapeHTML(false).
+func TestRenderJSONDoesNotEscapeHTML(t *testing.T) {
+	value, err := DecodeOrdered([]byte(`{"url":"https://x.io/?a=1&b=2","tag":"<b>"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buffer bytes.Buffer
+	if err := RenderJSON(&buffer, value); err != nil {
+		t.Fatal(err)
+	}
+
+	// Go's default encoder would write these escapes; JSON.stringify never does.
+	for _, forbidden := range []string{`\u0026`, `\u003c`, `\u003e`} {
+		if bytes.Contains(buffer.Bytes(), []byte(forbidden)) {
+			t.Errorf("output contains the escape %s, which JSON.stringify would not emit:\n%s",
+				forbidden, buffer.String())
+		}
+	}
+	for _, required := range []string{`?a=1&b=2`, `<b>`} {
+		if !bytes.Contains(buffer.Bytes(), []byte(required)) {
+			t.Errorf("output is missing the literal %s:\n%s", required, buffer.String())
+		}
+	}
+}
+
+// A large integer must survive rendering. Decoding through float64 would round
+// it, which for an ID or a timestamp is silent data loss.
+func TestRenderJSONPreservesLargeIntegers(t *testing.T) {
+	value, err := DecodeOrdered([]byte(`{"id":9007199254740993}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buffer bytes.Buffer
+	if err := RenderJSON(&buffer, value); err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Contains(buffer.Bytes(), []byte("9007199254740993")) {
+		t.Errorf("large integer was not preserved:\n%s", buffer.String())
+	}
+}
+
+// Redaction must not reorder a response.
+func TestMaskPreservesResponseOrder(t *testing.T) {
+	value, err := DecodeOrdered([]byte(sourceDocument))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	redactor := &Redactor{}
+	var buffer bytes.Buffer
+	if err := RenderJSON(&buffer, redactor.Mask(value, "")); err != nil {
+		t.Fatal(err)
+	}
+
+	if !redactor.Applied {
+		t.Error("expected redaction to fire on apiKey")
+	}
+
+	// Order is unchanged even though two fields were rewritten.
+	want := []string{`"name"`, `"url"`, `"nested"`, `"apiKey"`, `"list"`, `"secret"`}
+	previous := -1
+	for _, key := range want {
+		index := bytes.Index(buffer.Bytes(), []byte(key))
+		if index < 0 {
+			t.Fatalf("%s missing from output:\n%s", key, buffer.String())
+		}
+		if index < previous {
+			t.Errorf("%s appears out of order:\n%s", key, buffer.String())
+		}
+		previous = index
+	}
+}
+
+func TestDecodeOrderedHandlesArraysAndEmptyBodies(t *testing.T) {
+	value, err := DecodeOrdered([]byte(`[1,2,3]`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if items, ok := value.([]any); !ok || len(items) != 3 {
+		t.Errorf("array decode = %#v", value)
+	}
+
+	empty, err := DecodeOrdered([]byte("   "))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if empty != nil {
+		t.Errorf("empty body = %#v, want nil", empty)
+	}
+}

--- a/templates/go-cli/internal/output/redact.go
+++ b/templates/go-cli/internal/output/redact.go
@@ -3,6 +3,8 @@ package output
 import (
 	"encoding/json"
 	"strings"
+
+	"github.com/appwrite/appwrite-cli-go/internal/jsonx"
 )
 
 // Ports the redaction half of templates/cli/lib/parser.ts.
@@ -112,6 +114,15 @@ func (r *Redactor) Mask(value any, key string) any {
 		masked := make([]any, len(typed))
 		for i, item := range typed {
 			masked[i] = r.Mask(item, "")
+		}
+
+		return masked
+	case *jsonx.Object:
+		// Rebuilt in the same key order, so masking never reorders a response.
+		masked := jsonx.NewObject()
+		for _, name := range typed.Keys() {
+			item, _ := typed.Get(name)
+			masked.Set(name, r.Mask(item, name))
 		}
 
 		return masked

--- a/templates/go-cli/internal/output/redact.go
+++ b/templates/go-cli/internal/output/redact.go
@@ -1,0 +1,130 @@
+package output
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// Ports the redaction half of templates/cli/lib/parser.ts.
+//
+// docs/go-cli/PLAN.md lists this as invariant 5: a regression here leaks
+// credentials into terminal scrollback, CI logs and bug reports. The rules are
+// reproduced exactly, including the parts that look arbitrary.
+
+// HiddenValue replaces a redacted value.
+const HiddenValue = "[hidden]"
+
+// sensitiveKeys is matched against a normalised key. Ports SENSITIVE_KEYS at
+// templates/cli/lib/parser.ts:54 -- keep in the same order for reviewability.
+var sensitiveKeys = []string{
+	"secret",
+	"apikey",
+	"accesstoken",
+	"refreshtoken",
+	"password",
+	"jwt",
+	"clientsecret",
+	"secretkey",
+	"sessionsecret",
+}
+
+// normalizeKey lower-cases and strips everything that is not alphanumeric, so
+// `API-Key`, `api_key` and `apiKey` all collapse to `apikey`.
+func normalizeKey(key string) string {
+	var builder strings.Builder
+	builder.Grow(len(key))
+	for _, r := range strings.ToLower(key) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			builder.WriteRune(r)
+		}
+	}
+
+	return builder.String()
+}
+
+// IsSensitiveKey reports whether a field name names a credential.
+//
+// Suffix matching is deliberate: it catches `providerAccessToken` and
+// `x-appwrite-key` style names without an exhaustive list.
+func IsSensitiveKey(key string) bool {
+	normalized := normalizeKey(key)
+	for _, sensitive := range sensitiveKeys {
+		if normalized == sensitive || strings.HasSuffix(normalized, sensitive) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// MaskString redacts a credential, keeping just enough to identify which one it
+// is.
+//
+// A key or token tail helps a user tell two credentials apart; a password tail
+// is pure leakage, so passwords are masked whole regardless of length.
+func MaskString(value, key string) string {
+	if len(value) <= 16 || strings.Contains(strings.ToLower(key), "password") {
+		return HiddenValue
+	}
+
+	// Prefixed credentials such as `standard_abc...` keep their prefix, which
+	// identifies the credential type. The bound keeps at least the last four
+	// characters out of the prefix.
+	if index := strings.Index(value, "_"); index > 0 && index < len(value)-9 {
+		return value[:index+1] + HiddenValue + value[len(value)-4:]
+	}
+
+	return HiddenValue + value[len(value)-4:]
+}
+
+// Redactor walks decoded JSON and masks credential-bearing fields.
+//
+// ShowSecrets mirrors the --show-secrets flag. Applied records whether anything
+// was actually masked, which the renderer uses to decide whether to print the
+// "values were hidden" footer.
+type Redactor struct {
+	ShowSecrets bool
+	Applied     bool
+}
+
+// Mask returns a copy of value with sensitive fields replaced.
+//
+// key is the field name value was found under, empty at the root and for array
+// elements -- an array of strings under a sensitive key is masked by the
+// recursive call, not by the element's own (absent) name, which is why the TS
+// passes undefined there and this passes "".
+func (r *Redactor) Mask(value any, key string) any {
+	if key != "" && IsSensitiveKey(key) && !r.ShowSecrets {
+		r.Applied = true
+
+		switch typed := value.(type) {
+		case string:
+			return MaskString(typed, key)
+		case nil:
+			return nil
+		default:
+			return HiddenValue
+		}
+	}
+
+	switch typed := value.(type) {
+	case []any:
+		masked := make([]any, len(typed))
+		for i, item := range typed {
+			masked[i] = r.Mask(item, "")
+		}
+
+		return masked
+	case map[string]any:
+		masked := make(map[string]any, len(typed))
+		for name, item := range typed {
+			masked[name] = r.Mask(item, name)
+		}
+
+		return masked
+	case json.Number:
+		return typed
+	}
+
+	return value
+}

--- a/templates/go-cli/internal/output/redact_test.go
+++ b/templates/go-cli/internal/output/redact_test.go
@@ -1,0 +1,162 @@
+package output
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Every key in SENSITIVE_KEYS (templates/cli/lib/parser.ts:54) must be caught,
+// in each of the spellings the normaliser is supposed to collapse. A gap here
+// is a credential leak, not a formatting bug.
+func TestIsSensitiveKeyCoversEverySensitiveKey(t *testing.T) {
+	for _, base := range sensitiveKeys {
+		for _, spelling := range keySpellings(base) {
+			if !IsSensitiveKey(spelling) {
+				t.Errorf("IsSensitiveKey(%q) = false, want true (from %q)", spelling, base)
+			}
+		}
+	}
+}
+
+// keySpellings returns the ways a sensitive key realistically appears in an API
+// response or a config file.
+func keySpellings(base string) []string {
+	upper := strings.ToUpper(base[:1]) + base[1:]
+
+	return []string{
+		base,
+		upper,
+		strings.ToUpper(base),
+		"x-appwrite-" + base,
+		"provider" + upper,
+		"provider_" + base,
+		"provider-" + base,
+	}
+}
+
+func TestIsSensitiveKeyIgnoresOrdinaryFields(t *testing.T) {
+	// "name" and "id" must stay visible; "keyword" and "passwordless" are the
+	// interesting cases -- suffix matching must not fire on a prefix match.
+	insensitive := []string{
+		"name", "id", "$id", "email", "endpoint", "status", "total",
+		"keyword", "keyboard", "secretary", "jwtIssuer", "passwordPolicy",
+	}
+	for _, key := range insensitive {
+		if IsSensitiveKey(key) {
+			t.Errorf("IsSensitiveKey(%q) = true, want false", key)
+		}
+	}
+}
+
+func TestMaskString(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		key   string
+		want  string
+	}{
+		{"short values masked whole", "abc123", "secret", HiddenValue},
+		{"exactly 16 masked whole", "0123456789abcdef", "secret", HiddenValue},
+		{"passwords always masked whole", strings.Repeat("p", 64), "password", HiddenValue},
+		{"password case insensitive", strings.Repeat("p", 64), "userPassword", HiddenValue},
+		{
+			"prefixed credential keeps its prefix",
+			"standard_0123456789abcdefghij",
+			"apiKey",
+			"standard_" + HiddenValue + "ghij",
+		},
+		{
+			"unprefixed credential keeps a tail",
+			"0123456789abcdefghij",
+			"accessToken",
+			HiddenValue + "ghij",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MaskString(tc.value, tc.key); got != tc.want {
+				t.Errorf("MaskString(%q, %q) = %q, want %q", tc.value, tc.key, got, tc.want)
+			}
+		})
+	}
+}
+
+// A leading underscore, or one too close to the end, must not produce a prefix
+// split -- that would expose more of the credential than intended.
+func TestMaskStringUnderscoreBounds(t *testing.T) {
+	leading := MaskString("_123456789abcdefghij", "secret")
+	if strings.HasPrefix(leading, "_") {
+		t.Errorf("leading underscore produced a prefix split: %q", leading)
+	}
+
+	trailing := MaskString("0123456789abcdef_ghi", "secret")
+	if strings.Contains(trailing, "_"+HiddenValue) {
+		t.Errorf("late underscore produced a prefix split: %q", trailing)
+	}
+}
+
+func TestRedactorMasksNestedStructures(t *testing.T) {
+	input := map[string]any{
+		"name": "my project",
+		"providers": []any{
+			map[string]any{"name": "smtp", "password": strings.Repeat("x", 32)},
+		},
+		"nested": map[string]any{"apiKey": "standard_0123456789abcdefghij"},
+	}
+
+	redactor := &Redactor{}
+	masked, ok := redactor.Mask(input, "").(map[string]any)
+	if !ok {
+		t.Fatal("Mask did not return a map")
+	}
+
+	if !redactor.Applied {
+		t.Error("Applied = false, want true")
+	}
+	if masked["name"] != "my project" {
+		t.Errorf("non-sensitive field was altered: %v", masked["name"])
+	}
+
+	nested := masked["nested"].(map[string]any)
+	if nested["apiKey"] != "standard_"+HiddenValue+"ghij" {
+		t.Errorf("nested apiKey = %v", nested["apiKey"])
+	}
+
+	provider := masked["providers"].([]any)[0].(map[string]any)
+	if provider["password"] != HiddenValue {
+		t.Errorf("provider password = %v", provider["password"])
+	}
+}
+
+func TestRedactorShowSecretsDisablesMasking(t *testing.T) {
+	input := map[string]any{"secret": "standard_0123456789abcdefghij"}
+
+	redactor := &Redactor{ShowSecrets: true}
+	masked := redactor.Mask(input, "").(map[string]any)
+
+	if masked["secret"] != input["secret"] {
+		t.Errorf("secret was masked despite ShowSecrets: %v", masked["secret"])
+	}
+	if redactor.Applied {
+		t.Error("Applied = true, want false when secrets are shown")
+	}
+}
+
+// A null credential stays null rather than becoming the string "[hidden]":
+// scripts distinguish "not set" from "set but hidden".
+func TestRedactorPreservesNullAndNonStrings(t *testing.T) {
+	redactor := &Redactor{}
+	masked := redactor.Mask(map[string]any{
+		"secret": nil,
+		"apiKey": json.Number("42"),
+	}, "").(map[string]any)
+
+	if masked["secret"] != nil {
+		t.Errorf("null secret = %v, want nil", masked["secret"])
+	}
+	if masked["apiKey"] != HiddenValue {
+		t.Errorf("non-string credential = %v, want %q", masked["apiKey"], HiddenValue)
+	}
+}

--- a/templates/go-cli/internal/output/render.go
+++ b/templates/go-cli/internal/output/render.go
@@ -1,0 +1,228 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/appwrite/appwrite-cli-go/internal/jsonx"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
+)
+
+// Ports the human-readable half of templates/cli/lib/parser.ts:parse().
+//
+// Unlike --json and --raw this output is explicitly NOT part of the contract
+// (docs/go-cli/PLAN.md §3), so the structure is reproduced -- scalars first,
+// then one section per nested value -- without chasing the TypeScript's exact
+// spacing.
+//
+// NOT YET PORTED: response-config.ts, which supplies per-resource field
+// selection, timestamp formatting and duration humanising. Values render as
+// their raw JSON scalars until that lands.
+
+var (
+	sectionStyle = lipgloss.NewStyle().Bold(true).Underline(true).Foreground(lipgloss.Color("3"))
+	labelStyle   = lipgloss.NewStyle().Bold(true)
+)
+
+// Render writes a response in whichever mode the renderer is set to.
+func (r *Renderer) Render(value any) error {
+	writer := r.Writer
+	if writer == nil {
+		return nil
+	}
+
+	redactor := &Redactor{ShowSecrets: r.ShowSecrets}
+
+	switch r.Mode {
+	case ModeRaw:
+		return RenderJSON(writer, redactor.Mask(value, ""))
+	case ModeJSON:
+		masked := redactor.Mask(value, "")
+		if object, ok := masked.(*jsonx.Object); ok {
+			return RenderJSON(writer, FilterData(object))
+		}
+
+		return RenderJSON(writer, masked)
+	}
+
+	return r.renderHuman(writer, redactor.Mask(value, ""))
+}
+
+// renderHuman prints scalars as a key/value block, then each nested value as
+// its own titled section.
+func (r *Renderer) renderHuman(writer io.Writer, value any) error {
+	object, ok := value.(*jsonx.Object)
+	if !ok {
+		_, err := fmt.Fprintln(writer, formatScalar(value))
+
+		return err
+	}
+
+	type section struct {
+		key   string
+		value any
+	}
+
+	var (
+		scalars  [][2]string
+		sections []section
+	)
+
+	for _, key := range object.Keys() {
+		if IsNormalViewHiddenKey(key) {
+			continue
+		}
+		item, _ := object.Get(key)
+		if item == nil {
+			continue
+		}
+
+		switch typed := item.(type) {
+		case []any:
+			if len(typed) == 0 || allEmptyObjects(typed) {
+				continue
+			}
+			sections = append(sections, section{key, typed})
+		case *jsonx.Object:
+			if typed.Len() == 0 {
+				continue
+			}
+			sections = append(sections, section{key, typed})
+		case string:
+			if strings.TrimSpace(typed) == "" {
+				continue
+			}
+			scalars = append(scalars, [2]string{key, typed})
+		default:
+			scalars = append(scalars, [2]string{key, formatScalar(item)})
+		}
+	}
+
+	printed := false
+	if len(scalars) > 0 {
+		width := 0
+		for _, entry := range scalars {
+			if len(entry[0]) > width {
+				width = len(entry[0])
+			}
+		}
+		for _, entry := range scalars {
+			fmt.Fprintf(writer, "%s %s\n",
+				labelStyle.Render(fmt.Sprintf("%-*s :", width, entry[0])), entry[1])
+		}
+		printed = true
+	}
+
+	for _, item := range sections {
+		if printed {
+			fmt.Fprintln(writer, " ")
+		}
+
+		switch typed := item.value.(type) {
+		case []any:
+			rows := objectRows(typed)
+			if len(rows) > 0 {
+				fmt.Fprintln(writer, sectionStyle.Render(fmt.Sprintf("%s (%d)", item.key, len(typed))))
+				fmt.Fprintln(writer, renderTable(rows))
+			} else {
+				fmt.Fprintln(writer, sectionStyle.Render(item.key))
+				for _, entry := range typed {
+					fmt.Fprintf(writer, "  %s\n", formatScalar(entry))
+				}
+			}
+		case *jsonx.Object:
+			fmt.Fprintln(writer, sectionStyle.Render(item.key))
+			fmt.Fprintln(writer, renderTable([]*jsonx.Object{FilterObject(typed)}))
+		}
+		printed = true
+	}
+
+	if !printed {
+		fmt.Fprintln(writer, "Request completed successfully.")
+	}
+
+	return nil
+}
+
+// objectRows returns the elements that are objects, flattened for display.
+// Returns nil when the array is not a list of objects.
+func objectRows(items []any) []*jsonx.Object {
+	rows := make([]*jsonx.Object, 0, len(items))
+	for _, item := range items {
+		object, ok := item.(*jsonx.Object)
+		if !ok {
+			return nil
+		}
+		rows = append(rows, FilterObject(object))
+	}
+
+	return rows
+}
+
+func allEmptyObjects(items []any) bool {
+	for _, item := range items {
+		object, ok := item.(*jsonx.Object)
+		if !ok || object.Len() > 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
+// renderTable lays rows out as a table, using the union of their keys in
+// first-seen order so a field missing from the first row is not dropped.
+func renderTable(rows []*jsonx.Object) string {
+	headers := []string{}
+	seen := map[string]bool{}
+	for _, row := range rows {
+		for _, key := range row.Keys() {
+			if !seen[key] {
+				seen[key] = true
+				headers = append(headers, key)
+			}
+		}
+	}
+	if len(headers) == 0 {
+		return ""
+	}
+
+	data := make([][]string, 0, len(rows))
+	for _, row := range rows {
+		cells := make([]string, 0, len(headers))
+		for _, header := range headers {
+			value, _ := row.Get(header)
+			cells = append(cells, formatScalar(value))
+		}
+		data = append(data, cells)
+	}
+
+	return table.New().
+		Border(lipgloss.NormalBorder()).
+		Headers(headers...).
+		Rows(data...).
+		Render()
+}
+
+// formatScalar renders one value for display.
+func formatScalar(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return typed
+	case bool:
+		if typed {
+			return "true"
+		}
+
+		return "false"
+	case json.Number:
+		return typed.String()
+	}
+
+	return fmt.Sprint(value)
+}


### PR DESCRIPTION
Stacked on #1717. The runtime the generated commands sit on: config, sessions, authentication, HTTP client, output rendering. Hand-written Go rather than generated, so this is the PR to read as ordinary code.

## The four pieces

**`internal/config`** — global preferences (`~/.appwrite/prefs.json`) and the project's `appwrite.config.json`. The project config is committed and code-reviewed in user repositories, so **a read followed by a write must not change a byte** — that is PLAN.md invariant 2, and there is a round-trip test asserting it against a real config.

**`internal/auth`** — the browser device-code flow, the email-and-password flow with MFA, refresh tokens, and the keyring. Credentials go to the OS keyring where there is one and fall back to the preferences file where there is not.

**`internal/client`** — the CLI's own HTTP client, for the endpoints the generated SDK does not cover (OAuth2, `/console/*`, and the by-hand reads like `GET /projects/{id}`).

**`internal/output`** — tables, `--json`, `--raw`, and redaction. `--json` is scripted against, so its bytes are contractual.

## Two things a reviewer should push on

**Sessions are keyed per endpoint, not globally.** The preferences file holds several sessions and one current pointer, because a user with Cloud and a self-hosted instance must not have one login silently repoint the other. `client --endpoint` selects the session belonging to that endpoint rather than rewriting whichever was current — otherwise one server's credentials get sent to another.

**Config includes are containment-checked, and the check resolves symlinks.** `appwrite.config.json` can point `includes` at other files, and it is a file a pull request can add. A lexical check passes a link that sits inside the project and resolves outside it, and the next write follows it. Both sides of the comparison are resolved; there is a test that points an include at a file in another directory and asserts it is refused, and a second test that an ordinary include inside a symlinked project (macOS puts temp dirs behind one) still works.

## Both reported defects are fixed here

Rather than at the tip, so this PR reviews as finished code:

- **The session key.** It was the ID token's subject alone, so two endpoints issuing the same subject — normal when staging is seeded from a production dump — had the second sign-in overwrite the first endpoint's session and destroy its keyring refresh token. The whole endpoint is now part of the key, canonicalised so the same instance typed differently is still one session: host and scheme lower-cased, trailing slash dropped, path left alone. Keying on the host alone would still have collapsed `https://host/staging/v1` and `https://host/prod/v1`. The TypeScript keys on `ID.unique()` (`login.ts:548`), so this was a port divergence, not inherited behaviour.
- **The symlink escape**, described above.

## Verified

- `go test ./internal/...` — config, auth, client and output all covered.
- Every bug fixed in this PR carries a regression test that was **run against the reverted fix**, not just written. A green test nobody has watched fail is worth very little; that habit caught a differential check in a later phase that would have passed forever.
- The keyring was round-tripped on Linux as well as macOS. A static `CGO_ENABLED=0` build is exactly where a keyring quietly degrades to a no-op, so compiling is not evidence that it works.
