### PR TITLE
fix(cli): pass type when listing build/runtime specifications

### DIFF
--- a/templates/cli/lib/questions.ts
+++ b/templates/cli/lib/questions.ts
@@ -550,7 +550,9 @@ export const questionsCreateFunction: Question[] = [
     name: "buildSpecification",
     message: "What build specification would you like to use?",
     choices: async () => {
-      const response = await (await getFunctionsService()).listSpecifications();
+      const response = await (
+        await getFunctionsService()
+      ).listSpecifications({ type: "builds" });
       const specifications = response["specifications"];
       const choices = specifications.map((spec: any, _idx: number) => {
         return {
@@ -567,7 +569,9 @@ export const questionsCreateFunction: Question[] = [
     name: "runtimeSpecification",
     message: "What runtime specification would you like to use?",
     choices: async () => {
-      const response = await (await getFunctionsService()).listSpecifications();
+      const response = await (
+        await getFunctionsService()
+      ).listSpecifications({ type: "runtimes" });
       const specifications = response["specifications"];
       const choices = specifications.map((spec: any, _idx: number) => {
         return {
@@ -1317,7 +1321,9 @@ export const questionsCreateSite: Question[] = [
     name: "buildSpecification",
     message: "What build specification would you like to use?",
     choices: async () => {
-      const response = await (await getSitesService()).listSpecifications();
+      const response = await (
+        await getSitesService()
+      ).listSpecifications({ type: "builds" });
       const specifications = response["specifications"];
       const choices = specifications.map((spec: any) => {
         return {
@@ -1334,7 +1340,9 @@ export const questionsCreateSite: Question[] = [
     name: "runtimeSpecification",
     message: "What runtime specification would you like to use?",
     choices: async () => {
-      const response = await (await getSitesService()).listSpecifications();
+      const response = await (
+        await getSitesService()
+      ).listSpecifications({ type: "runtimes" });
       const specifications = response["specifications"];
       const choices = specifications.map((spec: any) => {
         return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`init function` and `init site` ask which build specification to use, write the answer into `appwrite.config.json`, and `push` then sends it to the API — which rejects it. The question was reading the wrong list.

## The bug

`GET /functions/specifications` and `GET /sites/specifications` take a `type` parameter, and its default is not the one the build question wants:

```
param 'type'  required=false  type=string  default='runtimes'
```

Every one of the four call sites omitted it, so the *build* specification prompt listed **runtime** specifications. `init` wrote one into `appwrite.config.json`, and `push` got an API rejection.

`buildSpecification` and `runtimeSpecification` are separate fields on both `POST /functions` and `POST /sites`.

## The fix

Both build questions now ask for `type: "builds"`; both runtime questions state `type: "runtimes"` instead of relying on the default.

```ts
).listSpecifications({ type: "builds" });
```

No CLI-side filtering of "below floor" build rows — the API should stop returning those. This is the same core fix as #1737 without the `buildSpecificationChoices` client workaround.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0a14792-94bc-42a8-9e40-838382b30ed5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0a14792-94bc-42a8-9e40-838382b30ed5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

