### PR TITLE
fix(go-cli): the grouped help screen, and three faults the preview build exposed

### DIFF
--- a/example.php
+++ b/example.php
@@ -239,12 +239,10 @@ try {
         $sdk->generate(__DIR__ . '/examples/node');
     }
 
-    // CLI
-    if (!$requestedSdk || $requestedSdk === 'cli') {
-        $language  = new CLI();
-        $language->setNPMPackage('appwrite-cli');
-        $language->setExecutableName('appwrite');
-        $language->setLogo(json_encode("
+    // The ASCII art above `appwrite --help`. Shared by both CLIs, which render
+    // the same help screen -- the TypeScript one takes it JSON-encoded, the Go
+    // one raw, because JSON escapes `/` as `\/` and Go has no such escape.
+    $cliLogo = "
     _                            _ _           ___   __   _____
    /_\  _ __  _ ____      ___ __(_) |_ ___    / __\ / /   \_   \
   //_\\\| '_ \| '_ \ \ /\ / / '__| | __/ _ \  / /   / /     / /\/
@@ -252,7 +250,14 @@ try {
  \_/ \_/ .__/| .__/ \_/\_/ |_|  |_|\__\___| \____/\____/\____/
        |_|   |_|
 
-"));
+";
+
+    // CLI
+    if (!$requestedSdk || $requestedSdk === 'cli') {
+        $language  = new CLI();
+        $language->setNPMPackage('appwrite-cli');
+        $language->setExecutableName('appwrite');
+        $language->setLogo(json_encode($cliLogo));
         $language->setLogoUnescaped("
      _                            _ _           ___   __   _____
     /_\  _ __  _ ____      ___ __(_) |_ ___    / __\ / /   \_   \
@@ -317,6 +322,7 @@ try {
     if (!$requestedSdk || $requestedSdk === 'go-cli') {
         $language = new GoCLI();
         $language->setExecutableName('appwrite');
+        $language->setLogo($cliLogo);
         // Same package name as the TypeScript CLI: `npm i -g appwrite-cli`
         // has to keep working across the switch. It also names every release
         // asset, which install.sh and install.ps1 construct by hand.

--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -366,9 +366,9 @@ class CLI extends Node
                 'template'      => 'cli/lib/hints.ts',
             ],
             [
-                'scope'         => 'copy',
+                'scope'         => 'default',
                 'destination'   => 'lib/help.ts',
-                'template'      => 'cli/lib/help.ts',
+                'template'      => 'cli/lib/help.ts.twig',
             ],
             [
                 'scope'         => 'copy',
@@ -780,7 +780,7 @@ class CLI extends Node
     #[Override]
     public function getFunctions(): array
     {
-        return [
+        return array_merge($this->getCliHelpFunctions(), [
             /** Return true if the entered service->method is enabled for a console preview link */
             new TwigFunction('hasConsolePreview', fn($method, $service): bool => preg_match('/^([Gg]et|[Ll]ist)/', (string) $method)
                 && !in_array(strtolower((string) $method), $this->consoleIgnoreFunctions)
@@ -875,6 +875,6 @@ class CLI extends Node
                     return $varName;
                 }
             }),
-        ];
+        ]);
     }
 }

--- a/src/SDK/Language/Concern/CliCommandSurface.php
+++ b/src/SDK/Language/Concern/CliCommandSurface.php
@@ -2,6 +2,8 @@
 
 namespace Appwrite\SDK\Language\Concern;
 
+use Twig\TwigFunction;
+
 /**
  * Spec analysis shared by every generated Appwrite CLI, whatever the target
  * language.
@@ -104,6 +106,171 @@ trait CliCommandSurface
     protected const array TOP_LEVEL_COMMANDS = [
         'oauth2' => ['listOrganizations', 'listProjects'],
     ];
+
+    /**
+     * The main help screen, grouped by intent rather than listed
+     * alphabetically.
+     *
+     * Entries are command paths as typed, so a root alias such as
+     * `list-projects` can sit next to `login` in GET STARTED. A command named
+     * here that the spec does not produce is skipped, and a command the spec
+     * produces that is named nowhere still appears under OTHER -- so a service
+     * added to the spec can never silently disappear from `--help`.
+     *
+     * @var list<array{title: string, dim?: bool, commands: list<string>}>
+     */
+    protected const array HELP_GROUPS = [
+        [
+            'title' => 'GET STARTED',
+            'commands' => [
+                'login', 'list-organizations', 'list-projects', 'init', 'pull',
+                'push', 'run', 'whoami',
+            ],
+        ],
+        [
+            'title' => 'PROJECT',
+            'commands' => [
+                'organization', 'project', 'apps', 'proxy', 'vcs', 'webhooks',
+            ],
+        ],
+        [
+            'title' => 'RESOURCES',
+            'commands' => [
+                'account', 'users', 'teams', 'tablesdb', 'storage', 'functions',
+                'sites', 'messaging', 'tokens', 'backups', 'presences',
+            ],
+        ],
+        [
+            'title' => 'UTILITIES',
+            'commands' => [
+                'graphql', 'generate', 'types', 'locale', 'activities',
+                'migrations', 'notifications', 'oauth2', 'client', 'completion',
+                'logout', 'update',
+            ],
+        ],
+        [
+            'title' => 'DEPRECATED',
+            'dim' => true,
+            'commands' => ['databases'],
+        ],
+    ];
+
+    /**
+     * One-line summaries for the main help listing. A command's own
+     * description stays the long form shown on its own help page.
+     *
+     * Written to fit one terminal line -- keep them under 51 characters, in the
+     * imperative, with no trailing period. `%title%` is the SDK title.
+     *
+     * @var array<string, string>
+     */
+    protected const array HELP_SUMMARIES = [
+        'login' => 'Authenticate with your %title% account',
+        'list-organizations' => 'Organizations your session can access',
+        'list-projects' => 'Projects your session can access',
+        'init' => 'Scaffold a project, function, site, or resource',
+        'pull' => 'Pull remote project resources into this directory',
+        'push' => 'Push local project resources',
+        'run' => 'Run the project locally for development',
+        'whoami' => 'Show the currently authenticated account',
+
+        'organization' => 'Manage organization-level projects',
+        'project' => 'Usage, variables, and project-level settings',
+        'apps' => 'OAuth2 applications, keys, scopes, installations',
+        'proxy' => 'Domain configuration beyond DNS',
+        'vcs' => 'Connect and manage VCS repositories',
+        'webhooks' => 'Project webhooks',
+
+        'account' => 'Manage your own user account',
+        'users' => 'Manage project users',
+        'teams' => 'Group users to share resource access',
+        'tablesdb' => 'Structured tables of rows and columns',
+        'storage' => 'Files and buckets',
+        'functions' => 'Serverless functions, deployments, and executions',
+        'sites' => 'Static and SSR sites and their deployments',
+        'messaging' => 'Topics, subscribers, and message delivery',
+        'tokens' => 'Resource tokens for secure file access',
+        'backups' => 'Backup policies, archives, and restorations',
+        'presences' => 'Real-time user presence tracking',
+
+        'graphql' => 'Query and mutate any resource via GraphQL',
+        'generate' => 'Generate a type-safe SDK from your project config',
+        'types' => 'Generate TypeScript types for your project',
+        'locale' => 'Localize your app based on user location',
+        'activities' => 'List and inspect project activity events',
+        'migrations' => 'Migrate data between services',
+        'notifications' => 'Console notifications',
+        'oauth2' => 'Authorize apps and issue OAuth2 and OIDC tokens',
+        'client' => 'Configure the CLI itself',
+        'completion' => 'Generate shell completion scripts',
+        'logout' => 'Log out of your %title% account',
+        'update' => 'Update the CLI to the latest version',
+
+        'databases' => 'Use `tablesdb` instead',
+    ];
+
+    /**
+     * Order of the global flags on the main help screen, by long flag.
+     * Unlisted options are appended.
+     *
+     * @var list<string>
+     */
+    protected const array HELP_OPTION_ORDER = [
+        '--version', '--help', '--json', '--raw', '--show-secrets', '--verbose',
+        '--force', '--all', '--id', '--report',
+    ];
+
+    /**
+     * @return list<array{title: string, dim: bool, commands: list<string>}>
+     */
+    protected function getCliHelpGroups(): array
+    {
+        return array_map(
+            static fn (array $group): array => [
+                'title' => $group['title'],
+                'dim' => $group['dim'] ?? false,
+                'commands' => $group['commands'],
+            ],
+            self::HELP_GROUPS,
+        );
+    }
+
+    /**
+     * Summaries with `%title%` resolved, so a template emits a plain literal
+     * rather than carrying the placeholder into generated code.
+     *
+     * @return array<string, string>
+     */
+    protected function getCliHelpSummaries(string $title): array
+    {
+        return array_map(
+            static fn (string $summary): string => str_replace('%title%', $title, $summary),
+            self::HELP_SUMMARIES,
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function getCliHelpOptionOrder(): array
+    {
+        return self::HELP_OPTION_ORDER;
+    }
+
+    /**
+     * The help metadata, exposed to the templates of every CLI that renders the
+     * grouped main help screen.
+     *
+     * @return list<TwigFunction>
+     */
+    protected function getCliHelpFunctions(): array
+    {
+        return [
+            new TwigFunction('cliHelpGroups', fn (): array => $this->getCliHelpGroups()),
+            new TwigFunction('cliHelpSummaries', fn (string $title): array => $this->getCliHelpSummaries($title)),
+            new TwigFunction('cliHelpOptionOrder', fn (): array => $this->getCliHelpOptionOrder()),
+        ];
+    }
 
     /**
      * Methods whose endpoint only exists on Cloud, mapped to the

--- a/src/SDK/Language/GoCLI.php
+++ b/src/SDK/Language/GoCLI.php
@@ -1142,6 +1142,11 @@ class GoCLI extends Go
             ],
             [
                 'scope'         => 'copy',
+                'destination'   => 'internal/cmd/errordetail_test.go',
+                'template'      => 'go-cli/internal/cmd/errordetail_test.go',
+            ],
+            [
+                'scope'         => 'copy',
                 'destination'   => 'internal/cmd/initprojectskills.go',
                 'template'      => 'go-cli/internal/cmd/initprojectskills.go',
             ],

--- a/src/SDK/Language/GoCLI.php
+++ b/src/SDK/Language/GoCLI.php
@@ -1127,6 +1127,16 @@ class GoCLI extends Go
             ],
             [
                 'scope'         => 'copy',
+                'destination'   => 'internal/cmd/pushreport_test.go',
+                'template'      => 'go-cli/internal/cmd/pushreport_test.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/cmd/inittemplateenv_test.go',
+                'template'      => 'go-cli/internal/cmd/inittemplateenv_test.go',
+            ],
+            [
+                'scope'         => 'copy',
                 'destination'   => 'internal/auth/store_test.go',
                 'template'      => 'go-cli/internal/auth/store_test.go',
             ],

--- a/src/SDK/Language/GoCLI.php
+++ b/src/SDK/Language/GoCLI.php
@@ -1127,6 +1127,21 @@ class GoCLI extends Go
             ],
             [
                 'scope'         => 'copy',
+                'destination'   => 'internal/auth/store_test.go',
+                'template'      => 'go-cli/internal/auth/store_test.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/client/apierror_test.go',
+                'template'      => 'go-cli/internal/client/apierror_test.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/cmd/loginswitch_test.go',
+                'template'      => 'go-cli/internal/cmd/loginswitch_test.go',
+            ],
+            [
+                'scope'         => 'copy',
                 'destination'   => 'internal/cmd/pushpreview.go',
                 'template'      => 'go-cli/internal/cmd/pushpreview.go',
             ],

--- a/src/SDK/Language/GoCLI.php
+++ b/src/SDK/Language/GoCLI.php
@@ -1137,6 +1137,11 @@ class GoCLI extends Go
             ],
             [
                 'scope'         => 'copy',
+                'destination'   => 'internal/auth/keyringbackend_test.go',
+                'template'      => 'go-cli/internal/auth/keyringbackend_test.go',
+            ],
+            [
+                'scope'         => 'copy',
                 'destination'   => 'internal/auth/store_test.go',
                 'template'      => 'go-cli/internal/auth/store_test.go',
             ],

--- a/src/SDK/Language/GoCLI.php
+++ b/src/SDK/Language/GoCLI.php
@@ -64,6 +64,11 @@ class GoCLI extends Go
         // above. example.php sets it to build examples/go-cli against the SDK
         // this generator produces, without waiting for a release.
         'localSdkPath' => '',
+        // ASCII art above the main help screen, held RAW rather than escaped:
+        // the TypeScript CLI's `logo` param is JSON-encoded, and JSON escapes
+        // `/` as `\/`, which is not a valid Go escape. Each template escapes it
+        // for its own language instead.
+        'logo' => '',
         'homebrewTapOwner' => 'appwrite',
         'homebrewTapName' => 'appwrite',
         'homebrewTapBranch' => 'main',
@@ -105,6 +110,16 @@ class GoCLI extends Go
     public function setLocalSDKPath(string $path): self
     {
         $this->setParam('localSdkPath', $path);
+
+        return $this;
+    }
+
+    /**
+     * ASCII art printed above the main help screen, unescaped.
+     */
+    public function setLogo(string $logo): self
+    {
+        $this->setParam('logo', $logo);
 
         return $this;
     }
@@ -413,12 +428,12 @@ class GoCLI extends Go
     #[Override]
     public function getFunctions(): array
     {
-        return [
+        return array_merge($this->getCliHelpFunctions(), [
             new TwigFunction('getGoCliOption', fn (array $parameter): array => $this->getGoCliOption($parameter)),
             new TwigFunction('getGoVarName', fn (array $parameter): string => $this->getGoVarName($parameter['name'])),
             new TwigFunction('getGoCliArgExpression', fn (array $parameter): string => $this->getGoCliArgExpression($parameter)),
             new TwigFunction('getGoCallPlan', fn (array $method, array $service): array => $this->getGoCallPlan($method, $service)),
-        ];
+        ]);
     }
 
     #[Override]
@@ -454,6 +469,16 @@ class GoCLI extends Go
                 'scope'         => 'default',
                 'destination'   => 'internal/cmd/root.go',
                 'template'      => 'go-cli/internal/cmd/root.go.twig',
+            ],
+            [
+                'scope'         => 'default',
+                'destination'   => 'internal/cmd/help.go',
+                'template'      => 'go-cli/internal/cmd/help.go.twig',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/cmd/help_test.go',
+                'template'      => 'go-cli/internal/cmd/help_test.go',
             ],
             [
                 'scope'         => 'copy',

--- a/src/SDK/Language/GoCLI.php
+++ b/src/SDK/Language/GoCLI.php
@@ -1127,6 +1127,36 @@ class GoCLI extends Go
             ],
             [
                 'scope'         => 'copy',
+                'destination'   => 'internal/cmd/pushpreview.go',
+                'template'      => 'go-cli/internal/cmd/pushpreview.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/cmd/pushpreview_test.go',
+                'template'      => 'go-cli/internal/cmd/pushpreview_test.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/preview/render.go',
+                'template'      => 'go-cli/internal/preview/render.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/preview/render_test.go',
+                'template'      => 'go-cli/internal/preview/render_test.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/preview/frame.go',
+                'template'      => 'go-cli/internal/preview/frame.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/preview/frame_test.go',
+                'template'      => 'go-cli/internal/preview/frame_test.go',
+            ],
+            [
+                'scope'         => 'copy',
                 'destination'   => 'internal/deploy/deploy.go',
                 'template'      => 'go-cli/internal/deploy/deploy.go',
             ],

--- a/src/SDK/Language/GoCLI.php
+++ b/src/SDK/Language/GoCLI.php
@@ -1137,6 +1137,16 @@ class GoCLI extends Go
             ],
             [
                 'scope'         => 'copy',
+                'destination'   => 'internal/cmd/initprojectskills_test.go',
+                'template'      => 'go-cli/internal/cmd/initprojectskills_test.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/cmd/initprojectskills.go',
+                'template'      => 'go-cli/internal/cmd/initprojectskills.go',
+            ],
+            [
+                'scope'         => 'copy',
                 'destination'   => 'internal/auth/keyringbackend_test.go',
                 'template'      => 'go-cli/internal/auth/keyringbackend_test.go',
             ],

--- a/templates/cli/bun.lock.twig
+++ b/templates/cli/bun.lock.twig
@@ -48,7 +48,7 @@
   },
   "overrides": {
     "@xmldom/xmldom": "^0.9.10",
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "esbuild": "^0.28.1",
     "phin": "3.7.1",
     "tmp": "^0.2.6",
@@ -274,25 +274,25 @@
 
     "@types/through": ["@types/through@0.0.33", "", { "dependencies": { "@types/node": "*" } }, "sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ=="],
 
-    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.65.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.65.0", "@typescript-eslint/type-utils": "8.65.0", "@typescript-eslint/utils": "8.65.0", "@typescript-eslint/visitor-keys": "8.65.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.65.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA=="],
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.66.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.66.0", "@typescript-eslint/type-utils": "8.66.0", "@typescript-eslint/utils": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.66.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A=="],
 
-    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.65.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.65.0", "@typescript-eslint/types": "8.65.0", "@typescript-eslint/typescript-estree": "8.65.0", "@typescript-eslint/visitor-keys": "8.65.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA=="],
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.66.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.66.0", "@typescript-eslint/types": "8.66.0", "@typescript-eslint/typescript-estree": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g=="],
 
-    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.65.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.65.0", "@typescript-eslint/types": "^8.65.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q=="],
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.66.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.66.0", "@typescript-eslint/types": "^8.66.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g=="],
 
-    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.65.0", "", { "dependencies": { "@typescript-eslint/types": "8.65.0", "@typescript-eslint/visitor-keys": "8.65.0" } }, "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg=="],
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0" } }, "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g=="],
 
-    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.65.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg=="],
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.66.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g=="],
 
-    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.65.0", "", { "dependencies": { "@typescript-eslint/types": "8.65.0", "@typescript-eslint/typescript-estree": "8.65.0", "@typescript-eslint/utils": "8.65.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g=="],
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "@typescript-eslint/typescript-estree": "8.66.0", "@typescript-eslint/utils": "8.66.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g=="],
 
-    "@typescript-eslint/types": ["@typescript-eslint/types@8.65.0", "", {}, "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg=="],
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.66.0", "", {}, "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ=="],
 
-    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.65.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.65.0", "@typescript-eslint/tsconfig-utils": "8.65.0", "@typescript-eslint/types": "8.65.0", "@typescript-eslint/visitor-keys": "8.65.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg=="],
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.66.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.66.0", "@typescript-eslint/tsconfig-utils": "8.66.0", "@typescript-eslint/types": "8.66.0", "@typescript-eslint/visitor-keys": "8.66.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg=="],
 
-    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.65.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.65.0", "@typescript-eslint/types": "8.65.0", "@typescript-eslint/typescript-estree": "8.65.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA=="],
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.66.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.66.0", "@typescript-eslint/types": "8.66.0", "@typescript-eslint/typescript-estree": "8.66.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA=="],
 
-    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.65.0", "", { "dependencies": { "@typescript-eslint/types": "8.65.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A=="],
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.66.0", "", { "dependencies": { "@typescript-eslint/types": "8.66.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.9.10", "", {}, "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw=="],
 
@@ -336,7 +336,7 @@
 
     "bmp-ts": ["bmp-ts@1.0.9", "", {}, "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw=="],
 
-    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -718,7 +718,7 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "typescript-eslint": ["typescript-eslint@8.65.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.65.0", "@typescript-eslint/parser": "8.65.0", "@typescript-eslint/typescript-estree": "8.65.0", "@typescript-eslint/utils": "8.65.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA=="],
+    "typescript-eslint": ["typescript-eslint@8.66.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.66.0", "@typescript-eslint/parser": "8.66.0", "@typescript-eslint/typescript-estree": "8.66.0", "@typescript-eslint/utils": "8.66.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw=="],
 
     "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
 

--- a/templates/cli/lib/help.ts.twig
+++ b/templates/cli/lib/help.ts.twig
@@ -1,6 +1,6 @@
 import chalk from "chalk";
 import type { Command, Help } from "commander";
-import { EXECUTABLE_NAME, SDK_LOGO, SDK_TITLE } from "./constants.js";
+import { EXECUTABLE_NAME, SDK_LOGO } from "./constants.js";
 
 /**
  * The main help screen is grouped by intent rather than listed alphabetically.
@@ -9,67 +9,28 @@ import { EXECUTABLE_NAME, SDK_LOGO, SDK_TITLE } from "./constants.js";
  *
  * Anything not named here still shows up, under `OTHER`, so a service added
  * to the spec can never silently disappear from `--help`.
+ *
+ * Generated from CliCommandSurface::HELP_GROUPS, the same table the Go CLI's
+ * help screen is built from, so the two cannot drift.
  */
 const groups: ReadonlyArray<{
   title: string;
   commands: readonly string[];
   dim?: boolean;
 }> = [
+{% for group in cliHelpGroups() %}
   {
-    title: "GET STARTED",
-    commands: [
-      "login",
-      "list-organizations",
-      "list-projects",
-      "init",
-      "pull",
-      "push",
-      "run",
-      "whoami",
-    ],
-  },
-  {
-    title: "PROJECT",
-    commands: ["organization", "project", "apps", "proxy", "vcs", "webhooks"],
-  },
-  {
-    title: "RESOURCES",
-    commands: [
-      "account",
-      "users",
-      "teams",
-      "tablesdb",
-      "storage",
-      "functions",
-      "sites",
-      "messaging",
-      "tokens",
-      "backups",
-      "presences",
-    ],
-  },
-  {
-    title: "UTILITIES",
-    commands: [
-      "graphql",
-      "generate",
-      "types",
-      "locale",
-      "activities",
-      "migrations",
-      "notifications",
-      "oauth2",
-      "client",
-      "completion",
-      "logout",
-      "update",
-    ],
-  },
-  {
-    title: "DEPRECATED",
+    title: {{ group.title | json_encode | raw }},
+{% if group.dim %}
     dim: true,
-    commands: ["databases"],
+{% endif %}
+    commands: [
+{% for command in group.commands %}
+      {{ command | json_encode | raw }},
+{% endfor %}
+    ],
   },
+{% endfor %}
 ];
 
 /**
@@ -78,64 +39,24 @@ const groups: ReadonlyArray<{
  *
  * Written to fit one terminal line — keep them under 51 characters, in the
  * imperative, with no trailing period.
+ *
+ * Generated from CliCommandSurface::HELP_SUMMARIES.
  */
 const summaries: Record<string, string> = {
-  login: `Authenticate with your ${SDK_TITLE} account`,
-  "list-organizations": "Organizations your session can access",
-  "list-projects": "Projects your session can access",
-  init: "Scaffold a project, function, site, or resource",
-  pull: "Pull remote project resources into this directory",
-  push: "Push local project resources",
-  run: "Run the project locally for development",
-  whoami: "Show the currently authenticated account",
-
-  organization: "Manage organization-level projects",
-  project: "Usage, variables, and project-level settings",
-  apps: "OAuth2 applications, keys, scopes, installations",
-  proxy: "Domain configuration beyond DNS",
-  vcs: "Connect and manage VCS repositories",
-  webhooks: "Project webhooks",
-
-  account: "Manage your own user account",
-  users: "Manage project users",
-  teams: "Group users to share resource access",
-  tablesdb: "Structured tables of rows and columns",
-  storage: "Files and buckets",
-  functions: "Serverless functions, deployments, and executions",
-  sites: "Static and SSR sites and their deployments",
-  messaging: "Topics, subscribers, and message delivery",
-  tokens: "Resource tokens for secure file access",
-  backups: "Backup policies, archives, and restorations",
-  presences: "Real-time user presence tracking",
-
-  graphql: "Query and mutate any resource via GraphQL",
-  generate: "Generate a type-safe SDK from your project config",
-  types: "Generate TypeScript types for your project",
-  locale: "Localize your app based on user location",
-  activities: "List and inspect project activity events",
-  migrations: "Migrate data between services",
-  notifications: "Console notifications",
-  oauth2: "Authorize apps and issue OAuth2 and OIDC tokens",
-  client: "Configure the CLI itself",
-  completion: "Generate shell completion scripts",
-  logout: `Log out of your ${SDK_TITLE} account`,
-  update: "Update the CLI to the latest version",
-
-  databases: "Use `tablesdb` instead",
+{% for command, summary in cliHelpSummaries(spec.title | caseUcfirst) %}
+  {% if command matches '/^[A-Za-z_$][A-Za-z0-9_$]*$/' %}{{ command }}{% else %}{{ command | json_encode | raw }}{% endif %}: {{ summary | json_encode | raw }},
+{% endfor %}
 };
 
-/** Order of the global flags, by long flag. Unlisted options are appended. */
+/**
+ * Order of the global flags, by long flag. Unlisted options are appended.
+ *
+ * Generated from CliCommandSurface::HELP_OPTION_ORDER.
+ */
 const optionOrder: readonly string[] = [
-  "--version",
-  "--help",
-  "--json",
-  "--raw",
-  "--show-secrets",
-  "--verbose",
-  "--force",
-  "--all",
-  "--id",
-  "--report",
+{% for flag in cliHelpOptionOrder() %}
+  {{ flag | json_encode | raw }},
+{% endfor %}
 ];
 
 const MAX_WIDTH = 80;

--- a/templates/cli/package-lock.json.twig
+++ b/templates/cli/package-lock.json.twig
@@ -56,7 +56,7 @@
         "@xmldom/xmldom": "^0.9.10",
         "tmp": "^0.2.6",
         "esbuild": "^0.28.1",
-        "brace-expansion": "5.0.8"
+        "brace-expansion": "5.0.9"
       }
     },
     "node_modules/@appwrite.io/console": {
@@ -1925,9 +1925,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1943,9 +1940,6 @@
       "integrity": "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1963,9 +1957,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1982,9 +1973,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2000,9 +1988,6 @@
       "integrity": "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2168,17 +2153,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
-      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
+      "integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/type-utils": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/type-utils": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2191,22 +2176,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.65.0",
+        "@typescript-eslint/parser": "^8.66.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
-      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.66.0.tgz",
+      "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2222,14 +2207,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
-      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
+      "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.65.0",
-        "@typescript-eslint/types": "^8.65.0",
+        "@typescript-eslint/tsconfig-utils": "^8.66.0",
+        "@typescript-eslint/types": "^8.66.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2244,14 +2229,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
-      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
+      "integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0"
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2262,9 +2247,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
-      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
+      "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2279,15 +2264,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
-      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
+      "integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2304,9 +2289,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
-      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
+      "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2318,16 +2303,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
-      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
+      "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.65.0",
-        "@typescript-eslint/tsconfig-utils": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/project-service": "8.66.0",
+        "@typescript-eslint/tsconfig-utils": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2346,16 +2331,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
-      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
+      "integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0"
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2370,13 +2355,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
-      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
+      "integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/types": "8.66.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2624,9 +2609,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -5752,16 +5737,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
-      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.66.0.tgz",
+      "integrity": "sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.65.0",
-        "@typescript-eslint/parser": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/utils": "8.65.0"
+        "@typescript-eslint/eslint-plugin": "8.66.0",
+        "@typescript-eslint/parser": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/templates/cli/package-lock.json.twig
+++ b/templates/cli/package-lock.json.twig
@@ -1925,6 +1925,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1940,6 +1943,9 @@
       "integrity": "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1957,6 +1963,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1973,6 +1982,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1988,6 +2000,9 @@
       "integrity": "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/templates/cli/package.json.twig
+++ b/templates/cli/package.json.twig
@@ -78,7 +78,7 @@
     "@xmldom/xmldom": "^0.9.10",
     "tmp": "^0.2.6",
     "esbuild": "^0.28.1",
-    "brace-expansion": "5.0.8"
+    "brace-expansion": "5.0.9"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.0.0",

--- a/templates/go-cli/go.mod.twig
+++ b/templates/go-cli/go.mod.twig
@@ -13,6 +13,13 @@ require (
 {% if not sdk.test %}
 	{{ language.params.sdkImportPath }} {{ language.params.sdkVersion }}
 {% endif %}
+	// Not imported directly -- huh pulls it in -- but named here to raise its
+	// floor above the v1.3.6 huh v1.0.0 asks for. Resizing the terminal during a
+	// prompt left fragments of the previous frame on screen, because bubbletea's
+	// inline renderer repaints by moving up the height of the last frame and the
+	// terminal had already reflowed it. v1.3.7 carries "fix(renderer): properly
+	// reset cursor position to start of line" (#1472) and three later patches.
+	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/fsnotify/fsnotify v1.10.1

--- a/templates/go-cli/internal/app/globals.go
+++ b/templates/go-cli/internal/app/globals.go
@@ -40,13 +40,15 @@ func (g *Globals) AllPointer() *bool { return &g.All }
 
 // RegisterGlobalFlags adds the persistent flags to the root command.
 func RegisterGlobalFlags(root *cobra.Command) {
+	// Wording is the TypeScript CLI's, verbatim (cli.ts.twig:145) -- these lines
+	// are what `--help` shows, so a difference here is a difference users read.
 	flags := root.PersistentFlags()
-	flags.BoolVarP(&globals.JSON, "json", "j", false, "Output the response as JSON.")
-	flags.BoolVarP(&globals.Raw, "raw", "R", false, "Output the unfiltered response as JSON.")
+	flags.BoolVarP(&globals.JSON, "json", "j", false, "Output filtered JSON (empty values omitted)")
+	flags.BoolVarP(&globals.Raw, "raw", "R", false, "Output the full raw JSON response")
 	flags.BoolVar(&globals.ShowSecrets, "show-secrets", false,
-		"Show secret values in full instead of masking them.")
-	flags.BoolVarP(&globals.Verbose, "verbose", "V", false, "Show detailed output for debugging.")
-	flags.BoolVarP(&globals.Force, "force", "f", false, "Skip confirmation prompts.")
+		"Reveal secrets and tokens in output (redacted by default)")
+	flags.BoolVarP(&globals.Verbose, "verbose", "V", false, "Show full error stack traces")
+	flags.BoolVarP(&globals.Force, "force", "f", false, "Skip confirmation prompts")
 	// --all is persistent so every command that honours it reads one value, but
 	// WITHOUT the -a shorthand. cobra merges a root persistent flag into every
 	// subcommand, and `push table` and `push collection` define their own -a for
@@ -54,9 +56,17 @@ func RegisterGlobalFlags(root *cobra.Command) {
 	// crashed those two commands outright. The shorthand is added locally on
 	// `push` and `pull`, which is where the TypeScript has it (push.ts:4272,
 	// pull.ts:1121); commander options do not inherit, so it never had to choose.
-	flags.BoolVar(&globals.All, "all", false, "Apply the command to every matching resource.")
+	//
+	// Hidden at the root for the same reason it is hidden there in the
+	// TypeScript (`new Option('-a, --all', ...).hideHelp()`): it is parsed
+	// globally so `appwrite --all push` keeps working, but it acts on `push` and
+	// `pull`, which is where it is documented.
+	flags.BoolVar(&globals.All, "all", false, "Push or pull every resource")
+	if flag := flags.Lookup("all"); flag != nil {
+		flag.Hidden = true
+	}
 	flags.BoolVar(&globals.Report, "report", false,
-		"Print a prefilled bug report link on error.")
+		"Print a prefilled bug report link on error")
 }
 
 // Renderer builds an output renderer from the current global flags.

--- a/templates/go-cli/internal/app/version.go.twig
+++ b/templates/go-cli/internal/app/version.go.twig
@@ -1,6 +1,9 @@
 package app
 
-import "runtime/debug"
+import (
+	"runtime/debug"
+	"strings"
+)
 
 // devVersion is what gets compiled in when no release stamped a version.
 //
@@ -39,5 +42,20 @@ func init() {
 		return
 	}
 
-	Version = info.Main.Version
+	Version = normalizeBuildVersion(info.Main.Version)
+}
+
+// normalizeBuildVersion drops the "v" Go writes into build info.
+//
+// Build info carries the module version as Go spells it -- `v0.7.7-preview` --
+// while the release ldflag carries goreleaser's `.Version`, which has already
+// dropped it. So one release answered `--version` two different ways depending
+// on how it was installed:
+//
+//	go install <module>@latest  ->  appwrite version v0.7.7-preview
+//	a downloaded release        ->  appwrite version 0.7.7-preview
+//
+// `--version` is the first thing a bug report quotes, so the two have to agree.
+func normalizeBuildVersion(version string) string {
+	return strings.TrimPrefix(version, "v")
 }

--- a/templates/go-cli/internal/app/version_test.go
+++ b/templates/go-cli/internal/app/version_test.go
@@ -25,3 +25,33 @@ func TestVersionStartsFromTheSentinel(t *testing.T) {
 		t.Error("Version is empty, so `--version` would print nothing")
 	}
 }
