### PR TITLE
fix(go-cli): install ldid from upstream, not from apt

### DIFF
--- a/templates/go-cli/.github/workflows/publish.yml.twig
+++ b/templates/go-cli/.github/workflows/publish.yml.twig
@@ -48,11 +48,23 @@ jobs:
 
       # Linux runners have no codesign, so ad-hoc signing the darwin builds
       # falls back to ldid.
+      # No apt package exists for ldid on any Ubuntu release, so this is the
+      # upstream prebuilt binary, pinned and checksummed: the runner downloads
+      # the thing that signs every macOS build, and a swapped artifact would
+      # otherwise be signing them.
       - name: Install ldid
+        env:
+          LDID_VERSION: v2.1.5-procursus7
+          LDID_SHA256: 4b8862b2fefa2cd7fa8f88cb0310779619aeaa8c72d6aff22f019b470f2fa99a
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y ldid
+
+          curl -fsSL -o /tmp/ldid \
+            "https://github.com/ProcursusTeam/ldid/releases/download/${LDID_VERSION}/ldid_linux_x86_64"
+          echo "${LDID_SHA256}  /tmp/ldid" | sha256sum --check --strict
+
+          sudo install -m 0755 /tmp/ldid /usr/local/bin/ldid
+          ldid -V
 
       - name: Build
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0


### PR DESCRIPTION
The `26.0.0-rc.1` release run failed at the first step that does any work:

```
sudo apt-get install -y ldid
E: Unable to locate package ldid
##[error]Process completed with exit code 100
```

No apt package named `ldid` exists on any Ubuntu release. The step could never
have succeeded; it took the first real release to find out, because
`publish.yml` runs only on `release: published` and no other workflow executes
it.

## What it would have cost

`scripts/adhoc-sign.sh` exits 1 when neither codesign nor ldid is present, so
goreleaser's post-build hook fails and the release produces **no binaries at
all** -- which is what happened, and is the cheap outcome: the run died before
uploading assets or publishing to npm, so the version is still reusable.

The expensive version is if signing had been skipped rather than failed:
`install.sh` runs `codesign -dv` and aborts on an unsigned download, and the Go
linker signs darwin/arm64 but not darwin/amd64. Every Intel Mac install would
have failed while Apple Silicon worked, which is easy to miss when arm64 is what
you develop on.

## The fix

The upstream prebuilt binary from ProcursusTeam/ldid, pinned by version and
verified by SHA-256. Pinned rather than latest because this binary signs every
macOS artifact the release ships -- an unpinned download is a supply chain hole
in the signing step itself.

## Verification

Ran the exact step in `ubuntu:24.04`, then signed a real artifact and checked
the property `install.sh` actually tests -- the exit code of `codesign -dv`:

| Artifact | `codesign -dv` |
|----------|----------------|
| darwin/amd64, as the Go linker leaves it | exit **1**, "code object is not signed at all" |
| the same binary after `ldid -S` | exit **0**, CodeDirectory embedded |

Observed red first, and against the real check rather than a proxy for it: the
unsigned build is the state that shipped, and it is the state `install.sh`
refuses.

For reference, a linker-signed arm64 build reports `flags=0x20002(adhoc,
linker-signed)` where ldid leaves `flags=0x0`. `install.sh` only checks the exit
code, so both pass; noting it so the difference is not mistaken for a defect
later.
