### PR TITLE
Fix Go CLI mutation timeout handling

### DIFF
--- a/templates/go-cli/internal/client/client.go
+++ b/templates/go-cli/internal/client/client.go
@@ -126,10 +126,27 @@ func baseTransport() *http.Transport {
 	return transport
 }
 
+// NewHTTPClient returns the HTTP policy shared by the CLI's direct requests
+// and its generated SDK-backed service commands.
+//
+// A whole-request deadline makes a slow upload fail even while it is still
+// making progress. The transport instead bounds the individual connection and
+// response-header phases. Self-signed verification is configured before any
+// caller wraps the transport, because the generated SDK cannot see through a
+// recording RoundTripper to change it later.
+func NewHTTPClient(selfSigned bool) *http.Client {
+	transport := baseTransport()
+	if selfSigned {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+
+	return &http.Client{Transport: transport}
+}
+
 func New(endpoint, sdkVersion string) *Client {
 	return &Client{
 		Endpoint:   strings.TrimRight(endpoint, "/"),
-		HTTP:       &http.Client{Transport: baseTransport()},
+		HTTP:       NewHTTPClient(false),
 		SDKVersion: sdkVersion,
 		headers: map[string]string{
 			"content-type":   "application/json",

--- a/templates/go-cli/internal/cmd/services/service.go.twig
+++ b/templates/go-cli/internal/cmd/services/service.go.twig
@@ -14,6 +14,7 @@ import (
 {% if hasQueryParam %}
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/query"
 {% endif %}
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/sdk"
 {% else %}
 	"github.com/spf13/cobra"
 
@@ -23,6 +24,7 @@ import (
 {% if hasQueryParam %}
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/query"
 {% endif %}
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/sdk"
 {% endif %}
 )
 {% if sdk.test %}
@@ -253,7 +255,7 @@ func new{{ service.name | caseUcfirst }}{{ method.name | caseUcfirst }}Command()
 			result, err := service.{{ plan.method }}({{ callArguments|join(', ') }})
 {% endif %}
 			if err != nil {
-				return err
+				return sdk.WrapMutationError("{{ method.method | upper }}", err)
 			}
 {% if method.type == 'location' and not sdk.test %}
 

--- a/templates/go-cli/internal/sdk/capture.go
+++ b/templates/go-cli/internal/sdk/capture.go
@@ -2,13 +2,14 @@ package sdk
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"strings"
 	"sync"
 	"sync/atomic"
-	"time"
 )
 
 // --raw is documented as "the full raw JSON response", and --json filters that
@@ -59,6 +60,50 @@ func (r *responseRecorder) Record(body []byte) {
 
 // requestWasMade records that the process reached the API.
 var requestWasMade atomic.Bool
+
+// UnknownMutationOutcome is a timeout returned after a mutating request may
+// already have reached the server. Retrying it as an ordinary failure can
+// duplicate a create or repeat another side effect.
+type UnknownMutationOutcome struct {
+	err error
+}
+
+func (e *UnknownMutationOutcome) Error() string {
+	return "the request timed out after it may have reached the server; its outcome is unknown. " +
+		"Check the resource before retrying to avoid duplicate changes"
+}
+
+// Unwrap keeps the transport error available to --verbose and errors.Is/As.
+func (e *UnknownMutationOutcome) Unwrap() error { return e.err }
+
+// WrapMutationError marks a timeout from an unsafe HTTP method as an unknown
+// outcome. Read-only requests and ordinary failures keep their original error.
+func WrapMutationError(method string, err error) error {
+	if err == nil || isReadMethod(method) || !isTimeout(err) {
+		return err
+	}
+
+	return &UnknownMutationOutcome{err: err}
+}
+
+func isReadMethod(method string) bool {
+	switch strings.ToUpper(method) {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return true
+	default:
+		return false
+	}
+}
+
+func isTimeout(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	var timeout interface{ Timeout() bool }
+
+	return errors.As(err, &timeout) && timeout.Timeout()
+}
 
 // RequestWasMade reports whether any request has been sent.
 //
@@ -114,19 +159,26 @@ func (t *recordingTransport) RoundTrip(request *http.Request) (*http.Response, e
 	return response, nil
 }
 
-// recordingHTTPClient is the http.Client the SDK client is given.
-//
-// It reproduces GetDefaultClient's cookie jar and timeout, because setting
-// Client on the SDK's struct skips that constructor entirely.
-func recordingHTTPClient(timeout time.Duration) *http.Client {
+// recordingHTTPClient adds response capture and the SDK's cookie jar to the
+// CLI's shared HTTP policy. In particular, it removes any whole-request
+// deadline instead of inheriting the SDK's ten-second timeout.
+func recordingHTTPClient(base *http.Client) *http.Client {
 	jar, err := cookiejar.New(nil)
 	if err != nil {
 		jar = nil
 	}
-
-	return &http.Client{
-		Jar:       jar,
-		Timeout:   timeout,
-		Transport: &recordingTransport{next: http.DefaultTransport},
+	if base == nil {
+		base = &http.Client{}
 	}
+
+	next := base.Transport
+	if next == nil {
+		next = http.DefaultTransport
+	}
+	recorded := *base
+	recorded.Jar = jar
+	recorded.Timeout = 0
+	recorded.Transport = &recordingTransport{next: next}
+
+	return &recorded
 }

--- a/templates/go-cli/internal/sdk/capture_test.go
+++ b/templates/go-cli/internal/sdk/capture_test.go
@@ -1,11 +1,20 @@
 package sdk
 
 import (
+	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
+	"time"
 )
+
+func testRecordingHTTPClient() *http.Client {
+	return recordingHTTPClient(&http.Client{Transport: http.DefaultTransport})
+}
 
 // --raw promises the full response. Rendering the typed struct instead dropped
 // every field the generated model does not declare, so a field the API added
@@ -20,7 +29,7 @@ func TestResponseBodyIsCaptured(t *testing.T) {
 	defer server.Close()
 
 	LastResponse.Take()
-	if _, err := recordingHTTPClient(0).Get(server.URL); err != nil {
+	if _, err := testRecordingHTTPClient().Get(server.URL); err != nil {
 		t.Fatal(err)
 	}
 
@@ -40,7 +49,7 @@ func TestCapturedBodyIsStillReadable(t *testing.T) {
 	}))
 	defer server.Close()
 
-	response, err := recordingHTTPClient(0).Get(server.URL)
+	response, err := testRecordingHTTPClient().Get(server.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +73,7 @@ func TestTakeClearsTheCapturedBody(t *testing.T) {
 	}))
 	defer server.Close()
 
-	if _, err := recordingHTTPClient(0).Get(server.URL); err != nil {
+	if _, err := testRecordingHTTPClient().Get(server.URL); err != nil {
 		t.Fatal(err)
 	}
 
@@ -86,7 +95,7 @@ func TestNonJSONResponsesAreNotCaptured(t *testing.T) {
 	defer server.Close()
 
 	LastResponse.Take()
-	if _, err := recordingHTTPClient(0).Get(server.URL); err != nil {
+	if _, err := testRecordingHTTPClient().Get(server.URL); err != nil {
 		t.Fatal(err)
 	}
 
@@ -108,7 +117,7 @@ func TestTheNewestResponseWins(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := recordingHTTPClient(0)
+	client := testRecordingHTTPClient()
 	for range responses {
 		if _, err := client.Get(server.URL); err != nil {
 			t.Fatal(err)
@@ -117,5 +126,64 @@ func TestTheNewestResponseWins(t *testing.T) {
 
 	if got := string(LastResponse.Take()); got != `{"chunk":3}` {
 		t.Errorf("captured %q, want the last response", got)
+	}
+}
+
+func TestRecordingClientUsesThePhaseBoundedTransport(t *testing.T) {
+	baseTransport := &http.Transport{ResponseHeaderTimeout: 60 * time.Second}
+	client := recordingHTTPClient(&http.Client{
+		Timeout:   10 * time.Second,
+		Transport: baseTransport,
+	})
+
+	if client.Timeout != 0 {
+		t.Errorf("http.Client.Timeout = %s, want no whole-request deadline", client.Timeout)
+	}
+	recorder, ok := client.Transport.(*recordingTransport)
+	if !ok {
+		t.Fatalf("transport is %T, want *recordingTransport", client.Transport)
+	}
+	transport, ok := recorder.next.(*http.Transport)
+	if !ok {
+		t.Fatalf("recorded transport is %T, want *http.Transport", recorder.next)
+	}
+	if transport.ResponseHeaderTimeout != 60*time.Second {
+		t.Errorf("ResponseHeaderTimeout = %s, want 60s", transport.ResponseHeaderTimeout)
+	}
+}
+
+func TestMutationTimeoutHasAnUnknownOutcome(t *testing.T) {
+	cause := &url.Error{Op: "Post", URL: "https://example.invalid", Err: context.DeadlineExceeded}
+	err := WrapMutationError(http.MethodPost, cause)
+
+	var unknown *UnknownMutationOutcome
+	if !errors.As(err, &unknown) {
+		t.Fatalf("error is %T, want *UnknownMutationOutcome", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Error("the original deadline error is not preserved")
+	}
+	if !strings.Contains(err.Error(), "outcome is unknown") ||
+		!strings.Contains(err.Error(), "before retrying") {
+		t.Errorf("error does not explain the uncertain mutation: %q", err)
+	}
+}
+
+func TestReadTimeoutIsUnchanged(t *testing.T) {
+	cause := &url.Error{Op: "Get", URL: "https://example.invalid", Err: context.DeadlineExceeded}
+
+	if got := WrapMutationError(http.MethodGet, cause); got != cause {
+		t.Errorf("read timeout was wrapped as %T", got)
+	}
+}
+
+func TestNonTimeoutMutationErrorIsUnchanged(t *testing.T) {
+	cause := errors.New("server rejected the request")
+
+	if got := WrapMutationError(http.MethodDelete, cause); got != cause {
+		t.Errorf("ordinary mutation error was wrapped as %T", got)
+	}
+	if got := WrapMutationError(http.MethodPost, nil); got != nil {
+		t.Errorf("nil error became %v", got)
 	}
 }

--- a/templates/go-cli/internal/sdk/sdk.go.twig
+++ b/templates/go-cli/internal/sdk/sdk.go.twig
@@ -15,6 +15,7 @@ import (
 	sdkclient "{{ language.params.sdkImportPath }}/client"
 
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/auth"
+	internalclient "github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/client"
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/config"
 )
 
@@ -55,13 +56,12 @@ func (c *Context) base(endpoint string) sdkclient.Client {
 	client := sdkclient.New()
 	client.Endpoint = endpoint
 	// Keeps the response body for --raw and --json, which must show what the
-	// API sent rather than the typed model re-encoded. See capture.go.
-	client.Client = recordingHTTPClient(client.Timeout)
-	// `client --self-signed true` is what a user running Appwrite behind its own
-	// certificate sets. The SDK honours this field; storing the preference and
-	// never passing it on left the flag inert and every request rejected on
-	// certificate validation.
-	client.SelfSigned = c.Global.CurrentBool(config.PreferenceSelfSigned)
+	// API sent rather than the typed model re-encoded. The underlying client is
+	// the CLI's phase-bounded transport, not the SDK's ten-second whole-request
+	// deadline. Self-signed verification is applied before response recording
+	// wraps the transport.
+	client.Client = recordingHTTPClient(internalclient.NewHTTPClient(
+		c.Global.CurrentBool(config.PreferenceSelfSigned)))
 	client.AddHeader("x-sdk-name", "Command Line")
 	client.AddHeader("x-sdk-platform", "console")
 	client.AddHeader("x-sdk-language", "cli")


### PR DESCRIPTION
## What changed

Generated Go CLI service commands no longer inherit the Go SDK's 10-second whole-request timeout. They now use the CLI's shared phase-bounded transport: standard connection and TLS limits, no whole-request deadline, and a 60-second response-header timeout.

If a non-read request still times out, the CLI reports that the mutation may already have reached the server and tells the user to verify the resource before retrying. The original transport error remains available through `--verbose` and Go's error chain.

## Result

```go
client.Client = recordingHTTPClient(internalclient.NewHTTPClient(
	c.Global.CurrentBool(config.PreferenceSelfSigned)))
```

```go
result, err := service.CreateProject(projectId, name, options...)
if err != nil {
	return sdk.WrapMutationError("POST", err)
}
```

```console
$ appwrite organization create-project \
    --project-id cli-timeout-fix-20260806b \
    --name "CLI Timeout Fix Verification" \
    --region fra \
    --organization-id <ORG_ID> \
    --json
{
  "$id": "cli-timeout-fix-20260806b",
  "name": "CLI Timeout Fix Verification",
  "region": "fra",
  "status": "active"
}
```

If a mutating request exceeds the remaining transport timeout:

```console
✗ Error: the request timed out after it may have reached the server; its outcome is unknown. Check the resource before retrying to avoid duplicate changes
```

## Verification

- Reproduced against staging with `26.0.0-rc.1`: the CLI timed out after 10.2 seconds, while the project was successfully created.
- Built the generated CLI and repeated the same staging create: the successful response returned after the old 10-second cutoff.
- Removed both disposable staging projects and confirmed they were absent.
- Generated Go CLI build, vet, tests, and race tests pass.
- Go CLI Docker e2e passes with 5,027 assertions.
- PHP unit tests pass with 125 assertions.
- Rector and all 590 Twig lint checks pass.

Addresses finding 1 in #1746.
