### PR TITLE
fix: generate the Go SDK under its real module path

### DIFF
--- a/example.php
+++ b/example.php
@@ -357,7 +357,12 @@ try {
     // GO
     if (!$requestedSdk || $requestedSdk === 'go') {
         $sdk  = new SDK(new Go(), buildSpec($specFormat, $spec));
-        configureSDK($sdk);
+        // Real module path: a `replace` only resolves when the target module
+        // declares the path being replaced.
+        configureSDK($sdk, [
+            'gitUserName' => 'appwrite',
+            'gitRepoName' => 'sdk-for-go',
+        ]);
         $sdk->generate(__DIR__ . '/examples/go');
     }
 


### PR DESCRIPTION
The example harness defaults every SDK to the `repoowner/reponame` placeholder, so `examples/go/go.mod` declared `module github.com/repoowner/reponame`.

Go has no relative imports, so the declared module path is baked into every import in the generated tree, and a `replace` directive only resolves when the target module declares the path being replaced. Anything depending on the generated SDK locally silently fails to resolve against a module calling itself something else.

Affects example generation only — the published repository already uses this path.

Split out of the Go CLI stack (#1719), where it was needed so `examples/go-cli` could build against the SDK generated alongside it.

```
$ php example.php go && head -1 examples/go/go.mod
module github.com/appwrite/sdk-for-go
```
