### PR TITLE
fix: let a Python SDK own its distribution and module name

### DIFF
--- a/example.php
+++ b/example.php
@@ -320,7 +320,9 @@ try {
 
     // Python
     if (!$requestedSdk || $requestedSdk === 'python') {
-        $sdk  = new SDK(new Python(), buildSpec($specFormat, $spec));
+        $python = new Python();
+        $python->setPipPackage('appwrite');
+        $sdk  = new SDK($python, buildSpec($specFormat, $spec));
         configureSDK($sdk);
         $sdk->generate(__DIR__ . '/examples/python');
     }

--- a/src/SDK/Language/Python.php
+++ b/src/SDK/Language/Python.php
@@ -133,7 +133,7 @@ class Python extends Language
             ],
             [
                 'scope' => 'default',
-                'destination' => '{{ spec.title | caseSnake}}/__init__.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/__init__.py',
                 'template' => 'python/package/__init__.py.twig',
             ],
             [
@@ -143,22 +143,22 @@ class Python extends Language
             ],
             [
                 'scope' => 'default',
-                'destination' => '{{ spec.title | caseSnake}}/utils/deprecated.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/utils/deprecated.py',
                 'template' => 'python/package/utils/deprecated.py.twig',
             ],
             [
                 'scope' => 'default',
-                'destination' => '{{ spec.title | caseSnake}}/utils/__init__.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/utils/__init__.py',
                 'template' => 'python/package/utils/__init__.py.twig',
             ],
             [
                 'scope' => 'default',
-                'destination' => '{{ spec.title | caseSnake}}/client.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/client.py',
                 'template' => 'python/package/client.py.twig',
             ],
             [
                 'scope' => 'default',
-                'destination' => '{{ spec.title | caseSnake}}/permission.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/permission.py',
                 'template' => 'python/package/permission.py.twig',
             ],
             [
@@ -168,7 +168,7 @@ class Python extends Language
             ],
             [
                 'scope' => 'default',
-                'destination' => '{{ spec.title | caseSnake}}/role.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/role.py',
                 'template' => 'python/package/role.py.twig',
             ],
             [
@@ -178,7 +178,7 @@ class Python extends Language
             ],
             [
                 'scope' => 'default',
-                'destination' => '{{ spec.title | caseSnake}}/id.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/id.py',
                 'template' => 'python/package/id.py.twig',
             ],
             [
@@ -188,7 +188,7 @@ class Python extends Language
             ],
             [
                 'scope' => 'default',
-                'destination' => '{{ spec.title | caseSnake}}/query.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/query.py',
                 'template' => 'python/package/query.py.twig',
             ],
             [
@@ -198,7 +198,7 @@ class Python extends Language
             ],
             [
                 'scope' => 'default',
-                'destination' => '{{ spec.title | caseSnake}}/operator.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/operator.py',
                 'template' => 'python/package/operator.py.twig',
             ],
             [
@@ -208,42 +208,42 @@ class Python extends Language
             ],
             [
                 'scope' => 'default',
-                'destination' => '{{ spec.title | caseSnake}}/exception.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/exception.py',
                 'template' => 'python/package/exception.py.twig',
             ],
             [
                 'scope' => 'default',
-                'destination' => '{{ spec.title | caseSnake}}/input_file.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/input_file.py',
                 'template' => 'python/package/input_file.py.twig',
             ],
             [
                 'scope' => 'default',
-                'destination' => '{{ spec.title | caseSnake}}/service.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/service.py',
                 'template' => 'python/package/service.py.twig',
             ],
             [
                 'scope' => 'default',
-                'destination' => '{{ spec.title | caseSnake}}/models/__init__.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/models/__init__.py',
                 'template' => 'python/package/models/__init__.py.twig',
             ],
             [
                 'scope' => 'default',
-                'destination' => '{{ spec.title | caseSnake}}/models/base_model.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/models/base_model.py',
                 'template' => 'python/package/models/base_model.py.twig',
             ],
             [
                 'scope' => 'default',
-                'destination' => '{{ spec.title | caseSnake}}/services/__init__.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/services/__init__.py',
                 'template' => 'python/package/services/__init__.py.twig',
             ],
             [
                 'scope' => 'default',
-                'destination' => '{{ spec.title | caseSnake}}/encoders/__init__.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/encoders/__init__.py',
                 'template' => 'python/package/services/__init__.py.twig',
             ],
             [
                 'scope' => 'default',
-                'destination' => '{{ spec.title | caseSnake}}/enums/__init__.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/enums/__init__.py',
                 'template' => 'python/package/services/__init__.py.twig',
             ],
             [
@@ -253,17 +253,17 @@ class Python extends Language
             ],
             [
                 'scope' => 'default',
-                'destination' => '{{ spec.title | caseSnake}}/encoders/value_class_encoder.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/encoders/value_class_encoder.py',
                 'template' => 'python/package/encoders/value_class_encoder.py.twig',
             ],
             [
                 'scope' => 'default',
-                'destination' => '{{ spec.title | caseSnake}}/encoders/__init__.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/encoders/__init__.py',
                 'template' => 'python/package/encoders/__init__.py.twig',
             ],
             [
                 'scope' => 'service',
-                'destination' => '{{ spec.title | caseSnake}}/services/{{service.name | caseSnake}}.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/services/{{service.name | caseSnake}}.py',
                 'template' => 'python/package/services/service.py.twig',
             ],
             [
@@ -283,22 +283,22 @@ class Python extends Language
             ],
             [
                 'scope' => 'enum',
-                'destination' => '{{ spec.title | caseSnake}}/enums/{{ enum.name | caseSnake }}.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/enums/{{ enum.name | caseSnake }}.py',
                 'template' => 'python/package/enums/enum.py.twig',
             ],
             [
                 'scope' => 'default',
-                'destination' => '{{ spec.title | caseSnake}}/enums/__init__.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/enums/__init__.py',
                 'template' => 'python/package/enums/__init__.py.twig',
             ],
             [
                 'scope' => 'requestModel',
-                'destination' => '{{ spec.title | caseSnake}}/models/{{ requestModel.name | caseSnake }}.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/models/{{ requestModel.name | caseSnake }}.py',
                 'template' => 'python/package/models/request_model.py.twig',
             ],
             [
                 'scope' => 'definition',
-                'destination' => '{{ spec.title | caseSnake}}/models/{{ definition.name | caseSnake }}.py',
+                'destination' => '{{ spec.namespace | caseSnake}}/models/{{ definition.name | caseSnake }}.py',
                 'template' => 'python/package/models/model.py.twig',
             ],
         ];

