### PR TITLE
Support headless CLI skill installation

### DIFF
--- a/templates/cli/cli.ts.twig
+++ b/templates/cli/cli.ts.twig
@@ -154,9 +154,10 @@ if (process.argv.includes('-v') || process.argv.includes('--version')) {
                 await migrate();
             })
             .option('-f, --force', 'Skip confirmation prompts')
-            // Parsed at the root so `appwrite --all push` keeps working, but
-            // documented on `push` and `pull`, which are what they act on.
-            .addOption(new Option('-a, --all', 'Push or pull every resource').hideHelp())
+            // Parsed at the root so `appwrite --all push` and
+            // `appwrite --all init skill` keep working, but documented only on
+            // the commands where it selects resources or skills.
+            .addOption(new Option('-a, --all', 'Select every applicable resource or skill').hideHelp())
             .addOption(new Option('--id [id...]', 'Limit the action to these resource ids').hideHelp())
             .option('--report', 'Print a prefilled bug report link on error')
             .hook('preAction', (_thisCommand, actionCommand) => {

--- a/templates/cli/lib/commands/init.ts
+++ b/templates/cli/lib/commands/init.ts
@@ -43,6 +43,7 @@ import {
   fetchAvailableSkills,
   detectProjectSkills,
   placeSkills,
+  resolveSkillSelection,
 } from "../utils.js";
 import {
   Account,
@@ -590,32 +591,6 @@ const collectInitSkillOption = (
   value: string,
   previous: string[] = [],
 ): string[] => [...previous, value];
-
-export const resolveSkillSelection = (
-  skills: { dirName: string }[],
-  requested: string[],
-  all: boolean,
-): string[] => {
-  if (all && requested.length > 0) {
-    throw new Error("The '--all' and '--skill' flags cannot be used together.");
-  }
-
-  const available = skills.map((skill) => skill.dirName);
-  if (all) {
-    return available;
-  }
-
-  const availableSet = new Set(available);
-  const selected = [...new Set(requested)];
-  const unknown = selected.find((skill) => !availableSet.has(skill));
-  if (unknown !== undefined) {
-    throw new Error(
-      `Unknown skill '${unknown}'. Available skills: ${available.join(", ")}`,
-    );
-  }
-
-  return selected;
-};
 
 const resolveSkillAgents = (requested: string[]): string[] => {
   const available = [".agents", ".claude"];

--- a/templates/cli/lib/commands/init.ts
+++ b/templates/cli/lib/commands/init.ts
@@ -55,6 +55,13 @@ import { DEFAULT_ENDPOINT, EXECUTABLE_NAME } from "../constants.js";
 type InitResourceAction = (_options?: unknown) => Promise<void>;
 type ProjectCreateRegion = Region;
 
+interface InitSkillOptions {
+  all?: boolean;
+  skill?: string[];
+  agent?: string[];
+  method?: string;
+}
+
 interface ExistingProjectSummary {
   $id: string;
   name?: string;
@@ -579,7 +586,67 @@ const initTopic = async (): Promise<void> => {
   );
 };
 
-const initSkill = async (): Promise<void> => {
+const collectInitSkillOption = (
+  value: string,
+  previous: string[] = [],
+): string[] => [...previous, value];
+
+export const resolveSkillSelection = (
+  skills: { dirName: string }[],
+  requested: string[],
+  all: boolean,
+): string[] => {
+  if (all && requested.length > 0) {
+    throw new Error("The '--all' and '--skill' flags cannot be used together.");
+  }
+
+  const available = skills.map((skill) => skill.dirName);
+  if (all) {
+    return available;
+  }
+
+  const availableSet = new Set(available);
+  const selected = [...new Set(requested)];
+  const unknown = selected.find((skill) => !availableSet.has(skill));
+  if (unknown !== undefined) {
+    throw new Error(
+      `Unknown skill '${unknown}'. Available skills: ${available.join(", ")}`,
+    );
+  }
+
+  return selected;
+};
+
+const resolveSkillAgents = (requested: string[]): string[] => {
+  const available = [".agents", ".claude"];
+  const selected = [...new Set(requested)];
+  const unknown = selected.find((agent) => !available.includes(agent));
+  if (unknown !== undefined) {
+    throw new Error(
+      `Unknown agent directory '${unknown}'. Available directories: ${available.join(", ")}`,
+    );
+  }
+
+  return selected;
+};
+
+const resolveSkillMethod = (requested?: string): string | undefined => {
+  const available = ["symlink", "copy"];
+  if (requested !== undefined && !available.includes(requested)) {
+    throw new Error(
+      `Unknown installation method '${requested}'. Available methods: ${available.join(", ")}`,
+    );
+  }
+
+  return requested;
+};
+
+const initSkill = async ({
+  all = false,
+  skill = [],
+  agent = [],
+  method,
+}: InitSkillOptions = {}): Promise<void> => {
   process.chdir(localConfig.configDirectoryPath);
   const cwd = process.cwd();
 
@@ -587,52 +654,71 @@ const initSkill = async (): Promise<void> => {
   const { skills, tempDir } = fetchAvailableSkills();
 
   try {
-    const { selectedSkills } = await inquirer.prompt([
-      {
-        type: "checkbox",
-        name: "selectedSkills",
-        message: "Which skills would you like to install?",
-        choices: skills.map((skill) => ({
-          name: skill.name,
-          value: skill.dirName,
-          checked: false,
-        })),
-        validate: (value: string[]) =>
-          value.length > 0 || "Please select at least one skill.",
-      },
-    ]);
+    const installAll = all || cliConfig.all;
+    const explicitSelection = installAll || skill.length > 0;
+    let selectedSkills = resolveSkillSelection(skills, skill, installAll);
+    if (!explicitSelection) {
+      ({ selectedSkills } = await inquirer.prompt([
+        {
+          type: "checkbox",
+          name: "selectedSkills",
+          message: "Which skills would you like to install?",
+          choices: skills.map((availableSkill) => ({
+            name: availableSkill.name,
+            value: availableSkill.dirName,
+            checked: false,
+          })),
+          validate: (value: string[]) =>
+            value.length > 0 || "Please select at least one skill.",
+        },
+      ]));
+    }
 
-    const { selectedAgents } = await inquirer.prompt([
-      {
-        type: "checkbox",
-        name: "selectedAgents",
-        message: "Which agent directories would you like to install to?",
-        choices: [
-          { name: ".agents", value: ".agents", checked: true },
-          { name: ".claude", value: ".claude", checked: false },
-        ],
-        validate: (value: string[]) =>
-          value.length > 0 || "Please select at least one agent directory.",
-      },
-    ]);
+    let selectedAgents = resolveSkillAgents(agent);
+    if (selectedAgents.length === 0) {
+      if (explicitSelection) {
+        selectedAgents = [".agents"];
+      } else {
+        ({ selectedAgents } = await inquirer.prompt([
+          {
+            type: "checkbox",
+            name: "selectedAgents",
+            message: "Which agent directories would you like to install to?",
+            choices: [
+              { name: ".agents", value: ".agents", checked: true },
+              { name: ".claude", value: ".claude", checked: false },
+            ],
+            validate: (value: string[]) =>
+              value.length > 0 || "Please select at least one agent directory.",
+          },
+        ]));
+      }
+    }
 
-    const { installMethod } = await inquirer.prompt([
-      {
-        type: "list",
-        name: "installMethod",
-        message: "How would you like to install the skills?",
-        choices: [
+    let installMethod = resolveSkillMethod(method);
+    if (installMethod === undefined) {
+      if (explicitSelection) {
+        installMethod = "symlink";
+      } else {
+        ({ installMethod } = await inquirer.prompt([
           {
-            name: "Symlink (recommended) — single source of truth, easy to update",
-            value: "symlink",
+            type: "list",
+            name: "installMethod",
+            message: "How would you like to install the skills?",
+            choices: [
+              {
+                name: "Symlink (recommended) — single source of truth, easy to update",
+                value: "symlink",
+              },
+              {
+                name: "Copy — independent copies in each agent directory",
+                value: "copy",
+              },
+            ],
           },
-          {
-            name: "Copy — independent copies in each agent directory",
-            value: "copy",
-          },
-        ],
-      },
-    ]);
+        ]));
+      }
+    }
 
     const useSymlinks = installMethod === "symlink";
     placeSkills(cwd, tempDir, selectedSkills, selectedAgents, useSymlinks);
@@ -1094,6 +1180,23 @@ init
   .command("skill")
   .alias("skills")
   .description("Install Appwrite skills for AI coding agents")
+  .option("--all", "Install every available Appwrite skill")
+  .option(
+    "--skill <skill>",
+    "Skill directory name to install. Repeat for multiple skills.",
+    collectInitSkillOption,
+    [],
+  )
+  .option(
+    "--agent <agent>",
+    "Agent directory to install to: .agents or .claude. Repeat for both. Defaults to .agents for non-interactive installs.",
+    collectInitSkillOption,
+    [],
+  )
+  .option(
+    "--method <method>",
+    "Installation method: symlink or copy. Defaults to symlink for non-interactive installs.",
+  )
   .action(actionRunner(initSkill));
 
 init

--- a/templates/cli/lib/utils.ts
+++ b/templates/cli/lib/utils.ts
@@ -1048,6 +1048,32 @@ export interface SkillInfo {
   dirName: string;
 }
 
+export const resolveSkillSelection = (
+  skills: Pick<SkillInfo, "dirName">[],
+  requested: string[],
+  all: boolean,
+): string[] => {
+  if (all && requested.length > 0) {
+    throw new Error("The '--all' and '--skill' flags cannot be used together.");
+  }
+
+  const available = skills.map((skill) => skill.dirName);
+  if (all) {
+    return available;
+  }
+
+  const availableSet = new Set(available);
+  const selected = [...new Set(requested)];
+  const unknown = selected.find((skill) => !availableSet.has(skill));
+  if (unknown !== undefined) {
+    throw new Error(
+      `Unknown skill '${unknown}'. Available skills: ${available.join(", ")}`,
+    );
+  }
+
+  return selected;
+};
+
 const parseSkillFrontmatter = (
   content: string,
 ): { name: string; description: string } => {

--- a/templates/go-cli/internal/app/globals.go
+++ b/templates/go-cli/internal/app/globals.go
@@ -57,9 +57,10 @@ func RegisterGlobalFlags(root *cobra.Command) {
 	//
 	// Hidden at the root for the same reason it is hidden there in the
 	// TypeScript (`new Option('-a, --all', ...).hideHelp()`): it is parsed
-	// globally so `appwrite --all push` keeps working, but it acts on `push` and
-	// `pull`, which is where it is documented.
-	flags.BoolVar(&globals.All, "all", false, "Push or pull every resource")
+	// globally so `appwrite --all push` and `appwrite --all init skill` keep
+	// working, but it is documented only on commands where it selects resources
+	// or skills.
+	flags.BoolVar(&globals.All, "all", false, "Select every applicable resource or skill")
 	if flag := flags.Lookup("all"); flag != nil {
 		flag.Hidden = true
 	}

--- a/templates/go-cli/internal/cmd/help_test.go
+++ b/templates/go-cli/internal/cmd/help_test.go
@@ -197,9 +197,9 @@ func TestOptionsFollowTheDeclaredOrder(t *testing.T) {
 	}
 }
 
-// --all is parsed at the root so `appwrite --all push` works, but it acts on
-// push and pull. Documenting it globally would offer it on every command.
-func TestAllIsHiddenAtTheRootAndDocumentedOnPush(t *testing.T) {
+// --all is parsed at the root so it can precede the command, but documenting it
+// globally would offer it on commands where it has no meaning.
+func TestAllIsHiddenAtTheRootAndDocumentedWhereUsed(t *testing.T) {
 	root := NewRootCommand()
 
 	if _, options, found := strings.Cut(RenderMainHelp(root), "\nOPTIONS\n"); found {
@@ -222,6 +222,24 @@ func TestAllIsHiddenAtTheRootAndDocumentedOnPush(t *testing.T) {
 	}
 	if flag.Shorthand != "a" {
 		t.Errorf("`push --all` shorthand = %q, want \"a\"", flag.Shorthand)
+	}
+}
+
+func TestInitSkillDocumentsHeadlessFlags(t *testing.T) {
+	command := resolveCommand(NewRootCommand(), "init skill")
+	if command == nil {
+		t.Fatal("`init skill` is missing")
+	}
+
+	for _, name := range []string{"all", "skill", "agent", "method"} {
+		flag := command.Flags().Lookup(name)
+		if flag == nil {
+			t.Errorf("`init skill` does not define --%s", name)
+			continue
+		}
+		if flag.Hidden {
+			t.Errorf("`init skill --%s` is hidden", name)
+		}
 	}
 }
 

--- a/templates/go-cli/internal/cmd/initprojectskills_test.go
+++ b/templates/go-cli/internal/cmd/initprojectskills_test.go
@@ -144,3 +144,41 @@ func TestPluralSuffix(t *testing.T) {
 		t.Error("2 skills were singularised")
 	}
 }
+
+func TestHeadlessSkillSelection(t *testing.T) {
+	available := skillsFor("appwrite-cli", "appwrite-go", "appwrite-typescript")
+
+	all, err := resolveSkillSelection(available, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(all, []string{"appwrite-cli", "appwrite-go", "appwrite-typescript"}) {
+		t.Errorf("--all selected %v", all)
+	}
+
+	selected, err := resolveSkillSelection(available,
+		[]string{"appwrite-go", "appwrite-go", "appwrite-cli"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(selected, []string{"appwrite-go", "appwrite-cli"}) {
+		t.Errorf("--skill selected %v", selected)
+	}
+}
+
+func TestHeadlessSkillSelectionRejectsInvalidFlags(t *testing.T) {
+	available := skillsFor("appwrite-cli", "appwrite-go")
+
+	if _, err := resolveSkillSelection(available, []string{"appwrite-go"}, true); err == nil {
+		t.Error("--all with --skill was accepted")
+	}
+	if _, err := resolveSkillSelection(available, []string{"missing"}, false); err == nil {
+		t.Error("an unknown skill was accepted")
+	}
+	if _, err := resolveSkillAgents([]string{"unknown"}); err == nil {
+		t.Error("an unknown agent directory was accepted")
+	}
+	if _, err := resolveSkillMethod("archive"); err == nil {
+		t.Error("an unknown installation method was accepted")
+	}
+}

--- a/templates/go-cli/internal/cmd/initskill.go
+++ b/templates/go-cli/internal/cmd/initskill.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/app"
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/output"
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/prompt"
 	"github.com/spf13/cobra"
@@ -35,6 +36,13 @@ var (
 	frontmatterDescription = regexp.MustCompile(`(?m)^description:\s*(.+)$`)
 )
 
+type initSkillOptions struct {
+	all    bool
+	skills []string
+	agents []string
+	method string
+}
+
 // parseSkillFrontmatter reads the name and description out of a SKILL.md.
 func parseSkillFrontmatter(contents string) (string, string) {
 	block := frontmatterBlock.FindStringSubmatch(contents)
@@ -56,17 +64,29 @@ func parseSkillFrontmatter(contents string) (string, string) {
 }
 
 func newInitSkillCommand() *cobra.Command {
-	return &cobra.Command{
+	options := initSkillOptions{}
+	command := &cobra.Command{
 		Use:     "skill",
 		Aliases: []string{"skills"},
 		Short:   "Install Appwrite skills for AI coding agents",
 		RunE: func(command *cobra.Command, args []string) error {
-			return runInitSkill(command)
+			return runInitSkill(command, options)
 		},
 	}
+
+	flags := command.Flags()
+	flags.BoolVar(&options.all, "all", false, "Install every available Appwrite skill")
+	flags.StringArrayVar(&options.skills, "skill", nil,
+		"Skill directory name to install. Repeat for multiple skills.")
+	flags.StringArrayVar(&options.agents, "agent", nil,
+		"Agent directory to install to: .agents or .claude. Repeat for both. Defaults to .agents for non-interactive installs.")
+	flags.StringVar(&options.method, "method", "",
+		"Installation method: symlink or copy. Defaults to symlink for non-interactive installs.")
+
+	return command
 }
 
-func runInitSkill(command *cobra.Command) error {
+func runInitSkill(command *cobra.Command, requested initSkillOptions) error {
 	context, err := newInitContext()
 	if err != nil {
 		return err
@@ -89,40 +109,71 @@ func runInitSkill(command *cobra.Command) error {
 		options = append(options, prompt.Option{Label: skill.Name, Value: skill.DirName})
 	}
 
-	selected, err := context.prompter.MultiChoice(prompt.MultiChoice{
-		Message:  "Which skills would you like to install?",
-		Options:  options,
-		Validate: prompt.RequiredSelection("skill"),
-	})
+	installAll := requested.all || app.Flags().All
+	explicitSelection := installAll || len(requested.skills) > 0
+	selected, err := resolveSkillSelection(skills, requested.skills, installAll)
 	if err != nil {
 		return err
 	}
+	if !explicitSelection {
+		selected, err = context.prompter.MultiChoice(prompt.MultiChoice{
+			Message:  "Which skills would you like to install?",
+			Options:  options,
+			Flag:     "--all or --skill",
+			Validate: prompt.RequiredSelection("skill"),
+		})
+		if err != nil {
+			return err
+		}
+	}
 
-	agents, err := context.prompter.MultiChoice(prompt.MultiChoice{
-		Message:  "Which agent directories would you like to install to?",
-		Options:  prompt.Options(".agents", ".claude"),
-		Default:  []string{".agents"},
-		Validate: prompt.RequiredSelection("agent directory"),
-	})
+	agents, err := resolveSkillAgents(requested.agents)
 	if err != nil {
 		return err
 	}
+	if len(agents) == 0 {
+		if explicitSelection {
+			agents = []string{".agents"}
+		} else {
+			agents, err = context.prompter.MultiChoice(prompt.MultiChoice{
+				Message:  "Which agent directories would you like to install to?",
+				Options:  prompt.Options(".agents", ".claude"),
+				Default:  []string{".agents"},
+				Flag:     "--agent",
+				Validate: prompt.RequiredSelection("agent directory"),
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
 
-	method, err := context.prompter.Choice(prompt.Choice{
-		Message: "How would you like to install the skills?",
-		Options: []prompt.Option{
-			{
-				Label: "Symlink (recommended) — single source of truth, easy to update",
-				Value: "symlink",
-			},
-			{
-				Label: "Copy — independent copies in each agent directory",
-				Value: "copy",
-			},
-		},
-	})
+	method, err := resolveSkillMethod(requested.method)
 	if err != nil {
 		return err
+	}
+	if method == "" {
+		if explicitSelection {
+			method = "symlink"
+		} else {
+			method, err = context.prompter.Choice(prompt.Choice{
+				Message: "How would you like to install the skills?",
+				Options: []prompt.Option{
+					{
+						Label: "Symlink (recommended) — single source of truth, easy to update",
+						Value: "symlink",
+					},
+					{
+						Label: "Copy — independent copies in each agent directory",
+						Value: "copy",
+					},
+				},
+				Flag: "--method",
+			})
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	if err := placeSkills(root, tempDir, selected, agents, method == "symlink"); err != nil {
@@ -138,6 +189,64 @@ func runInitSkill(command *cobra.Command) error {
 		"agents like Claude Code, Cursor, and GitHub Copilot.")
 
 	return nil
+}
+
+func resolveSkillSelection(available []skillInfo, requested []string, all bool) ([]string, error) {
+	if all && len(requested) > 0 {
+		return nil, errors.New("the --all and --skill flags cannot be used together")
+	}
+
+	availableNames := make([]string, 0, len(available))
+	availableSet := make(map[string]struct{}, len(available))
+	for _, skill := range available {
+		availableNames = append(availableNames, skill.DirName)
+		availableSet[skill.DirName] = struct{}{}
+	}
+
+	if all {
+		return availableNames, nil
+	}
+
+	selected := make([]string, 0, len(requested))
+	seen := make(map[string]struct{}, len(requested))
+	for _, name := range requested {
+		if _, ok := availableSet[name]; !ok {
+			return nil, fmt.Errorf("unknown skill %q. Available skills: %s",
+				name, strings.Join(availableNames, ", "))
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		selected = append(selected, name)
+	}
+
+	return selected, nil
+}
+
+func resolveSkillAgents(requested []string) ([]string, error) {
+	selected := make([]string, 0, len(requested))
+	seen := make(map[string]struct{}, len(requested))
+	for _, agent := range requested {
+		if agent != ".agents" && agent != ".claude" {
+			return nil, fmt.Errorf("unknown agent directory %q. Available directories: .agents, .claude", agent)
+		}
+		if _, ok := seen[agent]; ok {
+			continue
+		}
+		seen[agent] = struct{}{}
+		selected = append(selected, agent)
+	}
+
+	return selected, nil
+}
+
+func resolveSkillMethod(requested string) (string, error) {
+	if requested != "" && requested != "symlink" && requested != "copy" {
+		return "", fmt.Errorf("unknown installation method %q. Available methods: symlink, copy", requested)
+	}
+
+	return requested, nil
 }
 
 // fetchAvailableSkills clones the skills repository and reads the catalogue.

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -31,6 +31,7 @@ const {
   getAllFiles,
   getFunctionDeploymentConsoleUrl,
   getSiteDeploymentConsoleUrl,
+  resolveSkillSelection,
 } = require("./lib/utils.ts");
 const { EXECUTABLE_NAME } = require("./lib/constants.ts");
 const { isCompletionInvocation } = require("./lib/completions.ts");
@@ -88,9 +89,6 @@ const {
   questionsClientReset,
 } = require("./lib/questions.ts");
 const { logout, client, whoami } = require("./lib/commands/generic.ts");
-const {
-  resolveSkillSelection,
-} = require("./lib/commands/init.ts");
 const {
   getOrganizationForSession,
   listOrganizationsForSession,

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -89,6 +89,9 @@ const {
 } = require("./lib/questions.ts");
 const { logout, client, whoami } = require("./lib/commands/generic.ts");
 const {
+  resolveSkillSelection,
+} = require("./lib/commands/init.ts");
+const {
   getOrganizationForSession,
   listOrganizationsForSession,
   listProjectsForSession,
@@ -269,6 +272,31 @@ const zshRegistrationToken = `compdef ${completionFunctionName} ${EXECUTABLE_NAM
 const bashRegistrationToken =
   `complete -F ${completionFunctionName}_completion ${EXECUTABLE_NAME}`;
 const fishRegistrationToken = `complete -c '${EXECUTABLE_NAME}'`;
+
+const availableSkills = [
+  { dirName: "appwrite-cli" },
+  { dirName: "appwrite-go" },
+];
+assert.deepEqual(resolveSkillSelection(availableSkills, [], true), [
+  "appwrite-cli",
+  "appwrite-go",
+]);
+assert.deepEqual(
+  resolveSkillSelection(
+    availableSkills,
+    ["appwrite-go", "appwrite-go"],
+    false,
+  ),
+  ["appwrite-go"],
+);
+assert.throws(
+  () => resolveSkillSelection(availableSkills, ["appwrite-go"], true),
+  /cannot be used together/,
+);
+assert.throws(
+  () => resolveSkillSelection(availableSkills, ["missing"], false),
+  /Unknown skill/,
+);
 
 for (const commandName of extractHelpCommands(helpOutput)) {
   if (!zshCompletionOutput.includes(`'${commandName}'`)) {


### PR DESCRIPTION
## What changed

Both generated CLIs can now install Appwrite skills without an interactive terminal:

- `--all` selects every available skill;
- repeatable `--skill` selects deterministic skill directory names;
- repeatable `--agent` selects `.agents`, `.claude`, or both;
- `--method` selects `symlink` or `copy`;
- headless selections default to `.agents` and `symlink` when those flags are omitted.

Interactive behavior is unchanged when neither `--all` nor `--skill` is supplied. The global `--force` contract also remains unchanged: it skips confirmation prompts but does not invent answers to value-selection questions.

Invalid skills, agent directories, installation methods, and the conflicting `--all` plus `--skill` combination fail before installing files. Duplicate repeatable values are deduplicated while preserving their order.

## Before

```console
$ appwrite init skill --force </dev/null
ℹ Info: Fetching available Appwrite skills ...
✗ Error: "Which skills would you like to install?" needs an answer but there is no interactive terminal
```

There were no command-specific flags capable of answering the skill, agent-directory, or installation-method prompts in CI.

## After

Install selected skills using the documented defaults:

```console
$ appwrite init skill --skill appwrite-go </dev/null
ℹ Info: Fetching available Appwrite skills ...
✓ Success: 1 skill installed successfully.
```

Install every available skill:

```console
$ appwrite init skill --all </dev/null
ℹ Info: Fetching available Appwrite skills ...
✓ Success: 11 skills installed successfully.
```

Choose multiple skills and agent directories explicitly:

```console
$ appwrite init skill \
    --skill appwrite-go \
    --skill appwrite-typescript \
    --agent .agents \
    --agent .claude \
    --method symlink </dev/null
ℹ Info: Fetching available Appwrite skills ...
✓ Success: 2 skills installed successfully.
```

An unanswerable invocation now identifies the selection flags:

```console
$ appwrite init skill --force </dev/null
ℹ Info: Fetching available Appwrite skills ...
✗ Error: "Which skills would you like to install?" needs an answer but there is no interactive terminal. Pass --all or --skill instead
```

## Verification

- Regenerated both `cli` and `go-cli` outputs.
- Verified the generated Go and TypeScript CLIs using disposable copies of the staging project configuration.
- Confirmed selected-skill installation, all 11 current skills, multi-agent symlinks, default copy behavior for one agent, and zero files on conflicting selectors.
- Generated Go CLI build, vet, and all tests pass.
- Generated TypeScript CLI type and runtime builds pass; the modified generated `init.ts` passes ESLint.
- Go CLI Docker E2E passes with 5,047 assertions.
- TypeScript CLI Docker E2E passes with 2,256 assertions.
- PHP unit tests pass with 125 assertions.
- Rector and all 591 Twig lint checks pass.

Addresses finding 6 in #1746.
