### PR TITLE
fix(go): assert the response model the service actually builds

### DIFF
--- a/templates/go/services/service_test.go.twig
+++ b/templates/go/services/service_test.go.twig
@@ -101,7 +101,10 @@ func Test{{ service.name | caseUcfirst }}(t *testing.T) {
 {% set responseModels = method | getValidResponseModels %}
 {% set responseDiscriminator = method.responseDiscriminator ?? {} %}
 {% set responseModelName = '' %}
-{% if responseModels|length > 1 %}
+{# Mirror base/requests/api.twig: a union only picks between models when a
+   discriminator says how. Without one the service falls back to responseModel,
+   so asserting any other member gives a test the generated code cannot pass. #}
+{% if responseModels|length > 1 and responseDiscriminator is not empty %}
 {% set responseModelName = responseModels|last %}
 {% elseif method.responseModel and method.responseModel != 'any' %}
 {% set responseModelName = method.responseModel %}
@@ -196,7 +199,7 @@ func Test{{ service.name | caseUcfirst }}(t *testing.T) {
 		if err != nil {
 			t.Errorf("Method {{ method.name | caseUcfirst }} failed: %v", err)
 		}
-{% if responseModels|length > 1 %}
+{% if responseModels|length > 1 and responseModelName %}
 		if _, ok := response.(*models.{{ responseModelName | caseUcfirst }}); !ok {
 			t.Errorf("Expected response type *models.{{ responseModelName | caseUcfirst }}, got %T", response)
 		}


### PR DESCRIPTION
## What

A Go SDK method whose spec lists several response models generates a test that asserts the **last** of them:

```twig
{% if responseModels|length > 1 %}
{% set responseModelName = responseModels|last %}
```

But the service only chooses between models when the method carries a `responseDiscriminator`. Without one, `base/requests/api.twig` falls back to `method.responseModel` and builds a single type:

```go
parsed := models.Organization{}.New(bytes)
```

So the two templates disagreed, and the generated test asserted a type the generated code cannot return.

## Impact

`organizations.Create` is the case today — it has multiple response models and no discriminator:

```
--- FAIL: TestOrganizations/Test_Create
    organizations_test.go:235: Expected response type *models.PaymentAuthentication, got *models.Organization
```

Every console-platform Go SDK ships with this failing test. It goes unnoticed because the generated tests are rarely run — I only hit it while regenerating a vendored SDK.

## Fix

The test template now mirrors the runtime template:

- **discriminated** unions still assert their discriminated member, and the mock still carries the discriminator conditions — unchanged behaviour
- **undiscriminated** unions assert `method.responseModel`, which is what the service builds
- the assertion is skipped when no model name resolves, which would otherwise emit `*models.` and fail to compile

## Verification

- Console-platform SDK: `organizations` now passes; `go build`, `go vet` and the **full** `go test ./...` are green
- Discriminated unions (`tablesdb`, `databases`, `vcs`, `project`) regenerate unchanged and still pass
- Server-platform SDK (`examples/go`): builds, vets and tests clean
- `composer lint-twig` (566 files), `composer refactor:check`, and the Unit suite (33 tests) all pass