--- a/templates/python/docs/example.md.twig
+++ b/templates/python/docs/example.md.twig
@@ -1,17 +1,17 @@
 ```python
-from {{ spec.title | caseSnake }}.client import Client
-from {{ spec.title | caseSnake }}.services.{{ service.name | caseSnake }} import {{ service.name | caseUcfirst }}
+from {{ spec.namespace | caseSnake }}.client import Client
+from {{ spec.namespace | caseSnake }}.services.{{ service.name | caseSnake }} import {{ service.name | caseUcfirst }}
 {% if method.parameters.all | filter((param) => param.type == 'file') | length > 0 %}
-from {{ spec.title | caseSnake }}.input_file import InputFile
+from {{ spec.namespace | caseSnake }}.input_file import InputFile
 {% endif %}
 {% set serviceClassName = service.name | caseUcfirst %}
 {% set added = [] %}
 {% if method.responseModel and method.responseModel != 'any' %}
 {% if (method.responseModel | caseUcfirst) == serviceClassName %}
-from {{ spec.title | caseSnake }}.models import {{ method.responseModel | caseUcfirst }} as {{ method.responseModel | caseUcfirst }}Model
+from {{ spec.namespace | caseSnake }}.models import {{ method.responseModel | caseUcfirst }} as {{ method.responseModel | caseUcfirst }}Model
 {% set added = added|merge([(method.responseModel | caseUcfirst) ~ 'Model']) %}
 {% else %}
-from {{ spec.title | caseSnake }}.models import {{ method.responseModel | caseUcfirst }}
+from {{ spec.namespace | caseSnake }}.models import {{ method.responseModel | caseUcfirst }}
 {% set added = added|merge([method.responseModel | caseUcfirst]) %}
 {% endif %}
 {% endif %}
@@ -20,9 +20,9 @@ from {{ spec.title | caseSnake }}.models import {{ method.responseModel | caseUc
 {% set responseImportName = (responseModel | caseUcfirst) == serviceClassName ? ((responseModel | caseUcfirst) ~ 'Model') : (responseModel | caseUcfirst) %}
 {% if responseModel and responseModel != 'any' and responseImportName not in added %}
 {% if (responseModel | caseUcfirst) == serviceClassName %}
-from {{ spec.title | caseSnake }}.models import {{ responseModel | caseUcfirst }} as {{ responseModel | caseUcfirst }}Model
+from {{ spec.namespace | caseSnake }}.models import {{ responseModel | caseUcfirst }} as {{ responseModel | caseUcfirst }}Model
 {% else %}
-from {{ spec.title | caseSnake }}.models import {{ responseModel | caseUcfirst }}
+from {{ spec.namespace | caseSnake }}.models import {{ responseModel | caseUcfirst }}
 {% endif %}
 {% set added = added|merge([responseImportName]) %}
 {% endif %}
@@ -42,7 +42,7 @@ from typing import Union
 {% for parameter in method.parameters.all %}
 {% if parameter.enumValues is not empty %}
 {% if parameter.enumName not in added %}
-from {{ spec.title | caseSnake }}.enums import {{parameter.enumName | caseUcfirst}}
+from {{ spec.namespace | caseSnake }}.enums import {{parameter.enumName | caseUcfirst}}
 {% set added = added|merge([parameter.enumName]) %}
 {% endif %}
 {% endif %}
@@ -50,16 +50,16 @@ from {{ spec.title | caseSnake }}.enums import {{parameter.enumName | caseUcfirs
 {% set modelImportName = modelName ? ((modelName | caseUcfirst) == serviceClassName ? ((modelName | caseUcfirst) ~ 'Model') : (modelName | caseUcfirst)) : null %}
 {% if modelName and modelImportName not in added %}
 {% if (modelName | caseUcfirst) == serviceClassName %}
-from {{ spec.title | caseSnake }}.models import {{ modelName | caseUcfirst }} as {{ modelName | caseUcfirst }}Model
+from {{ spec.namespace | caseSnake }}.models import {{ modelName | caseUcfirst }} as {{ modelName | caseUcfirst }}Model
 {% else %}
-from {{ spec.title | caseSnake }}.models import {{ modelName | caseUcfirst }}
+from {{ spec.namespace | caseSnake }}.models import {{ modelName | caseUcfirst }}
 {% endif %}
 {% set added = added|merge([modelImportName]) %}
 {% endif %}
 {% endfor %}
 {% if method.parameters.all | hasPermissionParam %}
-from {{ spec.title | caseSnake }}.permission import Permission
-from {{ spec.title | caseSnake }}.role import Role
+from {{ spec.namespace | caseSnake }}.permission import Permission
+from {{ spec.namespace | caseSnake }}.role import Role
 {% endif %}
 
 client = Client()

--- a/templates/python/package/services/service.py.twig
+++ b/templates/python/package/services/service.py.twig
@@ -3,7 +3,7 @@ from urllib.parse import quote
 from typing import Any, Dict, List, Optional, Union{% set hasGenericModel = false %}{% for method in service.methods %}{% if method.responseModel and method.responseModel != 'any' and method.responseModel | hasGenericType(spec) %}{% set hasGenericModel = true %}{% endif %}{% endfor %}{% if hasGenericModel %}, Type, TypeVar{% endif %}
 
 from ..exception import AppwriteException
-from appwrite.utils.deprecated import deprecated
+from {{ spec.namespace | caseSnake }}.utils.deprecated import deprecated
 {% set added = [] %}
 {% for method in service.methods %}
 {% for parameter in method.parameters.all %}

--- a/templates/python/pyproject.toml.twig
+++ b/templates/python/pyproject.toml.twig
@@ -3,7 +3,7 @@ requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "{{ spec.title | caseSnake }}"
+name = "{{ language.params.pipPackage }}"
 version = "{{ sdk.version }}"
 description = "{{ sdk.shortDescription }}"
 readme = "README.md"
@@ -42,4 +42,4 @@ Homepage = "{{ spec.contactURL }}"
 Repository = "https://github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName }}"
 
 [tool.setuptools.packages.find]
-include = ["{{ spec.title | caseSnake }}*"]
+include = ["{{ spec.namespace | caseSnake }}*"]

--- a/templates/python/setup.py.twig
+++ b/templates/python/setup.py.twig
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as readme_file_desc:
     long_description = readme_file_desc.read()
 
 setuptools.setup(
-  name = '{{spec.title | caseSnake}}',
+  name = '{{ language.params.pipPackage }}',
   packages = setuptools.find_packages(),
   version = '{{sdk.version}}',
   license='{{spec.licenseName}}',

--- a/templates/python/test/services/test_service.py.twig
+++ b/templates/python/test/services/test_service.py.twig
@@ -2,10 +2,10 @@ import json
 import requests_mock
 import unittest
 
-from appwrite.client import Client
-from appwrite.input_file import InputFile
-from appwrite.models import *
-from appwrite.services.{{ service.name | caseSnake }} import {{ service.name | caseUcfirst }}
+from {{ spec.namespace | caseSnake }}.client import Client
+from {{ spec.namespace | caseSnake }}.input_file import InputFile
+from {{ spec.namespace | caseSnake }}.models import *
+from {{ spec.namespace | caseSnake }}.services.{{ service.name | caseSnake }} import {{ service.name | caseUcfirst }}
 
 class {{ service.name | caseUcfirst }}ServiceTest(unittest.TestCase):
 

--- a/templates/python/test/test_id.py.twig
+++ b/templates/python/test/test_id.py.twig
@@ -1,6 +1,6 @@
 import unittest
 
-from appwrite.id import ID
+from {{ spec.namespace | caseSnake }}.id import ID
 
 class TestIDMethods(unittest.TestCase):
 

--- a/templates/python/test/test_operator.py.twig
+++ b/templates/python/test/test_operator.py.twig
@@ -1,6 +1,6 @@
 import unittest
 
-from appwrite.operator import Operator, Condition
+from {{ spec.namespace | caseSnake }}.operator import Operator, Condition
 
 class TestOperatorMethods(unittest.TestCase):
 

--- a/templates/python/test/test_permission.py.twig
+++ b/templates/python/test/test_permission.py.twig
@@ -1,7 +1,7 @@
 import unittest
 
-from appwrite.permission import Permission
-from appwrite.role import Role
+from {{ spec.namespace | caseSnake }}.permission import Permission
+from {{ spec.namespace | caseSnake }}.role import Role
 
 class TestPermissionMethods(unittest.TestCase):
 

--- a/templates/python/test/test_query.py.twig
+++ b/templates/python/test/test_query.py.twig
@@ -1,6 +1,6 @@
 import unittest
 
-from appwrite.query import Query
+from {{ spec.namespace | caseSnake }}.query import Query
 
 class BasicFilterQueryTest:
     def __init__(self, description: str, value, expected_values: str):

--- a/templates/python/test/test_role.py.twig
+++ b/templates/python/test/test_role.py.twig
@@ -1,6 +1,6 @@
 import unittest
 
-from appwrite.role import Role
+from {{ spec.namespace | caseSnake }}.role import Role
 
 class TestRoleMethods(unittest.TestCase):
 


### PR DESCRIPTION
## What does this PR do?

Lets a Python SDK be published and imported under its own name, instead of every Python SDK claiming `appwrite`.

| | Before | After |
|---|---|---|
| `setup.py` / `pyproject.toml` name | `spec.title \| caseSnake` | `language.params.pipPackage` |
| Module directory and imports | `spec.title \| caseSnake` | `spec.namespace \| caseSnake` |

## Why

`pipPackage` existed but only reached the README's `pip install` line — the distribution name still came from the spec title. So the README told you to install one name while the package published as another, and the module directory was `appwrite` regardless.

The effect is that only one Python SDK can exist. A second one collides twice: same PyPI name, and same top-level `appwrite` module, so installing both corrupts each other.

Both new sources already default to `appwrite`:

- `pipPackage` defaults to `appwrite` in the consuming task.
- `spec.namespace` resolves to `language['namespace'] ?? 'appwrite'`, and `caseSnake('appwrite') == caseSnake('Appwrite')`.

So this is a no-op for every SDK in the repo today, and an SDK that wants its own identity sets `pipPackage` and `namespace` in its language config.

## Test Plan

**Regression — `sdk-for-python` is byte-identical.** Generated the server Python SDK from appwrite-labs/cloud before and after the change and diffed the full trees:

```
diff -rq <before>/ <after>/
(no output)
```

**New behaviour — a second Python SDK gets its own identity.** Generated a console Python SDK with `pipPackage: appwrite-console` and `namespace: appwrite_console`:

```
module dir:            appwrite_console/
setup.py name:         'appwrite-console'
pyproject name:        "appwrite-console"
pyproject find.include ["appwrite_console*"]
README:                pip install appwrite-console
```

Installed it into a clean venv and exercised it:

```
pip install -e .        -> Name: appwrite-console, Version: 0.1.0
from appwrite_console.client import Client
from appwrite_console.services.projects import Projects
from appwrite_console.query import Query
-> module OK: Projects | {"method":"limit","values":[5]}
```

Generated test suite: 1048 tests, 1042 pass. The 6 failures are pre-existing generator issues that this PR does not touch and that reproduce independently of it — an `Addon` model/enum import collision where the enum shadows the model, and two binary-returning endpoints that call `.to_dict()` on `bytes`. Both are specific to the console spec; I'll raise them separately.

## Related

Unblocks a console Python SDK in appwrite-labs/cloud. Follows appwrite/appwrite#13070, which made `pipPackage` configurable in the consuming task.

---

## Follow-up: placeholder distribution name

Review caught that routing the distribution name through `pipPackage` exposes its class default, which is the literal placeholder `packageName`:

```php
protected $params = [
    'pipPackage' => 'packageName',
];
```

Any caller that does not call `setPipPackage()` would generate `name = 'packageName'` in `setup.py` and `pyproject.toml`, where before it fell back to the spec title and always produced something sensible.

**Reachable in one place:** `example.php`, the documented generation entrypoint, which CI's validation matrix runs (`php example.php ${{ matrix.sdk }} ${{ matrix.platform }}`). Reproduced it:

```
# before the follow-up commit
name = 'packageName'      # setup.py
name = "packageName"      # pyproject.toml
```

Every other target that owns a package name already sets it in `example.php` (`php`, `unity`, `cli`, `dart`, `flutter`, `react-native`); Python was the omission. Fixed in `fix: set the pip package in the Python example target`, and the generated output is back to `appwrite` for both files with the module directory unchanged.

**Not reachable for any published Appwrite SDK.** `appwrite/appwrite`'s SDKs task always passes a value:

```php
$config->setPipPackage($language['pipPackage'] ?? 'appwrite');
```

The class default stays a placeholder, matching every other language (`PHP` uses `vendor-name`/`package-name`, `Ruby` uses `gemName`, `Dart` uses `packageName`), and Node's `package.json` name already reads `language.params.npmPackage` the same way. Changing that convention for Python alone seemed worse than fixing the one caller that had not opted in.