### PR TITLE
Fix Go CLI deployment directory packaging

### DIFF
--- a/src/SDK/Language/GoCLI.php
+++ b/src/SDK/Language/GoCLI.php
@@ -243,7 +243,7 @@ class GoCLI extends Go
      *     package: string,
      *     method: string,
      *     optionType: string,
-     *     decodes: list<array{var: string, source: string, helper: string}>,
+     *     decodes: list<array{var: string, source: string, helper: string, cleanup?: string}>,
      *     required: list<array{expression: string}>,
      *     optional: list<array{flag: string, setter: string, expression: string}>
      * }
@@ -264,7 +264,12 @@ class GoCLI extends Go
             $expression = $variable;
 
             if ($flagType !== $sdkType) {
-                [$expression, $decode] = $this->convertToSdkType($variable, $flagType, $sdkType);
+                [$expression, $decode] = $this->convertToSdkType(
+                    $variable,
+                    $flagType,
+                    $sdkType,
+                    (bool) ($method['packaging'] ?? false),
+                );
 
                 if ($decode !== null) {
                     $decodes[] = $decode;
@@ -300,9 +305,14 @@ class GoCLI extends Go
      * Returns the call-site expression, plus a statement to emit before the call
      * when the conversion can fail and its error has to surface.
      *
-     * @return array{0: string, 1: array{var: string, source: string, helper: string}|null}
+     * @return array{0: string, 1: array{var: string, source: string, helper: string, cleanup?: string}|null}
      */
-    protected function convertToSdkType(string $variable, string $flagType, string $sdkType): array
+    protected function convertToSdkType(
+        string $variable,
+        string $flagType,
+        string $sdkType,
+        bool $packaging = false,
+    ): array
     {
         // A JSON string or a file path becomes a decoded value, and either can
         // fail on bad input, so both are decoded into their own variable first.
@@ -310,7 +320,16 @@ class GoCLI extends Go
             return [$variable . 'Value', ['var' => $variable . 'Value', 'source' => $variable, 'helper' => 'JSONObject']];
         }
         if ($sdkType === 'file.InputFile') {
-            return [$variable . 'File', ['var' => $variable . 'File', 'source' => $variable, 'helper' => 'InputFile']];
+            $decode = [
+                'var' => $variable . 'File',
+                'source' => $variable,
+                'helper' => $packaging ? 'DeploymentInputFile' : 'InputFile',
+            ];
+            if ($packaging) {
+                $decode['cleanup'] = $variable . 'FileCleanup';
+            }
+
+            return [$variable . 'File', $decode];
         }
 
         // Widening a repeatable string flag to an untyped array cannot fail.
@@ -638,6 +657,11 @@ class GoCLI extends Go
                 'scope'         => 'default',
                 'destination'   => 'internal/app/inputfile.go',
                 'template'      => 'go-cli/internal/app/inputfile.go.twig',
+            ],
+            [
+                'scope'         => 'default',
+                'destination'   => 'internal/app/inputfile_test.go',
+                'template'      => 'go-cli/internal/app/inputfile_test.go.twig',
             ],
             [
                 'scope'         => 'default',

--- a/src/SDK/Language/GoCLI.php
+++ b/src/SDK/Language/GoCLI.php
@@ -312,8 +312,7 @@ class GoCLI extends Go
         string $flagType,
         string $sdkType,
         bool $packaging = false,
-    ): array
-    {
+    ): array {
         // A JSON string or a file path becomes a decoded value, and either can
         // fail on bad input, so both are decoded into their own variable first.
         if ($sdkType === 'interface{}' && $flagType === 'string') {

--- a/templates/go-cli/internal/app/inputfile.go.twig
+++ b/templates/go-cli/internal/app/inputfile.go.twig
@@ -9,6 +9,11 @@ package app
 func InputFile(path string) (any, error) {
 	return path, nil
 }
+
+// DeploymentInputFile is stubbed for the conformance build.
+func DeploymentInputFile(path string) (any, func(), error) {
+	return path, func() {}, nil
+}
 {% else %}
 import (
 	"fmt"
@@ -16,6 +21,10 @@ import (
 	"path/filepath"
 
 	sdkfile "{{ language.params.sdkImportPath }}/file"
+
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/config"
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/deploy"
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/output"
 )
 
 // InputFile turns a path into the SDK's upload type.
@@ -36,5 +45,53 @@ func InputFile(path string) (sdkfile.InputFile, error) {
 	}
 
 	return sdkfile.NewInputFile(resolved, filepath.Base(resolved)), nil
+}
+
+// DeploymentInputFile turns a deployment archive or source directory into the
+// SDK's upload type. Directories use the same packaging rules as `push`, and
+// the returned cleanup must run after the SDK has finished reading the file.
+func DeploymentInputFile(path string) (sdkfile.InputFile, func(), error) {
+	if path == "" {
+		return sdkfile.InputFile{}, func() {}, fmt.Errorf("a file or directory path is required")
+	}
+
+	resolved, err := filepath.Abs(path)
+	if err != nil {
+		return sdkfile.InputFile{}, func() {}, err
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return sdkfile.InputFile{}, func() {}, fmt.Errorf("cannot read %q: %w", path, err)
+	}
+	if !info.IsDir() {
+		return sdkfile.NewInputFile(resolved, filepath.Base(resolved)), func() {}, nil
+	}
+
+	packaged, err := deploy.PackageDirectory(
+		resolved,
+		nil,
+		inputFileProjectRoot(),
+		func(message string) { output.Warn(os.Stderr, "%s", message) },
+	)
+	if err != nil {
+		return sdkfile.InputFile{}, func() {}, err
+	}
+
+	cleanup := func() { _ = packaged.Remove() }
+
+	return sdkfile.NewInputFile(packaged.Path, deploy.ArchiveName), cleanup, nil
+}
+
+// inputFileProjectRoot mirrors the TypeScript CLI's best-effort local config
+// lookup. It bounds followed symlinks when the command runs inside a project,
+// while still allowing a directory passed from outside any project.
+func inputFileProjectRoot() string {
+	path := config.FindLocalPath()
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return ""
+	}
+
+	return filepath.Dir(path)
 }
 {% endif %}

--- a/templates/go-cli/internal/app/inputfile_test.go.twig
+++ b/templates/go-cli/internal/app/inputfile_test.go.twig
@@ -1,0 +1,67 @@
+package app
+
+{% if not sdk.test %}
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDeploymentInputFilePassesThroughAnArchive(t *testing.T) {
+	archive := filepath.Join(t.TempDir(), "existing.tar.gz")
+	if err := os.WriteFile(archive, []byte("archive"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	input, cleanup, err := DeploymentInputFile(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanup()
+
+	if input.Path != archive {
+		t.Fatalf("input path %q, want %q", input.Path, archive)
+	}
+	if input.Name != "existing.tar.gz" {
+		t.Fatalf("input name %q, want existing.tar.gz", input.Name)
+	}
+	if _, err := os.Stat(archive); err != nil {
+		t.Fatalf("cleanup removed the caller's archive: %v", err)
+	}
+}
+
+func TestDeploymentInputFilePackagesAndCleansUpADirectory(t *testing.T) {
+	directory := t.TempDir()
+	if err := os.WriteFile(filepath.Join(directory, "main.js"), []byte("export default () => {};"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	input, cleanup, err := DeploymentInputFile(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if input.Path == directory {
+		t.Fatal("directory was passed through instead of packaged")
+	}
+	if input.Name != "code.tar.gz" {
+		t.Fatalf("input name %q, want code.tar.gz", input.Name)
+	}
+	if _, err := os.Stat(input.Path); err != nil {
+		t.Fatalf("packaged archive is unavailable before cleanup: %v", err)
+	}
+
+	cleanup()
+	if _, err := os.Stat(input.Path); !os.IsNotExist(err) {
+		t.Fatalf("packaged archive still exists after cleanup: %v", err)
+	}
+}
+
+func TestDeploymentInputFileRejectsAMissingPath(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing")
+
+	if _, _, err := DeploymentInputFile(missing); err == nil {
+		t.Fatal("missing path was accepted")
+	}
+}
+{% endif %}

--- a/templates/go-cli/internal/cmd/services/service.go.twig
+++ b/templates/go-cli/internal/cmd/services/service.go.twig
@@ -169,10 +169,18 @@ func new{{ service.name | caseUcfirst }}{{ method.name | caseUcfirst }}Command()
 {% endif %}
 {% if not sdk.test %}
 {% for decode in plan.decodes %}
+{% if decode.cleanup is defined %}
+			{{ decode.var }}, {{ decode.cleanup }}, err := app.{{ decode.helper }}({{ decode.source }})
+			if err != nil {
+				return err
+			}
+			defer {{ decode.cleanup }}()
+{% else %}
 			{{ decode.var }}, err := app.{{ decode.helper }}({{ decode.source }})
 			if err != nil {
 				return err
 			}
+{% endif %}
 {% endfor %}
 {% endif %}
 {% if query.hasQueries %}


### PR DESCRIPTION
## What changed

Generated Go CLI service commands now honor the spec's `packaging` marker for file parameters. Function and site deployment commands accept either a source directory or an existing archive:

- directories use the existing deployment packager, including `.gitignore`, `.git`, and symlink-boundary handling;
- generated commands keep the temporary `code.tar.gz` alive for the upload and remove it afterward;
- existing archives pass through unchanged;
- ordinary file endpoints, such as storage uploads, remain file-only.

## Before

```console
$ appwrite functions create-deployment --function-id <function-id> --code ./function --entrypoint main.js --activate
✗ Error: read .../function: is a directory

$ appwrite sites create-deployment --site-id <site-id> --code ./site --activate
✗ Error: read .../site: is a directory
```

## After

```console
$ appwrite functions create-deployment --function-id <function-id> --code ./function --entrypoint main.js --activate --json
{
  "$id": "<deployment-id>",
  "resourceType": "functions",
  "entrypoint": "main.js",
  "sourceSize": 231,
  "activate": true,
  "status": "waiting"
}

$ appwrite sites create-deployment --site-id <site-id> --code ./site --activate --json
{
  "$id": "<deployment-id>",
  "resourceType": "sites",
  "sourceSize": 223,
  "activate": true,
  "status": "waiting"
}
```

Both staging deployments subsequently reached `ready`.

## Result

Generated deployment commands now resolve the directory and own its cleanup:

```go
codeFile, codeFileCleanup, err := app.DeploymentInputFile(code)
if err != nil {
	return err
}
defer codeFileCleanup()
```

Downloading the stored source archives produced:

```text
function: .gitignore, main.js
site:     .gitignore, index.html
```

An intentionally ignored `ignored.txt` was absent from both archives.

## Verification

- Reproduced both `is a directory` failures against staging with `26.0.0-rc.1`.
- Built the generated Go CLI and repeated both directory uploads against the same staging session.
- Confirmed both deployments reached `ready` and downloaded their source archives.
- Confirmed a prebuilt `.tar.gz` still uploads successfully.
- Removed the disposable staging function and site and confirmed they were absent.
- Go CLI generation is idempotent.
- Generated Go CLI build, vet, and tests pass.
- Go CLI Docker e2e passes with 5,045 assertions.
- PHP unit tests pass with 125 assertions.
- Rector and all 591 Twig lint checks pass.

Addresses finding 2 in #1746.
