### PR TITLE
Fix Go CLI JSON array flag decoding

### DIFF
--- a/src/SDK/Language/GoCLI.php
+++ b/src/SDK/Language/GoCLI.php
@@ -331,13 +331,9 @@ class GoCLI extends Go
             return [$variable . 'File', $decode];
         }
 
-        // Widening a repeatable string flag to an untyped array cannot fail.
-        if ($sdkType === '[]interface{}' && $flagType === '[]string') {
-            return ['app.ToAnySlice(' . $variable . ')', null];
-        }
-        // Any other typed slice -- []float64, [][]interface{}, []map[string]any --
-        // needs each repetition parsed, because Go cannot hand the API a string
-        // where it declares a number the way the TypeScript does.
+        // Slice parameters -- []interface{}, []float64, [][]interface{},
+        // []map[string]any -- need each repetition parsed, because Go cannot
+        // hand the API a JSON string where it declares an object or number.
         if (str_starts_with($sdkType, '[]') && $flagType === '[]string') {
             $element = substr($sdkType, 2);
 

--- a/templates/go-cli/internal/app/convert.go
+++ b/templates/go-cli/internal/app/convert.go
@@ -10,27 +10,10 @@ import (
 
 // Conversions between what a flag can hold and what an SDK parameter declares.
 //
-// A repeatable flag is []string but an untyped array parameter is
-// []interface{}; an object parameter arrives as a JSON string. The generated
-// call sites route through these so the conversion lives in one reviewable
-// place rather than in 600 inlined expressions.
-
-// ToAnySlice widens a repeatable string flag to an untyped slice.
-//
-// Returns nil for an empty input so an unset flag stays absent rather than
-// becoming an empty array, which the API treats differently.
-func ToAnySlice(values []string) []interface{} {
-	if len(values) == 0 {
-		return nil
-	}
-
-	widened := make([]interface{}, 0, len(values))
-	for _, value := range values {
-		widened = append(widened, value)
-	}
-
-	return widened
-}
+// A repeatable flag is []string but the SDK can declare a typed or untyped
+// slice; an object parameter arrives as a JSON string. The generated call sites
+// route through these so the conversion lives in one reviewable place rather
+// than in 600 inlined expressions.
 
 // JSONObject decodes a flag value that the SDK takes as an object.
 //
@@ -76,10 +59,10 @@ func WriteFile(destination string, content *[]byte) error {
 
 // DecodeSlice parses each value of a repeatable flag into T.
 //
-// Needed where the SDK declares a typed slice such as []float64 or
-// [][]interface{}. The TypeScript CLI hands the API raw strings and lets it
-// coerce them; Go's static typing does not allow that, so the parse happens
-// here instead. A malformed value therefore fails locally with a clear message
+// Needed where the SDK declares a slice such as []interface{}, []float64, or
+// [][]interface{}. Go's static typing does not allow the CLI to hand an API a
+// string where it declares an object or number, so the parse happens here
+// instead. A malformed value therefore fails locally with a clear message
 // rather than as a server-side validation error.
 func DecodeSlice[T any](raws []string) ([]T, error) {
 	if len(raws) == 0 {

--- a/tests/e2e/GoCLI126Test.php
+++ b/tests/e2e/GoCLI126Test.php
@@ -52,6 +52,31 @@ final class GoCLI126Test extends Base
     ];
 
     #[Override]
+    public function testHTTPSuccess(): void
+    {
+        $language = new class () extends GoCLI {
+            /**
+             * @return array{0: string, 1: array{var: string, source: string, helper: string, cleanup?: string}|null}
+             */
+            public function convertForTest(string $variable, string $flagType, string $sdkType): array
+            {
+                return $this->convertToSdkType($variable, $flagType, $sdkType);
+            }
+        };
+
+        [$expression, $decode] = $language->convertForTest('rows', '[]string', '[]interface{}');
+
+        $this->assertSame('rowsDecoded', $expression);
+        $this->assertSame([
+            'var' => 'rowsDecoded',
+            'source' => 'rows',
+            'helper' => 'DecodeSlice[interface{}]',
+        ], $decode);
+
+        parent::testHTTPSuccess();
+    }
+
+    #[Override]
     public function getLanguage(): GoCLI
     {
         $language = new GoCLI();


### PR DESCRIPTION
## What changed

Generated Go CLI commands now decode every repeated JSON flag before passing it to an SDK parameter typed as `[]interface{}`. Previously, the CLI only widened each raw flag value from `string` to `interface{}`, causing JSON objects to be sent as escaped strings.

This corrects bulk row and document mutations, table and collection definitions, and transaction operation arrays. Malformed JSON now fails locally with a clear parsing error. Server-side validation is intentionally outside this PR.

## Before

```go
result, err := service.CreateRows(
	databaseId,
	tableId,
	app.ToAnySlice(rows),
	options...,
)
```

```console
$ appwrite tablesdb create-rows \
    --database-id <database-id> \
    --table-id audit-table \
    --rows '{"$id":"row-one","title":"first","score":10}' \
    --rows '{"$id":"row-two","title":"second","score":20}' \
    --verbose
✗ Error: Server Error

status: 500
type:   general_unknown
```

The request body contained strings instead of objects:

```json
{
  "rows": [
    "{\"$id\":\"row-one\",\"title\":\"first\",\"score\":10}",
    "{\"$id\":\"row-two\",\"title\":\"second\",\"score\":20}"
  ]
}
```

## After

```go
rowsDecoded, err := app.DecodeSlice[interface{}](rows)
if err != nil {
	return err
}

result, err := service.CreateRows(
	databaseId,
	tableId,
	rowsDecoded,
	options...,
)
```

```console
$ appwrite tablesdb create-rows \
    --database-id <database-id> \
    --table-id audit-table \
    --rows '{"$id":"row-one","title":"first","score":10}' \
    --rows '{"$id":"row-two","title":"second","score":20}' \
    --json
{
  "total": 2,
  "rows": [
    {"$id":"row-one","title":"first","score":10},
    {"$id":"row-two","title":"second","score":20}
  ]
}
```

Malformed JSON is rejected before making an API request:

```console
✗ Error: expected JSON for this flag, got "{...": unexpected EOF
```

## Verification

- Reproduced the `500 general_unknown` response on staging with CLI `26.0.0-rc.1`.
- Generated and built the corrected Go CLI, then repeated the exact bulk-row command against the same staging session; both rows were created.
- Confirmed malformed JSON fails locally and creates no additional row.
- Removed the disposable staging database and confirmed it was absent.
- Go CLI generation is idempotent.
- Generated Go CLI build, vet, and tests pass.
- Go CLI Docker e2e passes with 5,047 assertions.
- PHP unit tests pass with 125 assertions.
- PHP code style, Rector, and all 591 Twig lint checks pass.

Addresses finding 4 in #1746.