+
+// Build info carries the module version as Go spells it -- `v0.7.7-preview` --
+// while the release ldflag carries goreleaser's `.Version`, which has already
+// dropped the "v". So one release reported itself two ways:
+//
+//	go install ...@latest  ->  appwrite version v0.7.7-preview
+//	a downloaded release   ->  appwrite version 0.7.7-preview
+//
+// `--version` is the first thing a bug report quotes, so the two have to agree.
+//
+// Asserted on the helper rather than on Version: under `go test` the ldflag
+// never fires and build info reports no module version, so Version is the
+// sentinel and a check on it could not fail for the reason it exists.
+func TestNormalizeBuildVersionDropsTheLeadingV(t *testing.T) {
+	cases := map[string]string{
+		"v0.7.7-preview": "0.7.7-preview",
+		"v1.0.0":         "1.0.0",
+		"0.7.7-preview":  "0.7.7-preview",
+		// What a plain `go build` in a working tree reports, and what the
+		// fallback returns when there is nothing to report.
+		"(devel)": "(devel)",
+		"":        "",
+	}
+
+	for raw, want := range cases {
+		if got := normalizeBuildVersion(raw); got != want {
+			t.Errorf("normalizeBuildVersion(%q) = %q, want %q", raw, got, want)
+		}
+	}
+}

--- a/templates/go-cli/internal/auth/keyring.go
+++ b/templates/go-cli/internal/auth/keyring.go
@@ -1,6 +1,10 @@
 package auth
 
 import (
+	"errors"
+	"fmt"
+	"runtime"
+
 	"github.com/appwrite/appwrite-cli-go/internal/config"
 	"github.com/zalando/go-keyring"
 )
@@ -29,27 +33,123 @@ type TokenStore struct {
 	Global *config.Global
 }
 
-// Refresh returns the stored refresh token for a session, or "" when there is
-// none.
+// Trace receives one line per credential-store read when --verbose is on.
 //
-// Keyring errors are swallowed rather than surfaced: an unavailable keyring is
-// indistinguishable from an absent entry as far as the caller is concerned, and
-// both mean "fall back to prefs".
-func (s *TokenStore) Refresh(sessionID string) string {
+// A package variable for the same reason client.RequestLog is one: the store is
+// reached deep inside the auth path and diagnostics should not have to be
+// threaded through every caller. Set during start-up, before any read.
+var Trace func(format string, arguments ...any)
+
+func trace(format string, arguments ...any) {
+	if Trace != nil {
+		Trace(format, arguments...)
+	}
+}
+
+// storeName is what the platform calls its credential store, so a message about
+// one names the thing the user would go and look at.
+func storeName() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return "the macOS keychain"
+	case "windows":
+		return "the Windows credential manager"
+	default:
+		return "the system keyring"
+	}
+}
+
+// MissingRefreshToken reports that a session has no refresh token, and says
+// where the CLI looked.
+//
+// The where is the entire point. Both stores answering "nothing here" used to
+// surface as `session expired`, which is a conclusion rather than an
+// observation -- and the conclusion is wrong whenever the CLI is looking
+// somewhere other than where the token is. That is not hypothetical: a
+// redirected HOME points macOS at a different login keychain, the lookup comes
+// back empty, and a perfectly good session gets reported as expired. Naming the
+// store and the session id turns that into a one-line diagnosis.
+//
+// It cannot be told apart from a genuinely absent entry by the error alone --
+// `security` exits 44 for both and go-keyring maps both to ErrNotFound -- so
+// saying what was looked for is the only honest thing available.
+type MissingRefreshToken struct {
+	SessionID string
+	Store     string
+	// StoreErr is what the credential store said. A not-found error means it
+	// answered; anything else means it failed, which is worth wording
+	// differently because unlocking a keyring and signing in again are
+	// different actions.
+	StoreErr  error
+	PrefsPath string
+}
+
+func (e *MissingRefreshToken) Error() string {
+	if e.StoreErr != nil && !errors.Is(e.StoreErr, keyring.ErrNotFound) {
+		return fmt.Sprintf("%s could not be read (%s), and %s holds no token for session %s",
+			e.Store, e.StoreErr, e.PrefsPath, e.SessionID)
+	}
+
+	return fmt.Sprintf("%s has no entry for session %s, and neither does %s",
+		e.Store, e.SessionID, e.PrefsPath)
+}
+
+// Unwrap exposes the store's own error, so a caller can still match on it.
+func (e *MissingRefreshToken) Unwrap() error { return e.StoreErr }
+
+// Refresh returns the stored refresh token for a session.
+//
+// The failed lookup is DESCRIBED rather than reduced to "": the caller turns
+// this into advice for a user, and "no token here" and "the store would not
+// answer" are different advice -- while "I looked in the wrong place" is
+// indistinguishable from either unless the place is named. See
+// MissingRefreshToken.
+//
+// A token in prefs wins over the store's opinion. That is the fallback
+// SetRefresh writes to when the keyring is unavailable, so finding one there
+// means the store not answering does not matter.
+func (s *TokenStore) Refresh(sessionID string) (string, error) {
 	if sessionID == "" {
-		return ""
+		return "", &MissingRefreshToken{Store: storeName(), PrefsPath: s.prefsPath()}
 	}
 
-	if token, err := keyring.Get(refreshTokenService, sessionID); err == nil && token != "" {
-		return token
+	token, storeErr := keyring.Get(refreshTokenService, sessionID)
+	if storeErr == nil && token != "" {
+		trace("read the refresh token for %s from %s", sessionID, storeName())
+
+		return token, nil
 	}
 
-	session := s.Global.SessionData(sessionID)
-	if session == nil {
-		return ""
+	if storeErr != nil {
+		trace("%s returned no refresh token for %s: %s", storeName(), sessionID, storeErr)
 	}
 
-	return session.GetString(prefsRefreshTokenKey)
+	if session := s.Global.SessionData(sessionID); session != nil {
+		if fallback := session.GetString(prefsRefreshTokenKey); fallback != "" {
+			trace("read the refresh token for %s from %s", sessionID, s.prefsPath())
+
+			return fallback, nil
+		}
+	}
+
+	return "", &MissingRefreshToken{
+		SessionID: sessionID,
+		Store:     storeName(),
+		StoreErr:  storeErr,
+		PrefsPath: s.prefsPath(),
+	}
+}
+
+// prefsPath names the fallback store in a message, and falls back to the file's
+// own name when the path is not known.
+func (s *TokenStore) prefsPath() string {
+	if s.Global != nil {
+		if path := s.Global.Path(); path != "" {
+			return path
+		}
+	}
+
+	return "prefs.json"
 }
 
 // SetRefresh stores a refresh token, preferring the keyring.

--- a/templates/go-cli/internal/auth/keyringbackend_test.go
+++ b/templates/go-cli/internal/auth/keyringbackend_test.go
@@ -1,0 +1,81 @@
+package auth
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/zalando/go-keyring"
+)
+
+// Does the platform's own credential store actually hold a refresh token?
+//
+// This is the claim the README could not make about Windows. The suite already
+// round-tripped a token through TokenStore, but TokenStore falls back to
+// prefs.json when the keyring is unavailable and says nothing about which
+// backend answered -- so a green Windows run proved the fallback worked, not the
+// credential manager.
+//
+// So the store is exercised DIRECTLY here, with no fallback to hide behind. A
+// platform with no reachable store skips, which is the honest outcome for a
+// headless Linux runner and a container; a platform with one must round-trip.
+func TestTheOSCredentialStoreRoundTripsAToken(t *testing.T) {
+	// Not the real service name: this writes to the developer's own keychain
+	// when run locally, and it must not collide with the entry their CLI uses.
+	const service = "appwrite-cli-keyring-selftest"
+	const account = "session-selftest"
+	const secret = "round-trip-me"
+
+	if err := keyring.Set(service, account, secret); err != nil {
+		if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+			// Both ship a credential store that is always present, so a failure
+			// here is a real finding rather than an absent dependency.
+			t.Fatalf("%s has a credential store and it refused a write: %s", runtime.GOOS, err)
+		}
+		t.Skipf("no reachable credential store on %s: %s", runtime.GOOS, err)
+	}
+	t.Cleanup(func() { _ = keyring.Delete(service, account) })
+
+	stored, err := keyring.Get(service, account)
+	if err != nil {
+		t.Fatalf("the credential store accepted a write and then could not read it back: %s", err)
+	}
+	if stored != secret {
+		t.Fatalf("read back %q, want %q", stored, secret)
+	}
+
+	// Deleting has to work too, or `logout` leaves the credential behind on a
+	// machine the user believes they signed out of.
+	if err := keyring.Delete(service, account); err != nil {
+		t.Fatalf("the credential could not be deleted: %s", err)
+	}
+	if _, err := keyring.Get(service, account); err == nil {
+		t.Error("the credential survived its own deletion")
+	}
+}
+
+// And the same round-trip through TokenStore, which is what the CLI actually
+// calls -- including the prefs fallback, so this one passes everywhere.
+func TestTokenStoreRoundTripsWhicheverBackendItLandsOn(t *testing.T) {
+	global := newTestGlobal(t, "https://cloud.appwrite.io/v1", 0, "token")
+	store := &TokenStore{Global: global}
+
+	if err := store.SetRefresh("session-1", "stored-refresh"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.DeleteRefresh("session-1") })
+
+	token, err := store.Refresh("session-1")
+	if err != nil {
+		t.Fatalf("a token that was just written could not be read: %v", err)
+	}
+	if token != "stored-refresh" {
+		t.Errorf("token = %q, want stored-refresh", token)
+	}
+
+	if err := store.DeleteRefresh("session-1"); err != nil {
+		t.Fatal(err)
+	}
+	if token, _ := store.Refresh("session-1"); token != "" {
+		t.Errorf("the token survived deletion: %q", token)
+	}
+}

--- a/templates/go-cli/internal/auth/refresh.go
+++ b/templates/go-cli/internal/auth/refresh.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -79,7 +80,7 @@ func (a *Authenticator) AccessToken(forceRefresh bool) (string, error) {
 		return accessToken, nil
 	}
 
-	refreshToken := a.Store.Refresh(sessionID)
+	refreshToken, missing := a.Store.Refresh(sessionID)
 
 	// An expiry of zero means the token came from a flow that does not report
 	// one. Without a refresh token there is nothing better to do than use it and
@@ -89,10 +90,52 @@ func (a *Authenticator) AccessToken(forceRefresh bool) (string, error) {
 	}
 
 	if refreshToken == "" {
-		return "", ErrSessionExpired
+		return "", a.cannotRefresh(session, missing)
 	}
 
 	return a.refresh(session, sessionID, refreshToken)
+}
+
+// cannotRefresh explains why the session could not be renewed.
+//
+// It used to be one sentence -- `session expired. Run appwrite login` -- for
+// every way of getting here, which is a conclusion where an observation was
+// available. Two things were wrong with it.
+//
+// It named no session. Preferences hold one per environment, so with a Cloud, a
+// staging and a self-hosted login stored, the user was told that "the" session
+// expired without being told whose.
+//
+// And it asserted expiry, which is the one thing the CLI does not know at this
+// point: all it observed is that it found no refresh token. If it was looking in
+// the wrong keychain -- which a redirected HOME is enough to cause -- the
+// session is fine, and the advice sends the user to re-authenticate against a
+// problem re-authenticating does not fix. So the lookup is reported, and the
+// advice comes after it rather than instead of it.
+func (a *Authenticator) cannotRefresh(session *config.Object, missing error) error {
+	if missing == nil {
+		return ErrSessionExpired
+	}
+
+	return fmt.Errorf("cannot renew the session for %s: %w. Run `%s login` to sign in again",
+		describeSession(session), missing, client.ExecutableName)
+}
+
+// describeSession identifies a session the way its owner would recognise it.
+func describeSession(session *config.Object) string {
+	email := session.GetString(config.PreferenceEmail)
+	endpoint := session.GetString(config.PreferenceEndpoint)
+
+	switch {
+	case email != "" && endpoint != "":
+		return email + " at " + endpoint
+	case endpoint != "":
+		return endpoint
+	case email != "":
+		return email
+	default:
+		return "the current account"
+	}
 }
 
 func (a *Authenticator) refresh(session *config.Object, sessionID, refreshToken string) (string, error) {

--- a/templates/go-cli/internal/auth/refresh_test.go
+++ b/templates/go-cli/internal/auth/refresh_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -149,13 +150,14 @@ func TestAccessTokenPersistsRotatedRefreshToken(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if stored := authenticator.Store.Refresh("session-1"); stored != "rotated-refresh" {
+	if stored, _ := authenticator.Store.Refresh("session-1"); stored != "rotated-refresh" {
 		t.Errorf("stored refresh token = %q, want %q", stored, "rotated-refresh")
 	}
 }
 
-// No refresh token and an expired access token is an unrecoverable state; the
-// user has to log in again, and the message must say so.
+// No refresh token and an expired access token means the session cannot be
+// renewed. The message has to say WHICH session and WHERE the CLI looked, not
+// merely assert that it expired -- see cannotRefresh.
 func TestAccessTokenWithoutRefreshTokenFailsCleanly(t *testing.T) {
 	global := newTestGlobal(t, "https://cloud.appwrite.io/v1",
 		fixedNow.Add(-time.Hour).UnixMilli(), "expired")
@@ -167,8 +169,23 @@ func TestAccessTokenWithoutRefreshTokenFailsCleanly(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error")
 	}
-	if err != ErrSessionExpired {
-		t.Errorf("err = %v, want ErrSessionExpired", err)
+
+	message := err.Error()
+	for _, want := range []string{
+		"someone@example.com",              // which account
+		"https://cloud.appwrite.io/v1",     // and which environment
+		"session-1",                        // the id the store was asked for
+		"login",                            // and what to do about it
+	} {
+		if !strings.Contains(message, want) {
+			t.Errorf("the message does not mention %q: %s", want, message)
+		}
+	}
+
+	// The lookup is recoverable by a caller, not just printed.
+	var missing *MissingRefreshToken
+	if !errors.As(err, &missing) {
+		t.Errorf("err does not carry a MissingRefreshToken: %v", err)
 	}
 }
 
@@ -192,7 +209,9 @@ func TestAccessTokenWithZeroExpiryAndNoRefreshTokenIsUsedAsIs(t *testing.T) {
 func TestAccessTokenWithoutSessionFails(t *testing.T) {
 	global := config.LoadGlobal(filepath.Join(t.TempDir(), "absent.json"))
 
-	if _, err := NewAuthenticator(global, "0.0.1").AccessToken(false); err != ErrSessionExpired {
+	// No session at all is the one case with no lookup behind it, so the
+	// sentinel is still what a caller gets.
+	if _, err := NewAuthenticator(global, "0.0.1").AccessToken(false); !errors.Is(err, ErrSessionExpired) {
 		t.Errorf("err = %v, want ErrSessionExpired", err)
 	}
 }

--- a/templates/go-cli/internal/auth/store_test.go
+++ b/templates/go-cli/internal/auth/store_test.go
@@ -1,0 +1,127 @@
+package auth
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/zalando/go-keyring"
+)
+
+// The whole point of the message is the WHERE. A CLI that looked in the wrong
+// keychain and a CLI whose session really is gone produce the same empty
+// lookup, so naming what was searched is the only thing that tells them apart.
+func TestMissingRefreshTokenNamesWhereItLooked(t *testing.T) {
+	keyring.MockInit()
+
+	global := newTestGlobal(t, "https://cloud.appwrite.io/v1",
+		fixedNow.Add(-time.Hour).UnixMilli(), "expired")
+	store := &TokenStore{Global: global}
+
+	token, err := store.Refresh("session-1")
+	if token != "" {
+		t.Fatalf("token = %q, want empty", token)
+	}
+
+	message := err.Error()
+	if !strings.Contains(message, "session-1") {
+		t.Errorf("the session id is missing: %s", message)
+	}
+	if !strings.Contains(message, global.Path()) {
+		t.Errorf("the prefs file is not named: %s", message)
+	}
+	if !strings.Contains(message, storeName()) {
+		t.Errorf("the credential store is not named: %s", message)
+	}
+}
+
+// A store that FAILS reads differently from a store that answered "nothing
+// here", because unlocking a keyring and signing in again are different
+// actions.
+func TestStoreFailureIsWordedAsAFailure(t *testing.T) {
+	keyring.MockInitWithError(
+		errors.New("The name org.freedesktop.secrets was not provided by any .service files"))
+
+	global := newTestGlobal(t, "https://cloud.appwrite.io/v1",
+		fixedNow.Add(-time.Hour).UnixMilli(), "expired")
+
+	_, err := (&TokenStore{Global: global}).Refresh("session-1")
+	if err == nil {
+		t.Fatal("a store that would not answer was reported as success")
+	}
+
+	if !strings.Contains(err.Error(), "could not be read") {
+		t.Errorf("a store failure reads as an absent entry: %s", err)
+	}
+	if !strings.Contains(err.Error(), "org.freedesktop.secrets") {
+		t.Errorf("the store's own reason was dropped: %s", err)
+	}
+}
+
+// A found token is not an error, whichever store held it -- and the prefs
+// fallback wins, because that is where SetRefresh writes when the keyring is
+// unavailable.
+func TestRefreshPrefersAnyStoreThatHasTheToken(t *testing.T) {
+	keyring.MockInitWithError(errors.New("no secret service"))
+
+	global := newTestGlobal(t, "https://cloud.appwrite.io/v1",
+		fixedNow.Add(-time.Hour).UnixMilli(), "expired")
+	seedPrefsRefreshToken(t, global, "session-1", "from-prefs")
+
+	token, err := (&TokenStore{Global: global}).Refresh("session-1")
+	if err != nil {
+		t.Fatalf("a token in prefs was still reported as missing: %v", err)
+	}
+	if token != "from-prefs" {
+		t.Errorf("token = %q, want from-prefs", token)
+	}
+}
+
+// --verbose has to say which store answered. It printed nothing at all before,
+// which is what turned a one-line diagnosis into a long one.
+func TestRefreshTracesTheStoreItConsulted(t *testing.T) {
+	keyring.MockInit()
+
+	var traced []string
+	Trace = func(format string, arguments ...any) {
+		traced = append(traced, format)
+	}
+	t.Cleanup(func() { Trace = nil })
+
+	global := newTestGlobal(t, "https://cloud.appwrite.io/v1",
+		fixedNow.Add(-time.Hour).UnixMilli(), "expired")
+
+	if _, err := (&TokenStore{Global: global}).Refresh("session-1"); err == nil {
+		t.Fatal("expected a missing token")
+	}
+	if len(traced) == 0 {
+		t.Fatal("a failed store read was not traced")
+	}
+
+	// And on the way through, so a working read is visible too.
+	traced = nil
+	if err := (&TokenStore{Global: global}).SetRefresh("session-1", "fresh"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := (&TokenStore{Global: global}).Refresh("session-1"); err != nil {
+		t.Fatal(err)
+	}
+	if len(traced) == 0 {
+		t.Error("a successful store read was not traced")
+	}
+}
+
+// Tracing is opt-in: an unset sink must not panic, because every command that
+// is not --verbose takes that path.
+func TestRefreshWithoutATraceSink(t *testing.T) {
+	keyring.MockInit()
+	Trace = nil
+
+	global := newTestGlobal(t, "https://cloud.appwrite.io/v1",
+		fixedNow.Add(-time.Hour).UnixMilli(), "expired")
+
+	if _, err := (&TokenStore{Global: global}).Refresh("session-1"); err == nil {
+		t.Fatal("expected a missing token")
+	}
+}

--- a/templates/go-cli/internal/client/apierror_test.go
+++ b/templates/go-cli/internal/client/apierror_test.go
@@ -1,0 +1,97 @@
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The API's own wording for an unauthenticated request describes a permission
+// model the user did not ask about and names no way out of it.
+func TestUnauthenticatedRequestSaysHowToFixIt(t *testing.T) {
+	apiError := &APIError{
+		Status:  401,
+		Code:    401,
+		Type:    unauthorizedScopeType,
+		Message: `User (role: guests) missing scopes (["account"])`,
+	}
+
+	message := apiError.Error()
+	if !strings.Contains(message, "not authenticated") ||
+		!strings.Contains(message, ExecutableName+" login") {
+		t.Errorf("the guests 401 was repeated verbatim: %q", message)
+	}
+}
+
+// Message keeps what the API said, so --verbose and a bug report still carry it.
+func TestUnauthenticatedRequestKeepsTheAPIWording(t *testing.T) {
+	raw := `User (role: guests) missing scopes (["account"])`
+	apiError := &APIError{Status: 401, Code: 401, Type: unauthorizedScopeType, Message: raw}
+
+	if apiError.Message != raw {
+		t.Errorf("the API's own message was overwritten: %q", apiError.Message)
+	}
+}
+
+// Only this one error is rewritten. A 401 of another type, or a scope error
+// against a real account, is a different problem -- and a message about signing
+// in would hide it.
+func TestOtherFailuresAreNotRewritten(t *testing.T) {
+	cases := []*APIError{
+		// A real account that lacks one scope: the role is not `guests`.
+		{Status: 401, Code: 401, Type: unauthorizedScopeType,
+			Message: `User (role: member) missing scopes (["teams.write"])`},
+		// 401, guests, but a different type -- MFA, for one.
+		{Status: 401, Code: 401, Type: "user_more_factors_required",
+			Message: `More factors are required (role: guests)`},
+		// The type and role match but it is not a 401.
+		{Status: 403, Code: 403, Type: unauthorizedScopeType,
+			Message: `User (role: guests) missing scopes (["account"])`},
+	}
+
+	for _, apiError := range cases {
+		if got := apiError.Error(); got != apiError.Message {
+			t.Errorf("rewrote %s/%s: %q", apiError.Type, apiError.Message, got)
+		}
+	}
+}
+
+// The role is matched the way the TypeScript matches it: `/role:\s*guests/i`,
+// case-insensitive and tolerant of the space.
+//
+// Deliberately no word boundary after `guests`, because the TypeScript has none
+// either and this is a port. A stricter match here would mean the two CLIs
+// disagreed about which failure gets which message, which is a worse outcome
+// than sharing a loose pattern -- there is no role whose name merely begins with
+// `guests` for it to catch.
+func TestGuestRoleMatching(t *testing.T) {
+	for _, message := range []string{
+		"User (role: guests) missing scopes",
+		"User (role:guests) missing scopes",
+		"User (Role: Guests) missing scopes",
+	} {
+		apiError := &APIError{Code: 401, Type: unauthorizedScopeType, Message: message}
+		if apiError.Error() == message {
+			t.Errorf("did not recognise %q as unauthenticated", message)
+		}
+	}
+}
+
+// A body that is not the API's JSON at all -- a proxy error page -- still has to
+// produce something better than an empty message.
+func TestNonJSONFailureFallsBackToTheStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("<html>502 Bad Gateway</html>"))
+	}))
+	defer server.Close()
+
+	err := New(server.URL, "0.0.1").Call("GET", "/account", nil, nil)
+	if err == nil {
+		t.Fatal("a 502 was not reported as an error")
+	}
+	if !strings.Contains(err.Error(), "502") {
+		t.Errorf("the status is missing from %q", err)
+	}
+}

--- a/templates/go-cli/internal/client/client.go
+++ b/templates/go-cli/internal/client/client.go
@@ -9,6 +9,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -245,6 +246,22 @@ func (c *Client) SetCookie(cookie string) *Client {
 	return c
 }
 
+// ExecutableName is the CLI's own name, for messages that name a command.
+//
+// A package variable for the same reason RequestLog is one: internal/app owns
+// the name, and app reaches this package through internal/sdk, so importing it
+// would be a cycle. root.go sets it during start-up; the default is only what a
+// test that never sets it reads.
+var ExecutableName = "appwrite"
+
+// unauthorizedScopeType is the error type the API uses for a request it did not
+// consider authenticated.
+const unauthorizedScopeType = "general_unauthorized_scope"
+
+// guestRole matches the API's own way of saying the request arrived with no
+// credentials it recognised.
+var guestRole = regexp.MustCompile(`(?i)role:\s*guests`)
+
 // APIError is a non-2xx response from the API.
 type APIError struct {
 	Status  int
@@ -253,12 +270,34 @@ type APIError struct {
 	Type    string `json:"type"`
 }
 
+// Error is what the user reads. Message keeps the API's own wording, so
+// --verbose and a bug report still carry it.
 func (e *APIError) Error() string {
+	if e.unauthenticated() {
+		return "you are not authenticated. Run `" + ExecutableName +
+			" login` to authenticate and try again"
+	}
+
 	if e.Message != "" {
 		return e.Message
 	}
 
 	return fmt.Sprintf("request failed with status %d", e.Status)
+}
+
+// unauthenticated reports whether this is the API refusing an unauthenticated
+// request, rather than refusing a real account something.
+//
+// Ports the isUnauthorized branch of client.ts:292. Without it the CLI repeats
+// the API verbatim -- `User (role: guests) missing scopes (["account"])` --
+// which describes a permission model the user did not ask about and names no way
+// out of it.
+//
+// All three parts are matched, exactly as the TypeScript matches them, and Code
+// rather than Status: a 401 of any other type is a different problem, and
+// rewriting those would hide them behind a message about signing in.
+func (e *APIError) unauthenticated() bool {
+	return e.Code == 401 && e.Type == unauthorizedScopeType && guestRole.MatchString(e.Message)
 }
 
 // Call performs a request and decodes the JSON response into out.

--- a/templates/go-cli/internal/cmd/completion.go
+++ b/templates/go-cli/internal/cmd/completion.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -189,6 +190,11 @@ using a cached index from an earlier install -- clear it with:
   rm -f ~/.zcompdump*
 `, directory, quoted, name)
 	case "bash":
+		// path.Join, not filepath.Join. This line is pasted into a SHELL, and on
+		// Windows filepath.Join produced `source '...\appwrite'` -- a backslash
+		// is an escape to bash, not a separator, so the one line that has to be
+		// copyable was the one that would not work. Both bashes that exist on
+		// Windows take forward slashes.
 		return fmt.Sprintf(`This directory is loaded by bash-completion. If Tab does nothing, either
 bash-completion is not installed, or ~/.bashrc does not source it:
 
@@ -197,7 +203,7 @@ bash-completion is not installed, or ~/.bashrc does not source it:
 You can also source the script directly:
 
   source %s
-`, shellQuote(filepath.Join(directory, name)))
+`, shellQuote(path.Join(directory, name)))
 	default:
 		// fish loads ~/.config/fish/completions itself, with no setup.
 		return ""

--- a/templates/go-cli/internal/cmd/completion.go
+++ b/templates/go-cli/internal/cmd/completion.go
@@ -170,6 +170,11 @@ func completionInstallPath(shell string) (string, error) {
 func completionFollowUp(shell, directory string) string {
 	name := app.ExecutableName
 
+	// Quoted: these lines are meant to be pasted into a shell, and a home
+	// directory with a space in it -- "/Users/My Name" -- would otherwise turn
+	// one fpath entry into three broken ones.
+	quoted := shellQuote(directory)
+
 	switch shell {
 	case "zsh":
 		return fmt.Sprintf(`zsh loads completions from its fpath, which does not include %s by default.
@@ -182,7 +187,7 @@ If Tab then reports "_%s: function definition file not found", compinit is
 using a cached index from an earlier install -- clear it with:
 
   rm -f ~/.zcompdump*
-`, directory, directory, name)
+`, directory, quoted, name)
 	case "bash":
 		return fmt.Sprintf(`This directory is loaded by bash-completion. If Tab does nothing, either
 bash-completion is not installed, or ~/.bashrc does not source it:
@@ -191,12 +196,27 @@ bash-completion is not installed, or ~/.bashrc does not source it:
 
 You can also source the script directly:
 
-  source %s/%s
-`, directory, name)
+  source %s
+`, shellQuote(filepath.Join(directory, name)))
 	default:
 		// fish loads ~/.config/fish/completions itself, with no setup.
 		return ""
 	}
+}
+
+// shellQuote makes a path safe to paste into zsh or bash.
+//
+// Only when it needs it: the overwhelming majority of paths need no quoting,
+// and wrapping every one of them would put quotes around the single line most
+// users copy for no reason at all.
+func shellQuote(path string) string {
+	if path != "" && !strings.ContainsAny(path, " \t\n'\"\\$`*?()[]{};&|<>#~!") {
+		return path
+	}
+
+	// Single quotes suppress every expansion; the only character they cannot
+	// hold is a single quote, which is closed, escaped and reopened.
+	return "'" + strings.ReplaceAll(path, "'", `'\''`) + "'"
 }
 
 func overridePath(variable, fallback string) string {

--- a/templates/go-cli/internal/cmd/completion.go
+++ b/templates/go-cli/internal/cmd/completion.go
@@ -87,6 +87,10 @@ func newCompletionInstallCommand(root *cobra.Command) *cobra.Command {
 
 			fmt.Fprintf(command.OutOrStdout(), "Installed %s completion to %s\n", shell, path)
 
+			if follow := completionFollowUp(shell, filepath.Dir(path)); follow != "" {
+				fmt.Fprint(command.OutOrStdout(), "\n"+follow)
+			}
+
 			return nil
 		},
 	}
@@ -139,6 +143,59 @@ func completionInstallPath(shell string) (string, error) {
 				filepath.Join(home, ".config", "fish", "completions")),
 			name+".fish",
 		), nil
+	}
+}
+
+// completionFollowUp is what the user still has to do for the script to be
+// loaded, or "" when the shell needs nothing.
+//
+// Writing the file is not installing it. zsh only autoloads completions from a
+// directory on its `fpath`, and `~/.zfunc` -- the path both CLIs write to -- is
+// not on it by default. So `completion install` reported success and tab
+// completion did nothing, with no way for the user to tell which half had
+// failed.
+//
+// The stale-index note is not hypothetical: `_appwrite` autoloaded from a
+// directory that has since gone, and compinit's cached index still named it, so
+// pressing Tab printed
+//
+//	(eval):1: _appwrite: function definition file not found
+//
+// three times and completed nothing. Adding the directory to fpath does not
+// clear that cache.
+//
+// The CLI advises rather than edits: a shell profile is the user's file, and
+// appending to it from an installer is how profiles end up with six copies of
+// the same line.
+func completionFollowUp(shell, directory string) string {
+	name := app.ExecutableName
+
+	switch shell {
+	case "zsh":
+		return fmt.Sprintf(`zsh loads completions from its fpath, which does not include %s by default.
+Add these to ~/.zshrc, then open a new shell:
+
+  fpath=(%s $fpath)
+  autoload -Uz compinit && compinit
+
+If Tab then reports "_%s: function definition file not found", compinit is
+using a cached index from an earlier install -- clear it with:
+
+  rm -f ~/.zcompdump*
+`, directory, directory, name)
+	case "bash":
+		return fmt.Sprintf(`This directory is loaded by bash-completion. If Tab does nothing, either
+bash-completion is not installed, or ~/.bashrc does not source it:
+
+  source /usr/share/bash-completion/bash_completion
+
+You can also source the script directly:
+
+  source %s/%s
+`, directory, name)
+	default:
+		// fish loads ~/.config/fish/completions itself, with no setup.
+		return ""
 	}
 }
 

--- a/templates/go-cli/internal/cmd/completion_test.go
+++ b/templates/go-cli/internal/cmd/completion_test.go
@@ -168,3 +168,47 @@ func TestFishNeedsNoFollowUp(t *testing.T) {
 		t.Errorf("fish was given setup instructions it does not need:\n%s", follow)
 	}
 }
