### PR TITLE
feat: publish Python SDKs to PyPI with trusted publishing

### DIFF
--- a/templates/python/.github/workflows/publish.yml.twig
+++ b/templates/python/.github/workflows/publish.yml.twig
@@ -3,6 +3,10 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish, e.g. 1.2.3'
+        required: true
 
 jobs:
   publish:
@@ -15,6 +19,11 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # A release build must come from the tag, never from a branch that may
+          # have moved on. On a release event github.ref is already the tag; on a
+          # manual retry the tag has to be named explicitly.
+          ref: {{ '${{ inputs.tag || github.ref }}' }}
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/templates/python/.github/workflows/publish.yml.twig
+++ b/templates/python/.github/workflows/publish.yml.twig
@@ -2,11 +2,16 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   publish:
     name: Release build and publish
     runs-on: ubuntu-latest
+    permissions:
+      # Mints the short-lived OIDC token PyPI exchanges for an upload token, so
+      # no long-lived API token has to be stored on the repository.
+      id-token: write
     steps:
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -22,10 +27,4 @@ jobs:
           python setup.py sdist bdist_wheel
 
       - name: Publish package
-        run: |
-          python -m pip install twine
-          python -m twine upload -r pypi dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: {{ '${{ secrets.PYPI_TOKEN }}' }}
-          TWINE_NON_INTERACTIVE: true
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2


### PR DESCRIPTION
## What does this PR do?

Switches the generated Python publish workflow from a stored `PYPI_TOKEN` to PyPI's [trusted publishing](https://docs.pypi.org/trusted-publishers/) (OIDC).

```diff
+  workflow_dispatch:
+
   jobs:
     publish:
+      permissions:
+        id-token: write
...
-      - name: Publish package
-        run: |
-          python -m pip install twine
-          python -m twine upload -r pypi dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-          TWINE_NON_INTERACTIVE: true
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
```

## Why

The job authenticates with a short-lived token minted from GitHub's identity provider, so no long-lived PyPI API token has to live on an SDK repository. Nothing to rotate, nothing to leak.

`workflow_dispatch` is added so a failed publish can be retried without cutting a new release — which is exactly the situation that prompted this: `sdk-for-console-python`'s 0.1.0 publish failed with `403 Forbidden` because no token was configured, and the only way to retry was to re-publish the release.

## ⚠️ Requires PyPI configuration before the next release

This affects **both** Python SDKs, since they share `templates/python`. A trusted publisher must be registered on PyPI for each project first, or the next publish fails:

| Project | Repository | Action |
|---|---|---|
| `appwrite` | `appwrite/sdk-for-python` | Manage project → Publishing → add trusted publisher |
| `appwrite-console` | `appwrite/sdk-for-console-python` | Add a [pending publisher](https://pypi.org/manage/account/publishing/) — the project does not exist yet |

For both: owner `appwrite`, workflow `publish.yml`, environment blank. Once configured, `PYPI_TOKEN` can be deleted from the repositories.

## Test Plan

Generated the Python SDK for the server and console platforms against pinned specs, before and after. **Exactly one file differs per platform** — `.github/workflows/publish.yml`. No SDK source, docs, or packaging output changed.

The rendered workflow parses as valid YAML with the expected structure:

```
triggers         : ['release', 'workflow_dispatch']
job permissions  : {'id-token': 'write'}
publish step uses: pypa/gh-action-pypi-publish@dc37677b...
leftover env     : None
PYPI_TOKEN refs  : 0
```

The action is pinned to the commit SHA behind tag `v1.14.2`, resolved through the annotated tag object rather than assumed, matching how other actions are pinned here.

`composer lint` clean, Unit suite 33/33.

## Note

The build step still uses `python setup.py sdist bdist_wheel`, which is deprecated in favour of `python -m build`. Left alone to keep this diff to the auth change — worth a follow-up.