### PR TITLE
fix(cli): the --verbose hint only appears where --verbose helps

### DIFF
--- a/templates/cli/lib/parser.ts
+++ b/templates/cli/lib/parser.ts
@@ -938,7 +938,9 @@ export const parseError = (err: Error): void => {
       console.error(formatErrorForLog(err));
       printErrorHints(err);
     } else {
-      log("For detailed error pass the --verbose or --report flag");
+      if (reportErrorDetails(err).length > 0) {
+        log("For detailed error pass the --verbose or --report flag");
+      }
       error(getErrorMessage(err));
       printErrorHints(err);
     }


### PR DESCRIPTION
Every non-verbose error ended with the same line:

```ts
log("For detailed error pass the --verbose or --report flag");
```

`--verbose` adds exactly three things — `code`, `type` and `response`, the keys
in `ERROR_DETAIL_KEYS`. All three come off a request. An error that never made
one carries none of them, so the advice pointed at detail that does not exist.

## What the user saw

A config with no tables in it, before:

```
ℹ Info: For detailed error pass the --verbose or --report flag
✗ Error: No tables or collections found in configuration. Make sure appwrite.config.json exists and contains tables or collections.
```

Taking that advice:

```
$ appwrite types ./out -l ts --verbose
Error: No tables or collections found in configuration. Make sure appwrite.config.json exists and contains tables or collections.

  Stack trace:
    at /path/to/cli.cjs:148449:15
    at _Command.<anonymous> (/path/to/cli.cjs:138048:12)
    at _Command.listener [as _actionHandler] (/path/to/cli.cjs:1346:21)
```

The same sentence, plus line numbers inside the bundled CLI. Nothing about the
config file that was actually the problem. The stack is not the missing half — it
names CLI internals, not what the user got wrong.

After:

```
✗ Error: No tables or collections found in configuration. Make sure appwrite.config.json exists and contains tables or collections.
```

An API error is unaffected: `AppwriteException` sets `code`, `type` and
`response` as own properties, `hasOwnProperty` passes, and the hint still prints
— which is the case where `--verbose` genuinely has more to show.

## The fix

```ts
if (reportErrorDetails(err).length > 0) {
  log("For detailed error pass the --verbose or --report flag");
}
```

`reportErrorDetails` is the same helper `--verbose` and `--report` already use to
render those keys, so the hint appears exactly when the flag has something to
print, by construction rather than by a separate list that could drift.

## One thing this also suppresses

The hint names two flags, and only `--verbose` is empty-handed here. `--report`
still assembles a prefilled GitHub issue URL from the stack frames on that same
detail-less error — I checked, it produces a complete issue link.

Suppressing it is right for a usage error, which is not a bug worth filing. It
is a small loss for the other kind of detail-less error: an unexpected
`TypeError` inside the CLI also has no `code`/`type`/`response`, and that is
precisely when someone should be told `--report` exists. Distinguishing the two
means guessing from `err.name`, which is a heuristic this change deliberately
avoids — so it is called out here rather than coded around. Splitting the hint
into two conditions is the follow-up if that case matters.

## Verification

Regenerated the CLI; `npx tsc --noEmit` exits 0 and `npm run build` succeeds.
Before/after captured against the built binary, as shown above.

Pre-existing behaviour in the shipping CLI, split out of #1733.
