### PR TITLE
fix(go-cli): emit the license, changelog and docs examples

### DIFF
--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -766,11 +766,7 @@ class CLI extends Node
             new TwigFilter('cliTopLevelAliases', fn (array $service): array => $this->getCliTopLevelAliases($service)),
             new TwigFilter('cliCommandTargets', fn (array $method, array $service): array => $this->getCliCommandTargets($method, $service)),
             new TwigFilter('cliFallbackHelpers', fn (array $service): array => $this->getCliFallbackHelpers($service)),
-            new TwigFilter('cliIsTopLevelAlias', fn (array $method, array $service): bool => in_array(
-                $method['name'] ?? '',
-                self::TOP_LEVEL_COMMANDS[$service['name'] ?? ''] ?? [],
-                true,
-            )),
+            new TwigFilter('cliIsTopLevelAlias', fn (array $method, array $service): bool => $this->isCliTopLevelAlias($method, $service)),
         ]);
     }
 

--- a/src/SDK/Language/Concern/CliCommandSurface.php
+++ b/src/SDK/Language/Concern/CliCommandSurface.php
@@ -287,6 +287,20 @@ trait CliCommandSurface
     }
 
     /**
+     * Whether a method is promoted to the root, which decides how the docs
+     * example spells its invocation. Both CLIs document the same surface, so
+     * the lookup belongs here rather than in either language class.
+     */
+    protected function isCliTopLevelAlias(array $method, array $service): bool
+    {
+        return \in_array(
+            $method['name'] ?? '',
+            self::TOP_LEVEL_COMMANDS[$service['name'] ?? ''] ?? [],
+            true,
+        );
+    }
+
+    /**
      * Emission targets for one method: the normal (possibly hidden) service
      * subcommand, plus a standalone root command when the method is aliased.
      *

--- a/src/SDK/Language/GoCLI.php
+++ b/src/SDK/Language/GoCLI.php
@@ -352,6 +352,7 @@ class GoCLI extends Go
             new TwigFilter('cliTopLevelAliases', fn (array $service): array => $this->getCliTopLevelAliases($service)),
             new TwigFilter('cliCommandTargets', fn (array $method, array $service): array => $this->getCliCommandTargets($method, $service)),
             new TwigFilter('cliFallbackHelpers', fn (array $service): array => $this->getCliFallbackHelpers($service)),
+            new TwigFilter('cliIsTopLevelAlias', fn (array $method, array $service): bool => $this->isCliTopLevelAlias($method, $service)),
             new TwigFilter('goPackage', fn (string $service): string => $this->getGoPackageName($service)),
             new TwigFilter('goString', fn (?string $value): string => $this->toGoString($value)),
         ]);
@@ -385,6 +386,22 @@ class GoCLI extends Go
                 'scope'         => 'default',
                 'destination'   => 'README.md',
                 'template'      => 'go-cli/README.md.twig',
+            ],
+
+            [
+                'scope'         => 'default',
+                'destination'   => 'LICENSE.md',
+                'template'      => 'cli/LICENSE.md.twig',
+            ],
+            [
+                'scope'         => 'default',
+                'destination'   => 'CHANGELOG.md',
+                'template'      => 'cli/CHANGELOG.md.twig',
+            ],
+            [
+                'scope'         => 'method',
+                'destination'   => 'docs/examples/{{service.name | caseLower}}/{{method.name | caseKebab}}.md',
+                'template'      => 'cli/docs/example.md.twig',
             ],
 
             // Shared verbatim with the TypeScript CLI. Both build their download


### PR DESCRIPTION
Found while preparing the `26.0.0-rc.1` release: the generated `go-cli` tree has
no `LICENSE.md`, no `CHANGELOG.md` and no `docs/examples/`.

A release wipes the SDK repository and copies the generated tree over it, so a
file the templates do not emit is a file **deleted** from the published
repository. Releasing the Go CLI as it stood would have stripped the BSD-3
license, the changelog and 628 example docs from `appwrite/sdk-for-cli`.

## The templates are already language-agnostic

`cli/LICENSE.md.twig` is `{{sdk.licenseContent | raw}}` and
`cli/CHANGELOG.md.twig` is `{{sdk.changelog | raw}}`. The example template emits
a shell invocation of a surface both CLIs share by construction. So all three
are registered as-is rather than copied into `go-cli/`.

Rendering the example needs one filter `go-cli` did not declare,
`cliIsTopLevelAlias` — and `CLI` declared it as an inline closure over
`TOP_LEVEL_COMMANDS`, a trait constant. That is exactly the drift
`CliCommandSurface` exists to prevent, so the lookup becomes
`isCliTopLevelAlias()` on the trait and both classes register a filter that
calls it. No behaviour change for the TypeScript CLI.

## The absence had nowhere to fail

Generation prints `Unknown "cliIsTopLevelAlias" filter` and **still exits 0** —
which is how a five-file tree looked like a successful generation while I was
testing this. And a tree missing its license still compiles, so neither the
build nor the idempotency check notices.

## Verification

`php example.php go-cli console` and `php example.php cli console` both emit all
five files; 553 and 615 example docs respectively; `oauth2/list-projects.md`
reads `appwrite list-projects` in both. The generated Go tree still passes
`gofmt -l`, `go vet`, `go build ./...` and `go test`. Observed red first: before
this change the same generation produced no `LICENSE.md` at all, and with the
docs template registered but the filter missing it produced five files.
