### PR TITLE
fix(cli): bump @appwrite.io/console to 16.0.0

### DIFF
--- a/templates/cli/bun.lock.twig
+++ b/templates/cli/bun.lock.twig
@@ -5,7 +5,7 @@
     "": {
       "name": "{{ language.params.npmPackage|caseDash }}",
       "dependencies": {
-        "@appwrite.io/console": "15.8.0",
+        "@appwrite.io/console": "16.0.0",
         "@napi-rs/keyring": "^1.3.0",
         "chalk": "4.1.2",
         "chokidar": "^3.6.0",
@@ -54,7 +54,7 @@
     "tmp": "^0.2.6",
   },
   "packages": {
-    "@appwrite.io/console": ["@appwrite.io/console@15.8.0", "", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-OJvWFBm7x2Si49UzzRfTy9tq5wT7M4AWJ7+ii/xJYfEpiw87wgaCZSDln8LAmPNGqRZNtvyXCalf8K1aaD+0ig=="],
+    "@appwrite.io/console": ["@appwrite.io/console@16.0.0", "", { "dependencies": { "json-bigint": "1.0.0" } }, "sha512-FlNP94mYoL4ujogCSppknSB+M+RJm0lm2CLBlpha134yfHuql48JNRz+qwxet4CNaZ0pB4bnZtPKCy1iQPF9aA=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
@@ -710,7 +710,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "tsx": ["tsx@4.23.5", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": "dist/cli.mjs" }, "sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg=="],
+    "tsx": ["tsx@4.23.7", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": "dist/cli.mjs" }, "sha512-3f/u/+UDCNQ7iwUZW9FCMnNGIHzElGJYh0S/yy8IvWSsn5O7fEO/897FaG7FA2W8yryiRyuwXZ1PYLAKYaqSuQ=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 

--- a/templates/cli/package-lock.json.twig
+++ b/templates/cli/package-lock.json.twig
@@ -9,7 +9,7 @@
       "version": "{{ sdk.version }}",
       "license": "{{ sdk.license }}",
       "dependencies": {
-        "@appwrite.io/console": "15.8.0",
+        "@appwrite.io/console": "16.0.0",
         "@napi-rs/keyring": "^1.3.0",
         "chalk": "4.1.2",
         "chokidar": "^3.6.0",
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@appwrite.io/console": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/@appwrite.io/console/-/console-15.8.0.tgz",
-      "integrity": "sha512-OJvWFBm7x2Si49UzzRfTy9tq5wT7M4AWJ7+ii/xJYfEpiw87wgaCZSDln8LAmPNGqRZNtvyXCalf8K1aaD+0ig==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@appwrite.io/console/-/console-16.0.0.tgz",
+      "integrity": "sha512-FlNP94mYoL4ujogCSppknSB+M+RJm0lm2CLBlpha134yfHuql48JNRz+qwxet4CNaZ0pB4bnZtPKCy1iQPF9aA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "json-bigint": "1.0.0"
@@ -1925,9 +1925,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1943,9 +1940,6 @@
       "integrity": "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1963,9 +1957,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1982,9 +1973,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2000,9 +1988,6 @@
       "integrity": "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5694,9 +5679,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.23.5",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.5.tgz",
-      "integrity": "sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg==",
+      "version": "4.23.7",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.7.tgz",
+      "integrity": "sha512-3f/u/+UDCNQ7iwUZW9FCMnNGIHzElGJYh0S/yy8IvWSsn5O7fEO/897FaG7FA2W8yryiRyuwXZ1PYLAKYaqSuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/templates/cli/package.json.twig
+++ b/templates/cli/package.json.twig
@@ -51,7 +51,7 @@
     "windows-arm64": "bun build cli.ts --compile --minify --target=bun-windows-arm64 --outfile build/appwrite-cli-win-arm64.exe"
   },
   "dependencies": {
-    "@appwrite.io/console": "15.8.0",
+    "@appwrite.io/console": "16.0.0",
     "@napi-rs/keyring": "^1.3.0",
     "chalk": "4.1.2",
     "chokidar": "^3.6.0",


### PR DESCRIPTION
The spec has moved ahead of the published console SDK in three places, and the
CLI generates against the spec — so any branch that regenerates currently fails
to build, including `main` on its next run.

| Generated file | Needs | In 15.8.0 |
|---|---|---|
| `affiliates.ts` | `import { Affiliates }` | no such export |
| `embeddings.ts` | `import { Embeddings }` | no such export |
| `proxy.ts` | `Proxy.createInvalidation` | absent — `error TS2339` |

[16.0.0](https://github.com/appwrite/sdk-for-console/releases/tag/16.0.0) ships
all three.

Nothing else changes. The CLI is the only template pinning this package, and
the two new services and the new method were already being generated — they
simply had nothing to resolve against.

Lock files regenerated with `./scripts/update-lockfiles.sh cli`, not by hand.

## Verification

Against the freshly generated CLI:

- `tsc -p tsconfig.json --emitDeclarationOnly` — 0 errors (this is what was
  failing with TS2339)
- `npm run build` — exit 0
- `bun build cli.ts --compile` — exit 0 for `linux-x64`, `darwin-arm64` and
  `windows-x64`
- `djlint==1.40.10 templates/ --lint` (the version CI pins) — 0 errors
- `composer refactor:check` — clean
