### PR TITLE
fix(cli): the Windows installers name the asset from one param

### DIFF
--- a/templates/cli/install.ps1.twig
+++ b/templates/cli/install.ps1.twig
@@ -13,8 +13,8 @@
 # You can use "View source" of this page to see the full script.
 
 # REPO
-$GITHUB_x64_URL = "https://github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/releases/download/{{ sdk.version }}/{{ language.params.executableName }}-cli-win-x64.exe"
-$GITHUB_arm64_URL = "https://github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/releases/download/{{ sdk.version }}/{{ language.params.executableName }}-cli-win-arm64.exe"
+$GITHUB_x64_URL = "https://github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/releases/download/{{ sdk.version }}/{{ language.params.npmPackage }}-win-x64.exe"
+$GITHUB_arm64_URL = "https://github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/releases/download/{{ sdk.version }}/{{ language.params.npmPackage }}-win-arm64.exe"
 
 ${{ spec.title | upper }}_BINARY_NAME = "{{ language.params.executableName }}.exe"
 

--- a/templates/cli/scoop/appwrite.config.json.twig
+++ b/templates/cli/scoop/appwrite.config.json.twig
@@ -6,19 +6,19 @@
 	"license": "BSD-3-Clause",
 	"architecture": {
 		"64bit": {
-			"url": "https://github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/releases/download/{{ sdk.version }}/{{ language.params.executableName }}-cli-win-x64.exe",
+			"url": "https://github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/releases/download/{{ sdk.version }}/{{ language.params.npmPackage }}-win-x64.exe",
 			"bin": [
 				[
-					"{{ language.params.executableName }}-cli-win-x64.exe",
+					"{{ language.params.npmPackage }}-win-x64.exe",
 					"{{ language.params.executableName|caseLower }}"
 				]
 			]
 		},
 		"arm64": {
-			"url": "https://github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/releases/download/{{ sdk.version }}/{{ language.params.executableName }}-cli-win-arm64.exe",
+			"url": "https://github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/releases/download/{{ sdk.version }}/{{ language.params.npmPackage }}-win-arm64.exe",
 			"bin": [
 				[
-					"{{ language.params.executableName }}-cli-win-arm64.exe",
+					"{{ language.params.npmPackage }}-win-arm64.exe",
 					"{{ language.params.executableName|caseLower }}"
 				]
 			]


### PR DESCRIPTION
Three files build the name of the same Windows release asset, and they did not
agree on where it comes from.

`install.sh` reads the package param:

```
GITHUB_FILE="{{ language.params.npmPackage }}-${OS}-${ARCH}"
```

`install.ps1` and the scoop manifest reconstructed it instead:

```
{{ language.params.executableName }}-cli-win-x64.exe
```

Both spellings render `appwrite-cli-win-x64.exe`, because `executableName` is
`appwrite` and `npmPackage` is `appwrite-cli` — the `-cli` suffix is hardcoded on
the assumption that the two params differ by exactly that. Nothing enforces it.
`setExecutableName` and `setNPMPackage` are independent calls in `example.php`,
so renaming the binary to `aw` silently repoints the PowerShell installer and the
scoop manifest at `aw-cli-win-x64.exe` while `install.sh`, the release assets and
the npm platform packages all stay on `appwrite-cli-*`. The `curl | bash` path
keeps working and the Windows paths 404.

## The change

Both now read the same param as `install.sh`:

```diff
-{{ language.params.executableName }}-cli-win-x64.exe
+{{ language.params.npmPackage }}-win-x64.exe
```

Six lines across the two files: two URLs in `install.ps1`, and in the scoop
manifest two `url` fields plus the two `bin` entries that must match the
downloaded filename. `executableName` is still used where it belongs — the
installed binary name, and scoop's shim alias.

After this, no template derives an asset name from `executableName ~ "-cli"`.

## Verification

Generated `examples/cli` before and after: **byte-identical**, including
`install.ps1` and `scoop/appwrite.config.json`. Rendered names unchanged —
`appwrite-cli-win-x64.exe`, `appwrite-cli-win-arm64.exe` — so this is a
single-source-of-truth change with no output movement, and the release assets it
points at are untouched.

Line endings preserved: the scoop manifest is CRLF and stays CRLF, so the diff is
the six substituted lines and nothing else.

`uvx djlint==1.40.10 templates/ --lint` reports 0 errors over 566 files, and the
Twig line-length check passes.

Unrelated but worth knowing while you are here: `composer lint-twig` on `main` is
`uvx djlint templates/ --lint` with no pin, while `.github/workflows/ci.yml:163`
pins `djlint==1.40.10` because "djlint 1.41.0+ false-positives T038 on multi-line
`{% if %}` tags". Running the composer script locally therefore reports 44 T038
false positives that CI never sees. Pinning the composer script to match is a
one-line fix; it is not in this PR.

Pre-existing in the shipping CLI, split out of #1733.