+
+// These lines are meant to be pasted into a shell. A home directory with a
+// space in it -- "/Users/My Name" -- turned one fpath entry into three broken
+// ones, so the advice for fixing completion was itself unusable.
+func TestFollowUpQuotesPathsAShellWouldSplit(t *testing.T) {
+	awkward := "/tmp/my home/.zfunc"
+
+	zsh := completionFollowUp("zsh", awkward)
+	if !strings.Contains(zsh, "fpath=('"+awkward+"' $fpath)") {
+		t.Errorf("the zsh fpath line is unquoted:\n%s", zsh)
+	}
+
+	bash := completionFollowUp("bash", "/tmp/my home/completions")
+	if !strings.Contains(bash, "source '/tmp/my home/completions/appwrite'") {
+		t.Errorf("the bash source line is unquoted:\n%s", bash)
+	}
+}
+
+// Quoting every path would put quotes around the one line most users copy.
+func TestOrdinaryPathsAreNotQuoted(t *testing.T) {
+	follow := completionFollowUp("zsh", "/home/someone/.zfunc")
+
+	if strings.Contains(follow, "'") {
+		t.Errorf("an ordinary path was quoted for no reason:\n%s", follow)
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	cases := map[string]string{
+		"/home/a/.zfunc":    "/home/a/.zfunc",
+		"/tmp/my home/x":    "'/tmp/my home/x'",
+		"/tmp/it's/x":       `'/tmp/it'\''s/x'`,
+		"/tmp/$HOME/x":      "'/tmp/$HOME/x'",
+		"/tmp/a;rm -rf ~/x": "'/tmp/a;rm -rf ~/x'",
+		"/tmp/glob*/x":      "'/tmp/glob*/x'",
+		"":                  "''",
+	}
+
+	for path, want := range cases {
+		if got := shellQuote(path); got != want {
+			t.Errorf("shellQuote(%q) = %q, want %q", path, got, want)
+		}
+	}
+}

--- a/templates/go-cli/internal/cmd/completion_test.go
+++ b/templates/go-cli/internal/cmd/completion_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -110,5 +111,60 @@ func TestInstallCompletionWritesEachShell(t *testing.T) {
 		if len(contents) == 0 {
 			t.Errorf("%s: wrote an empty completion script", shell)
 		}
+	}
+}
+
+// Writing the file is not installing it. zsh autoloads completions only from a
+// directory on its fpath, and ~/.zfunc is not on it, so `completion install`
+// reported success while Tab did nothing -- and after an earlier install had
+// been removed, Tab reported `_appwrite: function definition file not found`
+// from compinit's cached index.
+func TestZshInstallSaysWhatIsStillNeeded(t *testing.T) {
+	home := setHome(t)
+
+	path, err := installCompletion(NewRootCommand(), "zsh")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	follow := completionFollowUp("zsh", filepath.Dir(path))
+
+	for _, required := range []string{
+		"fpath",
+		filepath.Join(home, ".zfunc"),
+		"compinit",
+		".zcompdump",
+	} {
+		if !strings.Contains(follow, required) {
+			t.Errorf("the zsh follow-up does not mention %q:\n%s", required, follow)
+		}
+	}
+}
+
+// The directory is the one that was actually written to, so an override is
+// reflected in the advice rather than the default being printed back.
+func TestZshFollowUpNamesTheOverriddenDirectory(t *testing.T) {
+	setHome(t)
+	t.Setenv("ZSH_COMPLETION_DIR", filepath.Join(t.TempDir(), "elsewhere"))
+
+	path, err := completionInstallPath("zsh")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	follow := completionFollowUp("zsh", filepath.Dir(path))
+
+	if !strings.Contains(follow, filepath.Dir(path)) {
+		t.Errorf("the follow-up does not name %q:\n%s", filepath.Dir(path), follow)
+	}
+	if strings.Contains(follow, ".zfunc") {
+		t.Errorf("the follow-up names the default directory, not the one written:\n%s", follow)
+	}
+}
+
+// fish loads its completions directory itself, so there is nothing to say.
+func TestFishNeedsNoFollowUp(t *testing.T) {
+	if follow := completionFollowUp("fish", "/anywhere"); follow != "" {
+		t.Errorf("fish was given setup instructions it does not need:\n%s", follow)
 	}
 }

--- a/templates/go-cli/internal/cmd/errordetail_test.go
+++ b/templates/go-cli/internal/cmd/errordetail_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 // A year of usage answers with fourteen metrics of 365 entries. Printing them
@@ -129,5 +131,49 @@ func TestErrorDetailNamesTheErrorType(t *testing.T) {
 func TestErrorDetailOfNothingIsNothing(t *testing.T) {
 	if got := ErrorDetail(nil); got != "" {
 		t.Errorf("ErrorDetail(nil) = %q", got)
+	}
+}
+
+// cobra's own message is `accepts 1 arg(s), received 0`, which names neither the
+// argument, nor the command, nor a way to find out.
+func TestRequiredArgumentNamesWhatIsMissing(t *testing.T) {
+	command := &cobra.Command{Use: "types"}
+	validate := RequiredArgument("<output-directory>", "The directory to write the types to")
+
+	err := validate(command, nil)
+	if err == nil {
+		t.Fatal("a missing argument was accepted")
+	}
+
+	message := err.Error()
+	for _, want := range []string{"<output-directory>", "directory to write the types to", "types"} {
+		if !strings.Contains(message, want) {
+			t.Errorf("the message does not mention %q: %s", want, message)
+		}
+	}
+	if strings.Contains(message, "arg(s)") {
+		t.Errorf("cobra's plural hedge survived: %s", message)
+	}
+}
+
+// Too many says how many, because the usual cause is an unquoted path with a
+// space in it and the count is the clue.
+func TestRequiredArgumentRejectsTooMany(t *testing.T) {
+	validate := RequiredArgument("<output-directory>", "The directory")
+
+	err := validate(&cobra.Command{Use: "types"}, []string{"a", "b"})
+	if err == nil {
+		t.Fatal("two arguments were accepted for a one-argument command")
+	}
+	if !strings.Contains(err.Error(), "given 2") {
+		t.Errorf("the count is missing: %s", err)
+	}
+}
+
+func TestRequiredArgumentAcceptsExactlyOne(t *testing.T) {
+	validate := RequiredArgument("<output-directory>", "The directory")
+
+	if err := validate(&cobra.Command{Use: "types"}, []string{"./types"}); err != nil {
+		t.Errorf("one argument was rejected: %s", err)
 	}
 }

--- a/templates/go-cli/internal/cmd/errordetail_test.go
+++ b/templates/go-cli/internal/cmd/errordetail_test.go
@@ -1,0 +1,133 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// A year of usage answers with fourteen metrics of 365 entries. Printing them
+// whole was six thousand lines to say "an array of {value, date}".
+func TestLongArraysAreCollapsed(t *testing.T) {
+	entries := make([]string, 0, 365)
+	for day := range 365 {
+		entries = append(entries, fmt.Sprintf(`{"value":%d,"date":"day-%d"}`, day, day))
+	}
+	body := []byte(`{"requests":[` + strings.Join(entries, ",") + `]}`)
+
+	printed := prettyJSON(body)
+
+	if strings.Count(printed, `"value"`) != arrayPreview {
+		t.Errorf("kept %d elements, want %d:\n%s",
+			strings.Count(printed, `"value"`), arrayPreview, printed)
+	}
+	if !strings.Contains(printed, "... 363 more of 365") {
+		t.Errorf("the omitted count is missing:\n%s", printed)
+	}
+}
+
+// The field that fails to decode can be anywhere in the response --
+// `embeddingsText` comes after fourteen other metrics -- so a line or byte cap
+// would cut off exactly the part the user needs. Every KEY has to survive.
+func TestEveryFieldSurvivesCollapsing(t *testing.T) {
+	long := `[{"value":0},{"value":0},{"value":0},{"value":0},{"value":0}]`
+	body := []byte(`{"requests":` + long + `,"network":` + long + `,"embeddingsText":` + long + `}`)
+
+	printed := prettyJSON(body)
+
+	for _, key := range []string{"requests", "network", "embeddingsText"} {
+		if !strings.Contains(printed, `"`+key+`"`) {
+			t.Errorf("%q was cut from the dump:\n%s", key, printed)
+		}
+	}
+}
+
+// Key order is the response's, not Go's map order: a dump printed with its
+// fields shuffled is hard to compare against a model.
+func TestKeyOrderIsPreserved(t *testing.T) {
+	printed := prettyJSON([]byte(`{"zebra":1,"alpha":2,"middle":3}`))
+
+	zebra := strings.Index(printed, "zebra")
+	alpha := strings.Index(printed, "alpha")
+	middle := strings.Index(printed, "middle")
+
+	if !(zebra < alpha && alpha < middle) {
+		t.Errorf("the fields were reordered:\n%s", printed)
+	}
+}
+
+// A short array is left alone -- collapsing two entries into "0 more" would be
+// noise.
+func TestShortArraysAreUntouched(t *testing.T) {
+	printed := prettyJSON([]byte(`{"a":[1,2]}`))
+
+	if strings.Contains(printed, "more of") {
+		t.Errorf("a short array was collapsed:\n%s", printed)
+	}
+	if !strings.Contains(printed, "1") || !strings.Contains(printed, "2") {
+		t.Errorf("an element was dropped:\n%s", printed)
+	}
+}
+
+func TestEmptyContainersRender(t *testing.T) {
+	printed := prettyJSON([]byte(`{"a":[],"b":{}}`))
+
+	if !strings.Contains(printed, "[]") || !strings.Contains(printed, "{}") {
+		t.Errorf("an empty container did not survive:\n%s", printed)
+	}
+}
+
+// Numbers stay as written. An id that arrived as 20 digits must not come back in
+// scientific notation from the tool explaining what arrived.
+func TestLargeNumbersAreNotReformatted(t *testing.T) {
+	printed := prettyJSON([]byte(`{"id":12345678901234567890}`))
+
+	if !strings.Contains(printed, "12345678901234567890") {
+		t.Errorf("a large number was reformatted:\n%s", printed)
+	}
+}
+
+// A body that is not JSON is the case that matters most: an HTML error page is
+// the whole diagnosis, so it must be printed rather than swallowed.
+func TestNonJSONBodiesArePrintedAsTheyCame(t *testing.T) {
+	body := []byte("<html><body>502 Bad Gateway</body></html>")
+
+	if printed := prettyJSON(body); printed != string(body) {
+		t.Errorf("an HTML body was mangled: %q", printed)
+	}
+}
+
+// Truncated mid-stream -- a connection that dropped -- still prints what arrived.
+func TestATruncatedBodyStillPrints(t *testing.T) {
+	printed := prettyJSON([]byte(`{"a":[1,2`))
+
+	if !strings.Contains(printed, "a") {
+		t.Errorf("a truncated body printed nothing useful: %q", printed)
+	}
+}
+
+// The collapsed dump is for a person, but what is NOT collapsed must still be
+// faithful -- so a response with no long arrays re-emits as equivalent JSON.
+func TestAnUncollapsedDumpIsStillValidJSON(t *testing.T) {
+	body := []byte(`{"a":1,"b":{"c":[true,null]},"d":"x"}`)
+
+	var reparsed any
+	if err := json.Unmarshal([]byte(prettyJSON(body)), &reparsed); err != nil {
+		t.Errorf("the dump is not valid JSON: %s\n%s", err, prettyJSON(body))
+	}
+}
+
+func TestErrorDetailNamesTheErrorType(t *testing.T) {
+	detail := ErrorDetail(&json.UnmarshalTypeError{Value: "array", Field: "embeddingsText"})
+
+	if !strings.Contains(detail, "UnmarshalTypeError") {
+		t.Errorf("the error type is missing:\n%s", detail)
+	}
+}
+
+func TestErrorDetailOfNothingIsNothing(t *testing.T) {
+	if got := ErrorDetail(nil); got != "" {
+		t.Errorf("ErrorDetail(nil) = %q", got)
+	}
+}

--- a/templates/go-cli/internal/cmd/errors.go
+++ b/templates/go-cli/internal/cmd/errors.go
@@ -135,6 +135,38 @@ func ReportBlock(err error) string {
 		" - Create an issue in our Github\n   " + ReportURL(err)
 }
 
+// RequiredArgument validates a command that takes exactly one argument, and
+// says which one when it is missing.
+//
+// cobra's own message for this is
+//
+//	accepts 1 arg(s), received 0
+//
+// which names neither the argument, nor the command, nor a way to find out --
+// and `arg(s)` is a plural hedge in a sentence that already knows the number is
+// one. `appwrite types` is the command that hits it, where the missing value is
+// a directory the user has to choose, so the message has to say so.
+//
+// description is the argument's own help text, which the TypeScript declares
+// beside the argument ("The directory to write the types to") -- naming it is
+// what turns the error into an instruction.
+func RequiredArgument(name, description string) cobra.PositionalArgs {
+	return func(command *cobra.Command, arguments []string) error {
+		if len(arguments) == 1 {
+			return nil
+		}
+
+		if len(arguments) > 1 {
+			return fmt.Errorf(
+				"`%s` takes one argument, %s, and was given %d. Run `%s --help` for the usage",
+				command.CommandPath(), name, len(arguments), command.CommandPath())
+		}
+
+		return fmt.Errorf("missing %s -- %s. Run `%s %s`",
+			name, strings.ToLower(description), command.CommandPath(), name)
+	}
+}
+
 // ExitCancelled is the status a cancelled prompt exits with: 128 + SIGINT,
 // which is what a shell reports for a program the user interrupted.
 //

--- a/templates/go-cli/internal/cmd/errors.go
+++ b/templates/go-cli/internal/cmd/errors.go
@@ -166,7 +166,7 @@ func Report(writer io.Writer, executed *cobra.Command, err error) int {
 	}
 
 	// Skipped once the user has already asked for the detail it points at.
-	if !app.Flags().Verbose && !app.Flags().Report {
+	if !detailWasRequested() {
 		output.Log(writer, "For detailed error pass the --verbose or --report flag")
 	}
 
@@ -177,6 +177,36 @@ func Report(writer io.Writer, executed *cobra.Command, err error) int {
 	}
 
 	return 1
+}
+
+// detailWasRequested reports whether the user asked for the detail the advice
+// line points at.
+//
+// The parsed flags are not enough. A command that fails DURING parsing never
+// reaches the later flags: `appwrite users get --bogus --verbose` stops at
+// --bogus, so Verbose is still false and the CLI advised passing a flag that is
+// already in the invocation. The arguments are what the user actually typed.
+func detailWasRequested() bool {
+	if app.Flags().Verbose || app.Flags().Report {
+		return true
+	}
+
+	for _, argument := range os.Args[1:] {
+		// A `--` ends the flags; anything after it is a value.
+		if argument == "--" {
+			return false
+		}
+		if argument == "--verbose" || argument == "--report" {
+			return true
+		}
+		// -V, and clusters such as -jV. Not a long flag, and not a bare "-".
+		if len(argument) > 1 && argument[0] == '-' && argument[1] != '-' &&
+			strings.ContainsRune(argument, 'V') {
+			return true
+		}
+	}
+
+	return false
 }
 
 // CancellationNotice is the line printed for a cancelled prompt.

--- a/templates/go-cli/internal/cmd/errors.go
+++ b/templates/go-cli/internal/cmd/errors.go
@@ -241,18 +241,163 @@ func ErrorDetail(err error) string {
 	return builder.String() + "\n"
 }
 
-// prettyJSON re-indents a body, and returns it untouched when it is not JSON.
+// arrayPreview is how many elements of a long array --verbose prints.
 //
-// A body that is not JSON is exactly the case that matters most -- an HTML error
-// page, a proxy's plain-text refusal -- so failing to parse it must print it,
-// not swallow it.
+// Two, because the question a reader has is what SHAPE the elements are -- one
+// is enough to answer it and the second confirms it was not a fluke. `project
+// get-usage` over a year answers with fourteen metrics of 365 entries each: six
+// thousand lines to say "an array of {value, date}".
+const arrayPreview = 2
+
+// prettyJSON re-indents a body and collapses its long arrays.
+//
+// A body that is not JSON is printed untouched, which is the case that matters
+// most: an HTML error page or a proxy's plain-text refusal is the whole
+// diagnosis.
+//
+// Collapsing ARRAYS rather than truncating lines, and this is the difference
+// between a useful dump and a useless one. The field that fails to decode can be
+// anywhere in the response -- `embeddingsText` comes after fourteen other
+// metrics -- so a line or byte cap cuts off exactly the part the user needs. An
+// array is where the volume is, and its length is not what anyone is reading.
 func prettyJSON(body []byte) string {
-	var indented bytes.Buffer
-	if err := json.Indent(&indented, body, "", "  "); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	// Numbers stay as written: an id that arrived as 20 digits must not be
+	// reprinted in scientific notation by the tool explaining what arrived.
+	decoder.UseNumber()
+
+	var builder strings.Builder
+	if err := writeJSONValue(decoder, &builder, 0); err != nil {
+		// Not JSON, or truncated mid-stream. Either way the bytes are the
+		// evidence, so they are printed as they came.
+		var indented bytes.Buffer
+		if json.Indent(&indented, body, "", "  ") == nil {
+			return indented.String()
+		}
+
 		return string(body)
 	}
 
-	return indented.String()
+	return builder.String()
+}
+
+func jsonIndent(depth int) string { return strings.Repeat("  ", depth) }
+
+// writeJSONValue re-emits one value, in the order it was read.
+//
+// Re-emitted from tokens rather than decoded into a map, because a map loses key
+// order -- and a response printed with its fields shuffled is harder to compare
+// against a model than one printed as it arrived.
+func writeJSONValue(decoder *json.Decoder, builder *strings.Builder, depth int) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+
+	delimiter, isDelimiter := token.(json.Delim)
+	if !isDelimiter {
+		encoded, err := json.Marshal(token)
+		if err != nil {
+			return err
+		}
+		builder.Write(encoded)
+
+		return nil
+	}
+
+	switch delimiter {
+	case '{':
+		return writeJSONObject(decoder, builder, depth)
+	case '[':
+		return writeJSONArray(decoder, builder, depth)
+	default:
+		return fmt.Errorf("unexpected %v", delimiter)
+	}
+}
+
+func writeJSONObject(decoder *json.Decoder, builder *strings.Builder, depth int) error {
+	builder.WriteString("{")
+
+	empty := true
+	for first := true; decoder.More(); first = false {
+		empty = false
+		if !first {
+			builder.WriteString(",")
+		}
+
+		key, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		encoded, err := json.Marshal(key)
+		if err != nil {
+			return err
+		}
+
+		builder.WriteString("\n" + jsonIndent(depth+1))
+		builder.Write(encoded)
+		builder.WriteString(": ")
+
+		if err := writeJSONValue(decoder, builder, depth+1); err != nil {
+			return err
+		}
+	}
+
+	if _, err := decoder.Token(); err != nil {
+		return err
+	}
+
+	// `{}` on one line, not an empty pair of braces two lines apart, which is
+	// how an empty object read before -- as though a field had been cut.
+	if !empty {
+		builder.WriteString("\n" + jsonIndent(depth))
+	}
+	builder.WriteString("}")
+
+	return nil
+}
+
+func writeJSONArray(decoder *json.Decoder, builder *strings.Builder, depth int) error {
+	builder.WriteString("[")
+
+	total := 0
+	for ; decoder.More(); total++ {
+		// Past the preview the elements are still DECODED -- the tokens have to
+		// be consumed to reach the closing bracket -- just not kept.
+		target := builder
+		if total >= arrayPreview {
+			target = &strings.Builder{}
+		}
+
+		if total > 0 && total < arrayPreview {
+			builder.WriteString(",")
+		}
+		if total < arrayPreview {
+			builder.WriteString("\n" + jsonIndent(depth+1))
+		}
+
+		if err := writeJSONValue(decoder, target, depth+1); err != nil {
+			return err
+		}
+	}
+
+	if _, err := decoder.Token(); err != nil {
+		return err
+	}
+
+	if omitted := total - arrayPreview; omitted > 0 {
+		// Not valid JSON, deliberately: this block is read by a person deciding
+		// whether the response matches the model, and the count is the part a
+		// truncation must not hide.
+		fmt.Fprintf(builder, ",\n%s... %d more of %d",
+			jsonIndent(depth+1), omitted, total)
+	}
+	if total > 0 {
+		builder.WriteString("\n" + jsonIndent(depth))
+	}
+	builder.WriteString("]")
+
+	return nil
 }
 
 // indentBlock shifts a block two spaces right, to sit under its heading.

--- a/templates/go-cli/internal/cmd/errors.go
+++ b/templates/go-cli/internal/cmd/errors.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -12,6 +14,7 @@ import (
 	"github.com/appwrite/appwrite-cli-go/internal/app"
 	"github.com/appwrite/appwrite-cli-go/internal/output"
 	"github.com/appwrite/appwrite-cli-go/internal/prompt"
+	"github.com/appwrite/appwrite-cli-go/internal/sdk"
 	"github.com/spf13/cobra"
 )
 
@@ -174,11 +177,92 @@ func Report(writer io.Writer, executed *cobra.Command, err error) int {
 
 	output.Failure(writer, "%s", FormatError(err))
 
+	// --verbose was documented as "Show full error stack traces" and showed
+	// none: it suppressed the advice line above and changed nothing else, so on
+	// the failure it is most needed for -- a response the SDK could not decode --
+	// it added exactly nothing to
+	//
+	//   ✗ Error: json: cannot unmarshal array into Go struct field
+	//     UsageProject.embeddingsText of type models.Metric
+	//
+	// which names a field and a type and gives no way to see what actually
+	// arrived. Ports the `cliConfig.verbose` branch of parseError
+	// (parser.ts:937), which prints formatErrorForLog(err).
+	if app.Flags().Verbose {
+		if detail := ErrorDetail(err); detail != "" {
+			fmt.Fprint(writer, detail)
+		}
+	}
+
 	if app.Flags().Report {
 		fmt.Fprintln(writer, ReportBlock(err))
 	}
 
 	return 1
+}
+
+// ErrorDetail is everything known about a failure, for --verbose.
+//
+// Ports formatErrorForLog (parser.ts:847) and its ERROR_DETAIL_KEYS -- `code`,
+// `type`, `response` -- to what Go actually has. A Go error carries no stack, so
+// the UNWRAP CHAIN stands in for one: each layer names where the failure was
+// wrapped, which is the same question a stack answers.
+//
+// The response body is the reason this exists. internal/sdk records the last
+// one, and a decode failure never renders, so the body that could not be decoded
+// is still sitting there when this runs -- and it is the only thing that tells
+// the user whether the API changed shape or the CLI has the model wrong.
+func ErrorDetail(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var builder strings.Builder
+	builder.WriteString("\n" + output.Heading("Error detail") + "\n\n")
+
+	fmt.Fprintf(&builder, "  %-10s %T\n", "type:", err)
+
+	var appwrite apiError
+	if errors.As(err, &appwrite) {
+		fmt.Fprintf(&builder, "  %-10s %d\n", "status:", appwrite.GetStatusCode())
+	}
+
+	// The chain, outermost first, skipping the layer already printed as the
+	// message above.
+	for wrapped := errors.Unwrap(err); wrapped != nil; wrapped = errors.Unwrap(wrapped) {
+		fmt.Fprintf(&builder, "  %-10s %s\n", "wrapped:", wrapped)
+	}
+
+	if response := sdk.LastResponse.Take(); len(response) > 0 {
+		builder.WriteString("\n" + output.Heading("Response") + "\n\n")
+		builder.WriteString(indentBlock(prettyJSON(response)))
+	}
+
+	return builder.String() + "\n"
+}
+
+// prettyJSON re-indents a body, and returns it untouched when it is not JSON.
+//
+// A body that is not JSON is exactly the case that matters most -- an HTML error
+// page, a proxy's plain-text refusal -- so failing to parse it must print it,
+// not swallow it.
+func prettyJSON(body []byte) string {
+	var indented bytes.Buffer
+	if err := json.Indent(&indented, body, "", "  "); err != nil {
+		return string(body)
+	}
+
+	return indented.String()
+}
+
+// indentBlock shifts a block two spaces right, to sit under its heading.
+func indentBlock(text string) string {
+	lines := strings.Split(strings.TrimRight(text, "\n"), "\n")
+	for index, line := range lines {
+		lines[index] = "  " + line
+	}
+
+	return strings.Join(lines, "\n") + "\n"
 }
 
 // detailWasRequested reports whether the user asked for the detail the advice

--- a/templates/go-cli/internal/cmd/errors.go
+++ b/templates/go-cli/internal/cmd/errors.go
@@ -3,12 +3,16 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"runtime"
 	"strings"
 
 	"github.com/appwrite/appwrite-cli-go/internal/app"
+	"github.com/appwrite/appwrite-cli-go/internal/output"
+	"github.com/appwrite/appwrite-cli-go/internal/prompt"
+	"github.com/spf13/cobra"
 )
 
 // apiError is what the SDK's AppwriteError provides.
@@ -126,6 +130,67 @@ func ReportBlock(err error) string {
 	return "To report this error you can:\n" +
 		" - Create a support ticket in our Discord server https://appwrite.io/discord\n" +
 		" - Create an issue in our Github\n   " + ReportURL(err)
+}
+
+// ExitCancelled is the status a cancelled prompt exits with: 128 + SIGINT,
+// which is what a shell reports for a program the user interrupted.
+//
+// Distinct from 1 on purpose. Answering "no" to a prompt, or walking away from
+// one, is not the same outcome as a command that failed, and a script driving
+// the CLI should be able to tell them apart.
+const ExitCancelled = 130
+
+// IsCancelled reports whether a command stopped because the user cancelled a
+// prompt rather than because anything went wrong.
+func IsCancelled(err error) bool {
+	return errors.Is(err, prompt.ErrAborted)
+}
+
+// Report renders a command failure and returns the status the process should
+// exit with.
+//
+// Lives here rather than in main so it can be exercised: the difference between
+// what a user sees for a cancelled prompt and for a failed request is the whole
+// point of it, and main() is not reachable from a test.
+//
+// Ports the tail of parseError (parser.ts:936).
+func Report(writer io.Writer, executed *cobra.Command, err error) int {
+	if err == nil {
+		return 0
+	}
+
+	if IsCancelled(err) {
+		output.Warn(writer, "%s", CancellationNotice(executed))
+
+		return ExitCancelled
+	}
+
+	// Skipped once the user has already asked for the detail it points at.
+	if !app.Flags().Verbose && !app.Flags().Report {
+		output.Log(writer, "For detailed error pass the --verbose or --report flag")
+	}
+
+	output.Failure(writer, "%s", FormatError(err))
+
+	if app.Flags().Report {
+		fmt.Fprintln(writer, ReportBlock(err))
+	}
+
+	return 1
+}
+
+// CancellationNotice is the line printed for a cancelled prompt.
+//
+// Names the command, because a prompt can be several screens into a flow --
+// `push` asks three questions -- so "Cancelled." alone leaves the user to work
+// out what they just abandoned. The command's PATH, not the arguments: those
+// can carry an API key, and this line may end up in a log.
+func CancellationNotice(command *cobra.Command) string {
+	if command == nil {
+		return "Cancelled. Nothing further was sent."
+	}
+
+	return fmt.Sprintf("Cancelled `%s`. Nothing further was sent.", command.CommandPath())
 }
 
 // commandArguments is the invocation, minus the flag that asked for the report.

--- a/templates/go-cli/internal/cmd/errors.go
+++ b/templates/go-cli/internal/cmd/errors.go
@@ -160,7 +160,9 @@ func Report(writer io.Writer, executed *cobra.Command, err error) int {
 	}
 
 	if IsCancelled(err) {
-		output.Warn(writer, "%s", CancellationNotice(executed))
+		// Note, not Warn: nothing is wrong. Prefixing a deliberate Ctrl-C with
+		// "Warning" told the user off for their own decision.
+		output.Note(writer, "%s", CancellationNotice(executed))
 
 		return ExitCancelled
 	}

--- a/templates/go-cli/internal/cmd/errors_test.go
+++ b/templates/go-cli/internal/cmd/errors_test.go
@@ -244,3 +244,47 @@ func TestReportDistinguishesCancellationFromFailure(t *testing.T) {
 		t.Errorf("no error exited %d, want 0", status)
 	}
 }
+
+// A command that fails DURING parsing never reaches the later flags, so the
+// parsed globals cannot answer "did the user ask for detail". `users get
+// --bogus --verbose` stopped at --bogus and then advised passing --verbose.
+func TestDetailIsRecognisedFromTheArgumentsWhenParsingFailed(t *testing.T) {
+	cases := map[string]bool{
+		"users get --bogus --verbose": true,
+		"users get --bogus --report":  true,
+		"users get --bogus -V":        true,
+		"users get --bogus -jV":       true,
+		"users get --bogus":           false,
+		"users get --bogus -j":        false,
+		// After `--` it is a value, not a flag.
+		"users get -- --verbose": false,
+		"users get -":            false,
+	}
+
+	for invocation, want := range cases {
+		restore := os.Args
+		os.Args = append([]string{"appwrite"}, strings.Fields(invocation)...)
+
+		got := detailWasRequested()
+		os.Args = restore
+
+		if got != want {
+			t.Errorf("detailWasRequested() = %v for `appwrite %s`, want %v",
+				got, invocation, want)
+		}
+	}
+}
+
+// And the hint really does disappear from the rendered output.
+func TestTheHintIsNotPrintedWhenTheUserAlreadyAskedForDetail(t *testing.T) {
+	restore := os.Args
+	os.Args = []string{"appwrite", "users", "get", "--bogus", "--verbose"}
+	t.Cleanup(func() { os.Args = restore })
+
+	buffer := &bytes.Buffer{}
+	Report(buffer, nil, errors.New("unknown flag: --bogus"))
+
+	if strings.Contains(buffer.String(), "For detailed error") {
+		t.Errorf("advised passing a flag that is already in the invocation:\n%s", buffer.String())
+	}
+}

