### PR TITLE
fix(cli): init function stops claiming a missing install command

### DIFF
--- a/templates/cli/lib/commands/init.ts
+++ b/templates/cli/lib/commands/init.ts
@@ -684,12 +684,6 @@ const initFunction = async (): Promise<void> => {
     );
   }
 
-  if (!answers.runtime.commands) {
-    log(
-      `Installation command for this runtime not found. You will be asked to configure the install command when you first push the function.`,
-    );
-  }
-
   fs.mkdirSync(functionDir, { mode: 0o777 });
   fs.mkdirSync(templatesDir, { mode: 0o777 });
   const repo = "https://github.com/appwrite/templates";


### PR DESCRIPTION
`init function` ends by telling the user what the starter template left for them
to configure. One of the two notices names an action nobody has to take.

```ts
if (!answers.runtime.commands) {
  log(
    `Installation command for this runtime not found. You will be asked to configure the install command when you first push the function.`,
  );
}
```

**Push never asks.** It reads `commands` out of `appwrite.config.json` and sends
it — `push.ts:1807`, `:1843`, `:1973` all pass `commands: func.commands`
straight through to the API. Nothing anywhere prompts for the field. The
sentence describes a step in a flow that does not exist, so a user who believes
it waits for a question that never comes.

The condition is also a poor proxy for "not found". `getInstallCommand()` in
`questions.ts` returns two different falsy values for two different reasons, and
the notice cannot tell them apart:

- `""` for `swift`, `java`, `kotlin` and `cpp` — deliberate. These runtimes have
  nothing to fetch before a build.
- `undefined` for a runtime absent from the switch, `go` among them — its build
  resolves its own dependencies.

Either way the starter template deploys exactly as intended, and
`init.ts:813` writes `commands: answers.runtime.commands || ""` into the config
regardless, so there is no missing field to fill in later.

The entrypoint notice immediately above it stays. That one is true: push does
prompt for a missing entrypoint.

Extracted from #1733, where it was incidental to the Go CLI work and had no
business riding along in a 264-file diff.
