### PR TITLE
fix(cli): init asks for build specifications the build accepts

### DIFF
--- a/templates/cli/lib/questions.ts
+++ b/templates/cli/lib/questions.ts
@@ -211,34 +211,6 @@ const getInstallCommand = (runtime: string): string | undefined => {
   return undefined;
 };
 
-/**
- * Build specification choices, with the rows below the plan's allowlist dropped.
- *
- * The endpoint answers with a bare `enabled` and no reason for it, and on the
- * build list the disabled rows are two different things: the small
- * specifications are never valid for a build on any plan, while the large ones
- * are the tier gate. Marking both "Upgrade to use" offered an upgrade that does
- * not exist. Nothing server-side distinguishes them — Validator/Specification.php
- * intersects the plan's list with the env CPU and memory caps and keeps no notion
- * of a build floor — so the response's own order does: the allowlist is a
- * contiguous band, and anything before it is below the floor.
- *
- * When the plan allows none of them, nothing is hidden. A prompt with every row
- * disabled at least shows what the account has, where an empty one would read as
- * a fault in the CLI.
- */
-const buildSpecificationChoices = (specifications: any[]) => {
-  const floor = specifications.findIndex((spec: any) => spec.enabled !== false);
-
-  return specifications
-    .filter((_spec: any, index: number) => floor <= 0 || index >= floor)
-    .map((spec: any) => ({
-      name: `${spec.cpus} CPU, ${spec.memory}MB RAM`,
-      value: spec.slug,
-      disabled: spec.enabled === false ? "Upgrade to use" : false,
-    }));
-};
-
 export const questionsInitProject: Question[] = [
   {
     type: "confirm",
@@ -578,15 +550,18 @@ export const questionsCreateFunction: Question[] = [
     name: "buildSpecification",
     message: "What build specification would you like to use?",
     choices: async () => {
-      // `builds`, because a plan allows a different set for each type and it is
-      // `type` that decides which set `enabled` is computed from. Asking for the
-      // default offered every runtime specification as available, and `push` was
-      // the first thing to disagree -- rejecting a buildSpecification that
-      // `init function` had just written into appwrite.config.json.
       const response = await (
         await getFunctionsService()
       ).listSpecifications({ type: "builds" });
-      return buildSpecificationChoices(response["specifications"]);
+      const specifications = response["specifications"];
+      const choices = specifications.map((spec: any, _idx: number) => {
+        return {
+          name: `${spec.cpus} CPU, ${spec.memory}MB RAM`,
+          value: spec.slug,
+          disabled: spec.enabled === false ? "Upgrade to use" : false,
+        };
+      });
+      return choices;
     },
   },
   {
@@ -1349,7 +1324,15 @@ export const questionsCreateSite: Question[] = [
       const response = await (
         await getSitesService()
       ).listSpecifications({ type: "builds" });
-      return buildSpecificationChoices(response["specifications"]);
+      const specifications = response["specifications"];
+      const choices = specifications.map((spec: any) => {
+        return {
+          name: `${spec.cpus} CPU, ${spec.memory}MB RAM`,
+          value: spec.slug,
+          disabled: spec.enabled === false ? "Upgrade to use" : false,
+        };
+      });
+      return choices;
     },
   },
   {

--- a/templates/cli/lib/questions.ts
+++ b/templates/cli/lib/questions.ts
@@ -211,6 +211,34 @@ const getInstallCommand = (runtime: string): string | undefined => {
   return undefined;
 };
 
+/**
+ * Build specification choices, with the rows below the plan's allowlist dropped.
+ *
+ * The endpoint answers with a bare `enabled` and no reason for it, and on the
+ * build list the disabled rows are two different things: the small
+ * specifications are never valid for a build on any plan, while the large ones
+ * are the tier gate. Marking both "Upgrade to use" offered an upgrade that does
+ * not exist. Nothing server-side distinguishes them — Validator/Specification.php
+ * intersects the plan's list with the env CPU and memory caps and keeps no notion
+ * of a build floor — so the response's own order does: the allowlist is a
+ * contiguous band, and anything before it is below the floor.
+ *
+ * When the plan allows none of them, nothing is hidden. A prompt with every row
+ * disabled at least shows what the account has, where an empty one would read as
+ * a fault in the CLI.
+ */
+const buildSpecificationChoices = (specifications: any[]) => {
+  const floor = specifications.findIndex((spec: any) => spec.enabled !== false);
+
+  return specifications
+    .filter((_spec: any, index: number) => floor <= 0 || index >= floor)
+    .map((spec: any) => ({
+      name: `${spec.cpus} CPU, ${spec.memory}MB RAM`,
+      value: spec.slug,
+      disabled: spec.enabled === false ? "Upgrade to use" : false,
+    }));
+};
+
 export const questionsInitProject: Question[] = [
   {
     type: "confirm",
@@ -550,16 +578,15 @@ export const questionsCreateFunction: Question[] = [
     name: "buildSpecification",
     message: "What build specification would you like to use?",
     choices: async () => {
-      const response = await (await getFunctionsService()).listSpecifications();
-      const specifications = response["specifications"];
-      const choices = specifications.map((spec: any, _idx: number) => {
-        return {
-          name: `${spec.cpus} CPU, ${spec.memory}MB RAM`,
-          value: spec.slug,
-          disabled: spec.enabled === false ? "Upgrade to use" : false,
-        };
-      });
-      return choices;
+      // `builds`, because a plan allows a different set for each type and it is
+      // `type` that decides which set `enabled` is computed from. Asking for the
+      // default offered every runtime specification as available, and `push` was
+      // the first thing to disagree -- rejecting a buildSpecification that
+      // `init function` had just written into appwrite.config.json.
+      const response = await (
+        await getFunctionsService()
+      ).listSpecifications({ type: "builds" });
+      return buildSpecificationChoices(response["specifications"]);
     },
   },
   {
@@ -567,7 +594,9 @@ export const questionsCreateFunction: Question[] = [
     name: "runtimeSpecification",
     message: "What runtime specification would you like to use?",
     choices: async () => {
-      const response = await (await getFunctionsService()).listSpecifications();
+      const response = await (
+        await getFunctionsService()
+      ).listSpecifications({ type: "runtimes" });
       const specifications = response["specifications"];
       const choices = specifications.map((spec: any, _idx: number) => {
         return {
@@ -1317,16 +1346,10 @@ export const questionsCreateSite: Question[] = [
     name: "buildSpecification",
     message: "What build specification would you like to use?",
     choices: async () => {
-      const response = await (await getSitesService()).listSpecifications();
-      const specifications = response["specifications"];
-      const choices = specifications.map((spec: any) => {
-        return {
-          name: `${spec.cpus} CPU, ${spec.memory}MB RAM`,
-          value: spec.slug,
-          disabled: spec.enabled === false ? "Upgrade to use" : false,
-        };
-      });
-      return choices;
+      const response = await (
+        await getSitesService()
+      ).listSpecifications({ type: "builds" });
+      return buildSpecificationChoices(response["specifications"]);
     },
   },
   {
@@ -1334,7 +1357,9 @@ export const questionsCreateSite: Question[] = [
     name: "runtimeSpecification",
     message: "What runtime specification would you like to use?",
     choices: async () => {
-      const response = await (await getSitesService()).listSpecifications();
+      const response = await (
+        await getSitesService()
+      ).listSpecifications({ type: "runtimes" });
       const specifications = response["specifications"];
       const choices = specifications.map((spec: any) => {
         return {


### PR DESCRIPTION
`init function` and `init site` ask which build specification to use, write the
answer into `appwrite.config.json`, and `push` then sends it to the API — which
rejects it. The question was reading the wrong list.

## The bug

`GET /functions/specifications` and `GET /sites/specifications` take a `type`
parameter, and its default is not the one the build question wants:

```
param 'type'  required=false  type=string  default='runtimes'
```

Every one of the four call sites omitted it:

```ts
const response = await (await getFunctionsService()).listSpecifications();
```

So the *build* specification prompt listed **runtime** specifications, with
`enabled` computed for runtimes. A plan allows a different set per type, so the
prompt offered rows that are not valid for a build, `init` wrote one into
`appwrite.config.json`, and the first thing to notice was `push` — which passes
the value straight through (`push.ts:1809`, `:1845`, `:2321`, `:2362`) and gets
an API rejection. The user had no way to tell that the value they were offered
was never acceptable.

`buildSpecification` and `runtimeSpecification` are separate fields on both
`POST /functions` and `POST /sites`, so this is two lists, not one.

## The fix

Both build questions now ask for `type: "builds"`; both runtime questions state
`type: "runtimes"` instead of relying on the default, so a future change to that
default cannot silently repoint them.

```ts
).listSpecifications({ type: "builds" });
```

`@appwrite.io/console@16.0.0`, already pinned by the CLI, declares
`listSpecifications(params?: { type?: string })` documented as *"Can be one of:
runtimes, builds"*, so no dependency change is needed.

## The disabled rows

Fixing the list exposed a second problem. The endpoint returns a bare `enabled`
with no reason attached, and on the *build* list a disabled row is one of two
unrelated things:

- **below the build floor** — the small specifications are never valid for a
  build, on any plan
- **above the plan** — the large ones are the tier gate

Labelling both `"Upgrade to use"` advertised an upgrade that does not exist for
the first group. Nothing server-side distinguishes them: the validator
intersects the plan's list with the environment's CPU and memory caps and holds
no notion of a build floor. The response's own ordering does — the allowed set is
a contiguous ascending band — so `buildSpecificationChoices` drops everything
before the first enabled row.

The property that makes this safe: rows before the first enabled index are, by
definition, all disabled. **The filter can never hide a selectable choice.** I
checked the branches explicitly, including a non-contiguous response the API
does not currently produce:

| response | shown | hidden |
|---|---|---|
| small below floor, mid enabled, large gated | mid, large *(disabled)* | small |
| plan allows only the smallest | all three, larger two disabled | — |
| plan allows none | both, both disabled | — |
| plan allows all | all | — |
| non-contiguous `[off, on, off, on]` | b, c *(disabled)*, d | a |

When the plan allows nothing, `floor <= 0` short-circuits and nothing is hidden:
a prompt showing every row disabled tells the user what their account has, where
an empty prompt would read as a bug in the CLI.

The runtime questions deliberately keep the plain `.map()` — on that list every
disabled row really is the tier gate, so `"Upgrade to use"` is accurate and
there is no floor to trim.

## Verification

Regenerated the CLI and, against the pinned SDK, `npx tsc --noEmit` exits 0,
`npm run build` succeeds, and `node dist/cli.cjs --help` runs. All four
generated call sites carry an explicit type.

This is a pre-existing bug in the shipping CLI, split out of #1733 so it can
land on its own.
