### PR TITLE
fix(generator): caseKebab treats _ and spaces as separators

### DIFF
--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -99,7 +99,11 @@ class SDK
         $this->twig->addFilter(new TwigFilter('caseCamel', fn(?string $value): string => $this->helperCamelCase($value)));
         $this->twig->addFilter(new TwigFilter('removeDash', fn($value): string|array => str_replace('-', '', $value)));
         $this->twig->addFilter(new TwigFilter('caseDash', fn($value) => str_replace([' ', '_'], '-', strtolower((string) preg_replace('/([a-zA-Z])(?=[A-Z])/', '$1-', (string) $value)))));
-        $this->twig->addFilter(new TwigFilter('caseKebab', fn($value) => strtolower((string) preg_replace('/(?<!^)([A-Z][a-z]|(?<=[a-z])[^a-z\s]|(?<=[A-Z])[0-9_])/', '-$1', (string) $value))));
+        $this->twig->addFilter(new TwigFilter('caseKebab', function ($value): string {
+            $value = preg_replace('/(?<!^)([A-Z][a-z]|(?<=[a-z])[^a-z\s_]|(?<=[A-Z])\d)/', '-$1', (string) $value);
+            $value = str_replace(['_', ' '], '-', strtolower((string) $value));
+            return trim((string) preg_replace('/-+/', '-', $value), '-');
+        }));
         $this->twig->addFilter(new TwigFilter('caseSlash', fn($value) => str_replace([' ', '_', '.'], '/', strtolower((string) preg_replace('/([a-zA-Z])(?=[A-Z])/', '$1/', (string) $value)))));
         $this->twig->addFilter(new TwigFilter('caseDot', fn($value) => str_replace([' ', '_'], '.', strtolower((string) preg_replace('/([a-zA-Z])(?=[A-Z])/', '$1.', (string) $value)))));
         $this->twig->addFilter(new TwigFilter('caseSnake', function ($value): string {


### PR DESCRIPTION
`caseKebab` inserted a dash *before* an underscore instead of replacing it, so a
snake_case name came out with both:

```
client_id   →  client-_id
grant_type  →  grant-_type
```

The cause is the character class `[^a-z\s]`, which matches `_`, and
`(?<=[A-Z])[0-9_]`, which matches it again after a capital. Nothing downstream
ever removed it.

## What it broke

The five `oauth2` command docs, which are the only place the filter meets a
snake_case name today. They documented flags that do not exist:

```diff
-    --grant-_type <GRANT_TYPE>
-    --client-_id <CLIENT_ID> \
-    --redirect-_uri https://example.com \
-    --response-_type code
-    --grant-_id <GRANT_ID>
-    --user-_code <USER_CODE>
+    --grant-type <GRANT_TYPE>
+    --client-id <CLIENT_ID> \
+    --redirect-uri https://example.com \
+    --response-type code
+    --grant-id <GRANT_ID>
+    --user-code <USER_CODE>
```

The CLI itself was always right — its flags come from `getCliOptionName`, which
handles underscores with an explicit `str_replace`. So the binary accepted
`--grant-type` while its own generated documentation told you to pass
`--grant-_type`. Anyone copying an OAuth2 example got an unknown-flag error.

## The fix

```php
$value = preg_replace('/(?<!^)([A-Z][a-z]|(?<=[a-z])[^a-z\s_]|(?<=[A-Z])\d)/', '-$1', (string) $value);
$value = str_replace(['_', ' '], '-', strtolower((string) $value));
return trim((string) preg_replace('/-+/', '-', $value), '-');
```

`_` drops out of the word-boundary class and becomes a separator alongside
spaces, then repeats collapse and edges are trimmed. This is the same treatment
`getCliOptionName` already applies, so the two agree by construction.

## Blast radius

`caseKebab` feeds `cli`, `node`, `react-native`, `web` and `deno`, and in the
CLI it produces command names as well as documented flags — so this was checked
rather than assumed.

Every one of the filter's inputs was compared across the whole spec: of **1,501
distinct service, method and parameter names, 21 change**, all of them the
OAuth2 snake_case parameters. Regenerating `cli`, `node`, `react-native` and
`web` before and after:

| SDK | files changed |
|---|---|
| `cli` | 5 — all `docs/examples/oauth2/*.md` |
| `node` | 0 |
| `react-native` | 0 |
| `web` | 0 |

No command name moves. Every other name in the spec is camelCase or PascalCase,
which the filter already handled and still handles identically.

Rector, phpcs and the Unit suite pass.