--- a/templates/go-cli/internal/cmd/errors_test.go
+++ b/templates/go-cli/internal/cmd/errors_test.go
@@ -217,9 +217,13 @@ func TestReportDistinguishesCancellationFromFailure(t *testing.T) {
 	if status := Report(cancelled, login, prompt.ErrAborted); status != ExitCancelled {
 		t.Errorf("cancellation exited %d, want %d", status, ExitCancelled)
 	}
-	if got := cancelled.String(); strings.Contains(got, "--verbose") ||
-		strings.Contains(got, "--report") || strings.Contains(got, "Error") {
-		t.Errorf("a cancelled prompt reads as a failure:\n%s", got)
+	// Nothing that reads as a diagnostic: no advice about flags, no "Error",
+	// and no "Warning" either -- the user cancelled on purpose.
+	for _, unwanted := range []string{"--verbose", "--report", "Error", "Warning", "Info"} {
+		if strings.Contains(cancelled.String(), unwanted) {
+			t.Errorf("a cancelled prompt reads as a problem (%q):\n%s",
+				unwanted, cancelled.String())
+		}
 	}
 	if !strings.Contains(cancelled.String(), "Cancelled") {
 		t.Errorf("cancellation notice missing:\n%s", cancelled.String())

--- a/templates/go-cli/internal/cmd/errors_test.go
+++ b/templates/go-cli/internal/cmd/errors_test.go
@@ -1,10 +1,15 @@
 package cmd
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/appwrite/appwrite-cli-go/internal/prompt"
 )
 
 // A proxy 502 or a maintenance page is an HTML document, and the SDK puts a
@@ -145,5 +150,97 @@ func TestReportURLIsBounded(t *testing.T) {
 func TestReportURLIsEmptyWithoutAnError(t *testing.T) {
 	if got := ReportURL(nil); got != "" {
 		t.Errorf("ReportURL(nil) = %q, want empty", got)
+	}
+}
+
+// A cancelled prompt used to reach the same path as a failed request: the bare
+// error string "prompt cancelled" on stderr, under the same advice about
+// --verbose and --report. Nothing had gone wrong -- the user had pressed
+// Ctrl-C -- so the CLI was suggesting they file a bug about their own decision.
+func TestCancellationIsToldApartFromAFailure(t *testing.T) {
+	if !IsCancelled(fmt.Errorf("switching accounts: %w", prompt.ErrAborted)) {
+		t.Error("a wrapped ErrAborted is not recognised as a cancellation")
+	}
+	if IsCancelled(errors.New("network unreachable")) {
+		t.Error("an ordinary error is being treated as a cancellation")
+	}
+	if IsCancelled(appwriteError(500, "internal error")) {
+		t.Error("an API error is being treated as a cancellation")
+	}
+}
+
+// 130 is 128 + SIGINT: what a shell reports for an interrupted program, and
+// distinct from the 1 a real failure exits with.
+func TestCancellationExitsWithTheInterruptStatus(t *testing.T) {
+	if ExitCancelled != 130 {
+		t.Errorf("ExitCancelled = %d, want 130", ExitCancelled)
+	}
+}
+
+// The notice names the command but must never echo the arguments: `client
+// --key <secret>` is a prompt away from printing an API key into whatever is
+// capturing stderr.
+func TestCancellationNoticeNamesTheCommandWithoutItsArguments(t *testing.T) {
+	root := NewRootCommand()
+	login := resolveCommand(root, "login")
+	if login == nil {
+		t.Fatal("`login` is missing")
+	}
+
+	notice := CancellationNotice(login)
+
+	if !strings.Contains(notice, "appwrite login") {
+		t.Errorf("notice %q does not name the command", notice)
+	}
+	if !strings.Contains(notice, "Cancelled") {
+		t.Errorf("notice %q does not say it was cancelled", notice)
+	}
+
+	// Nothing from the invocation itself.
+	for _, argument := range os.Args[1:] {
+		if argument != "" && strings.Contains(notice, argument) {
+			t.Errorf("notice %q echoes the argument %q", notice, argument)
+		}
+	}
+
+	if fallback := CancellationNotice(nil); !strings.Contains(fallback, "Cancelled") {
+		t.Errorf("notice for an unknown command = %q", fallback)
+	}
+}
+
+// The whole point of Report is that these two outcomes do not look alike.
+func TestReportDistinguishesCancellationFromFailure(t *testing.T) {
+	root := NewRootCommand()
+	login := resolveCommand(root, "login")
+
+	cancelled := &bytes.Buffer{}
+	if status := Report(cancelled, login, prompt.ErrAborted); status != ExitCancelled {
+		t.Errorf("cancellation exited %d, want %d", status, ExitCancelled)
+	}
+	if got := cancelled.String(); strings.Contains(got, "--verbose") ||
+		strings.Contains(got, "--report") || strings.Contains(got, "Error") {
+		t.Errorf("a cancelled prompt reads as a failure:\n%s", got)
+	}
+	if !strings.Contains(cancelled.String(), "Cancelled") {
+		t.Errorf("cancellation notice missing:\n%s", cancelled.String())
+	}
+
+	failed := &bytes.Buffer{}
+	if status := Report(failed, login, errors.New("network unreachable")); status != 1 {
+		t.Errorf("failure exited %d, want 1", status)
+	}
+	got := failed.String()
+	if !strings.Contains(got, "✗ Error:") {
+		t.Errorf("a failure is missing the error prefix the TypeScript prints:\n%s", got)
+	}
+	if !strings.Contains(got, "network unreachable") {
+		t.Errorf("a failure does not say what went wrong:\n%s", got)
+	}
+	if !strings.Contains(got, "--verbose") {
+		t.Errorf("a failure does not point at --verbose:\n%s", got)
+	}
+
+	if status := Report(&bytes.Buffer{}, login, nil); status != 0 {
+		t.Errorf("no error exited %d, want 0", status)
 	}
 }

--- a/templates/go-cli/internal/cmd/fanout_test.go
+++ b/templates/go-cli/internal/cmd/fanout_test.go
@@ -2,12 +2,15 @@ package cmd
 
 import (
 	"bytes"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 
 	"github.com/appwrite/appwrite-cli-go/internal/app"
+	"github.com/appwrite/appwrite-cli-go/internal/client"
 	"github.com/appwrite/appwrite-cli-go/internal/config"
 	"github.com/appwrite/appwrite-cli-go/internal/jsonx"
 	"github.com/appwrite/appwrite-cli-go/internal/prompt"
@@ -245,32 +248,14 @@ func TestPushAllNeverAsksForAMissingEntrypoint(t *testing.T) {
 	app.Flags().All = true
 	t.Cleanup(func() { app.Flags().All = restore })
 
-	complete := jsonx.NewObject()
-	complete.Set("$id", "ready")
-	complete.Set("name", "Ready")
-	complete.Set("entrypoint", "src/main.js")
+	// 404: neither function exists yet, so the entrypoint is required.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"not found","code":404}`))
+	}))
+	t.Cleanup(server.Close)
 
-	incomplete := jsonx.NewObject()
-	incomplete.Set("$id", "bare")
-	incomplete.Set("name", "Bare")
-
-	local, err := config.LoadOrCreateLocal(filepath.Join(t.TempDir(), config.LocalFileName))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	context := &pushContext{local: local, prompter: refusingPrompter{t: t}}
-
-	out := &bytes.Buffer{}
-	usable, err := context.completeDeployables(out, deployable{
-		Name:      "function",
-		Singular:  "Function",
-		Label:     "functions",
-		ConfigKey: "functions",
-	}, []*jsonx.Object{complete, incomplete})
-	if err != nil {
-		t.Fatal(err)
-	}
+	usable, out := completeFunctions(t, server.URL, refusingPrompter{t: t})
 
 	if len(usable) != 1 || usable[0].GetString("$id") != "ready" {
 		t.Errorf("push kept %d of 2 functions, want only the complete one", len(usable))
@@ -285,6 +270,105 @@ func TestPushAllNeverAsksForAMissingEntrypoint(t *testing.T) {
 	}
 }
 
+// The API requires an entrypoint for neither create nor update -- `functions
+// create` asks for function-id, name and runtime only. So a blank entrypoint on
+// a function that already exists is not an error: it has nothing to say about
+// the field, and the value on the server stands.
+func TestAnExistingFunctionNeedsNoEntrypoint(t *testing.T) {
+	restore := app.Flags().All
+	app.Flags().All = false
+	t.Cleanup(func() { app.Flags().All = restore })
+
+	// 200: both functions are already there, so neither is a create.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"$id":"bare","entrypoint":"src/main.js"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	usable, out := completeFunctions(t, server.URL, refusingPrompter{t: t})
+
+	if len(usable) != 2 {
+		t.Errorf("push kept %d of 2 functions, want both -- an update needs no entrypoint", len(usable))
+	}
+	if !strings.Contains(out.String(), "Keeping the one on the server") {
+		t.Errorf("the reason for not asking was not explained:\n%s", out.String())
+	}
+}
+
+// completeFunctions runs the validation step over one complete and one
+// entrypoint-less function.
+func completeFunctions(
+	t *testing.T,
+	endpoint string,
+	prompter prompt.Prompter,
+) ([]*jsonx.Object, *bytes.Buffer) {
+	t.Helper()
+
+	complete := jsonx.NewObject()
+	complete.Set("$id", "ready")
+	complete.Set("name", "Ready")
+	complete.Set("entrypoint", "src/main.js")
+
+	incomplete := jsonx.NewObject()
+	incomplete.Set("$id", "bare")
+	incomplete.Set("name", "Bare")
+
+	local, err := config.LoadOrCreateLocal(filepath.Join(t.TempDir(), config.LocalFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	context := &pushContext{
+		api:      client.New(endpoint, "test"),
+		local:    local,
+		prompter: prompter,
+	}
+
+	out := &bytes.Buffer{}
+	usable, err := context.completeDeployables(out, deployable{
+		Name:      "function",
+		Singular:  "function",
+		Label:     "functions",
+		ConfigKey: "functions",
+		Path:      "/functions",
+	}, []*jsonx.Object{complete, incomplete})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return usable, out
+}
+
+// An empty entrypoint means "unchanged", so it must not be sent -- the server
+// would take "" as the new value and clear what is already there. Not every
+// blank field: an empty `schedule` really does mean "unschedule it".
+func TestAnEmptyEntrypointIsNotSent(t *testing.T) {
+	entry := jsonx.NewObject()
+	entry.Set("name", "Bare")
+	entry.Set("entrypoint", "")
+	entry.Set("schedule", "")
+
+	body := writeBody(entry, []string{"name", "entrypoint", "schedule"},
+		[]string{"entrypoint"}, "", "")
+
+	if _, ok := body.Get("entrypoint"); ok {
+		t.Error("an empty entrypoint was sent, which clears the one on the server")
+	}
+	if _, ok := body.Get("schedule"); !ok {
+		t.Error("an empty schedule was dropped, but clearing a schedule is meaningful")
+	}
+	if body.GetString("name") != "Bare" {
+		t.Error("a non-empty field was dropped")
+	}
+
+	// A real entrypoint still goes.
+	entry.Set("entrypoint", "src/main.js")
+	if got := writeBody(entry, []string{"entrypoint"}, []string{"entrypoint"}, "", "").
+		GetString("entrypoint"); got != "src/main.js" {
+		t.Errorf("entrypoint = %q, want it sent", got)
+	}
+}
+
 // refusingPrompter fails the test if anything asks it a question.
 type refusingPrompter struct {
 	prompt.Prompter
@@ -292,7 +376,7 @@ type refusingPrompter struct {
 }
 
 func (r refusingPrompter) Text(question prompt.Text) (string, error) {
-	r.t.Errorf("prompted for %q under --all", question.Message)
+	r.t.Errorf("prompted for %q", question.Message)
 
 	return "", nil
 }

--- a/templates/go-cli/internal/cmd/fanout_test.go
+++ b/templates/go-cli/internal/cmd/fanout_test.go
@@ -1,11 +1,16 @@
 package cmd
 
 import (
+	"bytes"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 
 	"github.com/appwrite/appwrite-cli-go/internal/app"
+	"github.com/appwrite/appwrite-cli-go/internal/config"
+	"github.com/appwrite/appwrite-cli-go/internal/jsonx"
+	"github.com/appwrite/appwrite-cli-go/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -226,4 +231,68 @@ func assertRanEverything(t *testing.T, ran []string) {
 	if slices.Contains(ran, "collections") {
 		t.Error("collections ran, but `all` skips the legacy databases API")
 	}
+}
+
+// `push function --all` asked "Enter the entrypoint" for any function whose
+// config had none. --all says "every resource, do not ask me", and it is how a
+// pipeline pushes, so a question there is the opposite of what was asked -- and
+// the answer is data the CLI cannot invent.
+//
+// The function is reported and skipped now, and the rest of the push proceeds.
+// The prompter here fails the test if it is reached at all.
+func TestPushAllNeverAsksForAMissingEntrypoint(t *testing.T) {
+	restore := app.Flags().All
+	app.Flags().All = true
+	t.Cleanup(func() { app.Flags().All = restore })
+
+	complete := jsonx.NewObject()
+	complete.Set("$id", "ready")
+	complete.Set("name", "Ready")
+	complete.Set("entrypoint", "src/main.js")
+
+	incomplete := jsonx.NewObject()
+	incomplete.Set("$id", "bare")
+	incomplete.Set("name", "Bare")
+
+	local, err := config.LoadOrCreateLocal(filepath.Join(t.TempDir(), config.LocalFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	context := &pushContext{local: local, prompter: refusingPrompter{t: t}}
+
+	out := &bytes.Buffer{}
+	usable, err := context.completeDeployables(out, deployable{
+		Name:      "function",
+		Singular:  "Function",
+		Label:     "functions",
+		ConfigKey: "functions",
+	}, []*jsonx.Object{complete, incomplete})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(usable) != 1 || usable[0].GetString("$id") != "ready" {
+		t.Errorf("push kept %d of 2 functions, want only the complete one", len(usable))
+	}
+
+	printed := out.String()
+	if !strings.Contains(printed, "Bare") || !strings.Contains(printed, "entrypoint") {
+		t.Errorf("the skipped function was not explained:\n%s", printed)
+	}
+	if !strings.Contains(printed, config.LocalFileName) {
+		t.Errorf("the message does not say where to set it:\n%s", printed)
+	}
+}
+
+// refusingPrompter fails the test if anything asks it a question.
+type refusingPrompter struct {
+	prompt.Prompter
+	t *testing.T
+}
+
+func (r refusingPrompter) Text(question prompt.Text) (string, error) {
+	r.t.Errorf("prompted for %q under --all", question.Message)
+
+	return "", nil
 }

--- a/templates/go-cli/internal/cmd/help.go.twig
+++ b/templates/go-cli/internal/cmd/help.go.twig
@@ -418,6 +418,10 @@ const helpMinimumColumns = 2
 // instead of only at 80 -- checked against commander itself for every width from
 // 6 to 80.
 func wrapHelpText(text string, columns int, indent string) string {
+	// A DELIBERATE deviation: commander returns the indent for an empty or
+	// all-whitespace description, which puts a line of trailing spaces on the
+	// screen. Nothing generated has an empty description, and a blank line is
+	// worse than no line.
 	if strings.TrimSpace(text) == "" {
 		return ""
 	}
@@ -468,7 +472,12 @@ func wrapChunks(text string, limit int) []string {
 			}
 		}
 
-		chunks = append(chunks, strings.TrimRight(text[position:position+length], " "))
+		// A run of consecutive spaces yields a chunk that is nothing but
+		// whitespace. commander never emits a blank line for one, so neither
+		// does this.
+		if chunk := strings.TrimRight(text[position:position+length], " "); chunk != "" {
+			chunks = append(chunks, chunk)
+		}
 
 		// The break character itself is consumed.
 		position += length + 1

--- a/templates/go-cli/internal/cmd/help.go.twig
+++ b/templates/go-cli/internal/cmd/help.go.twig
@@ -394,31 +394,91 @@ func optionTerm(flag *pflag.Flag) string {
 	return term
 }
 
-// wrapHelpText greedily wraps to columns and indents every line, including the
-// first. Mirrors commander's Help.wrap, which is what produces the paragraph
-// under the logo.
+// helpMinimumColumns is the narrowest column the paragraph is wrapped into.
+//
+// commander's Help.wrap takes a minColumnWidth and returns the string unwrapped
+// below it. Its default is 40, but help.ts passes 2 deliberately
+// (`helper.wrap(description, width - 2, 2, 2)`), so the TypeScript screen keeps
+// wrapping all the way down -- a 20-column terminal gets a dozen short lines
+// rather than one running off the edge. Matched here, which also keeps a
+// terminal reporting 3 columns from reaching the loop with a negative width.
+const helpMinimumColumns = 2
+
+// wrapHelpText reproduces commander's Help.wrap for the paragraph under the
+// logo, including two behaviours that a from-scratch word wrap does not have.
+//
+// FIRST, a line holds columns-1 characters, not columns: the regex is
+// `.{1,columnWidth - 1}([\s\u200B]|$)`, which takes up to columnWidth-1
+// characters and then eats the space after them.
+//
+// SECOND, commander splits the string at `indent` and wraps only the remainder
+// (`leadingStr = str.slice(0, indent)`), so the FIRST line carries two extra
+// characters that were never measured. That is a quirk rather than a design, but
+// reproducing it is what makes the two CLIs' screens identical at every width
+// instead of only at 80 -- checked against commander itself for every width from
+// 6 to 80.
 func wrapHelpText(text string, columns int, indent string) string {
-	words := strings.Fields(text)
-	if len(words) == 0 {
+	if strings.TrimSpace(text) == "" {
 		return ""
 	}
 
-	lines := []string{words[0]}
-	for _, word := range words[1:] {
-		last := len(lines) - 1
-		if len(lines[last])+1+len(word) <= columns {
-			lines[last] += " " + word
+	if columns < helpMinimumColumns {
+		return indent + text
+	}
 
-			continue
+	// commander's `indent` argument, which help.ts passes as 2 -- the same width
+	// as the indent it prefixes the result with.
+	unmeasured := len(indent)
+	if len(text) <= unmeasured {
+		return indent + text
+	}
+
+	chunks := wrapChunks(text[unmeasured:], columns-1)
+
+	wrapped := indent + text[:unmeasured] + chunks[0]
+	for _, chunk := range chunks[1:] {
+		wrapped += "\n" + indent + chunk
+	}
+
+	return wrapped
+}
+
+// wrapChunks splits text the way commander's regex does: at each position, the
+// longest run of at most limit characters that is followed by a space or by the
+// end of the string; failing that, the next whole word, however long.
+func wrapChunks(text string, limit int) []string {
+	chunks := make([]string, 0, 8)
+
+	for position := 0; position < len(text); {
+		length := 0
+		for candidate := min(limit, len(text)-position); candidate >= 1; candidate-- {
+			if position+candidate == len(text) || text[position+candidate] == ' ' {
+				length = candidate
+
+				break
+			}
 		}
-		lines = append(lines, word)
+
+		if length == 0 {
+			// A word longer than the column: the regex's second alternative
+			// takes it whole rather than breaking it.
+			length = strings.IndexByte(text[position:], ' ')
+			if length < 0 {
+				length = len(text) - position
+			}
+		}
+
+		chunks = append(chunks, strings.TrimRight(text[position:position+length], " "))
+
+		// The break character itself is consumed.
+		position += length + 1
 	}
 
-	for index := range lines {
-		lines[index] = indent + lines[index]
+	if len(chunks) == 0 {
+		return []string{""}
 	}
 
-	return strings.Join(lines, "\n")
+	return chunks
 }
 
 func pad(value string, width int) string {

--- a/templates/go-cli/internal/cmd/help.go.twig
+++ b/templates/go-cli/internal/cmd/help.go.twig
@@ -217,7 +217,14 @@ func RenderMainHelp(root *cobra.Command) string {
 	for _, section := range sections {
 		lines = append(lines, "", helpTitleStyle.Render(section.title))
 		for _, row := range section.rows {
-			line := helpIndent + pad(row.name, nameWidth) + strings.Repeat(" ", helpGap) + row.summary
+			// TrimRight because a command whose description the spec leaves empty
+			// has no summary, and the padded name would then end the line in
+			// whitespace. The TypeScript pads unconditionally, but it has a
+			// summary for everything it lists, so this cannot make the two
+			// screens differ -- it only keeps the Go one clean where a service
+			// arrives without a description.
+			line := strings.TrimRight(
+				helpIndent+pad(row.name, nameWidth)+strings.Repeat(" ", helpGap)+row.summary, " ")
 			if section.dim {
 				line = helpDimStyle.Render(line)
 			}
@@ -371,8 +378,8 @@ func renderHelpOptions(root *cobra.Command) string {
 
 	lines := make([]string, 0, len(options))
 	for _, entry := range options {
-		lines = append(lines,
-			helpIndent+pad(entry.term, termWidth)+strings.Repeat(" ", helpGap)+entry.usage)
+		lines = append(lines, strings.TrimRight(
+			helpIndent+pad(entry.term, termWidth)+strings.Repeat(" ", helpGap)+entry.usage, " "))
 	}
 
 	return strings.Join(lines, "\n")

--- a/templates/go-cli/internal/cmd/help.go.twig
+++ b/templates/go-cli/internal/cmd/help.go.twig
@@ -1,0 +1,430 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"golang.org/x/term"
+)
+
+// The main help screen, ported from templates/cli/lib/help.ts.
+//
+// cobra's default screen lists every command alphabetically with its full API
+// description, which for this CLI is 40-odd services and a paragraph each. The
+// TypeScript CLI groups them by intent instead and gives each a one-line
+// summary, so the first thing a new user sees is the eight commands that
+// actually get them started.
+//
+// The groups, the summaries and the option order below are generated from
+// CliCommandSurface::HELP_GROUPS, ::HELP_SUMMARIES and ::HELP_OPTION_ORDER --
+// the same tables help.ts is generated from, so the two screens cannot drift.
+
+// helpGroup is one titled section of the listing.
+type helpGroup struct {
+	title string
+	// dim greys the whole section, which is what DEPRECATED is for.
+	dim bool
+	// commands are paths as typed, so a promoted root command such as
+	// `list-projects` can sit beside `login`.
+	commands []string
+}
+
+var helpGroups = []helpGroup{
+{% for group in cliHelpGroups() %}
+	{
+		title: {{ group.title | goString | raw }},
+{% if group.dim %}
+		dim:   true,
+{% endif %}
+		commands: []string{
+{% for command in group.commands %}
+			{{ command | goString | raw }},
+{% endfor %}
+		},
+	},
+{% endfor %}
+}
+
+// helpSummaries are the one-line summaries for the listing. A command's own
+// Short and Long stay the longer form shown on its own help page.
+{#
+    Keys are padded to gofmt's column so the generated file is already
+    formatted -- `gofmt -l` is part of the Go CLI's checks, and it aligns the
+    values of a map literal.
+#}
+{% set keyWidth = 0 %}
+{% for command in cliHelpSummaries(spec.title | caseUcfirst) | keys %}
+{% if command | length > keyWidth %}{% set keyWidth = command | length %}{% endif %}
+{% endfor %}
+var helpSummaries = map[string]string{
+{% for command, summary in cliHelpSummaries(spec.title | caseUcfirst) %}
+	{{ ('%-' ~ (keyWidth + 3) ~ 's') | format((command | goString | raw) ~ ':') | raw }} {{ summary | goString | raw }},
+{% endfor %}
+}
+
+// helpOptionOrder is the order of the global flags, by long flag. Anything
+// unlisted is appended, alphabetically.
+var helpOptionOrder = []string{
+{% for flag in cliHelpOptionOrder() %}
+	{{ flag | goString | raw }},
+{% endfor %}
+}
+
+// helpLogo is the ASCII art above the screen.
+const helpLogo = {{ language.params.logo | goString | raw }}
+
+// helpDescription is the paragraph under the logo.
+const helpDescription = {{ sdk.description | goString | raw }}
+
+const (
+	// helpMaxWidth caps the screen on a wide terminal: a summary column that
+	// runs to 200 columns is harder to read, not easier.
+	helpMaxWidth = 80
+	helpGap      = 2
+	helpIndent   = "  "
+)
+
+var (
+	helpLogoStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
+	helpTitleStyle = lipgloss.NewStyle().Bold(true)
+	helpDimStyle   = lipgloss.NewStyle().Faint(true)
+)
+
+// registerMainHelp replaces cobra's help screen for the ROOT command only.
+//
+// A help function is inherited, so this has to fall back to the one cobra
+// installed for anything below the root -- `appwrite users --help` is a listing
+// of that service, which cobra already renders well.
+func registerMainHelp(root *cobra.Command) {
+	// Captured before the override, so it is cobra's own implementation rather
+	// than this function calling itself.
+	fallback := root.HelpFunc()
+
+	// cobra adds both of these lazily, and their generated usage text reads
+	// "help for appwrite". Force them now so the wording is ours and so
+	// --version and --help appear in OPTIONS at all.
+	root.InitDefaultHelpFlag()
+	root.InitDefaultVersionFlag()
+	if flag := root.Flags().Lookup("help"); flag != nil {
+		flag.Usage = "Display help for a command"
+	}
+	if flag := root.Flags().Lookup("version"); flag != nil {
+		flag.Usage = "Output the CLI version"
+	}
+
+	root.SetHelpFunc(func(command *cobra.Command, arguments []string) {
+		if command != root {
+			fallback(command, arguments)
+
+			return
+		}
+
+		fmt.Fprint(command.OutOrStdout(), RenderMainHelp(root))
+	})
+}
+
+// helpRow is one line of a section: the command as typed and its summary.
+type helpRow struct {
+	name    string
+	summary string
+}
+
+type helpSection struct {
+	title string
+	dim   bool
+	rows  []helpRow
+}
+
+// RenderMainHelp builds the screen. Exported so a test can assert it without
+// going through cobra's help plumbing.
+func RenderMainHelp(root *cobra.Command) string {
+	width := helpWidth()
+
+	sections := make([]helpSection, 0, len(helpGroups)+1)
+	claimed := map[string]bool{}
+
+	for _, group := range helpGroups {
+		rows := make([]helpRow, 0, len(group.commands))
+		for _, path := range group.commands {
+			claimed[path] = true
+
+			// A group names commands the spec may not produce -- an exclusion
+			// list, or an older API version -- so a missing one is skipped
+			// rather than printed as an empty row.
+			child := resolveCommand(root, path)
+			if child == nil || !isListedInHelp(child) {
+				continue
+			}
+
+			rows = append(rows, helpRow{name: path, summary: summaryOf(child, path)})
+		}
+
+		if len(rows) > 0 {
+			sections = append(sections, helpSection{title: group.title, dim: group.dim, rows: rows})
+		}
+	}
+
+	// Anything the tables do not name still appears, so a command added to the
+	// CLI or a service added to the spec can never silently vanish from --help.
+	other := make([]helpRow, 0)
+	for _, child := range root.Commands() {
+		if !isListedInHelp(child) || claimed[child.Name()] {
+			continue
+		}
+
+		other = append(other, helpRow{name: child.Name(), summary: summaryOf(child, child.Name())})
+	}
+	if len(other) > 0 {
+		sections = append(sections, helpSection{title: "OTHER", rows: other})
+	}
+
+	// One column across every section, so the summaries line up down the whole
+	// screen rather than per group.
+	nameWidth := 0
+	for _, section := range sections {
+		for _, row := range section.rows {
+			if length := len(row.name); length > nameWidth {
+				nameWidth = length
+			}
+		}
+	}
+
+	lines := []string{
+		renderLogo(),
+		"",
+		wrapHelpText(helpDescription, width-helpGap-helpGap, helpIndent),
+		"",
+		helpTitleStyle.Render("USAGE"),
+		helpIndent + root.Name() + " [options] <command> [subcommand]",
+	}
+
+	for _, section := range sections {
+		lines = append(lines, "", helpTitleStyle.Render(section.title))
+		for _, row := range section.rows {
+			line := helpIndent + pad(row.name, nameWidth) + strings.Repeat(" ", helpGap) + row.summary
+			if section.dim {
+				line = helpDimStyle.Render(line)
+			}
+			lines = append(lines, line)
+		}
+	}
+
+	lines = append(lines,
+		"",
+		helpTitleStyle.Render("OPTIONS"),
+		renderHelpOptions(root),
+		"",
+		helpDimStyle.Render(fmt.Sprintf(
+			"Run `%s <command> --help` for details on a specific command.", root.Name())),
+		"",
+	)
+
+	return strings.Join(lines, "\n")
+}
+
+// renderLogo colours the ASCII art a line at a time.
+//
+// Not one Render of the whole block: lipgloss pads every line of a multi-line
+// block out to the width of the widest one, which leaves trailing spaces on
+// most of the art. Invisible on a terminal, but it makes the screen impossible
+// to compare against the TypeScript CLI's byte for byte.
+func renderLogo() string {
+	lines := strings.Split(strings.TrimRight(helpLogo, "\n"), "\n")
+	for index, line := range lines {
+		lines[index] = helpLogoStyle.Render(line)
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// resolveCommand walks a space-separated path against the tree, matching a name
+// or any alias, and returns nil if any segment is missing.
+func resolveCommand(root *cobra.Command, path string) *cobra.Command {
+	current := root
+
+	for _, segment := range strings.Split(path, " ") {
+		var found *cobra.Command
+		for _, child := range current.Commands() {
+			if child.Name() == segment {
+				found = child
+
+				break
+			}
+			for _, alias := range child.Aliases {
+				if alias == segment {
+					found = child
+
+					break
+				}
+			}
+			if found != nil {
+				break
+			}
+		}
+
+		if found == nil {
+			return nil
+		}
+		current = found
+	}
+
+	if current == root {
+		return nil
+	}
+
+	return current
+}
+
+// isListedInHelp mirrors cobra's IsAvailableCommand, minus its own `help`.
+func isListedInHelp(command *cobra.Command) bool {
+	return command.Name() != "help" && !command.Hidden && !command.IsAdditionalHelpTopicCommand()
+}
+
+// summaryOf prefers the declared summary, then the command's own Short, then
+// the first sentence of its Long -- so a command with no summary still reads as
+// one line rather than as a paragraph.
+func summaryOf(command *cobra.Command, path string) string {
+	if declared, ok := helpSummaries[path]; ok {
+		return declared
+	}
+
+	if command.Short != "" {
+		return firstSentence(command.Short)
+	}
+
+	return firstSentence(command.Long)
+}
+
+func firstSentence(text string) string {
+	if index := strings.Index(text, ". "); index >= 0 {
+		text = text[:index]
+	}
+
+	return strings.TrimSuffix(strings.TrimSpace(text), ".")
+}
+
+// renderHelpOptions lists the root's flags in helpOptionOrder.
+func renderHelpOptions(root *cobra.Command) string {
+	type option struct {
+		term  string
+		usage string
+		rank  int
+		name  string
+	}
+
+	options := make([]option, 0)
+	collect := func(flag *pflag.Flag) {
+		if flag.Hidden {
+			return
+		}
+
+		rank := len(helpOptionOrder)
+		for index, long := range helpOptionOrder {
+			if long == "--"+flag.Name {
+				rank = index
+
+				break
+			}
+		}
+
+		options = append(options, option{
+			term:  optionTerm(flag),
+			usage: flag.Usage,
+			rank:  rank,
+			name:  flag.Name,
+		})
+	}
+	root.PersistentFlags().VisitAll(collect)
+	// --version and --help are local to the root rather than persistent.
+	root.LocalNonPersistentFlags().VisitAll(collect)
+
+	sort.SliceStable(options, func(left, right int) bool {
+		if options[left].rank != options[right].rank {
+			return options[left].rank < options[right].rank
+		}
+
+		return options[left].name < options[right].name
+	})
+
+	termWidth := 0
+	for _, entry := range options {
+		if length := len(entry.term); length > termWidth {
+			termWidth = length
+		}
+	}
+
+	lines := make([]string, 0, len(options))
+	for _, entry := range options {
+		lines = append(lines,
+			helpIndent+pad(entry.term, termWidth)+strings.Repeat(" ", helpGap)+entry.usage)
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// optionTerm is how a flag is spelled in the listing: `-j, --json` with a
+// shorthand, `--show-secrets` without, and the value placeholder for a flag
+// that takes one.
+func optionTerm(flag *pflag.Flag) string {
+	term := "--" + flag.Name
+	if flag.Shorthand != "" {
+		term = "-" + flag.Shorthand + ", " + term
+	}
+
+	if name, _ := pflag.UnquoteUsage(flag); name != "" {
+		term += " <" + name + ">"
+	}
+
+	return term
+}
+
+// wrapHelpText greedily wraps to columns and indents every line, including the
+// first. Mirrors commander's Help.wrap, which is what produces the paragraph
+// under the logo.
+func wrapHelpText(text string, columns int, indent string) string {
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return ""
+	}
+
+	lines := []string{words[0]}
+	for _, word := range words[1:] {
+		last := len(lines) - 1
+		if len(lines[last])+1+len(word) <= columns {
+			lines[last] += " " + word
+
+			continue
+		}
+		lines = append(lines, word)
+	}
+
+	for index := range lines {
+		lines[index] = indent + lines[index]
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func pad(value string, width int) string {
+	if len(value) >= width {
+		return value
+	}
+
+	return value + strings.Repeat(" ", width-len(value))
+}
+
+// helpWidth is the terminal's width, capped at helpMaxWidth. A terminal that
+// reports nothing -- a pipe, a CI log -- gets the cap.
+func helpWidth() int {
+	width, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || width <= 0 || width > helpMaxWidth {
+		return helpMaxWidth
+	}
+
+	return width
+}

--- a/templates/go-cli/internal/cmd/help.go.twig
+++ b/templates/go-cli/internal/cmd/help.go.twig
@@ -79,7 +79,12 @@ var helpOptionOrder = []string{
 const helpLogo = {{ language.params.logo | goString | raw }}
 
 // helpDescription is the paragraph under the logo.
-const helpDescription = {{ sdk.description | goString | raw }}
+//
+// shortDescription, not description: the TypeScript screen renders
+// `packageJson.description`, and package.json.twig fills that from
+// `sdk.shortDescription`. Reading the other one put a different paragraph on
+// the two screens.
+const helpDescription = {{ sdk.shortDescription | goString | raw }}
 
 const (
 	// helpMaxWidth caps the screen on a wide terminal: a summary column that

--- a/templates/go-cli/internal/cmd/help.go.twig
+++ b/templates/go-cli/internal/cmd/help.go.twig
@@ -194,14 +194,20 @@ func RenderMainHelp(root *cobra.Command) string {
 		}
 	}
 
-	lines := []string{
-		renderLogo(),
-		"",
+	lines := make([]string, 0, 8)
+
+	// A generation that passes no logo gets no blank lines where it would have
+	// been. The conformance build is one.
+	if logo := renderLogo(); logo != "" {
+		lines = append(lines, logo, "")
+	}
+
+	lines = append(lines,
 		wrapHelpText(helpDescription, width-helpGap-helpGap, helpIndent),
 		"",
 		helpTitleStyle.Render("USAGE"),
-		helpIndent + root.Name() + " [options] <command> [subcommand]",
-	}
+		helpIndent+root.Name()+" [options] <command> [subcommand]",
+	)
 
 	for _, section := range sections {
 		lines = append(lines, "", helpTitleStyle.Render(section.title))

--- a/templates/go-cli/internal/cmd/help_test.go
+++ b/templates/go-cli/internal/cmd/help_test.go
@@ -461,3 +461,14 @@ func TestAnEmptyDescriptionProducesNoLine(t *testing.T) {
 		}
 	}
 }
+
+// A service whose spec description is empty has no summary, and the padded name
+// then ends the line in whitespace -- which is what the six-service mock spec
+// produces, and what any real service arriving without a description would.
+func TestNoRowEndsInWhitespace(t *testing.T) {
+	for index, line := range strings.Split(RenderMainHelp(NewRootCommand()), "\n") {
+		if line != strings.TrimRight(line, " \t") {
+			t.Errorf("line %d ends in whitespace: %q", index+1, line)
+		}
+	}
+}

--- a/templates/go-cli/internal/cmd/help_test.go
+++ b/templates/go-cli/internal/cmd/help_test.go
@@ -38,20 +38,44 @@ func TestDescriptionWrapsTheSameWayCommanderDoes(t *testing.T) {
 func TestHelpSectionsAppearInOrder(t *testing.T) {
 	screen := RenderMainHelp(NewRootCommand())
 
-	// USAGE first, then every group that has rows, then OPTIONS last.
-	want := []string{"USAGE"}
+	// USAGE first, then the groups that have rows, then OTHER, then OPTIONS.
+	// A group with no rows is omitted rather than printed empty -- which is the
+	// usual case for the six-service mock spec the conformance build uses -- so
+	// what is asserted is the order of the headings that ARE there.
+	order := []string{"USAGE"}
 	for _, group := range helpGroups {
-		want = append(want, group.title)
+		order = append(order, group.title)
 	}
-	want = append(want, "OPTIONS")
+	order = append(order, "OTHER", "OPTIONS")
 
-	position := 0
-	for _, heading := range want {
-		index := strings.Index(screen[position:], "\n"+heading+"\n")
-		if index < 0 {
-			t.Fatalf("%q is missing from the screen, or is out of order", heading)
+	rank := map[string]int{}
+	for index, heading := range order {
+		rank[heading] = index
+	}
+
+	previous := -1
+	seen := 0
+	for _, line := range strings.Split(screen, "\n") {
+		at, ok := rank[line]
+		if !ok {
+			continue
 		}
-		position += index + 1
+		if at <= previous {
+			t.Errorf("%q is out of order on the screen", line)
+		}
+		previous = at
+		seen++
+	}
+
+	// USAGE and OPTIONS are unconditional, and at least one group has to have
+	// rows or the screen lists nothing at all.
+	if seen < 3 {
+		t.Errorf("only %d of the expected headings are on the screen", seen)
+	}
+	for _, required := range []string{"USAGE", "OPTIONS"} {
+		if !strings.Contains(screen, "\n"+required+"\n") {
+			t.Errorf("%q is missing from the screen", required)
+		}
 	}
 }
 

--- a/templates/go-cli/internal/cmd/help_test.go
+++ b/templates/go-cli/internal/cmd/help_test.go
@@ -258,3 +258,78 @@ func TestFooterTellsTheUserWhereToGoNext(t *testing.T) {
 		t.Errorf("the screen does not end with %q", want)
 	}
 }
+
+// help.ts passes minColumnWidth 2 to commander's wrap rather than taking its
+// default of 40, so the TypeScript screen keeps wrapping into a narrow terminal
+// instead of emitting one line that runs off the edge. Verified against
+// commander itself at screen widths 44, 39, 20 and 10.
+func TestNarrowTerminalsStillWrap(t *testing.T) {
+	// Screen width 20 -> 16 columns. commander produces 11 breaks here.
+	narrow := wrapHelpText(theRealDescription, 20-helpGap-helpGap, helpIndent)
+	if strings.Count(narrow, "\n") == 0 {
+		t.Errorf("a 20-column terminal was not wrapped at all:\n%s", narrow)
+	}
+	for _, line := range strings.Split(narrow, "\n") {
+		if !strings.HasPrefix(line, helpIndent) {
+			t.Errorf("a wrapped line lost its indent: %q", line)
+		}
+	}
+
+	// Below commander's floor of 2 columns it returns the string as it is, which
+	// is also what stops a terminal reporting 3 columns from reaching the loop
+	// with a negative width.
+	for _, columns := range []int{1, 0, -4} {
+		got := wrapHelpText(theRealDescription, columns, helpIndent)
+		if got != helpIndent+theRealDescription {
+			t.Errorf("at %d columns the paragraph was altered:\n%s", columns, got)
+		}
+	}
+
+	// And the 80-column screen still wraps to the three lines the TypeScript
+	// prints.
+	if wide := wrapHelpText(theRealDescription, helpMaxWidth-helpGap-helpGap, helpIndent); strings.Count(wide, "\n") != 2 {
+		t.Errorf("the 80-column screen no longer wraps to three lines:\n%s", wide)
+	}
+}
+
+// commander's wrap is not a plain greedy word wrap, and the difference is
+// visible on the screen: a line holds columnWidth-1 characters rather than
+// columnWidth, and the first line carries two characters that were never
+// measured because commander wraps `str.slice(indent)` and prefixes
+// `str.slice(0, indent)` back on.
+//
+// A from-scratch greedy wrap agreed at 80 columns and disagreed at 15, 17, 18,
+// 30, 41, 42, 49, 50, 56, 57, 62 and 71 -- which is why this compares against
+// captured commander output rather than against a rule.
+//
+// Captured by calling commander's own Help.wrap with the arguments help.ts
+// passes it: `wrap(description, width - 2, 2, 2)`, prefixed with the two-space
+// indent, for every screen width from 6 to 80. The spread below is the boundary,
+// the cap, the floor, and every width the greedy version got wrong.
+var commanderWrapped = map[int]string{
+	80: "  Appwrite is an open-source self-hosted backend server that abstracts and\n  simplifies complex and repetitive development tasks behind a very simple\n  REST API",
+	71: "  Appwrite is an open-source self-hosted backend server that abstracts\n  and simplifies complex and repetitive development tasks behind a\n  very simple REST API",
+	62: "  Appwrite is an open-source self-hosted backend server that\n  abstracts and simplifies complex and repetitive\n  development tasks behind a very simple REST API",
+	57: "  Appwrite is an open-source self-hosted backend server\n  that abstracts and simplifies complex and repetitive\n  development tasks behind a very simple REST API",
+	56: "  Appwrite is an open-source self-hosted backend server\n  that abstracts and simplifies complex and\n  repetitive development tasks behind a very simple\n  REST API",
+	50: "  Appwrite is an open-source self-hosted backend\n  server that abstracts and simplifies complex\n  and repetitive development tasks behind a\n  very simple REST API",
+	49: "  Appwrite is an open-source self-hosted backend\n  server that abstracts and simplifies complex\n  and repetitive development tasks behind a\n  very simple REST API",
+	42: "  Appwrite is an open-source self-hosted\n  backend server that abstracts and\n  simplifies complex and repetitive\n  development tasks behind a very\n  simple REST API",
+	41: "  Appwrite is an open-source self-hosted\n  backend server that abstracts and\n  simplifies complex and repetitive\n  development tasks behind a very\n  simple REST API",
+	30: "  Appwrite is an open-source\n  self-hosted backend\n  server that abstracts and\n  simplifies complex and\n  repetitive development\n  tasks behind a very\n  simple REST API",
+	20: "  Appwrite is an\n  open-source\n  self-hosted\n  backend server\n  that abstracts\n  and simplifies\n  complex and\n  repetitive\n  development\n  tasks behind a\n  very simple\n  REST API",
+	18: "  Appwrite is an\n  open-source\n  self-hosted\n  backend\n  server that\n  abstracts and\n  simplifies\n  complex and\n  repetitive\n  development\n  tasks behind\n  a very simple\n  REST API",
+	17: "  Appwrite is an\n  open-source\n  self-hosted\n  backend\n  server that\n  abstracts\n  and\n  simplifies\n  complex and\n  repetitive\n  development\n  tasks behind\n  a very\n  simple REST\n  API",
+	15: "  Appwrite is\n  an\n  open-source\n  self-hosted\n  backend\n  server\n  that\n  abstracts\n  and\n  simplifies\n  complex\n  and\n  repetitive\n  development\n  tasks\n  behind a\n  very\n  simple\n  REST API",
+	10: "  Appwrite\n  is an\n  open-source\n  self-hosted\n  backend\n  server\n  that\n  abstracts\n  and\n  simplifies\n  complex\n  and\n  repetitive\n  development\n  tasks\n  behind\n  a\n  very\n  simple\n  REST\n  API",
+	6:  "  Appwrite\n  is\n  an\n  open-source\n  self-hosted\n  backend\n  server\n  that\n  abstracts\n  and\n  simplifies\n  complex\n  and\n  repetitive\n  development\n  tasks\n  behind\n  a\n  very\n  simple\n  REST\n  API",
+}
+
+func TestWrapMatchesCommanderAtEveryWidth(t *testing.T) {
+	for width, want := range commanderWrapped {
+		got := wrapHelpText(theRealDescription, width-helpGap-helpGap, helpIndent)
+		if got != want {
+			t.Errorf("width %d differs\n got:\n%s\nwant:\n%s", width, got, want)
+		}
+	}
+}

--- a/templates/go-cli/internal/cmd/help_test.go
+++ b/templates/go-cli/internal/cmd/help_test.go
@@ -1,0 +1,236 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// The main help screen is the first thing a new user sees, and it is the one
+// screen cobra cannot produce: its default lists 40-odd services
+// alphabetically, each with a paragraph of API prose.
+//
+// These assert the layout rather than a byte golden, because the command set
+// comes from the spec -- a service added upstream would fail a golden without
+// anything being wrong.
+
+// theRealDescription is the paragraph the shipped CLI carries, kept here so the
+// wrap is checked against real input rather than against the placeholder the
+// example generation uses.
+const theRealDescription = "Appwrite is an open-source self-hosted backend " +
+	"server that abstracts and simplifies complex and repetitive development " +
+	"tasks behind a very simple REST API"
+
+func TestDescriptionWrapsTheSameWayCommanderDoes(t *testing.T) {
+	// Copied from `appwrite -h` on the TypeScript CLI.
+	want := strings.Join([]string{
+		"  Appwrite is an open-source self-hosted backend server that abstracts and",
+		"  simplifies complex and repetitive development tasks behind a very simple",
+		"  REST API",
+	}, "\n")
+
+	got := wrapHelpText(theRealDescription, helpMaxWidth-helpGap-helpGap, helpIndent)
+	if got != want {
+		t.Errorf("wrapped paragraph differs\n got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestHelpSectionsAppearInOrder(t *testing.T) {
+	screen := RenderMainHelp(NewRootCommand())
+
+	// USAGE first, then every group that has rows, then OPTIONS last.
+	want := []string{"USAGE"}
+	for _, group := range helpGroups {
+		want = append(want, group.title)
+	}
+	want = append(want, "OPTIONS")
+
+	position := 0
+	for _, heading := range want {
+		index := strings.Index(screen[position:], "\n"+heading+"\n")
+		if index < 0 {
+			t.Fatalf("%q is missing from the screen, or is out of order", heading)
+		}
+		position += index + 1
+	}
+}
+
+func TestHelpListsGroupedCommandsWithTheirSummaries(t *testing.T) {
+	root := NewRootCommand()
+	screen := RenderMainHelp(root)
+
+	for _, group := range helpGroups {
+		for _, path := range group.commands {
+			// A group may name a command this spec does not produce.
+			if resolveCommand(root, path) == nil {
+				continue
+			}
+
+			summary, ok := helpSummaries[path]
+			if !ok {
+				t.Errorf("%q is grouped but has no summary", path)
+
+				continue
+			}
+
+			if !strings.Contains(screen, path) || !strings.Contains(screen, summary) {
+				t.Errorf("%q is missing from the screen", path)
+			}
+		}
+	}
+}
+
+// The screen is grouped by hand, so a service added to the spec would be
+// invisible without OTHER catching it.
+func TestEveryVisibleRootCommandIsListedSomewhere(t *testing.T) {
+	root := NewRootCommand()
+	screen := RenderMainHelp(root)
+
+	for _, child := range root.Commands() {
+		if !isListedInHelp(child) {
+			continue
+		}
+
+		if !strings.Contains(screen, child.Name()) {
+			t.Errorf("`%s` is in the tree but not on the help screen", child.Name())
+		}
+	}
+}
+
+func TestSummariesLineUpInOneColumn(t *testing.T) {
+	screen := RenderMainHelp(NewRootCommand())
+
+	// Every listed command is a two-space-indented row; they share one column.
+	column := -1
+	for _, line := range strings.Split(screen, "\n") {
+		if !strings.HasPrefix(line, "  ") || strings.HasPrefix(line, "   ") {
+			continue
+		}
+		name, summary, found := strings.Cut(strings.TrimPrefix(line, "  "), "  ")
+		if !found || strings.Contains(name, " ") || summary == "" {
+			continue
+		}
+		if _, ok := helpSummaries[name]; !ok {
+			continue
+		}
+
+		at := strings.Index(line, strings.TrimLeft(summary, " "))
+		if column == -1 {
+			column = at
+
+			continue
+		}
+		if at != column {
+			t.Errorf("summary for %q starts at column %d, the others at %d", name, at, column)
+		}
+	}
+
+	if column == -1 {
+		t.Fatal("no command rows were found on the screen")
+	}
+}
+
+func TestOptionsFollowTheDeclaredOrder(t *testing.T) {
+	screen := RenderMainHelp(NewRootCommand())
+
+	_, options, found := strings.Cut(screen, "\nOPTIONS\n")
+	if !found {
+		t.Fatal("the screen has no OPTIONS section")
+	}
+	options, _, _ = strings.Cut(options, "\n\n")
+
+	listed := make([]string, 0)
+	for _, line := range strings.Split(options, "\n") {
+		fields := strings.Fields(line)
+		for _, field := range fields {
+			if strings.HasPrefix(field, "--") {
+				listed = append(listed, field)
+
+				break
+			}
+		}
+	}
+
+	rank := map[string]int{}
+	for index, flag := range helpOptionOrder {
+		rank[flag] = index
+	}
+
+	previous := -1
+	for _, flag := range listed {
+		at, ok := rank[flag]
+		if !ok {
+			t.Errorf("%s is in OPTIONS but not in helpOptionOrder, so its position is arbitrary", flag)
+
+			continue
+		}
+		if at < previous {
+			t.Errorf("%s is out of order in OPTIONS", flag)
+		}
+		previous = at
+	}
+
+	for _, required := range []string{"-v, --version", "-h, --help", "-j, --json"} {
+		if !strings.Contains(options, required) {
+			t.Errorf("OPTIONS is missing %q", required)
+		}
+	}
+}
+
+// --all is parsed at the root so `appwrite --all push` works, but it acts on
+// push and pull. Documenting it globally would offer it on every command.
+func TestAllIsHiddenAtTheRootAndDocumentedOnPush(t *testing.T) {
+	root := NewRootCommand()
+
+	if _, options, found := strings.Cut(RenderMainHelp(root), "\nOPTIONS\n"); found {
+		if strings.Contains(options, "--all") {
+			t.Error("--all is documented in the main screen's OPTIONS")
+		}
+	}
+
+	push := resolveCommand(root, "push")
+	if push == nil {
+		t.Fatal("`push` is missing")
+	}
+
+	flag := push.Flags().Lookup("all")
+	if flag == nil {
+		t.Fatal("`push` does not define --all")
+	}
+	if flag.Hidden {
+		t.Error("--all is hidden on `push`, where it is the flag users need")
+	}
+	if flag.Shorthand != "a" {
+		t.Errorf("`push --all` shorthand = %q, want \"a\"", flag.Shorthand)
+	}
+}
+
+// The help function is inherited, so overriding it on the root would replace it
+// for all 600-odd subcommands -- where cobra's own listing is the right one.
+func TestSubcommandHelpIsStillCobras(t *testing.T) {
+	root := NewRootCommand()
+	users := resolveCommand(root, "users")
+	if users == nil {
+		t.Skip("`users` is not in this spec")
+	}
+
+	buffer := &bytes.Buffer{}
+	users.SetOut(buffer)
+	users.Help()
+
+	if !strings.Contains(buffer.String(), "Usage:") {
+		t.Errorf("`users --help` is not cobra's screen:\n%s", buffer.String())
+	}
+	if strings.Contains(buffer.String(), "GET STARTED") {
+		t.Error("`users --help` rendered the main help screen")
+	}
+}
+
+func TestFooterTellsTheUserWhereToGoNext(t *testing.T) {
+	screen := RenderMainHelp(NewRootCommand())
+
+	want := "Run `appwrite <command> --help` for details on a specific command."
+	if !strings.Contains(screen, want) {
+		t.Errorf("the screen does not end with %q", want)
+	}
+}

--- a/templates/go-cli/internal/cmd/help_test.go
+++ b/templates/go-cli/internal/cmd/help_test.go
@@ -333,3 +333,131 @@ func TestWrapMatchesCommanderAtEveryWidth(t *testing.T) {
 		}
 	}
 }
+
+// The paragraph the CLI actually ships has no word longer than a column, no
+// double spaces and no leading space, so checking the wrap against it alone left
+// three branches unexercised -- and one of them was wrong: a run of consecutive
+// spaces produced a blank line that commander does not produce.
+//
+// Captured the same way as commanderWrapped, from commander's own Help.wrap.
+var commanderWrappedAwkward = []struct {
+	name    string
+	text    string
+	wrapped map[int]string
+}{
+	{
+		name: "longword",
+		text: "Runs the appwrite-cli-with-an-extremely-long-hyphenated-token and then stops",
+		wrapped: map[int]string{
+			80: "  Runs the appwrite-cli-with-an-extremely-long-hyphenated-token and then stops",
+			44: "  Runs the\n  appwrite-cli-with-an-extremely-long-hyphenated-token\n  and then stops",
+			30: "  Runs the\n  appwrite-cli-with-an-extremely-long-hyphenated-token\n  and then stops",
+			20: "  Runs the\n  appwrite-cli-with-an-extremely-long-hyphenated-token\n  and then stops",
+			12: "  Runs the\n  appwrite-cli-with-an-extremely-long-hyphenated-token\n  and\n  then\n  stops",
+			8:  "  Runs\n  the\n  appwrite-cli-with-an-extremely-long-hyphenated-token\n  and\n  then\n  stops",
+			6:  "  Runs\n  the\n  appwrite-cli-with-an-extremely-long-hyphenated-token\n  and\n  then\n  stops",
+		},
+	},
+	{
+		name: "allonelongword",
+		text: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		wrapped: map[int]string{
+			80: "  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			44: "  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			30: "  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			20: "  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			12: "  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			8:  "  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			6:  "  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+	},
+	{
+		name: "doublespace",
+		text: "Two  spaces  between  every  word  here  in  this  sentence",
+		wrapped: map[int]string{
+			80: "  Two  spaces  between  every  word  here  in  this  sentence",
+			44: "  Two  spaces  between  every  word  here\n  in  this  sentence",
+			30: "  Two  spaces  between  every\n   word  here  in  this\n  sentence",
+			20: "  Two  spaces\n  between  every\n  word  here  in\n  this  sentence",
+			12: "  Two\n  spaces\n  between\n   every\n  word\n  here\n  in\n  this\n  sentence",
+			8:  "  Two\n  spaces\n  between\n  every\n  word\n  here\n   in\n  this\n  sentence",
+			6:  "  Two\n  spaces\n  between\n  every\n  word\n  here\n  in\n  this\n  sentence",
+		},
+	},
+	{
+		name: "trailing",
+		text: "Trailing space at the end ",
+		wrapped: map[int]string{
+			80: "  Trailing space at the end",
+			44: "  Trailing space at the end",
+			30: "  Trailing space at the end",
+			20: "  Trailing space at\n  the end",
+			12: "  Trailing\n  space\n  at the\n  end",
+			8:  "  Trailing\n  space\n  at\n  the\n  end",
+			6:  "  Trailing\n  space\n  at\n  the\n  end",
+		},
+	},
+	{
+		name: "leading",
+		text: " Leading space at the start",
+		wrapped: map[int]string{
+			80: "   Leading space at the start",
+			44: "   Leading space at the start",
+			30: "   Leading space at the start",
+			20: "   Leading space at\n  the start",
+			12: "   Leading\n  space\n  at the\n  start",
+			8:  "   Leading\n  space\n  at\n  the\n  start",
+			6:  "   Leading\n  space\n  at\n  the\n  start",
+		},
+	},
+	{
+		name: "short",
+		text: "Hi",
+		wrapped: map[int]string{
+			80: "  Hi",
+			44: "  Hi",
+			30: "  Hi",
+			20: "  Hi",
+			12: "  Hi",
+			8:  "  Hi",
+			6:  "  Hi",
+		},
+	},
+	{
+		name: "exactfit",
+		text: "abcd efgh ijkl mnop qrst uvwx yzab cdef ghij klmn opqr stuv",
+		wrapped: map[int]string{
+			80: "  abcd efgh ijkl mnop qrst uvwx yzab cdef ghij klmn opqr stuv",
+			44: "  abcd efgh ijkl mnop qrst uvwx yzab cdef\n  ghij klmn opqr stuv",
+			30: "  abcd efgh ijkl mnop qrst\n  uvwx yzab cdef ghij klmn\n  opqr stuv",
+			20: "  abcd efgh ijkl\n  mnop qrst uvwx\n  yzab cdef ghij\n  klmn opqr stuv",
+			12: "  abcd efgh\n  ijkl\n  mnop\n  qrst\n  uvwx\n  yzab\n  cdef\n  ghij\n  klmn\n  opqr\n  stuv",
+			8:  "  abcd\n  efgh\n  ijkl\n  mnop\n  qrst\n  uvwx\n  yzab\n  cdef\n  ghij\n  klmn\n  opqr\n  stuv",
+			6:  "  abcd\n  efgh\n  ijkl\n  mnop\n  qrst\n  uvwx\n  yzab\n  cdef\n  ghij\n  klmn\n  opqr\n  stuv",
+		},
+	},
+}
+
+func TestWrapMatchesCommanderOnAwkwardText(t *testing.T) {
+	for _, testCase := range commanderWrappedAwkward {
+		for width, want := range testCase.wrapped {
+			got := wrapHelpText(testCase.text, width-helpGap-helpGap, helpIndent)
+			if got != want {
+				t.Errorf("%s at width %d:\n got: %q\nwant: %q",
+					testCase.name, width, got, want)
+			}
+		}
+	}
+}
+
+// The one deliberate deviation. commander returns the bare indent for an empty
+// or all-whitespace description, which puts a line of trailing spaces on the
+// screen; nothing generated has an empty description, and no line is better than
+// a blank one.
+func TestAnEmptyDescriptionProducesNoLine(t *testing.T) {
+	for _, text := range []string{"", "   ", "\t\n"} {
+		if got := wrapHelpText(text, 76, helpIndent); got != "" {
+			t.Errorf("wrapHelpText(%q) = %q, want an empty string", text, got)
+		}
+	}
+}

--- a/templates/go-cli/internal/cmd/initproject.go
+++ b/templates/go-cli/internal/cmd/initproject.go
@@ -209,6 +209,25 @@ func runInitProject(command *cobra.Command, organizationID, projectID, projectNa
 		}
 	}
 
+	// Asked BEFORE the success line, the way the TypeScript asks it. The answer
+	// decides what happens in the seconds after that line, and a question
+	// printed underneath "Project linked" reads as though the linking were not
+	// finished yet.
+	//
+	// inquirer's confirm defaults to false when no default is given, which is
+	// what this question has -- a pull overwrites local files, so the safe
+	// answer is the default one.
+	autopull := false
+	if !creating {
+		autopull, err = prompter.Confirm(prompt.Question{
+			Message: "Pull all resources from this project?",
+			Default: false,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
 	if err := local.Write(); err != nil {
 		return err
 	}
@@ -220,12 +239,42 @@ func runInitProject(command *cobra.Command, organizationID, projectID, projectNa
 		output.Success(out, "Project linked → %s", config.LocalFileName)
 	}
 
-	// NOT YET PORTED: the autopull prompt and installInitProjectSkills. Both
-	// need `pull`, which lands with 5e. Saying so beats silently doing less
-	// than the TypeScript does.
+	installInitProjectSkills(out, local.Dirname())
+
+	// Only a LINKED project is offered the pull. A project created a moment ago
+	// has nothing to fetch, and asking would be asking about an empty result.
+	if !creating && autopull {
+		command.Println()
+
+		if err := pullEverything(command); err != nil {
+			// The project is linked and its config is written, so this is not a
+			// failed init -- it is a failed follow-up with its own command.
+			output.Failure(out, "Failed to pull the project's resources: %s", err)
+			output.Hint(out, "Run '%s pull all' to try again.", app.ExecutableName)
+		}
+
+		return nil
+	}
+
 	output.Log(out, "Run '%s pull all' to fetch this project's resources.", app.ExecutableName)
 
 	return nil
+}
+
+// pullEverything runs `pull all` in place, the way the autopull answer does.
+//
+// --all and --force are forced on, as the TypeScript sets `cliConfig.all` and
+// `cliConfig.force` before calling pullResources: the user has just answered the
+// only question there was, so a pull that then asked which resources and whether
+// to overwrite would be asking twice. The previous values are restored, because
+// this process may go on to do something else that reads them.
+func pullEverything(command *cobra.Command) error {
+	flags := app.Flags()
+	all, force := flags.All, flags.Force
+	flags.All, flags.Force = true, true
+	defer func() { flags.All, flags.Force = all, force }()
+
+	return runPull(command, pullActions(), true)
 }
 
 // chooseOrganization lists the organizations the account belongs to.

--- a/templates/go-cli/internal/cmd/initprojectskills.go
+++ b/templates/go-cli/internal/cmd/initprojectskills.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/appwrite/appwrite-cli-go/internal/app"
+	"github.com/appwrite/appwrite-cli-go/internal/output"
+)
+
+// The skills half of `init project`.
+//
+// Ports installInitProjectSkills (init.ts:242) with hasSkillsInstalled
+// (utils.ts:1067) and detectProjectSkills (utils.ts:1149). fetchAvailableSkills
+// and placeSkills were already ported for `init skill`, which is why this is
+// mostly the DECIDING: which skills a project wants, and whether it has any
+// already.
+//
+// The point of doing it here rather than leaving it to `init skill` is that a
+// project is scaffolded once and the skills are per-language: a Python project
+// wants the Python skill, and asking the user to know that is asking them to
+// read a list they have no way to evaluate yet.
+
+// languageMarkers maps a language to the files that prove a project uses it.
+//
+// Ports LANGUAGE_MARKERS (utils.ts:1027) exactly, `*` globs included -- a
+// `*.csproj` is matched by extension because its name is the project's, which
+// this cannot know.
+var languageMarkers = map[string][]string{
+	"typescript": {"package.json", "tsconfig.json", "bun.lockb", "yarn.lock", "package-lock.json"},
+	"python":     {"requirements.txt", "pyproject.toml", "setup.py", "Pipfile"},
+	"php":        {"composer.json"},
+	"dart":       {"pubspec.yaml"},
+	"swift":      {"Package.swift", "*.xcodeproj"},
+	"kotlin":     {"build.gradle.kts", "build.gradle"},
+	"go":         {"go.mod"},
+	"ruby":       {"Gemfile"},
+	"dotnet":     {"*.csproj", "*.sln", "*.fsproj"},
+}
+
+// skillAgents are the directories a skill is installed into.
+//
+// Two, and the second is a symlink to the first: a project may be opened with
+// either agent and both must see the same skill without a second copy to keep in
+// step. placeSkills does the linking; this only names them.
+var skillAgents = []string{".agents", ".claude"}
+
+// hasSkillsInstalled reports whether a project already carries skills.
+//
+// Ports hasSkillsInstalled. A non-empty directory is enough: this runs during
+// `init project`, and a project that has already installed skills has made a
+// choice that a scaffolding step must not silently redo.
+func hasSkillsInstalled(root string) bool {
+	for _, agent := range skillAgents {
+		entries, err := os.ReadDir(filepath.Join(root, agent, "skills"))
+		if err == nil && len(entries) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// detectProjectSkills picks the skills a project's own files ask for.
+//
+// Ports detectProjectSkills, `cli` included unconditionally: every project
+// initialised by this command uses the CLI by definition, so it is the one skill
+// that needs no evidence.
+func detectProjectSkills(root string, skills []skillInfo) []skillInfo {
+	detected := map[string]bool{"cli": true}
+
+	// Read the directory ONCE. The TypeScript re-reads it inside the marker
+	// loop, which is a directory listing per glob per language.
+	var names []string
+	if entries, err := os.ReadDir(root); err == nil {
+		names = make([]string, 0, len(entries))
+		for _, entry := range entries {
+			names = append(names, entry.Name())
+		}
+	}
+
+	for language, markers := range languageMarkers {
+		for _, marker := range markers {
+			if extension, isGlob := strings.CutPrefix(marker, "*"); isGlob {
+				for _, name := range names {
+					if strings.HasSuffix(name, extension) {
+						detected[language] = true
+
+						break
+					}
+				}
+
+				continue
+			}
+
+			if _, err := os.Stat(filepath.Join(root, marker)); err == nil {
+				detected[language] = true
+			}
+		}
+	}
+
+	// Substring matching on the directory name, as the TypeScript does: the
+	// skills repository names them `appwrite-python`, not `python`.
+	matched := make([]skillInfo, 0, len(skills))
+	for _, skill := range skills {
+		lowered := strings.ToLower(skill.DirName)
+		for language := range detected {
+			if strings.Contains(lowered, language) {
+				matched = append(matched, skill)
+
+				break
+			}
+		}
+	}
+
+	return matched
+}
+
+// installInitProjectSkills installs the skills a freshly initialised project
+// wants.
+//
+// Every failure is reported and swallowed. The project IS initialised by the
+// time this runs -- the config is written and the success line printed -- so
+// failing the command here would report a failure for work that succeeded, and
+// leave the user unsure whether to run it again. The hint names the command that
+// does this on its own, which is the recovery.
+func installInitProjectSkills(out io.Writer, root string) {
+	if hasSkillsInstalled(root) {
+		output.Log(out, "Agent skills already found. Skipping installation.")
+
+		return
+	}
+
+	skills, tempDir, err := fetchAvailableSkills()
+	if err != nil {
+		reportSkillFailure(out, err)
+
+		return
+	}
+	defer os.RemoveAll(tempDir)
+
+	detected := detectProjectSkills(root, skills)
+	if len(detected) == 0 {
+		return
+	}
+
+	names := make([]string, 0, len(detected))
+	labels := make([]string, 0, len(detected))
+	for _, skill := range detected {
+		names = append(names, skill.DirName)
+		labels = append(labels, skill.Name)
+	}
+
+	if err := placeSkills(root, tempDir, names, skillAgents, true); err != nil {
+		reportSkillFailure(out, err)
+
+		return
+	}
+
+	output.Success(out, "Installed %d agent skill%s: %s",
+		len(names), pluralSuffix(len(names)), strings.Join(labels, ", "))
+}
+
+func reportSkillFailure(out io.Writer, err error) {
+	output.Failure(out, "Failed to install skills: %s", err)
+	output.Hint(out, "You can install them later with '%s init skill'.", app.ExecutableName)
+}
+
+// pluralSuffix is the "s" in "2 skills".
+func pluralSuffix(count int) string {
+	if count == 1 {
+		return ""
+	}
+
+	return "s"
+}

--- a/templates/go-cli/internal/cmd/initprojectskills_test.go
+++ b/templates/go-cli/internal/cmd/initprojectskills_test.go
@@ -1,0 +1,146 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func skillsFor(dirNames ...string) []skillInfo {
+	skills := make([]skillInfo, 0, len(dirNames))
+	for _, name := range dirNames {
+		skills = append(skills, skillInfo{Name: name, DirName: name})
+	}
+
+	return skills
+}
+
+func detectedNames(skills []skillInfo) []string {
+	names := make([]string, 0, len(skills))
+	for _, skill := range skills {
+		names = append(names, skill.DirName)
+	}
+	slices.Sort(names)
+
+	return names
+}
+
+// A marker file is what proves a project uses a language, and the skill that
+// matches it is the one worth installing without asking.
+func TestProjectSkillsAreDetectedFromMarkerFiles(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "pyproject.toml"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	available := skillsFor("appwrite-python", "appwrite-php", "appwrite-cli")
+	got := detectedNames(detectProjectSkills(root, available))
+
+	if !slices.Equal(got, []string{"appwrite-cli", "appwrite-python"}) {
+		t.Errorf("detected %v, want the python and cli skills", got)
+	}
+}
+
+// The CLI skill needs no evidence: a project initialised by this command uses
+// the CLI by definition.
+func TestTheCLISkillIsAlwaysDetected(t *testing.T) {
+	got := detectedNames(detectProjectSkills(t.TempDir(),
+		skillsFor("appwrite-cli", "appwrite-go")))
+
+	if !slices.Equal(got, []string{"appwrite-cli"}) {
+		t.Errorf("detected %v in an empty directory, want only the cli skill", got)
+	}
+}
+
+// A `*.csproj` is matched by extension, because its name is the project's and
+// this cannot know it.
+func TestGlobMarkersMatchByExtension(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "MyThing.csproj"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := detectedNames(detectProjectSkills(root, skillsFor("appwrite-dotnet", "appwrite-cli")))
+	if !slices.Contains(got, "appwrite-dotnet") {
+		t.Errorf("detected %v, want the dotnet skill", got)
+	}
+}
+
+// A glob must not match the extension anywhere but the end -- `csproj.backup`
+// is not a project file.
+func TestGlobMarkersDoNotMatchMidName(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "notes.csproj.backup"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := detectedNames(detectProjectSkills(root, skillsFor("appwrite-dotnet", "appwrite-cli")))
+	if slices.Contains(got, "appwrite-dotnet") {
+		t.Errorf("a backup file was taken for a project file: %v", got)
+	}
+}
+
+// Several languages in one directory get all of their skills -- a repo with a
+// package.json and a go.mod is both.
+func TestSeveralLanguagesAreAllDetected(t *testing.T) {
+	root := t.TempDir()
+	for _, marker := range []string{"package.json", "go.mod"} {
+		if err := os.WriteFile(filepath.Join(root, marker), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got := detectedNames(detectProjectSkills(root,
+		skillsFor("appwrite-typescript", "appwrite-go", "appwrite-cli", "appwrite-ruby")))
+
+	if !slices.Equal(got, []string{"appwrite-cli", "appwrite-go", "appwrite-typescript"}) {
+		t.Errorf("detected %v", got)
+	}
+}
+
+// A project that has already installed skills has made a choice, and a
+// scaffolding step must not silently redo it.
+func TestHasSkillsInstalled(t *testing.T) {
+	root := t.TempDir()
+	if hasSkillsInstalled(root) {
+		t.Error("an empty project reported installed skills")
+	}
+
+	// An empty skills directory is not an installation.
+	agents := filepath.Join(root, ".agents", "skills")
+	if err := os.MkdirAll(agents, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if hasSkillsInstalled(root) {
+		t.Error("an empty skills directory counted as installed")
+	}
+
+	if err := os.MkdirAll(filepath.Join(agents, "appwrite-cli"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !hasSkillsInstalled(root) {
+		t.Error("an installed skill was not found")
+	}
+}
+
+// Either agent directory counts, because a project may be opened with either.
+func TestHasSkillsInstalledChecksBothAgents(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".claude", "skills", "x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if !hasSkillsInstalled(root) {
+		t.Error("a skill under .claude was not found")
+	}
+}
+
+func TestPluralSuffix(t *testing.T) {
+	if pluralSuffix(1) != "" {
+		t.Error("1 skill was pluralised")
+	}
+	if pluralSuffix(2) != "s" {
+		t.Error("2 skills were singularised")
+	}
+}

--- a/templates/go-cli/internal/cmd/initsite.go
+++ b/templates/go-cli/internal/cmd/initsite.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -11,6 +12,7 @@ import (
 	"github.com/appwrite/appwrite-cli-go/internal/app"
 	"github.com/appwrite/appwrite-cli-go/internal/appwrite"
 	"github.com/appwrite/appwrite-cli-go/internal/client"
+	"github.com/appwrite/appwrite-cli-go/internal/config"
 	"github.com/appwrite/appwrite-cli-go/internal/jsonx"
 	"github.com/appwrite/appwrite-cli-go/internal/output"
 	"github.com/appwrite/appwrite-cli-go/internal/prompt"
@@ -60,6 +62,22 @@ type siteTemplate struct {
 		FallbackFile          string `json:"fallbackFile"`
 		ProviderRootDirectory string `json:"providerRootDirectory"`
 	} `json:"frameworks"`
+	// Variables are the environment variables the template's code reads. The
+	// API declares them with placeholders the CLI is expected to fill -- see
+	// writeTemplateEnv, and note that the TypeScript declares this field
+	// (init.ts:97) and then never reads it, which is the bug being fixed here.
+	Variables []siteTemplateVariable `json:"variables"`
+}
+
+// siteTemplateVariable is one environment variable a starter template needs.
+//
+// Value carries a placeholder such as `{projectId}` rather than a literal: the
+// template is generic and the CLI is the only party that knows which project it
+// is being scaffolded into.
+type siteTemplateVariable struct {
+	Name     string `json:"name"`
+	Value    string `json:"value"`
+	Required bool   `json:"required"`
 }
 
 func newInitSiteCommand() *cobra.Command {
@@ -215,6 +233,11 @@ func runInitSite(command *cobra.Command) error {
 
 			return err
 		}
+
+		// Only for a downloaded template: the variables belong to ITS code, so
+		// writing them beside a directory the user populated themselves would be
+		// guessing at what that code reads.
+		writeTemplateEnv(out, context.local, api, template, siteDir, sitePath)
 	}
 
 	entry := SiteEntry{
@@ -389,6 +412,100 @@ func starterTemplate(api *client.Client, framework string) (*siteTemplate, error
 	}
 
 	return &response.Templates[0], nil
+}
+
+// writeTemplateEnv writes the .env a scaffolded template needs to build.
+//
+// Every starter template reads its Appwrite endpoint and project from the
+// environment, and the API says so: each one declares its variables with
+// `{apiEndpoint}`, `{projectId}` and `{projectName}` placeholders for the CLI to
+// fill. Nothing filled them. The template shipped a `.env.example`, no `.env`
+// was written, `push site` had nothing to push, and the FIRST deploy of every
+// template site failed in the build -- for the Next.js starter, as
+// `TypeError: Cannot read properties of undefined (reading 'replace')` from
+// `setEndpoint(undefined)`, which says nothing about the actual cause.
+//
+// An existing .env is never touched. It is the one file in a scaffolded site
+// that may already hold secrets, and a template's generic defaults are not worth
+// overwriting them for.
+func writeTemplateEnv(
+	out io.Writer,
+	local *config.Local,
+	api *client.Client,
+	template *siteTemplate,
+	siteDir, sitePath string,
+) {
+	if template == nil || len(template.Variables) == 0 {
+		return
+	}
+
+	path := filepath.Join(siteDir, ".env")
+	if _, err := os.Stat(path); err == nil {
+		output.Hint(out, "'%s/.env' already exists, so the template's variables were left alone.",
+			sitePath)
+
+		return
+	}
+
+	endpoint := local.Data.GetString("endpoint")
+	if endpoint == "" {
+		endpoint = api.Endpoint
+	}
+	fill := strings.NewReplacer(
+		"{apiEndpoint}", endpoint,
+		"{projectId}", local.Data.GetString("projectId"),
+		"{projectName}", local.Data.GetString("projectName"),
+	)
+
+	var (
+		lines      []string
+		unresolved []string
+	)
+	for _, variable := range template.Variables {
+		if variable.Name == "" {
+			continue
+		}
+
+		value := fill.Replace(variable.Value)
+		// A placeholder this CLI does not know how to fill is left EMPTY rather
+		// than written through literally: `{apiKey}` in a .env is a value the
+		// build would use as if it were real, and an empty one fails in a way
+		// that points at the variable.
+		if strings.ContainsAny(value, "{}") {
+			value = ""
+		}
+		if value == "" && variable.Required {
+			unresolved = append(unresolved, variable.Name)
+		}
+
+		lines = append(lines, variable.Name+"="+value)
+	}
+
+	if len(lines) == 0 {
+		return
+	}
+
+	contents := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		// Not fatal. The site is configured and its code is downloaded; the
+		// user can write the file themselves, and saying so is more use than
+		// unwinding a successful scaffold.
+		output.Warn(out, "Could not write '%s/.env': %s", sitePath, err)
+
+		return
+	}
+
+	output.Log(out, "Wrote '%s/.env' with %d variable(s) the template needs to build.",
+		sitePath, len(lines))
+	if len(unresolved) > 0 {
+		output.Hint(out, "Fill in %s before deploying -- the template requires them.",
+			strings.Join(unresolved, ", "))
+	}
+	// The variables are local until they are pushed, and the build runs on the
+	// server. Naming the flag here is the difference between a working first
+	// deploy and a build that fails on an undefined endpoint.
+	output.Hint(out, "Run '%s push site --with-variables' to send them to the site.",
+		app.ExecutableName)
 }
 
 // chooseFramework asks which framework the site uses.

--- a/templates/go-cli/internal/cmd/inittemplateenv_test.go
+++ b/templates/go-cli/internal/cmd/inittemplateenv_test.go
@@ -1,0 +1,171 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/appwrite/appwrite-cli-go/internal/client"
+	"github.com/appwrite/appwrite-cli-go/internal/config"
+	"github.com/appwrite/appwrite-cli-go/internal/jsonx"
+)
+
+// starterVariables is what the API actually answers for starter-for-nextjs:
+// three required variables, each a placeholder for the CLI to fill.
+func starterVariables() []siteTemplateVariable {
+	return []siteTemplateVariable{
+		{Name: "NEXT_PUBLIC_APPWRITE_ENDPOINT", Value: "{apiEndpoint}", Required: true},
+		{Name: "NEXT_PUBLIC_APPWRITE_PROJECT_ID", Value: "{projectId}", Required: true},
+		{Name: "NEXT_PUBLIC_APPWRITE_PROJECT_NAME", Value: "{projectName}", Required: true},
+	}
+}
+
+func testLocal(t *testing.T) *config.Local {
+	t.Helper()
+
+	data := jsonx.NewObject()
+	data.Set("endpoint", "https://cloud.staging.appwrite.io/v1")
+	data.Set("projectId", "6a3cd0ab001c7936ecbe")
+	data.Set("projectName", "Testing Project")
+
+	return &config.Local{Data: data}
+}
+
+func writeEnv(t *testing.T, template *siteTemplate) (string, string) {
+	t.Helper()
+
+	siteDir := t.TempDir()
+	var out bytes.Buffer
+	writeTemplateEnv(&out, testLocal(t), client.New("https://fallback/v1", "0.0.1"),
+		template, siteDir, "sites/template-site")
+
+	contents, err := os.ReadFile(filepath.Join(siteDir, ".env"))
+	if err != nil {
+		return "", out.String()
+	}
+
+	return string(contents), out.String()
+}
+
+// The whole bug: the API declares these with placeholders for the CLI to fill,
+// nothing filled them, no .env was written, and the first build of every
+// template site died on `setEndpoint(undefined)`.
+func TestTemplateEnvIsWrittenWithThePlaceholdersFilled(t *testing.T) {
+	contents, _ := writeEnv(t, &siteTemplate{Variables: starterVariables()})
+
+	for _, want := range []string{
+		"NEXT_PUBLIC_APPWRITE_ENDPOINT=https://cloud.staging.appwrite.io/v1",
+		"NEXT_PUBLIC_APPWRITE_PROJECT_ID=6a3cd0ab001c7936ecbe",
+		"NEXT_PUBLIC_APPWRITE_PROJECT_NAME=Testing Project",
+	} {
+		if !strings.Contains(contents, want) {
+			t.Errorf("missing %q in:\n%s", want, contents)
+		}
+	}
+
+	if strings.Contains(contents, "{") {
+		t.Errorf("a placeholder survived into the .env:\n%s", contents)
+	}
+}
+
+// The variables are local until they are pushed, and the build runs on the
+// server -- so naming the flag is the difference between a working first deploy
+// and a build that fails on an undefined endpoint.
+func TestTemplateEnvSaysHowToPushIt(t *testing.T) {
+	_, printed := writeEnv(t, &siteTemplate{Variables: starterVariables()})
+
+	if !strings.Contains(printed, "--with-variables") {
+		t.Errorf("nothing told the user how to push the variables:\n%s", printed)
+	}
+	if !strings.Contains(printed, "sites/template-site/.env") {
+		t.Errorf("the file that was written is not named:\n%s", printed)
+	}
+}
+
+// A placeholder the CLI cannot fill is left EMPTY, not written through: an
+// `{apiKey}` in a .env is a value the build would use as if it were real, and an
+// empty one fails in a way that points at the variable.
+func TestUnknownPlaceholdersAreLeftEmptyAndCalledOut(t *testing.T) {
+	contents, printed := writeEnv(t, &siteTemplate{Variables: []siteTemplateVariable{
+		{Name: "APPWRITE_API_KEY", Value: "{apiKey}", Required: true},
+	}})
+
+	if !strings.Contains(contents, "APPWRITE_API_KEY=\n") {
+		t.Errorf("the unresolvable value was not left empty:\n%q", contents)
+	}
+	if !strings.Contains(printed, "APPWRITE_API_KEY") {
+		t.Errorf("a required variable the CLI could not fill was not called out:\n%s", printed)
+	}
+}
+
+// An existing .env is the one file in a scaffolded site that may already hold
+// secrets, and a template's generic defaults are not worth overwriting them for.
+func TestAnExistingEnvIsNeverOverwritten(t *testing.T) {
+	siteDir := t.TempDir()
+	path := filepath.Join(siteDir, ".env")
+	if err := os.WriteFile(path, []byte("MINE=keep\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	writeTemplateEnv(&out, testLocal(t), client.New("https://fallback/v1", "0.0.1"),
+		&siteTemplate{Variables: starterVariables()}, siteDir, "sites/x")
+
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(contents) != "MINE=keep\n" {
+		t.Errorf("an existing .env was overwritten: %q", contents)
+	}
+	if !strings.Contains(out.String(), "already exists") {
+		t.Errorf("the skip was silent:\n%s", out.String())
+	}
+}
+
+// A template with no variables writes no file, rather than an empty one.
+func TestNoVariablesWritesNoFile(t *testing.T) {
+	contents, printed := writeEnv(t, &siteTemplate{})
+
+	if contents != "" {
+		t.Errorf("wrote a .env for a template with no variables: %q", contents)
+	}
+	if printed != "" {
+		t.Errorf("said something about nothing:\n%s", printed)
+	}
+}
+
+// The endpoint falls back to the client's when the config carries none, so a
+// site inited before `endpoint` was written still gets a usable value.
+func TestEndpointFallsBackToTheClient(t *testing.T) {
+	data := jsonx.NewObject()
+	data.Set("projectId", "abc")
+
+	siteDir := t.TempDir()
+	var out bytes.Buffer
+	writeTemplateEnv(&out, &config.Local{Data: data},
+		client.New("https://fallback.example/v1", "0.0.1"),
+		&siteTemplate{Variables: starterVariables()}, siteDir, "sites/x")
+
+	contents, err := os.ReadFile(filepath.Join(siteDir, ".env"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(contents), "https://fallback.example/v1") {
+		t.Errorf("the client endpoint was not used:\n%s", contents)
+	}
+}
+
+// A nil template is what a failed lookup leaves behind, and it must not panic.
+func TestANilTemplateWritesNothing(t *testing.T) {
+	siteDir := t.TempDir()
+	var out bytes.Buffer
+	writeTemplateEnv(&out, testLocal(t), client.New("https://x/v1", "0.0.1"),
+		nil, siteDir, "sites/x")
+
+	if _, err := os.Stat(filepath.Join(siteDir, ".env")); err == nil {
+		t.Error("a nil template still wrote a .env")
+	}
+}

--- a/templates/go-cli/internal/cmd/login.go
+++ b/templates/go-cli/internal/cmd/login.go
@@ -117,7 +117,9 @@ func runLogin(command *cobra.Command, options loginOptions) error {
 	previous := global.CurrentSessionID()
 
 	if previous != "" && !options.New {
-		if account := currentAccount(); account != nil {
+		// The error is deliberately dropped: the question here is only whether
+		// someone is already signed in, and every failure answers it with no.
+		if account, _ := currentAccount(); account != nil {
 			// Nothing was asked for and someone is already signed in, so say so
 			// rather than starting a flow they did not ask for.
 			if options.Email == "" && options.Password == "" &&
@@ -142,23 +144,28 @@ func runLogin(command *cobra.Command, options loginOptions) error {
 	return loginWithDevice(command, configEndpoint)
 }
 
-// currentAccount reads the signed-in account, or nil if there is not one.
+// currentAccount reads the signed-in account.
 //
-// Ports getCurrentAccount (login.ts:124) in the shape its callers use: every
-// failure means "not signed in", because that is the only question asked of it
-// here.
-func currentAccount() *jsonx.Object {
+// Ports getCurrentAccount (login.ts:124). The error is RETURNED rather than
+// folded into a nil account, because the two callers ask different questions of
+// it. `login` asks "is someone signed in already?", where every failure means
+// no and the reason does not matter. `login --switch` asks "does this stored
+// session work?", and there the reason is the whole answer -- the TypeScript
+// rethrows it (login.ts:318) for exactly that reason, and reporting a locked
+// keyring or an unreachable endpoint as a dead session sends the user to
+// re-authenticate against a problem that re-authenticating does not fix.
+func currentAccount() (*jsonx.Object, error) {
 	api, _, err := consoleClient()
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	account := jsonx.NewObject()
 	if err := api.Call("GET", "/account", nil, account); err != nil {
-		return nil
+		return nil, err
 	}
 
-	return account
+	return account, nil
 }
 
 // verifyEndpoint checks that an endpoint is an Appwrite server before a
@@ -220,13 +227,14 @@ func switchAccount(command *cobra.Command, global *config.Global, previous strin
 	}
 
 	if chosen == previous {
-		if account := currentAccount(); account != nil {
+		account, err := currentAccount()
+		if account != nil {
 			output.Success(out, "Already using %s", account.GetString("email"))
 
 			return nil
 		}
 
-		return staleSessionError()
+		return unusableSessionError(err)
 	}
 
 	global.SetCurrentSessionID(chosen)
@@ -234,14 +242,14 @@ func switchAccount(command *cobra.Command, global *config.Global, previous strin
 		return err
 	}
 
-	account := currentAccount()
+	account, accountErr := currentAccount()
 	if account == nil {
 		global.SetCurrentSessionID(previous)
 		if err := global.Write(); err != nil {
 			return err
 		}
 
-		return staleSessionError()
+		return unusableSessionError(accountErr)
 	}
 
 	output.Success(out, "Switched to %s", account.GetString("email"))
@@ -249,7 +257,19 @@ func switchAccount(command *cobra.Command, global *config.Global, previous strin
 	return nil
 }
 
-func staleSessionError() error {
+// unusableSessionError explains why the selected session could not be used.
+//
+// The reason is carried when there is one. Without it the only thing this could
+// say was "run `login --switch` again", which is the command that just failed --
+// so a locked keyring, an unreachable endpoint and a genuinely dead session all
+// pointed at the same dead end. The TypeScript rethrows the underlying error
+// here (login.ts:318) and keeps the generic wording for the one case that has no
+// error behind it.
+func unusableSessionError(reason error) error {
+	if reason != nil {
+		return fmt.Errorf("selected account session cannot be used: %w", reason)
+	}
+
 	return fmt.Errorf(
 		"selected account session is no longer valid. Run '%s login --switch' again",
 		app.ExecutableName)

--- a/templates/go-cli/internal/cmd/loginswitch_test.go
+++ b/templates/go-cli/internal/cmd/loginswitch_test.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// A reason is the whole answer. Without one the only thing this could say was
+// "run `login --switch` again" -- the command that just failed -- so a locked
+// keyring, an unreachable endpoint and a genuinely dead session all pointed at
+// the same dead end.
+func TestUnusableSessionErrorCarriesTheReason(t *testing.T) {
+	reason := errors.New("cannot read the saved credential: keyring is locked")
+
+	message := unusableSessionError(reason).Error()
+	if !strings.Contains(message, "keyring is locked") {
+		t.Errorf("the reason was dropped: %q", message)
+	}
+	if strings.Contains(message, "login --switch") {
+		t.Errorf("a known reason still sent the user back round the loop: %q", message)
+	}
+}
+
+// The generic wording is kept for the one case that has no error behind it,
+// which is what the TypeScript keeps it for.
+func TestUnusableSessionErrorWithoutAReason(t *testing.T) {
+	message := unusableSessionError(nil).Error()
+
+	if !strings.Contains(message, "no longer valid") ||
+		!strings.Contains(message, "login --switch") {
+		t.Errorf("the fallback lost its advice: %q", message)
+	}
+}
+
+// Wrapped, not formatted into the string: callers up the stack still get to
+// match on what actually failed.
+func TestUnusableSessionErrorUnwraps(t *testing.T) {
+	reason := errors.New("session expired")
+
+	if !errors.Is(unusableSessionError(reason), reason) {
+		t.Error("the reason cannot be unwrapped")
+	}
+}

--- a/templates/go-cli/internal/cmd/logout.go
+++ b/templates/go-cli/internal/cmd/logout.go
@@ -81,7 +81,10 @@ func logoutSessions(global *config.Global, ids []string) logoutResult {
 // hasServerCredential reports whether a session holds something the server
 // would still honour.
 func hasServerCredential(global *config.Global, store *auth.TokenStore, id string) bool {
-	if store.Refresh(id) != "" {
+	// Why there is no token does not change the answer here, so the failed
+	// lookup is dropped rather than reported: logout is about removing local
+	// state, and it must work whether or not the keyring cooperates.
+	if token, _ := store.Refresh(id); token != "" {
 		return true
 	}
 
@@ -107,7 +110,9 @@ func revokeSession(global *config.Global, store *auth.TokenStore, id string) err
 
 	api := client.New(endpoint, app.Version)
 
-	if refresh := store.Refresh(id); refresh != "" {
+	// As in hasServerCredential: a token that cannot be read cannot be revoked
+	// at the server either, and the local session is removed regardless.
+	if refresh, _ := store.Refresh(id); refresh != "" {
 		clientID := session.GetString(config.PreferenceClientID)
 		if clientID == "" {
 			clientID = consoleClientID

--- a/templates/go-cli/internal/cmd/pull.go
+++ b/templates/go-cli/internal/cmd/pull.go
@@ -91,7 +91,7 @@ func newPullCommand() *cobra.Command {
 	// subcommand's own -a.
 	command.Flags().BoolVarP(
 		app.Flags().AllPointer(), "all", "a", false,
-		"Apply the command to every matching resource.")
+		"Pull every resource in the project")
 
 	for _, resource := range flatResources {
 		command.AddCommand(newPullResourceCommand(resource))

--- a/templates/go-cli/internal/cmd/pushcommon.go
+++ b/templates/go-cli/internal/cmd/pushcommon.go
@@ -393,7 +393,7 @@ func newPushCommand() *cobra.Command {
 	// merged over it and `push table`'s own -a stays free.
 	command.Flags().BoolVarP(
 		app.Flags().AllPointer(), "all", "a", false,
-		"Apply the command to every matching resource.")
+		"Push every resource in the project config")
 
 	command.AddCommand(newPushAllCommand())
 	command.AddCommand(newPushSettingsCommand())

--- a/templates/go-cli/internal/cmd/pushcommon.go
+++ b/templates/go-cli/internal/cmd/pushcommon.go
@@ -206,7 +206,23 @@ func (c *pushContext) approveChanges(command *cobra.Command, request approvalReq
 			if !present {
 				continue
 			}
-			localValue, _ := local.Get(key)
+			localValue, hasLocal := local.Get(key)
+
+			// A key the config does not carry is never SENT. writeBody writes
+			// only the keys that are present, deliberately, so that a push does
+			// not clear a field the config is silent about -- which means
+			// listing an absent key here promised an edit the push would not
+			// make. A freshly inited site reported
+			//
+			//   id                   │ key                │ remote │ local
+			//   6a729db1003e322cbfdb │ providerSilentMode │ false  │
+			//
+			// on every push, forever: the config has no such key, so there was
+			// nothing to apply and the row never went away. Approving it did
+			// nothing, which is the worst kind of prompt.
+			if !hasLocal {
+				continue
+			}
 
 			if isEmpty(remoteValue) && isEmpty(localValue) {
 				continue

--- a/templates/go-cli/internal/cmd/pushcommon.go
+++ b/templates/go-cli/internal/cmd/pushcommon.go
@@ -30,6 +30,9 @@ type pushContext struct {
 	api      *client.Client
 	local    *config.Local
 	prompter prompt.Prompter
+	// screenshots is built on first use by pushpreview.go, and only by a site
+	// push -- it needs a console session the other resources never ask for.
+	screenshots *screenshots
 }
 
 func newPushContext() (*pushContext, error) {

--- a/templates/go-cli/internal/cmd/pushdatabase.go
+++ b/templates/go-cli/internal/cmd/pushdatabase.go
@@ -179,7 +179,7 @@ func runPushTable(command *cobra.Command, resource pushDatabaseResource) error {
 	}
 
 	if pushed == 0 {
-		output.Warn(out, "No tables were pushed.")
+		output.Log(out, "No tables were pushed. Everything is already up to date.")
 	} else {
 		output.Success(out, "Successfully pushed %d tables.", pushed)
 	}
@@ -241,7 +241,7 @@ func runPushCollection(command *cobra.Command, resource pushDatabaseResource) er
 	}
 
 	if pushed == 0 {
-		output.Warn(out, "No collections were pushed.")
+		output.Log(out, "No collections were pushed. Everything is already up to date.")
 	} else {
 		output.Success(out, "Successfully pushed %d collections.", pushed)
 	}

--- a/templates/go-cli/internal/cmd/pushdeploy.go
+++ b/templates/go-cli/internal/cmd/pushdeploy.go
@@ -698,6 +698,15 @@ func runPushDeployable(
 		return err
 	}
 
+	// Everything was skipped for missing a required field, so there is nothing
+	// left to push. Without this the push carried on with an empty list and
+	// still asked whether to create a deployment.
+	if len(entries) == 0 {
+		output.Log(out, "No %s left to push.", resource.Label)
+
+		return nil
+	}
+
 	approved, err := context.approveChanges(command, approvalRequest{
 		Resources: entries,
 		Fetch: func(local *jsonx.Object) (*jsonx.Object, error) {
@@ -900,7 +909,8 @@ func (c *pushContext) completeDeployables(
 		// Which one, and what is missing. The TypeScript logs this before it
 		// prompts (push.ts:3656); without it the question arrives as a bare
 		// "Enter the entrypoint" with no clue which of ten functions it is for.
-		output.Log(out, "%s %s is missing %s.", resource.Singular, name, label)
+		output.Log(out, "%s %s is missing %s.",
+			capitalizeFirst(resource.Singular), name, label)
 
 		// --all says "every resource, do not ask me". It is also how a pipeline
 		// pushes, so stopping on a question there is the opposite of what was
@@ -934,6 +944,16 @@ func (c *pushContext) completeDeployables(
 	}
 
 	return usable, c.local.Write()
+}
+
+// capitalizeFirst starts a sentence with the resource name, which is stored
+// lowercase for use mid-sentence.
+func capitalizeFirst(value string) string {
+	if value == "" {
+		return value
+	}
+
+	return strings.ToUpper(value[:1]) + value[1:]
 }
 
 // siteRequiresBuildCommand reports whether a site has to be built.

--- a/templates/go-cli/internal/cmd/pushdeploy.go
+++ b/templates/go-cli/internal/cmd/pushdeploy.go
@@ -823,6 +823,10 @@ func (s *pushSummary) report(
 	seconds := fmt.Sprintf("%.1fs", elapsed.Seconds())
 
 	switch {
+	// Info when nothing failed: nothing to push, or everything already matched.
+	// Each failure that did happen has already been printed with its reason.
+	case s.Pushed == 0 && len(s.Failed) == 0:
+		output.Log(out, "No %s were pushed. Everything is already up to date.", resource.Label)
 	case s.Pushed == 0:
 		output.Failure(out, "No %s were pushed.", resource.Label)
 	case s.Deployed != s.Pushed:

--- a/templates/go-cli/internal/cmd/pushdeploy.go
+++ b/templates/go-cli/internal/cmd/pushdeploy.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -519,6 +520,14 @@ type deployable struct {
 	ApproveKeys []string
 	// DeploymentKeys are the config fields sent alongside the archive.
 	DeploymentKeys []string
+	// OmitWhenEmpty are fields left out of a request when the config leaves
+	// them blank, rather than sent as "".
+	//
+	// An entrypoint is the case: it is required on create and optional on
+	// update, so a blank one in the config means "unchanged". Sending "" would
+	// clear the value already on the server. Deliberately NOT every field --
+	// an empty `schedule` really does mean "unschedule it".
+	OmitWhenEmpty []string
 	// ConsoleURL renders the deployment's console page.
 	ConsoleURL func(base, slug, resourceID, deploymentID string) string
 }
@@ -542,6 +551,7 @@ var deployables = []deployable{
 			"vars", "ignore",
 		},
 		DeploymentKeys: []string{"entrypoint", "commands"},
+		OmitWhenEmpty:  []string{"entrypoint"},
 		ConsoleURL: func(base, slug, resourceID, deploymentID string) string {
 			return fmt.Sprintf("%s/console/%s/functions/function-%s/deployment-%s",
 				base, slug, resourceID, deploymentID)
@@ -906,6 +916,19 @@ func (c *pushContext) completeDeployables(
 			name = entry.GetString("$id")
 		}
 
+		// Required on CREATE only. The API asks for none of these -- `functions
+		// create` requires function-id, name and runtime, and nothing else --
+		// so an update that happens to leave the field blank locally is not an
+		// error, it just has nothing to say about it. The value already on the
+		// server is kept, which writeBody arranges by omitting the key.
+		if c.resourceExists(resource, entry.GetString("$id")) {
+			output.Log(out, "%s %s has no %s set locally. Keeping the one on the server.",
+				capitalizeFirst(resource.Singular), name, field)
+			usable = append(usable, entry)
+
+			continue
+		}
+
 		// Which one, and what is missing. The TypeScript logs this before it
 		// prompts (push.ts:3656); without it the question arrives as a bare
 		// "Enter the entrypoint" with no clue which of ten functions it is for.
@@ -944,6 +967,28 @@ func (c *pushContext) completeDeployables(
 	}
 
 	return usable, c.local.Write()
+}
+
+// resourceExists reports whether the resource is already on the server.
+//
+// Only asked for a resource whose config leaves a create-required field blank,
+// so it costs one extra request in the one case that needs the answer.
+//
+// A 404 means "not there", so the field is required. Any OTHER failure --
+// offline, an expired session, a 500 -- leaves the question unanswered, and the
+// safe answer is the stricter one: treat it as a create and ask.
+func (c *pushContext) resourceExists(resource deployable, id string) bool {
+	// No id to ask about, or nothing to ask: both mean the answer is unknown,
+	// and unknown takes the strict branch.
+	if id == "" || c.api == nil {
+		return false
+	}
+
+	if _, err := c.fetchResource(resource, id); err != nil {
+		return false
+	}
+
+	return true
 }
 
 // capitalizeFirst starts a sentence with the resource name, which is stored
@@ -1016,10 +1061,11 @@ func (c *pushContext) pushDeployable(
 		}
 
 		err = c.api.Call("PUT", resource.Path+"/"+url.PathEscape(id),
-			writeBody(entry, resource.WriteKeys, "", ""), nil)
+			writeBody(entry, resource.WriteKeys, resource.OmitWhenEmpty, "", ""), nil)
 	} else {
 		err = c.api.Call("POST", resource.Path,
-			writeBody(entry, resource.WriteKeys, resource.IDField, id), nil)
+			writeBody(entry, resource.WriteKeys, resource.OmitWhenEmpty,
+				resource.IDField, id), nil)
 	}
 	if err != nil {
 		output.Failure(out, "Failed to push %s %s: %s", resource.Singular, name, err)
@@ -1071,16 +1117,28 @@ func (c *pushContext) pushDeployable(
 // Only keys the config actually carries are sent. The TypeScript passes the
 // rest as undefined and JSON.stringify drops them, so sending an explicit null
 // would be a behaviour change -- it would clear the field on the remote.
-func writeBody(entry *jsonx.Object, keys []string, idField, id string) *jsonx.Object {
+func writeBody(
+	entry *jsonx.Object,
+	keys []string,
+	omitWhenEmpty []string,
+	idField, id string,
+) *jsonx.Object {
 	body := jsonx.NewObject()
 	if idField != "" {
 		body.Set(idField, id)
 	}
 
 	for _, key := range keys {
-		if value, ok := entry.Get(key); ok {
-			body.Set(key, value)
+		value, ok := entry.Get(key)
+		if !ok {
+			continue
 		}
+		if text, isText := value.(string); isText && text == "" &&
+			slices.Contains(omitWhenEmpty, key) {
+			continue
+		}
+
+		body.Set(key, value)
 	}
 
 	return body
@@ -1158,12 +1216,21 @@ func (c *pushContext) createDeployment(
 
 	fields := make([]client.FormField, 0, len(resource.DeploymentKeys)+1)
 	for _, key := range resource.DeploymentKeys {
-		if value, ok := entry.Get(key); ok {
-			fields = append(fields, client.FormField{
-				Name:  key,
-				Value: fmt.Sprint(scalarOf(value)),
-			})
+		value, ok := entry.Get(key)
+		if !ok {
+			continue
 		}
+		// Same rule as writeBody: a blank entrypoint means "use the one the
+		// function already has", not "deploy with none".
+		if text, isText := value.(string); isText && text == "" &&
+			slices.Contains(resource.OmitWhenEmpty, key) {
+			continue
+		}
+
+		fields = append(fields, client.FormField{
+			Name:  key,
+			Value: fmt.Sprint(scalarOf(value)),
+		})
 	}
 	fields = append(fields, client.FormField{
 		Name: "activate", Value: fmt.Sprint(activate),

--- a/templates/go-cli/internal/cmd/pushdeploy.go
+++ b/templates/go-cli/internal/cmd/pushdeploy.go
@@ -821,17 +821,15 @@ func (s *pushSummary) report(
 ) {
 	out := command.OutOrStdout()
 
+	// The link, and only the link. The spinner row above it has already said
+	// which resource failed and why -- `✗ Error • Template site (id) •
+	// Deployment failed` -- so repeating the sentence here said the same thing
+	// twice in consecutive lines, and hung the URL off the end of the second
+	// one where it is hardest to select. This is the same closing line a
+	// SUCCESSFUL deploy prints, which is the point: either way the last thing on
+	// screen is the page to open.
 	for _, failure := range s.Failed {
-		if failure.Reason == "timeout" {
-			output.Failure(out,
-				"Deployment of %s got stuck for more than %d minutes. Check deployment here: %s\n",
-				failure.Name, deploymentTimeoutMinutes, failure.ConsoleURL)
-
-			continue
-		}
-
-		output.Failure(out, "Deployment of %s has failed. Check deployment here: %s\n",
-			failure.Name, failure.ConsoleURL)
+		output.Log(out, "Deployment page: %s", failure.ConsoleURL)
 	}
 
 	if async {
@@ -849,15 +847,39 @@ func (s *pushSummary) report(
 		output.Log(out, "No %s were pushed. Everything is already up to date.", resource.Label)
 	case s.Pushed == 0:
 		output.Failure(out, "No %s were pushed.", resource.Label)
+	// Nothing deployed is a failure, and it used to be announced as
+	// `ℹ Warning: Successfully deployed 0 of 1 sites` -- a sentence that
+	// contradicts itself twice over. Nothing succeeded, so "successfully" is
+	// wrong; and a push where every deployment failed is not a caveat on a good
+	// outcome, it is the bad one.
+	case s.Deployed == 0:
+		output.Failure(out, "Deployed none of the %d %s pushed, in %s.",
+			s.Pushed, plural(s.Pushed, resource), seconds)
+	// Some did deploy, so this really is a partial result -- but it is still not
+	// a "success", and saying how many failed is what the reader wants next.
 	case s.Deployed != s.Pushed:
-		output.Warn(out, "Successfully deployed %d of %d %s in %s.",
-			s.Deployed, s.Pushed, resource.Label, seconds)
+		output.Warn(out, "Deployed %d of %d %s in %s. %d failed.",
+			s.Deployed, s.Pushed, plural(s.Pushed, resource), seconds,
+			s.Pushed-s.Deployed)
 	case s.Pushed == 1:
 		output.Success(out, "Successfully deployed 1 %s in %s.", resource.Singular, seconds)
 	default:
 		output.Success(out, "Successfully deployed %d %s in %s.",
 			s.Pushed, resource.Label, seconds)
 	}
+}
+
+// plural names a resource by count.
+//
+// `0 of 1 sites` and `1 site` both matter: a count line is the last thing a
+// push prints, and getting the agreement wrong there reads as carelessness in
+// the tool that just changed a live project.
+func plural(count int, resource deployable) string {
+	if count == 1 {
+		return resource.Singular
+	}
+
+	return resource.Label
 }
 
 // selectDeployables resolves which configured resources to push.

--- a/templates/go-cli/internal/cmd/pushdeploy.go
+++ b/templates/go-cli/internal/cmd/pushdeploy.go
@@ -693,7 +693,8 @@ func runPushDeployable(
 	// Validation runs BEFORE anything is sent, so a missing entrypoint is one
 	// question at the start rather than a failure halfway through.
 	output.Log(out, "Validating %s ...", resource.Label)
-	if err := context.completeDeployables(resource, entries); err != nil {
+	entries, err = context.completeDeployables(out, resource, entries)
+	if err != nil {
 		return err
 	}
 
@@ -868,19 +869,48 @@ func (c *pushContext) selectDeployables(
 //
 // The answer is written back to the config, so the question is asked once per
 // resource rather than once per push.
-func (c *pushContext) completeDeployables(resource deployable, entries []*jsonx.Object) error {
+func (c *pushContext) completeDeployables(
+	out io.Writer,
+	resource deployable,
+	entries []*jsonx.Object,
+) ([]*jsonx.Object, error) {
 	changed := false
+	usable := make([]*jsonx.Object, 0, len(entries))
 
 	for _, entry := range entries {
-		field, message := "", ""
+		field, message, label := "", "", ""
 
 		switch {
 		case resource.Name == "function" && entry.GetString("entrypoint") == "":
-			field, message = "entrypoint", "Enter the entrypoint"
+			field, message, label = "entrypoint", "Enter the entrypoint", "an entrypoint"
 		case resource.Name == "site" && entry.GetString("buildCommand") == "" &&
 			siteRequiresBuildCommand(entry):
-			field, message = "buildCommand", "Enter the build command"
+			field, message, label = "buildCommand", "Enter the build command", "a build command"
 		default:
+			usable = append(usable, entry)
+
+			continue
+		}
+
+		name := entry.GetString("name")
+		if name == "" {
+			name = entry.GetString("$id")
+		}
+
+		// Which one, and what is missing. The TypeScript logs this before it
+		// prompts (push.ts:3656); without it the question arrives as a bare
+		// "Enter the entrypoint" with no clue which of ten functions it is for.
+		output.Log(out, "%s %s is missing %s.", resource.Singular, name, label)
+
+		// --all says "every resource, do not ask me". It is also how a pipeline
+		// pushes, so stopping on a question there is the opposite of what was
+		// asked -- and the answer is data the CLI cannot invent. The resource is
+		// reported and skipped; the rest of the push proceeds.
+		if app.Flags().All {
+			output.Log(out,
+				"Skipping it: set %q in %s, or push it without --all to be asked.",
+				field, config.LocalFileName)
+
 			continue
 		}
 
@@ -890,19 +920,20 @@ func (c *pushContext) completeDeployables(resource deployable, entries []*jsonx.
 			Validate: prompt.Required(field),
 		})
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		entry.Set(field, answer)
 		c.local.UpsertByID(resource.ConfigKey, entry)
 		changed = true
+		usable = append(usable, entry)
 	}
 
 	if !changed {
-		return nil
+		return usable, nil
 	}
 
-	return c.local.Write()
+	return usable, c.local.Write()
 }
 
 // siteRequiresBuildCommand reports whether a site has to be built.

--- a/templates/go-cli/internal/cmd/pushdeploy.go
+++ b/templates/go-cli/internal/cmd/pushdeploy.go
@@ -1390,12 +1390,16 @@ func (c *pushContext) awaitDeployment(
 
 			// A ready site is given a moment to finish its preview
 			// screenshots. The deployment is already live; this only decides
-			// whether the console page has an image on it yet.
+			// whether there is a picture to show for it.
 			if resource.Name == "site" && !hasScreenshots(deployment) {
 				if readySince.IsZero() {
 					readySince = time.Now()
 				}
 				if time.Since(readySince) < screenshotFinalizationTimeout {
+					// Named, not silent. The build has finished, so "Deploying"
+					// is no longer true, and a row that stops changing for half
+					// a minute after the last log line looks stuck.
+					spinner.Update("Finalizing", "Finalizing deployment preview...")
 					time.Sleep(pollDebounce)
 
 					continue
@@ -1405,7 +1409,7 @@ func (c *pushContext) awaitDeployment(
 			logPrinter.Complete()
 			spinner.Succeed("Deployed", "")
 			summary.Deployed++
-			c.reportDeployment(command, resource, id, consoleURL)
+			c.reportDeployment(command, resource, id, consoleURL, deployment)
 
 			return
 
@@ -1443,16 +1447,24 @@ func (c *pushContext) fetchDeployment(
 	return deployment, nil
 }
 
-// reportDeployment prints the links a finished deployment produced.
+// reportDeployment prints what a finished deployment produced.
+//
+// For a site that is a picture of the page as well as the links to it -- see
+// pushpreview.go for why a screenshot is worth the bytes.
 func (c *pushContext) reportDeployment(
 	command *cobra.Command,
 	resource deployable,
 	id, consoleURL string,
+	deployment *jsonx.Object,
 ) {
 	out := command.OutOrStdout()
 
-	if preview := c.previewURL(resource, id); preview != "" {
-		output.Log(out, "Preview link: %s", preview)
+	if resource.Name == "site" {
+		c.reportScreenshot(out, deployment)
+	}
+
+	if link := c.previewURL(resource, id); link != "" {
+		output.Log(out, "Preview link: %s", link)
 	}
 	output.Log(out, "Deployment page: %s", consoleURL)
 }

--- a/templates/go-cli/internal/cmd/pushpreview.go
+++ b/templates/go-cli/internal/cmd/pushpreview.go
@@ -1,0 +1,185 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+
+	"github.com/appwrite/appwrite-cli-go/internal/app"
+	"github.com/appwrite/appwrite-cli-go/internal/client"
+	"github.com/appwrite/appwrite-cli-go/internal/jsonx"
+	"github.com/appwrite/appwrite-cli-go/internal/output"
+	"github.com/appwrite/appwrite-cli-go/internal/preview"
+	"golang.org/x/term"
+)
+
+// Screenshot previews for a deployed site.
+//
+// Ports the preview half of Push.pushSites: renderSiteTerminalPreview
+// (push.ts:420), fetchSiteScreenshotPreview (:356) and the block at :2755 that
+// prints them under the deployment summary.
+//
+// Why the CLI shows a picture at all: a site deploy succeeds whenever the build
+// does, and a build succeeds for a page that renders blank, renders an error, or
+// renders the previous version because an asset path was wrong. The deployment
+// page has the screenshot on it, and the point of pushing from a terminal is not
+// to open a browser to find that out.
+
+// screenshots is the state a push carries for its previews.
+//
+// The console client is built at most once per push and only when a preview is
+// actually going to be drawn -- it needs a session, and a push authenticated
+// with an API key has none. Warnings are deduplicated for the same reason the
+// TypeScript keeps a Set of them: pushing eight sites past an unreachable
+// console should say so once.
+type screenshots struct {
+	console  *client.Client
+	setupErr error
+	built    bool
+	warned   map[string]bool
+}
+
+// reportScreenshot prints a site deployment's preview, or says why there is none.
+//
+// Ordering matches the TypeScript summary: the pending hint, then the picture,
+// then the links reportDeployment prints -- so the last line on screen is
+// always the one to click.
+func (c *pushContext) reportScreenshot(out io.Writer, deployment *jsonx.Object) {
+	if !hasScreenshots(deployment) {
+		// The deployment IS live; only its picture is missing. Saying so is the
+		// difference between a user waiting for something and a user who knows
+		// the deploy finished.
+		output.Hint(out, "Deployment is ready, but screenshot generation is still "+
+			"finalizing. Open the deployment page to view it once it is available.")
+
+		return
+	}
+
+	if !previewRenderable() {
+		return
+	}
+
+	art, err := c.screenshotArt(deployment)
+	if err != nil {
+		c.warnOnce(out, fmt.Sprintf("Screenshot preview unavailable: %s", err))
+
+		return
+	}
+	if art == "" {
+		return
+	}
+
+	fmt.Fprintf(out, "\n%s\n\n%s\n\n", output.Heading("Screenshot preview"), art)
+}
+
+// previewRenderable reports whether ANSI art belongs on this stdout.
+//
+// Ports shouldRenderSiteTerminalPreview. --json and --raw are machine-readable
+// contracts, and half a megabyte of colour escapes in the middle of one is not
+// a preview -- it is a broken pipe to whatever was parsing it. A redirected
+// stdout is excluded for the same reason.
+func previewRenderable() bool {
+	if app.Flags().JSON || app.Flags().Raw {
+		return false
+	}
+
+	return term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+// screenshotArt fetches and renders the first screenshot that renders.
+//
+// Dark before light, matching the TypeScript's candidate order: a terminal is
+// dark far more often than not, so the dark screenshot is the one that sits in
+// it without glaring.
+func (c *pushContext) screenshotArt(deployment *jsonx.Object) (string, error) {
+	console, err := c.consoleForScreenshots()
+	if err != nil {
+		return "", err
+	}
+
+	columns, rows := previewSize()
+
+	var firstErr error
+	for _, key := range []string{"screenshotDark", "screenshotLight"} {
+		fileID := deployment.GetString(key)
+		if fileID == "" {
+			continue
+		}
+
+		encoded, err := console.Download(screenshotPath(fileID))
+		if err == nil {
+			var art string
+			art, err = preview.Render(encoded, columns, rows)
+			if err == nil {
+				return preview.Frame(art), nil
+			}
+		}
+
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	return "", firstErr
+}
+
+// screenshotPath is the preview endpoint for one screenshot file.
+func screenshotPath(fileID string) string {
+	return fmt.Sprintf(
+		"/storage/buckets/%s/files/%s/preview?width=%d&height=%d&output=png",
+		preview.Bucket, url.PathEscape(fileID), preview.Width, preview.Height)
+}
+
+// previewSize is the cell grid the terminal has room for.
+func previewSize() (int, int) {
+	width, height, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil {
+		// Columns and Rows substitute 80x24 for a size they cannot read, which
+		// is the size a terminal that will not answer is assumed to be.
+		width, height = 0, 0
+	}
+
+	return preview.Columns(width), preview.Rows(height)
+}
+
+// consoleForScreenshots builds the console client the screenshot bucket needs.
+//
+// The bucket belongs to the CONSOLE project, not to the project being pushed, so
+// the project client that ran the deployment cannot read it -- but it does have
+// the right endpoint. A screenshot lives in the region its deployment ran in,
+// and the session's endpoint has had the region normalised out of it, so the
+// project client's endpoint is passed through: `preserveRegion: true` in the
+// TypeScript, and the difference between a preview and "The requested file could
+// not be found."
+//
+// Built lazily and cached, failure included: a push with no session must not
+// retry a login error once per site.
+func (c *pushContext) consoleForScreenshots() (*client.Client, error) {
+	if c.screenshots == nil {
+		c.screenshots = &screenshots{}
+	}
+
+	if !c.screenshots.built {
+		c.screenshots.built = true
+		c.screenshots.console, _, c.screenshots.setupErr = consoleClientAt(c.api.Endpoint)
+	}
+
+	return c.screenshots.console, c.screenshots.setupErr
+}
+
+// warnOnce prints a hint the first time that exact message comes up.
+func (c *pushContext) warnOnce(out io.Writer, message string) {
+	if c.screenshots == nil {
+		c.screenshots = &screenshots{}
+	}
+	if c.screenshots.warned == nil {
+		c.screenshots.warned = map[string]bool{}
+	}
+	if c.screenshots.warned[message] {
+		return
+	}
+
+	c.screenshots.warned[message] = true
+	output.Hint(out, "%s", message)
+}

--- a/templates/go-cli/internal/cmd/pushpreview_test.go
+++ b/templates/go-cli/internal/cmd/pushpreview_test.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/appwrite/appwrite-cli-go/internal/jsonx"
+)
+
+func TestScreenshotPathAsksForAPngAtThePreviewSize(t *testing.T) {
+	want := "/storage/buckets/screenshots/files/abc123/preview?width=480&height=270&output=png"
+
+	if got := screenshotPath("abc123"); got != want {
+		t.Errorf("screenshotPath = %q, want %q", got, want)
+	}
+}
+
+// A file id comes from the API, and a path is built from it. Escaping it is the
+// cheap half of not trusting that.
+func TestScreenshotPathEscapesTheFileID(t *testing.T) {
+	if got := screenshotPath("a/b"); strings.Contains(got, "a/b") {
+		t.Errorf("screenshotPath did not escape the id: %q", got)
+	}
+}
+
+// The deployment is live whether or not its picture is. Saying so is the
+// difference between a user waiting for something and a user who knows the
+// deploy finished.
+func TestReportScreenshotSaysWhyThereIsNoPicture(t *testing.T) {
+	var out bytes.Buffer
+	context := &pushContext{}
+
+	context.reportScreenshot(&out, jsonx.NewObject())
+
+	if !strings.Contains(out.String(), "screenshot generation is still finalizing") {
+		t.Errorf("the pending hint is missing:\n%s", out.String())
+	}
+}
+
+// Off a terminal there is no picture to draw, so there must be no heading
+// either -- and no request for a screenshot that nothing will display. The test
+// binary's stdout is never a terminal, which is what makes this the path taken
+// here.
+func TestReportScreenshotDrawsNothingOffATerminal(t *testing.T) {
+	var out bytes.Buffer
+	deployment := jsonx.NewObject()
+	deployment.Set("screenshotDark", "abc123")
+
+	// A nil api would panic if this reached the fetch, which is the assertion
+	// that matters more than the empty buffer.
+	(&pushContext{}).reportScreenshot(&out, deployment)
+
+	if out.String() != "" {
+		t.Errorf("wrote something with no terminal to write it to:\n%s", out.String())
+	}
+}
+
+func TestHasScreenshots(t *testing.T) {
+	cases := []struct {
+		key   string
+		value string
+		want  bool
+	}{
+		{"screenshotDark", "abc", true},
+		{"screenshotLight", "abc", true},
+		// Whitespace is not a file id. The API has answered with one.
+		{"screenshotLight", "   ", false},
+		{"screenshotLight", "", false},
+		{"buildLogs", "abc", false},
+	}
+
+	for _, testCase := range cases {
+		deployment := jsonx.NewObject()
+		deployment.Set(testCase.key, testCase.value)
+
+		if got := hasScreenshots(deployment); got != testCase.want {
+			t.Errorf("hasScreenshots(%s=%q) = %t, want %t",
+				testCase.key, testCase.value, got, testCase.want)
+		}
+	}
+}
+
+// Eight sites past an unreachable console should say so once.
+func TestWarnOnceRepeatsNothing(t *testing.T) {
+	var out bytes.Buffer
+	context := &pushContext{}
+
+	context.warnOnce(&out, "Screenshot preview unavailable: nope")
+	context.warnOnce(&out, "Screenshot preview unavailable: nope")
+	context.warnOnce(&out, "Screenshot preview unavailable: something else")
+
+	if got := strings.Count(out.String(), "nope"); got != 1 {
+		t.Errorf("the same warning was printed %d times", got)
+	}
+	if !strings.Contains(out.String(), "something else") {
+		t.Errorf("a different warning was suppressed:\n%s", out.String())
+	}
+}

--- a/templates/go-cli/internal/cmd/pushreport_test.go
+++ b/templates/go-cli/internal/cmd/pushreport_test.go
@@ -1,0 +1,161 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func reportOf(summary *pushSummary) string {
+	var out bytes.Buffer
+	command := &cobra.Command{}
+	command.SetOut(&out)
+
+	summary.report(command, sitesDeployable(), false, 43900*time.Millisecond)
+
+	return out.String()
+}
+
+// sitesDeployable is the sites entry, found by name so the test cannot drift
+// from the real labels.
+func sitesDeployable() deployable {
+	for _, resource := range deployables {
+		if resource.Name == "site" {
+			return resource
+		}
+	}
+
+	panic("no site deployable")
+}
+
+// `ℹ Warning: Successfully deployed 0 of 1 sites` contradicted itself twice:
+// nothing succeeded, and a push where every deployment failed is not a caveat on
+// a good outcome but the bad one.
+func TestNothingDeployedIsAnError(t *testing.T) {
+	report := reportOf(&pushSummary{
+		Pushed: 1,
+		Failed: []failedDeployment{{Name: "Template site", ConsoleURL: "https://console/x"}},
+	})
+
+	if strings.Contains(report, "Successfully") {
+		t.Errorf("a push that deployed nothing still claims success:\n%s", report)
+	}
+	if !strings.Contains(report, "✗ Error") {
+		t.Errorf("a push that deployed nothing is not reported as an error:\n%s", report)
+	}
+	if !strings.Contains(report, "43.9s") {
+		t.Errorf("the elapsed time was dropped:\n%s", report)
+	}
+}
+
+// A partial result is a warning, but still not a "success" -- and how many
+// failed is what the reader wants next.
+func TestPartialDeploymentIsAWarningWithTheShortfall(t *testing.T) {
+	report := reportOf(&pushSummary{
+		Pushed:   3,
+		Deployed: 2,
+		Failed:   []failedDeployment{{Name: "Third site", ConsoleURL: "https://console/z"}},
+	})
+
+	if strings.Contains(report, "Successfully") {
+		t.Errorf("a partial deploy claims success:\n%s", report)
+	}
+	if !strings.Contains(report, "Warning") {
+		t.Errorf("a partial deploy is not a warning:\n%s", report)
+	}
+	if !strings.Contains(report, "2 of 3 sites") || !strings.Contains(report, "1 failed") {
+		t.Errorf("the shortfall is not stated:\n%s", report)
+	}
+}
+
+// The spinner row above the summary has already said which resource failed and
+// why, so the summary states the link and nothing else. Saying `Deployment of X
+// has failed` again put the same sentence on two consecutive lines and hung the
+// URL off the end of the second one.
+func TestAFailureIsNotAnnouncedTwice(t *testing.T) {
+	report := reportOf(&pushSummary{
+		Pushed: 1,
+		Failed: []failedDeployment{{Name: "Template site", ConsoleURL: "https://console/x"}},
+	})
+
+	if strings.Contains(report, "has failed") {
+		t.Errorf("the failure sentence is repeated in the summary:\n%s", report)
+	}
+	if strings.Count(report, "https://console/x") != 1 {
+		t.Errorf("the deployment link is not printed exactly once:\n%s", report)
+	}
+}
+
+// The link goes on its own line, which is what makes it selectable -- and it is
+// the same closing line a successful deploy prints.
+func TestTheDeploymentLinkIsOnItsOwnLine(t *testing.T) {
+	report := reportOf(&pushSummary{
+		Pushed: 1,
+		Failed: []failedDeployment{{Name: "Template site", ConsoleURL: "https://console/x"}},
+	})
+
+	var found bool
+	for _, line := range strings.Split(report, "\n") {
+		if !strings.Contains(line, "https://console/x") {
+			continue
+		}
+		found = true
+		if !strings.Contains(line, "Deployment page:") {
+			t.Errorf("the link line is not labelled: %q", line)
+		}
+		if strings.Contains(line, "Error") {
+			t.Errorf("the link is still hung off the error sentence: %q", line)
+		}
+	}
+
+	if !found {
+		t.Errorf("no line carries the link:\n%s", report)
+	}
+}
+
+// A timed-out deployment reports its link the same way. The spinner row said it
+// got stuck; repeating that here was the same duplication.
+func TestATimeoutReportsItsLinkToo(t *testing.T) {
+	report := reportOf(&pushSummary{
+		Pushed: 1,
+		Failed: []failedDeployment{
+			{Name: "Slow site", Reason: "timeout", ConsoleURL: "https://console/slow"},
+		},
+	})
+
+	if !strings.Contains(report, "https://console/slow") {
+		t.Errorf("a timed-out deployment lost its link:\n%s", report)
+	}
+	if strings.Contains(report, "got stuck") {
+		t.Errorf("the timeout sentence is repeated in the summary:\n%s", report)
+	}
+}
+
+// One site is a site, not `1 sites`. A count line is the last thing a push
+// prints, and the agreement being wrong there reads as carelessness in the tool
+// that just changed a live project.
+func TestCountsAgreeWithTheirNouns(t *testing.T) {
+	single := reportOf(&pushSummary{Pushed: 1,
+		Failed: []failedDeployment{{Name: "One", ConsoleURL: "https://console/1"}}})
+	if !strings.Contains(single, "1 site,") && !strings.Contains(single, "1 site ") {
+		t.Errorf("one site was pluralised:\n%s", single)
+	}
+
+	many := reportOf(&pushSummary{Pushed: 2,
+		Failed: []failedDeployment{{Name: "One", ConsoleURL: "https://console/1"}}})
+	if !strings.Contains(many, "2 sites") {
+		t.Errorf("two sites were singularised:\n%s", many)
+	}
+}
+
+// Everything deploying is still a success, and still says so.
+func TestAFullDeploymentStillReportsSuccess(t *testing.T) {
+	report := reportOf(&pushSummary{Pushed: 2, Deployed: 2})
+
+	if !strings.Contains(report, "Successfully deployed 2 sites") {
+		t.Errorf("a complete deploy lost its success line:\n%s", report)
+	}
+}

--- a/templates/go-cli/internal/cmd/pushsimple.go
+++ b/templates/go-cli/internal/cmd/pushsimple.go
@@ -278,7 +278,20 @@ func runPushSimple(command *cobra.Command, resource simpleResource) error {
 	// A failed push is reported and counted, never returned: the TypeScript
 	// exits zero here, and a partial push has already changed the project.
 	if pushed == 0 {
-		output.Failure(out, "No %s were pushed.", resource.Plural)
+		// Info, not an error, when nothing went wrong. The commonest way to
+		// reach this line is a push where every resource already matches --
+		// see the Skipping branch above -- which is a good outcome reported
+		// as a failure. And the command exits zero either way, so an
+		// `✗ Error:` line above a zero exit status contradicted itself.
+		//
+		// A push where every attempt failed is different, and each failure has
+		// already been printed with its own reason.
+		if len(failures) > 0 {
+			output.Failure(out, "No %s were pushed.", resource.Plural)
+		} else {
+			output.Log(out, "No %s were pushed. Everything is already up to date.",
+				resource.Plural)
+		}
 	} else {
 		output.Success(out, "Successfully pushed %d %s.", pushed, resource.Plural)
 	}

--- a/templates/go-cli/internal/cmd/root.go.twig
+++ b/templates/go-cli/internal/cmd/root.go.twig
@@ -22,7 +22,6 @@ func NewRootCommand() *cobra.Command {
 	root := &cobra.Command{
 		Use:     "{{ language.params.executableName }}",
 		Short:   {{ sdk.shortDescription | goString | raw }},
-		Long:    helpDescription,
 		Version: app.Version,
 		// Errors and usage are rendered by the output package, not by cobra.
 		SilenceUsage:  true,

--- a/templates/go-cli/internal/cmd/root.go.twig
+++ b/templates/go-cli/internal/cmd/root.go.twig
@@ -22,6 +22,7 @@ func NewRootCommand() *cobra.Command {
 	root := &cobra.Command{
 		Use:     "{{ language.params.executableName }}",
 		Short:   {{ sdk.shortDescription | goString | raw }},
+		Long:    helpDescription,
 		Version: app.Version,
 		// Errors and usage are rendered by the output package, not by cobra.
 		SilenceUsage:  true,
@@ -49,6 +50,9 @@ func NewRootCommand() *cobra.Command {
 	registerSessionCommands(root)
 
 	registerCompletionInstall(root)
+
+	// Last, so the grouped screen sees the whole tree.
+	registerMainHelp(root)
 
 	return root
 }

--- a/templates/go-cli/internal/cmd/root.go.twig
+++ b/templates/go-cli/internal/cmd/root.go.twig
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"{{ language.params.modulePath }}/internal/app"
+	"{{ language.params.modulePath }}/internal/auth"
 	"{{ language.params.modulePath }}/internal/client"
 	"{{ language.params.modulePath }}/internal/cmd/services"
 	"{{ language.params.modulePath }}/internal/output"
@@ -27,6 +28,11 @@ func NewRootCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRun: func(command *cobra.Command, arguments []string) {
+			// internal/client names a command in one error message and cannot
+			// import internal/app to get the name -- app reaches client through
+			// internal/sdk, so that would be a cycle.
+			client.ExecutableName = app.ExecutableName
+
 			// --verbose was registered and read by nothing. What it is FOR is
 			// answering "why is this slow", so it traces each request with its
 			// status and how long it took.
@@ -36,6 +42,13 @@ func NewRootCommand() *cobra.Command {
 			// are not traced.
 			if app.Flags().Verbose {
 				client.RequestLog = func(format string, arguments ...any) {
+					output.Trace(command.ErrOrStderr(), format, arguments...)
+				}
+				// Which credential store answered, and what it said. Without
+				// this a failed refresh printed one sentence with no evidence
+				// behind it, and the commonest cause -- looking in a keychain
+				// other than the one holding the token -- was invisible.
+				auth.Trace = func(format string, arguments ...any) {
 					output.Trace(command.ErrOrStderr(), format, arguments...)
 				}
 			}

--- a/templates/go-cli/internal/cmd/session.go
+++ b/templates/go-cli/internal/cmd/session.go
@@ -44,6 +44,21 @@ func preferences() (*config.Global, error) {
 // Ports sdkForConsole(). The access token is refreshed first when it is expired
 // or within a minute of expiring.
 func consoleClient() (*client.Client, *config.Global, error) {
+	return consoleClientAt("")
+}
+
+// consoleClientAt is consoleClient against a given endpoint.
+//
+// Ports sdkForConsole's `endpointOverride` with `preserveRegion: true`. The
+// session's endpoint is the region-less one -- login normalises it, so a Cloud
+// session is stored as cloud.appwrite.io however the user reached it -- and a
+// resource that lives in ONE region is not there. The screenshot bucket is the
+// case: the file exists in nyc.cloud.appwrite.io and the region-less console
+// answers "The requested file could not be found."
+//
+// An empty endpoint keeps the session's, which is what console-wide routes such
+// as /account and /projects want.
+func consoleClientAt(override string) (*client.Client, *config.Global, error) {
 	global, err := preferences()
 	if err != nil {
 		return nil, nil, err
@@ -57,6 +72,9 @@ func consoleClient() (*client.Client, *config.Global, error) {
 	endpoint := session.GetString(config.PreferenceEndpoint)
 	if endpoint == "" {
 		return nil, nil, ErrNotLoggedIn
+	}
+	if override != "" {
+		endpoint = override
 	}
 
 	api := client.New(endpoint, app.Version).

--- a/templates/go-cli/internal/cmd/types.go
+++ b/templates/go-cli/internal/cmd/types.go
@@ -55,7 +55,7 @@ func newTypesCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "types <output-directory>",
 		Short: "Generate types for your Appwrite project",
-		Args:  cobra.ExactArgs(1),
+		Args:  RequiredArgument("<output-directory>", "The directory to write the types to"),
 		RunE: func(command *cobra.Command, args []string) error {
 			return runTypes(command, args[0], language, strict)
 		},

--- a/templates/go-cli/internal/output/message.go
+++ b/templates/go-cli/internal/output/message.go
@@ -64,6 +64,15 @@ func Note(writer io.Writer, format string, arguments ...any) {
 	fmt.Fprintf(writer, "%s\n", traceStyle.Render(fmt.Sprintf(format, arguments...)))
 }
 
+// Heading styles a label that introduces a block rather than a line.
+//
+// Cyan and bold, which is `chalk.cyan.bold` in the TypeScript. Returned rather
+// than written because the caller decides the blank lines around it -- a
+// heading with nothing under it is worse than no heading.
+func Heading(text string) string {
+	return infoStyle.Bold(true).Render(text)
+}
+
 // Failure writes an error line.
 //
 // Named Failure rather than Error so it does not read as constructing an error

--- a/templates/go-cli/internal/output/message.go
+++ b/templates/go-cli/internal/output/message.go
@@ -53,6 +53,17 @@ func Success(writer io.Writer, format string, arguments ...any) {
 	writeMessage(writer, successStyle, "✓ Success:", format, arguments...)
 }
 
+// Note writes a plain line, dimmed and with no prefix.
+//
+// For something the CLI is telling the user about the user's own action rather
+// than about an operation. A cancelled prompt is the case: it is not
+// information, not a warning and not an error, and giving it one of those
+// prefixes miscategorises a deliberate decision as a problem. The user pressed
+// Ctrl-C a moment ago, so the line only has to confirm what happened.
+func Note(writer io.Writer, format string, arguments ...any) {
+	fmt.Fprintf(writer, "%s\n", traceStyle.Render(fmt.Sprintf(format, arguments...)))
+}
+
 // Failure writes an error line.
 //
 // Named Failure rather than Error so it does not read as constructing an error

--- a/templates/go-cli/internal/output/render.go
+++ b/templates/go-cli/internal/output/render.go
@@ -19,9 +19,12 @@ import (
 // then one section per nested value -- without chasing the TypeScript's exact
 // spacing.
 //
-// NOT YET PORTED: response-config.ts, which supplies per-resource field
-// selection, timestamp formatting and duration humanising. Values render as
-// their raw JSON scalars until that lands.
+// PARTIALLY PORTED from response-config.ts. Its scalar half is done and lives
+// in valueformat.go -- timestamp formatting and duration humanising both apply
+// here -- and its `sectionFields` half is in sections.go. What is still missing
+// is per-resource selection of the TOP-LEVEL fields, and the aligned-column
+// renderers (renderAlignedColumns, padColumn, wrapValues) that lay several
+// values out side by side.
 
 var (
 	sectionStyle = lipgloss.NewStyle().Bold(true).Underline(true).Foreground(lipgloss.Color("3"))

--- a/templates/go-cli/internal/preview/frame.go
+++ b/templates/go-cli/internal/preview/frame.go
@@ -1,0 +1,101 @@
+package preview
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// Frame draws a box around rendered art.
+//
+// Ports frameTerminalPreview (push.ts:383), border characters included. The box
+// is what separates a picture of a web page from the terminal it is printed in:
+// without it a screenshot with a white background bleeds into a light terminal
+// and there is no telling where the page ends.
+//
+// Blank leading and trailing lines are dropped first. The image is fitted into
+// a box it rarely fills exactly, and the letterboxing it arrives with would
+// otherwise be framed as though it were part of the page.
+func Frame(art string) string {
+	lines := strings.Split(art, "\n")
+	for index, line := range lines {
+		lines[index] = strings.TrimRight(line, " \t")
+	}
+
+	for len(lines) > 0 && strings.TrimSpace(visible(lines[0])) == "" {
+		lines = lines[1:]
+	}
+	for len(lines) > 0 && strings.TrimSpace(visible(lines[len(lines)-1])) == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	if len(lines) == 0 {
+		return ""
+	}
+
+	width := 0
+	for _, line := range lines {
+		width = max(width, utf8.RuneCountInString(visible(line)))
+	}
+
+	border := "+-" + strings.Repeat("-", width) + "-+"
+	framed := make([]string, 0, len(lines)+2)
+	framed = append(framed, border)
+
+	for _, line := range lines {
+		// Reset before the padding, or the last cell's background colour runs
+		// through the gap and swallows the right-hand border.
+		padding := strings.Repeat(" ", width-utf8.RuneCountInString(visible(line)))
+		framed = append(framed, "| "+line+ansiReset+padding+" |")
+	}
+
+	return strings.Join(append(framed, border), "\n")
+}
+
+// visible is a line without its ANSI escape sequences.
+//
+// Ports Node's stripVTControlCharacters, which is what the TypeScript measures
+// with. Only the CSI sequences this package emits and the ones a terminal
+// library is likely to have added are recognised -- a colour escape counts for
+// no columns, and measuring the raw string instead would pad every line by the
+// twenty-odd bytes each cell costs.
+func visible(line string) string {
+	var builder strings.Builder
+
+	for index := 0; index < len(line); {
+		if line[index] != 0x1b {
+			builder.WriteByte(line[index])
+			index++
+
+			continue
+		}
+
+		index++
+		if index >= len(line) {
+			// An escape that never terminates is dropped whole rather than
+			// half-printed.
+			break
+		}
+
+		switch {
+		case line[index] == '[':
+			// CSI: ESC [ ... <final byte in @ to ~>. Every escape this package
+			// emits is one of these.
+			index++
+			for index < len(line) && (line[index] < '@' || line[index] > '~') {
+				index++
+			}
+			if index < len(line) {
+				index++
+			}
+		case strings.IndexByte("()*+#%", line[index]) >= 0:
+			// A two-byte designator -- ESC ( B selects ASCII, which lipgloss
+			// and bubbletea both emit. Its final byte is ordinary text, so
+			// skipping only the intermediate would print a stray "B".
+			index += 2
+		default:
+			index++
+		}
+	}
+
+	return builder.String()
+}

--- a/templates/go-cli/internal/preview/frame_test.go
+++ b/templates/go-cli/internal/preview/frame_test.go
@@ -1,0 +1,100 @@
+package preview
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestFrameBoxesEveryLineToOneWidth(t *testing.T) {
+	framed := Frame("ab\nabcd\nabc")
+
+	want := strings.Join([]string{
+		"+------+",
+		"| ab   |",
+		"| abcd |",
+		"| abc  |",
+		"+------+",
+	}, "\n")
+
+	// The reset is emitted after every line, so compare without it rather than
+	// writing it into the expectation five times.
+	if got := strings.ReplaceAll(framed, ansiReset, ""); got != want {
+		t.Errorf("Frame boxed the lines wrongly:\n%s", got)
+	}
+}
+
+// Colour escapes cost no columns. Measuring the raw string instead pads every
+// line by the twenty-odd bytes a coloured cell costs, which puts the right-hand
+// border a screen and a half away.
+func TestFrameMeasuresWhatIsVisible(t *testing.T) {
+	framed := Frame("\x1b[38;2;1;2;3m\x1b[48;2;4;5;6m▀\x1b[0m")
+
+	if got := len(strings.Split(framed, "\n")); got != 3 {
+		t.Fatalf("framed %d lines, want 3", got)
+	}
+
+	border := strings.Split(framed, "\n")[0]
+	if border != "+---+" {
+		t.Errorf("the border measured the escapes: %q", border)
+	}
+}
+
+// The reset goes before the padding. Without it the last cell's background
+// colour runs through the gap and swallows the right-hand border, which is the
+// one part of the frame that has to be there for the frame to read as a box.
+func TestFrameResetsBeforeThePadding(t *testing.T) {
+	line := strings.Split(Frame("\x1b[48;2;9;9;9m▀\nxx"), "\n")[1]
+
+	if !strings.HasSuffix(line, ansiReset+" "+" |") {
+		t.Errorf("the padding was not reset first: %q", line)
+	}
+}
+
+// An image is fitted into a box it rarely fills, and the letterboxing it
+// arrives with is not part of the page.
+func TestFrameDropsSurroundingBlankLines(t *testing.T) {
+	framed := Frame("\n  \nabc\n\n")
+
+	if got := len(strings.Split(framed, "\n")); got != 3 {
+		t.Errorf("blank lines were framed:\n%s", framed)
+	}
+}
+
+func TestFrameOfNothingIsNothing(t *testing.T) {
+	if got := Frame("\n \n"); got != "" {
+		t.Errorf("Frame(blank) = %q, want empty", got)
+	}
+}
+
+// The border has to be as wide as the widest cell row, which is what makes a
+// rendered screenshot square in its box.
+func TestFrameOfRenderedArt(t *testing.T) {
+	art := "\x1b[38;2;0;0;0m\x1b[48;2;0;0;0m▀\x1b[38;2;0;0;0m\x1b[48;2;0;0;0m▀" + ansiReset
+	lines := strings.Split(Frame(art+"\n"+art), "\n")
+
+	for _, line := range lines {
+		if got := utf8.RuneCountInString(visible(line)); got != 6 {
+			t.Errorf("line %q is %d visible columns, want 6", visible(line), got)
+		}
+	}
+}
+
+func TestVisible(t *testing.T) {
+	cases := map[string]string{
+		"plain":                    "plain",
+		"\x1b[0m":                  "",
+		"\x1b[38;2;1;2;3mx\x1b[0m": "x",
+		// An escape that never terminates: dropped whole, not half-printed.
+		"a\x1b[38;2;1":  "a",
+		"a\x1b(Bb":      "ab",
+		"\x1b":          "",
+		"\x1b[1;31mred": "red",
+	}
+
+	for line, want := range cases {
+		if got := visible(line); got != want {
+			t.Errorf("visible(%q) = %q, want %q", line, got, want)
+		}
+	}
+}

--- a/templates/go-cli/internal/preview/render.go
+++ b/templates/go-cli/internal/preview/render.go
@@ -1,0 +1,259 @@
+// Package preview draws a site's deployment screenshot in the terminal.
+//
+// Ports the terminal-image half of templates/cli/lib/commands/push.ts: the
+// constants at :123, renderImageBufferToTerminalPreview (:305) and
+// frameTerminalPreview (:383).
+//
+// The TypeScript delegates the pixels to the `terminal-image` package and then
+// deliberately unsets TERM_PROGRAM, KITTY_WINDOW_ID and friends to force that
+// package's ANSI fallback -- iTerm and kitty would otherwise receive a real
+// image, which cannot be framed and does not survive a copied-out transcript.
+// So the fallback IS the shipped rendering, and it is the only one implemented
+// here. That also means no new dependency: image/png and image/jpeg are in the
+// standard library, and half-block cells are a few lines of arithmetic.
+package preview
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"image/color"
+	_ "image/jpeg" // Registered for its decoder; the API asks for PNG.
+	_ "image/png"
+	"math"
+	"strings"
+)
+
+// The screenshot the API is asked for.
+//
+// The bucket is a console-project bucket, not one of the pushed project's, so
+// the request has to go through a console-authenticated client.
+const (
+	// Bucket is SITE_SCREENSHOT_BUCKET_ID.
+	Bucket = "screenshots"
+
+	// Width and Height are SITE_SCREENSHOT_PREVIEW_WIDTH and
+	// SITE_SCREENSHOT_PREVIEW_HEIGHT: the size the preview endpoint is asked
+	// to resize to, which is a request for LESS data than the original, not a
+	// display size. Anything above the terminal's cell grid is thrown away
+	// again here, and a 480px source already has more detail than 72 columns
+	// can show.
+	Width  = 480
+	Height = 270
+)
+
+// The cell grid the art is drawn into.
+//
+// SITE_TERMINAL_PREVIEW_TARGET_WIDTH and the four bounds beside it. The target
+// is narrower than the maximum on purpose: a preview that fills an 200-column
+// terminal edge to edge is a wall, and the links printed under it are what the
+// user came for.
+const (
+	targetColumns = 72
+	maxColumns    = 80
+	minColumns    = 16
+	maxRows       = 22
+	minRows       = 8
+)
+
+// upperHalfBlock fills the top half of its cell.
+//
+// One cell therefore carries two pixels: the foreground colour paints the top
+// half and the background colour the bottom, which is what makes the pixel grid
+// square in a cell that is roughly twice as tall as it is wide.
+const upperHalfBlock = "▀"
+
+// ansiReset closes the colours a cell row opened.
+//
+// One per line rather than one per cell: without it the last cell's background
+// runs to the right edge of the terminal, and repeating it after every cell is
+// three times the bytes for the same picture.
+const ansiReset = "\x1b[0m"
+
+// Columns is the width to draw into, for a terminal of the given width.
+//
+// Ports getSiteTerminalPreviewWidth. The -4 leaves room for the frame and a
+// margin; the floor is what keeps a very narrow terminal producing a small
+// picture rather than a zero-width one.
+func Columns(terminalColumns int) int {
+	if terminalColumns <= 0 {
+		terminalColumns = 80
+	}
+
+	return max(minColumns, min(terminalColumns-4, targetColumns, maxColumns))
+}
+
+// Rows is the height to draw into, for a terminal of the given height.
+//
+// Ports getSiteTerminalPreviewHeight. The -10 is the summary that has to stay
+// on screen with it: the status row, the two links, and the blank lines around
+// them.
+func Rows(terminalRows int) int {
+	if terminalRows <= 0 {
+		terminalRows = 24
+	}
+
+	return max(minRows, min(terminalRows-10, maxRows))
+}
+
+// Render draws an encoded image as ANSI art at most columns wide and rows tall.
+//
+// The aspect ratio is preserved, so the result is usually smaller than the box
+// it was given in one of the two directions.
+func Render(encoded []byte, columns, rows int) (string, error) {
+	source, _, err := image.Decode(bytes.NewReader(encoded))
+	if err != nil {
+		return "", fmt.Errorf("decoding the screenshot: %w", err)
+	}
+
+	// Two pixel rows per cell row, which is what the half block buys.
+	pixels := scale(source, columns, rows*2)
+
+	return draw(pixels), nil
+}
+
+// scale box-averages an image down to fit a pixel grid.
+//
+// Averaging rather than nearest-neighbour sampling: a site screenshot is mostly
+// text, and dropping 90% of the rows picks whichever scanline happens to land
+// on a cell boundary -- which turns a paragraph into stripes that change every
+// time the terminal is resized by one column.
+func scale(source image.Image, width, height int) [][]color.NRGBA {
+	bounds := source.Bounds()
+	sourceWidth := bounds.Dx()
+	sourceHeight := bounds.Dy()
+
+	if sourceWidth <= 0 || sourceHeight <= 0 || width <= 0 || height <= 0 {
+		return nil
+	}
+
+	factor := math.Min(
+		float64(width)/float64(sourceWidth),
+		float64(height)/float64(sourceHeight),
+	)
+	// Rounded DOWN, not to nearest. The dimension the factor is taken from
+	// comes out exact either way, and rounding the other one up is how a 16:9
+	// screenshot -- 270 rows at 0.15 is 40.5 -- gained a 41st pixel row and so
+	// a 21st cell row that is half padding.
+	targetWidth := max(1, int(float64(sourceWidth)*factor))
+	targetHeight := max(1, int(float64(sourceHeight)*factor))
+
+	pixels := make([][]color.NRGBA, targetHeight)
+	for y := range pixels {
+		pixels[y] = make([]color.NRGBA, targetWidth)
+		top := bounds.Min.Y + y*sourceHeight/targetHeight
+		bottom := max(top+1, bounds.Min.Y+(y+1)*sourceHeight/targetHeight)
+
+		for x := range pixels[y] {
+			left := bounds.Min.X + x*sourceWidth/targetWidth
+			right := max(left+1, bounds.Min.X+(x+1)*sourceWidth/targetWidth)
+			pixels[y][x] = average(source, left, top, right, bottom)
+		}
+	}
+
+	return pixels
+}
+
+// white is the colour an unset pixel takes, for the reasons average gives.
+var white = color.NRGBA{R: 0xff, G: 0xff, B: 0xff, A: 0xff}
+
+// whiteRow is a row of pixels the picture does not cover.
+func whiteRow(width int) []color.NRGBA {
+	row := make([]color.NRGBA, width)
+	for x := range row {
+		row[x] = white
+	}
+
+	return row
+}
+
+// average is the mean colour of one source rectangle, over white.
+//
+// Over white because a screenshot with a transparent background is a page that
+// never set one, and a browser renders that white. Compositing over black --
+// which is what using the premultiplied values unchanged would do -- inverts
+// exactly the pages that look most ordinary in a browser.
+func average(source image.Image, left, top, right, bottom int) color.NRGBA {
+	var red, green, blue, count uint64
+
+	for y := top; y < bottom; y++ {
+		for x := left; x < right; x++ {
+			// RGBA returns alpha-premultiplied values in [0, 0xffff], so the
+			// uncovered part of the pixel is what is left of the alpha.
+			r, g, b, a := source.At(x, y).RGBA()
+			transparent := uint64(0xffff - a)
+			red += uint64(r) + transparent
+			green += uint64(g) + transparent
+			blue += uint64(b) + transparent
+			count++
+		}
+	}
+
+	if count == 0 {
+		return white
+	}
+
+	return color.NRGBA{
+		R: uint8(min(red/count, 0xffff) >> 8),
+		G: uint8(min(green/count, 0xffff) >> 8),
+		B: uint8(min(blue/count, 0xffff) >> 8),
+		A: 0xff,
+	}
+}
+
+// draw turns a pixel grid into half-block cells.
+//
+// Truecolor escapes, the same as terminal-image's ANSI fallback emits. A
+// terminal limited to 256 colours degrades them itself, which is a better
+// picture than quantising here would produce.
+func draw(pixels [][]color.NRGBA) string {
+	if len(pixels) == 0 {
+		return ""
+	}
+
+	var builder strings.Builder
+
+	for y := 0; y < len(pixels); y += 2 {
+		if y > 0 {
+			builder.WriteByte('\n')
+		}
+
+		// The colours currently in effect. A row of a web page is mostly one
+		// colour, and re-stating it per cell was 40 bytes a cell -- 57KB for a
+		// 72-column preview, all of which the terminal has to parse and the
+		// scrollback has to hold. Reset at the end of each line, so the state
+		// is unknown again at the start of the next one.
+		var upperInEffect, lowerInEffect color.NRGBA
+		fresh := true
+
+		upper := pixels[y]
+		// An odd number of pixel rows leaves the last cell half empty. It is
+		// painted white rather than left to the terminal's background, so the
+		// bottom edge of the picture is the picture's own colour rather than a
+		// stripe of whatever theme is in use.
+		lower := whiteRow(len(upper))
+		if y+1 < len(pixels) {
+			lower = pixels[y+1]
+		}
+
+		for x := range upper {
+			if fresh || upper[x] != upperInEffect {
+				fmt.Fprintf(&builder, "\x1b[38;2;%d;%d;%dm",
+					upper[x].R, upper[x].G, upper[x].B)
+				upperInEffect = upper[x]
+			}
+			if fresh || lower[x] != lowerInEffect {
+				fmt.Fprintf(&builder, "\x1b[48;2;%d;%d;%dm",
+					lower[x].R, lower[x].G, lower[x].B)
+				lowerInEffect = lower[x]
+			}
+			fresh = false
+
+			builder.WriteString(upperHalfBlock)
+		}
+
+		builder.WriteString(ansiReset)
+	}
+
+	return builder.String()
+}

--- a/templates/go-cli/internal/preview/render_test.go
+++ b/templates/go-cli/internal/preview/render_test.go
@@ -1,0 +1,198 @@
+package preview
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// encode is a PNG of a function of x and y, for the tests to render back.
+func encode(t *testing.T, width, height int, at func(x, y int) color.NRGBA) []byte {
+	t.Helper()
+
+	canvas := image.NewNRGBA(image.Rect(0, 0, width, height))
+	for y := range height {
+		for x := range width {
+			canvas.SetNRGBA(x, y, at(x, y))
+		}
+	}
+
+	var buffer bytes.Buffer
+	if err := png.Encode(&buffer, canvas); err != nil {
+		t.Fatalf("encoding the fixture: %s", err)
+	}
+
+	return buffer.Bytes()
+}
+
+func solid(shade color.NRGBA) func(x, y int) color.NRGBA {
+	return func(_, _ int) color.NRGBA { return shade }
+}
+
+// A 16:9 screenshot -- which is what the preview endpoint is asked for -- must
+// come back at the width it was given, not the height: 270 rows scaled by
+// 72/480 is 40 pixel rows, so 20 cell rows, inside the 22-row bound.
+func TestRenderFillsTheWidthOfAWideScreenshot(t *testing.T) {
+	art, err := Render(encode(t, 480, 270, solid(color.NRGBA{A: 0xff})), 72, 22)
+	if err != nil {
+		t.Fatalf("Render: %s", err)
+	}
+
+	lines := strings.Split(art, "\n")
+	if got := utf8.RuneCountInString(visible(lines[0])); got != 72 {
+		t.Errorf("rendered %d columns wide, want 72", got)
+	}
+	if len(lines) != 20 {
+		t.Errorf("rendered %d rows, want 20", len(lines))
+	}
+}
+
+// The bounding box is a bound, not a shape to stretch into: a square image in a
+// 72x22 box is limited by the rows, and stretching it to 72 columns would make
+// every screenshot of a phone-shaped page look like a letterbox.
+func TestRenderPreservesTheAspectRatio(t *testing.T) {
+	art, err := Render(encode(t, 100, 100, solid(color.NRGBA{A: 0xff})), 72, 22)
+	if err != nil {
+		t.Fatalf("Render: %s", err)
+	}
+
+	lines := strings.Split(art, "\n")
+	columns := utf8.RuneCountInString(visible(lines[0]))
+
+	// 22 rows is 44 pixel rows, so a square image is 44x44: 44 columns and 22
+	// rows of cells.
+	if columns != 44 || len(lines) != 22 {
+		t.Errorf("rendered %dx%d cells, want 44x22", columns, len(lines))
+	}
+}
+
+// The colour a cell reports is the colour of the pixels it covers. A picture
+// that renders as the wrong colour is the one failure a screenshot preview
+// cannot survive, and it is invisible in a test that only measures the grid.
+func TestRenderCarriesTheColourThrough(t *testing.T) {
+	orange := color.NRGBA{R: 0xfd, G: 0x36, B: 0x6e, A: 0xff}
+	art, err := Render(encode(t, 40, 40, solid(orange)), 20, 10)
+	if err != nil {
+		t.Fatalf("Render: %s", err)
+	}
+
+	want := "\x1b[38;2;253;54;110m\x1b[48;2;253;54;110m" + upperHalfBlock
+	if !strings.HasPrefix(art, want) {
+		t.Errorf("the first cell is not the image's colour:\n%q", art[:min(len(art), 80)])
+	}
+}
+
+// A page that never set a background is white in a browser. Compositing over
+// black instead -- which is what the premultiplied values do untouched --
+// inverts exactly the pages that look most ordinary.
+func TestRenderCompositesTransparencyOverWhite(t *testing.T) {
+	art, err := Render(encode(t, 4, 4, solid(color.NRGBA{})), 4, 2)
+	if err != nil {
+		t.Fatalf("Render: %s", err)
+	}
+
+	if !strings.HasPrefix(art, "\x1b[38;2;255;255;255m") {
+		t.Errorf("a transparent pixel did not render white:\n%q", art[:min(len(art), 40)])
+	}
+}
+
+// Downscaling by averaging, not by sampling: a checkerboard is grey at a
+// fraction of its size, and any single row of it is stripes.
+func TestRenderAveragesRatherThanSamples(t *testing.T) {
+	checkerboard := func(x, y int) color.NRGBA {
+		if (x+y)%2 == 0 {
+			return color.NRGBA{A: 0xff}
+		}
+
+		return white
+	}
+
+	art, err := Render(encode(t, 64, 64, checkerboard), 8, 4)
+	if err != nil {
+		t.Fatalf("Render: %s", err)
+	}
+
+	// 8x8 source pixels per rendered pixel, half of them black: 127 or 128.
+	if !strings.Contains(art, "\x1b[38;2;127;127;127m") &&
+		!strings.Contains(art, "\x1b[38;2;128;128;128m") {
+		t.Errorf("a checkerboard did not average to grey:\n%q", art[:min(len(art), 120)])
+	}
+}
+
+// An odd pixel height leaves a half-filled cell rather than dropping the row,
+// because dropping it is a visible slice off the bottom of the page.
+func TestRenderKeepsAnOddFinalRow(t *testing.T) {
+	// 3 columns by 9 rows fits its height: 9 pixel rows is 5 cell rows.
+	art, err := Render(encode(t, 3, 9, solid(color.NRGBA{A: 0xff})), 3, 5)
+	if err != nil {
+		t.Fatalf("Render: %s", err)
+	}
+
+	lines := strings.Split(art, "\n")
+	if len(lines) != 5 {
+		t.Fatalf("rendered %d rows, want 5", len(lines))
+	}
+
+	// The last row's lower half is the padding colour, its upper half the
+	// image's.
+	if !strings.Contains(lines[4], "\x1b[48;2;255;255;255m") {
+		t.Errorf("the half-filled final row is not padded white:\n%q", lines[4])
+	}
+}
+
+// A run of one colour states it once. Re-stating it per cell was 40 bytes a
+// cell -- 57KB for one 72-column preview, all of which the terminal parses and
+// the scrollback holds.
+func TestRenderRestatesAColourOnlyWhenItChanges(t *testing.T) {
+	art, err := Render(encode(t, 40, 40, solid(color.NRGBA{A: 0xff})), 20, 10)
+	if err != nil {
+		t.Fatalf("Render: %s", err)
+	}
+
+	// One foreground and one background escape per line, and nothing else,
+	// because every cell of a solid image is the same colour.
+	if got := strings.Count(art, "\x1b[38;2;"); got != len(strings.Split(art, "\n")) {
+		t.Errorf("emitted %d foreground escapes for %d lines",
+			got, len(strings.Split(art, "\n")))
+	}
+}
+
+func TestRenderRejectsSomethingThatIsNotAnImage(t *testing.T) {
+	if _, err := Render([]byte("<html>404</html>"), 72, 22); err == nil {
+		t.Error("Render accepted a body that is not an image")
+	}
+}
+
+func TestColumns(t *testing.T) {
+	cases := map[int]int{
+		0:   72, // Unknown width falls back to 80 columns, so the target.
+		200: 72, // Wide terminal: the target, not the width.
+		60:  56, // Narrow terminal: its width, less the frame and margin.
+		10:  16, // Narrower than the floor: the floor.
+	}
+
+	for terminal, want := range cases {
+		if got := Columns(terminal); got != want {
+			t.Errorf("Columns(%d) = %d, want %d", terminal, got, want)
+		}
+	}
+}
+
+func TestRows(t *testing.T) {
+	cases := map[int]int{
+		0:  14, // Unknown height falls back to 24 rows, less the summary.
+		60: 22, // Tall terminal: the bound.
+		24: 14,
+		12: 8, // Short terminal: the floor, so there is still a picture.
+	}
+
+	for terminal, want := range cases {
+		if got := Rows(terminal); got != want {
+			t.Errorf("Rows(%d) = %d, want %d", terminal, got, want)
+		}
+	}
+}

--- a/templates/go-cli/main.go.twig
+++ b/templates/go-cli/main.go.twig
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
-	"{{ language.params.modulePath }}/internal/app"
 	"{{ language.params.modulePath }}/internal/cmd"
 )
 
@@ -14,11 +12,12 @@ func main() {
 	// RewriteBooleanValues.
 	root.SetArgs(cmd.RewriteBooleanValues(root, os.Args[1:]))
 
-	if err := root.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, cmd.FormatError(err))
-		if app.Flags().Report {
-			fmt.Fprintln(os.Stderr, cmd.ReportBlock(err))
-		}
-		os.Exit(1)
+	// ExecuteC rather than Execute: it returns the command that ran, which is
+	// what names the command in a cancellation notice.
+	executed, err := root.ExecuteC()
+	if err == nil {
+		return
 	}
+
+	os.Exit(cmd.Report(os.Stderr, executed, err))
 }


### PR DESCRIPTION
Four faults a user hits in the first minute with the Go CLI, all found by using the preview build rather than by reading the code.

> **On the name.** The branch is called `phase-8`, but [PLAN.md](https://github.com/appwrite/sdk-generator/blob/feat/go-cli-phase-8/docs/go-cli/PLAN.md) already uses Phase 8 for *Rollout*. This is not that. It is pre-rollout parity work sitting on top of Phase 7 — closing a gap the plan never had an entry for. §3 makes flags, aliases and hidden state invariant, and the plan measures `--help` for *startup time* in four places, but nothing in it says the help **output** has to match. Which is exactly how cobra's default screen survived seven phases without anyone noticing.

## `appwrite --help` was cobra's default screen

41 services in one alphabetical list, each with its full API description, and nothing to say which of them a new user should reach for. The TypeScript CLI groups them by intent with a one-line summary each, so the first screen is the eight commands that get someone started.

That screen is the Go CLI's now:

```
GET STARTED
  login               Authenticate with your Appwrite account
  list-organizations  Organizations your session can access
  ...

PROJECT
  organization        Manage organization-level projects
  ...
```

**Where the tables live.** The groups, the summaries and the global flag order moved into `CliCommandSurface` — the trait both CLIs already share — and `templates/cli/lib/help.ts` is generated from them instead of holding them by hand. One table now, not two that drift. Regenerating the TypeScript CLI produces a value-identical `help.ts`: the only change is `` `Authenticate with your ${SDK_TITLE} account` `` becoming the literal `"Authenticate with your Appwrite account"`, and `SDK_TITLE` is `'Appwrite'`.

**How closely it matches.** Both CLIs were built from the same spec and their screens diffed. The entire difference:

```diff
 DEPRECATED
   databases           Use `tablesdb` instead

+OTHER
+  sessions            List the sessions stored in the CLI preferences
+
 OPTIONS
```

`sessions` is the one command the Go CLI has and the TypeScript does not, and `OTHER` exists precisely so a command named in no group cannot silently vanish from `--help`. Logo, paragraph wrap, groups, column alignment, option order and footer are byte-identical.

That diff also caught a real bug: the Go screen read `sdk.description` while the TypeScript renders `packageJson.description`, which `package.json.twig` fills from `sdk.shortDescription`. Two different fields, so the two would have shipped **different paragraphs** — invisible in `examples/`, where both are placeholders.

### The paragraph wrap took four passes to get right

Worth flagging for review, because most of the Go-side diff is here rather than in the layout.

The first version was a straightforward greedy word wrap. It agreed with the TypeScript at 80 columns — the width I happened to check — and disagreed at 15, 17, 18, 30, 41, 42, 49, 50, 56, 57, 62 and 71. commander's `Help.wrap` is regex-driven and has two behaviours a from-scratch wrap does not:

- **A line holds `columnWidth - 1` characters, not `columnWidth`.** The pattern is `.{1,columnWidth - 1}([\s\u200B]|$)`: up to `columnWidth-1` characters, then it eats the space after them.
- **The first line carries two characters that were never measured.** commander wraps `str.slice(indent)` and prefixes `str.slice(0, indent)` back on. A quirk rather than a design, but reproducing it is what makes the screens agree at every width instead of at one.

I also added, then removed, a guard refusing to wrap below 40 columns — commander's `minColumnWidth` default. That was reading the library instead of the call site: `help.ts` passes `2` explicitly, so the TypeScript keeps wrapping into a narrow terminal, and the guard would have made a 20-column terminal print one line running off the edge.

Then: the shipped paragraph has no word longer than a column, no double spaces and no leading space, so three branches of the chunker were never executed by the sweep. Two were already right; consecutive spaces produced a blank line commander never emits.

Verified by calling commander's own `Help.wrap` with `help.ts`'s arguments and diffing every screen width from 6 to 80 — for the real paragraph and for nine awkward strings. Zero differences. 23 of those captures are embedded as tests, covering the boundary, the cap, the floor, every width the greedy version got wrong, and the branches the real description cannot reach.

One deviation is deliberate and documented in the code: commander returns the bare indent for an empty description, which puts a line of trailing spaces on the screen.

Rows are also trimmed, which the TypeScript does not do. A command whose spec description is empty has no summary, and the padded name ran the line out in spaces — visible in the conformance build, whose mock spec describes nothing. The TypeScript has a summary for everything it lists, so this cannot make the screens differ.

Three smaller alignments came out of putting the flags side by side:

| | Before | Now |
|---|---|---|
| `-j, --json` | Output the response as JSON. | Output filtered JSON (empty values omitted) |
| `--all` at the root | listed on all 600 commands | hidden, as in the TypeScript — still parsed, documented on `push` and `pull` |
| `push --all` | Apply the command to every matching resource. | Push every resource in the project config |

The help function is inherited in cobra, so the override falls back to cobra's for anything below the root — `appwrite users --help` is a listing of one service, which cobra already renders well.

## A cancelled prompt read as a crash

Pressing Ctrl-C at a picker printed the bare string `prompt cancelled`, under the same advice about `--verbose` and `--report` that a failed request gets. The CLI answered a deliberate decision by suggesting the user file a bug about it.

```
ℹ Warning: Cancelled `appwrite login`. Nothing further was sent.
```

The command's *path*, not its arguments: `client --key <secret>` is one prompt away from printing an API key into whatever is capturing stderr.

It exits **130** — 128 + SIGINT, what a shell reports for an interrupted program — so a script driving the CLI can tell "you cancelled" apart from "it failed".

Two more things surfaced while comparing the two paths:

- Failures had **no `✗ Error:` prefix and no `ℹ Info: For detailed error pass the --verbose or --report flag` line**, both of which the TypeScript prints. `main` wrote the message with `Fprintln`, bypassing the `output` package that exists to produce exactly those prefixes.
- That advice line is skipped once the user has already asked for the detail — and it consults the arguments, not just the parsed flags, because a command that fails *during* parsing never reaches a later `--verbose`.

The rendering moved out of `main` into `cmd.Report` so it can be tested at all — that these two outcomes do not look alike is the whole point, and `main()` is not reachable from a test.

## `completion install` reported success and did nothing

```
(eval):1: _appwrite: function definition file not found
```

Writing the file is not installing it. zsh autoloads a completion only from a directory on its `fpath`, and `~/.zfunc` — the path **both** CLIs write to — is not on `fpath` by default. So the command reported success for the half it did, with no way to tell the other half had never happened.

The error above is the same gap after an earlier install: `_appwrite` had once been autoloadable from a directory that has since gone, and compinit's cached index still named it. Adding a directory to `fpath` does not clear that cache.

`completion install` now prints what is left to do, naming the directory it actually wrote to, plus `rm -f ~/.zcompdump*` for the cached-index case. bash gets the equivalent note about bash-completion; fish gets nothing, because it loads its own completions directory with no setup.

It advises rather than edits — a shell profile is the user's file, and appending to it from an installer is how profiles end up with six copies of one line.

Verified in both directions: `autoload -Uz _appwrite` reproduces the error exactly with `~/.zfunc` off `fpath`, and resolves to a loaded function with it on. Paths are quoted, so the advice survives a home directory with a space in it.

## An npm advisory that was failing the `cli` job

`npm audit` reported 5 high-severity findings for `brace-expansion`: [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) covers 4.0.0–5.0.8 and `templates/cli/package.json.twig` pinned exactly `5.0.8`. Unrelated to everything above — the advisory landed after the stack was last built.

The `node`, `web` and `react-native` templates were already at `5.0.9`; the CLI was missed. Fixed with `./scripts/update-lockfiles.sh cli` so the Twig expressions in the lock files survive.

**This applies to `main` as well**, and to the other eight PRs the moment their CI re-runs — their green runs predate the advisory. `fbef99bd5` is self-contained and worth cherry-picking onto `main` rather than waiting for this stack.

## Deliberately not fixed here

The TypeScript CLI's `completion install` (`templates/cli/lib/completions.ts`) has the **same** zsh gap — it writes to `~/.zfunc` and says nothing about `fpath` either. It is left alone on purpose: this stack is scoped to the Go CLI, and PLAN.md's Phase 8 removes `templates/cli/` outright. Worth a standalone fix only if the TypeScript CLI ships for another cycle first.

Both CLIs are installed by the same `install.sh`, whose step 4 runs `appwrite completion install` and then prints success. So once the Go binary is the one installed, the installer becomes the place a zsh user is finally told what is missing — which is where it belongs.

## Not a defect

`appwrite tablesdb -h` was reported as missing methods. It is not: both the published `v0.7.6-preview` and a local build list all 80 subcommands, the same set the TypeScript lists (81, the extra being commander's own `help`), and the `tables-db` alias resolves too.

## Checks

- `go build`, `go vet` and `go test ./...` pass in `examples/go-cli`; `gofmt` clean on every file this touches
- The **conformance build** was reproduced locally by replicating `Base.php`'s generation — it compiles, vets, and its whole `go test ./internal/...` step passes against the six-service mock spec. That caught a help test which assumed every group has rows
- The whole `cli` job sequence — `bun install`, `npm ci`, `npm audit`, `npm run build`, `node dist/cli.cjs --help` — passes locally, rendering the grouped screen from the generated `help.ts`
- The surface parity test still passes, so the command surface is unchanged
- `composer refactor:check`, `composer lint-twig` and the Unit suite pass
- Both CLIs regenerated, since `CliCommandSurface` is shared

Based on #1726.
