### PR TITLE
fix: stop a Python service module shadowing a model with an enum

### DIFF
--- a/src/SDK/Language/Python.php
+++ b/src/SDK/Language/Python.php
@@ -647,9 +647,61 @@ class Python extends Language
         return $modelType;
     }
 
-    protected function getServicePropertyType(array $parameter, string $serviceName): string
+    /**
+     * Symbols a service module imports from `..models`.
+     *
+     * An enum sharing one of these names cannot be imported plainly: the enum
+     * import lands second and shadows the model, so every method annotated with
+     * that model returns the enum and hydration fails at runtime.
+     *
+     * @return list<string>
+     */
+    protected function getServiceModelNames(array $service): array
     {
-        if (!empty($parameter['array']['model'])) {
+        $names = [];
+
+        foreach ($service['methods'] ?? [] as $method) {
+            foreach ($method['parameters']['all'] ?? [] as $parameter) {
+                foreach ([$parameter['model'] ?? null, $parameter['array']['model'] ?? null] as $model) {
+                    if (!empty($model)) {
+                        $names[] = \ucfirst((string) $model);
+                    }
+                }
+            }
+
+            foreach ([...(array) ($method['responseModels'] ?? []), $method['responseModel'] ?? null] as $model) {
+                if (!empty($model) && $model !== 'any') {
+                    $names[] = \ucfirst((string) $model);
+                }
+            }
+        }
+
+        return \array_values(\array_unique($names));
+    }
+
+    /**
+     * The name an enum is referenced by inside a service module, suffixed when a
+     * model of the same name is imported alongside it.
+     */
+    protected function getServiceEnumName(array $parameter, array $service): string
+    {
+        $enumName = \ucfirst((string) ($parameter['enumName'] ?? $parameter['name'] ?? ''));
+
+        return \in_array($enumName, $this->getServiceModelNames($service), true)
+            ? $enumName . 'Enum'
+            : $enumName;
+    }
+
+    protected function getServicePropertyType(array $parameter, array $service): string
+    {
+        $serviceName = (string) ($service['name'] ?? '');
+
+        if (isset($parameter['enumName']) || !empty($parameter['enumValues'])) {
+            $enumName = $this->getServiceEnumName($parameter, $service);
+            $typeName = ($parameter['type'] ?? null) === self::TYPE_ARRAY
+                ? 'List[' . $enumName . ']'
+                : $enumName;
+        } elseif (!empty($parameter['array']['model'])) {
             $typeName = 'List[' . $this->getServiceModelTypeName($parameter['array']['model'], $serviceName) . ']';
         } elseif (!empty($parameter['model'])) {
             $modelType = $this->getServiceModelTypeName($parameter['model'], $serviceName);
@@ -762,7 +814,8 @@ class Python extends Language
             new TwigFilter('getPropertyType', fn(array $value, array $method = []): string => $this->getTypeName($value, $method)),
             new TwigFilter('hasGenericType', fn(string $model, array $spec): bool => $this->hasGenericType($model, $spec)),
             new TwigFilter('hasGenericTypeProperty', fn(array $properties, array $spec): bool => array_any($properties, fn($property): bool => !empty($property['sub_schema']) && $this->hasGenericType($property['sub_schema'], $spec))),
-            new TwigFilter('getServicePropertyType', fn(array $value, string $serviceName): string => $this->getServicePropertyType($value, $serviceName)),
+            new TwigFilter('getServicePropertyType', fn(array $value, array $service): string => $this->getServicePropertyType($value, $service)),
+            new TwigFilter('getServiceEnumName', fn(array $parameter, array $service): string => $this->getServiceEnumName($parameter, $service)),
             new TwigFilter('getModelPropertyType', fn(array $value, string $ownerName = ''): string => $this->getModelPropertyType($value, $ownerName)),
             new TwigFilter('getModelFieldName', fn(array $value, array $properties): string => $this->getModelFieldName($value, $properties)),
             new TwigFilter('getResponseType', fn(array $method, string $serviceName = ''): string => $this->getResponseType($method, $serviceName)),

--- a/templates/python/base/requests/api.twig
+++ b/templates/python/base/requests/api.twig
@@ -9,7 +9,11 @@
             '{{ key }}': '{{ header }}',
 {% endfor %}
         }, api_params{% if method.type == 'webAuth' %}, response_type='location'{% endif %})
-{% if method.responseModels is defined and method.responseModels|length > 1 %}
+{% if method.type == 'location' %}
+{# Signature says bytes. A responseModel may still be declared, but hydrating it would call to_dict() on the body. #}
+
+        return response
+{% elseif method.responseModels is defined and method.responseModels|length > 1 %}
 {% set hasResponseDiscriminator = method.responseDiscriminator is defined and method.responseDiscriminator is not empty %}
 {% set responseDiscriminator = method.responseDiscriminator ?? {} %}
 {% if hasResponseDiscriminator %}

--- a/templates/python/package/services/service.py.twig
+++ b/templates/python/package/services/service.py.twig
@@ -13,7 +13,9 @@ from ..input_file import InputFile
 {% endif %}
 {% if parameter.enumValues is not empty%}
 {% if parameter.enumName not in added %}
-from ..enums.{{ parameter.enumName | caseSnake }} import {{ parameter.enumName | caseUcfirst }}
+{% set enumRef = parameter | getServiceEnumName(service) %}
+from ..enums.{{ parameter.enumName | caseSnake }} import {{ parameter.enumName | caseUcfirst }}{% if enumRef != (parameter.enumName | caseUcfirst) %} as {{ enumRef }}{% endif %}
+
 {% set added = added|merge([parameter.enumName]) %}
 {% endif %}
 {% endif %}
@@ -107,7 +109,7 @@ Dict[str, Any]
 {% endset %}
     def {{ method.name | caseSnake }}(
         self{% for parameter in method.parameters.all %},
-        {{ parameter.name | escapeKeyword | caseSnake }}: {{ parameter | getServicePropertyType(service.name) | raw }}{% if not parameter.required %} = None{% endif %}{% endfor %}{% if 'multipart/form-data' in method.consumes %},
+        {{ parameter.name | escapeKeyword | caseSnake }}: {{ parameter | getServicePropertyType(service) | raw }}{% if not parameter.required %} = None{% endif %}{% endfor %}{% if 'multipart/form-data' in method.consumes %},
         on_progress = None{% endif %}{% if isGenericResponse %},
         model_type: Type[T] = dict{% endif %}
 
@@ -128,7 +130,7 @@ Dict[str, Any]
 {% endif %}
         Parameters
         ----------
-        {% for parameter in method.parameters.all %}{{ parameter.name | escapeKeyword | caseSnake }} : {{ parameter | getServicePropertyType(service.name) | raw }}
+        {% for parameter in method.parameters.all %}{{ parameter.name | escapeKeyword | caseSnake }} : {{ parameter | getServicePropertyType(service) | raw }}
             {% autoescape false %}{{ parameter.description | replace({"\n": "\n            "}) }}{% endautoescape %}
 
         {% endfor %}{% if 'multipart/form-data' in method.consumes %}

--- a/templates/python/test/services/test_service.py.twig
+++ b/templates/python/test/services/test_service.py.twig
@@ -34,7 +34,7 @@ class {{ service.name | caseUcfirst }}ServiceTest(unittest.TestCase):
             {% if parameter.type == 'object' %}{}{% elseif parameter.type == 'array' %}[]{% elseif parameter.type == 'file' %}InputFile.from_bytes(bytearray(), "example.file"){% elseif parameter.type == 'boolean' %}True{% elseif parameter.type == 'string' %}'{% if parameter.example is not empty %}{{parameter.example | escapeDollarSign}}{% endif %}'{% elseif parameter.type == 'integer' and parameter['x-example'] is empty %}1{% elseif parameter.type == 'number' and parameter['x-example'] is empty %}1.0{% else %}{{parameter.example}}{%~ endif ~%},{%~ endfor ~%}
         )
 
-        {%~ if method.type != 'webAuth' and method.responseModel and method.responseModel != 'any' %}
+        {%~ if method.type != 'webAuth' and method.type != 'location' and method.responseModel and method.responseModel != 'any' %}
         {%~ if spec.definitions[method.responseModel].additionalProperties %}
         data['{{ 'data' }}'] = {}
         {%~ endif  %}


### PR DESCRIPTION
## What does this PR do?

Fixes two defects that make generated Python service modules wrong at runtime. Both need no spec changes and no method exclusions by the consumer.

### 1. An enum import shadows a model of the same name

When a service uses both a model and an enum called `Addon`, the module emitted:

```python
from ..models.addon import Addon
from ..enums.addon import Addon   # lands second, wins
```

Every method annotated with the model then returned the enum, and hydration died on `AttributeError: type object 'Addon' has no attribute 'model_validate'`. In the console spec this broke four `organizations` methods.

The enum is now aliased, and **only** when a model of the same name is imported in the same service:

```python
from ..models.addon import Addon
from ..enums.addon import Addon as AddonEnum
...
    addon: AddonEnum
```

The model keeps the plain name, so the public surface users touch is unchanged. This mirrors the existing rule that aliases a model as `XModel` when it clashes with the service class.

### 2. `location` methods hydrate a response model

`getResponseType()` already returns `bytes` for `method.type == 'location'`, and the signature said so — but the body ignored it and hydrated whatever `responseModel` the spec declared:

```python
def get_invoice_download(...) -> bytes:
    ...
    return self._parse_response(response, model=PaymentMethod)   # to_dict() on bytes
```

`api.twig` now returns the raw response for `location` methods, and the generated test stops asserting `response.to_dict()` on them. Storage downloads were unaffected only because their spec entries declare no `responseModel`.

## Test Plan

**No existing SDK changes.** Generated the Python SDK for all three platforms against pinned local specs, before and after, with a clean output directory each run:

```
server  -> identical
client  -> identical
console -> only services/organizations.py and test/services/test_organizations.py differ
```

The entire console diff is six lines, all intended:

```diff
-from ..enums.addon import Addon
+from ..enums.addon import Addon as AddonEnum
-        addon: Addon
+        addon: AddonEnum
-        return self._parse_response(response, model=PaymentMethod)
+        return response
```

**Generated suite goes green.** A console Python SDK built from these templates: **1048 tests, all passing** (was 1042 passing / 6 erroring). Verified in a clean venv that the previously broken methods now resolve correctly:

```
get_addon             -> models.addon.Addon
confirm_addon_payment -> models.addon.Addon
get_addon_price       -> models.addon_price.AddonPrice
get_invoice_download  -> bytes
get_invoice_view      -> bytes
```

`composer lint` and `composer refactor:check` clean; Unit suite 33/33. `lint-twig` reports 44 errors both with and without this change — pre-existing djlint parsing of inline Twig, not a regression.

## Related

Follows #1723. Together these let a console Python SDK generate correctly with no method exclusions.