### PR TITLE
fix(go-cli): drop the ldid version check that always fails

### DIFF
--- a/templates/go-cli/.github/workflows/publish.yml.twig
+++ b/templates/go-cli/.github/workflows/publish.yml.twig
@@ -64,7 +64,10 @@ jobs:
           echo "${LDID_SHA256}  /tmp/ldid" | sha256sum --check --strict
 
           sudo install -m 0755 /tmp/ldid /usr/local/bin/ldid
-          ldid -V
+          # The gate adhoc-sign.sh itself uses. ldid has no flag that exits 0 --
+          # -V, -v and --version all print usage and exit 1 -- so a version
+          # check here fails the step it is meant to be reassuring about.
+          command -v ldid
 
       - name: Build
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0


### PR DESCRIPTION
The `26.0.0-rc.1` run reached the ldid step, downloaded and checksummed the binary, installed it -- and then failed:

```
ldid -V
Usage: ldid [-Acputype:subtype] [-a] [-C[adhoc | enforcement | ...
##[error]Process completed with exit code 1
```

ldid has no version flag: `-V`, `-v` and `--version` all print usage and exit 1. Under `set -euo pipefail` the smoke check failed the step it was added to reassure about, two lines after the work had succeeded.

It is now `command -v ldid` -- the same gate `scripts/adhoc-sign.sh` uses to decide whether ldid is available, so the step checks the property the build depends on rather than one ldid does not implement.

## Verification

The full step run in `ubuntu:24.04`, checking the exit code rather than the output:

```
/tmp/ldid: OK
/usr/local/bin/ldid
STEP EXIT CODE = 0
```

Exit codes for every candidate, measured rather than assumed: `ldid -V` → 1, `ldid -v` → 1, `ldid --version` → 1, `command -v ldid` → 0, `ldid -S <mach-o>` → 0.

Introduced by #1750, which verified the step by reading its output instead of its exit status.