### PR TITLE
Accept raw GraphQL documents in generated CLIs

### DIFF
--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -797,12 +797,14 @@ class CLI extends Node
              * Get CLI argument expression for a parameter when calling the SDK method.
              * Handles JSON parsing for objects, or plain variable.
              */
-            new TwigFunction('getCliArgExpression', function (array $parameter): string {
+            new TwigFunction('getCliArgExpression', function (array $parameter, array $method, array $service): string {
                 $optionName = $this->getCliOptionName($parameter['name']);
                 $varName = lcfirst(str_replace(' ', '', ucwords(str_replace('-', ' ', $optionName))));
                 $type = $parameter['type'] ?? 'string';
 
-                if ($type === 'object') {
+                if ($this->isCliGraphQLInput($parameter, $method, $service)) {
+                    return "parseGraphQLParams({$varName}, \"--{$optionName}\")";
+                } elseif ($type === 'object') {
                     return "parseJsonObject({$varName}, \"--{$optionName}\")";
                 } elseif ($type === 'file') {
                     return "{$varName} !== undefined ? await resolveFileParam({$varName}) : undefined";

--- a/src/SDK/Language/Concern/CliCommandSurface.php
+++ b/src/SDK/Language/Concern/CliCommandSurface.php
@@ -371,6 +371,41 @@ trait CliCommandSurface
         return false;
     }
 
+    /**
+     * GraphQL SDK methods take a JSON request object, but a CLI flag named
+     * `--query` should also accept the GraphQL document users naturally type.
+     * Keep the identification shared so the TypeScript and Go CLIs cannot
+     * apply different input or help contracts.
+     */
+    protected function isCliGraphQLInput(array $parameter, array $method, array $service): bool
+    {
+        return ($service['name'] ?? '') === 'graphql'
+            && ($method['type'] ?? '') === 'graphql'
+            && ($parameter['name'] ?? '') === 'query';
+    }
+
+    protected function getCliMethodDescription(array $method, array $service): string
+    {
+        if (($service['name'] ?? '') === 'graphql' && ($method['type'] ?? '') === 'graphql') {
+            return match ($method['name'] ?? '') {
+                'query' => 'Execute a GraphQL query.',
+                'mutation' => 'Execute a GraphQL mutation.',
+                default => $method['description'] ?? '',
+            };
+        }
+
+        return $method['description'] ?? '';
+    }
+
+    protected function getCliParameterDescription(array $parameter, array $method, array $service): string
+    {
+        if ($this->isCliGraphQLInput($parameter, $method, $service)) {
+            return 'Raw GraphQL document, or a JSON request object or array for variables, operation names, or batching.';
+        }
+
+        return $parameter['description'] ?? '';
+    }
+
     protected function getCliOptionName(string $name): string
     {
         $kebabName = strtolower((string) preg_replace('/(?<!^)([A-Z][a-z]|(?<=[a-z])[^a-z\s_]|(?<=[A-Z])\d)/', '-$1', $name));
@@ -483,6 +518,9 @@ trait CliCommandSurface
             new TwigFunction('cliHelpGroups', fn (): array => $this->getCliHelpGroups()),
             new TwigFunction('cliHelpSummaries', fn (string $title): array => $this->getCliHelpSummaries($title)),
             new TwigFunction('cliHelpOptionOrder', fn (): array => $this->getCliHelpOptionOrder()),
+            new TwigFunction('cliIsGraphQLInput', fn (array $parameter, array $method, array $service): bool => $this->isCliGraphQLInput($parameter, $method, $service)),
+            new TwigFunction('cliMethodDescription', fn (array $method, array $service): string => $this->getCliMethodDescription($method, $service)),
+            new TwigFunction('cliParameterDescription', fn (array $parameter, array $method, array $service): string => $this->getCliParameterDescription($parameter, $method, $service)),
         ];
     }
 

--- a/src/SDK/Language/GoCLI.php
+++ b/src/SDK/Language/GoCLI.php
@@ -263,7 +263,14 @@ class GoCLI extends Go
             $sdkType = parent::getTypeName($parameter);
             $expression = $variable;
 
-            if ($flagType !== $sdkType) {
+            if ($this->isCliGraphQLInput($parameter, $method, $service)) {
+                $expression = $variable . 'Value';
+                $decodes[] = [
+                    'var' => $expression,
+                    'source' => $variable,
+                    'helper' => 'GraphQLRequest',
+                ];
+            } elseif ($flagType !== $sdkType) {
                 [$expression, $decode] = $this->convertToSdkType(
                     $variable,
                     $flagType,

--- a/templates/cli/lib/commands/services/services.ts.twig
+++ b/templates/cli/lib/commands/services/services.ts.twig
@@ -2,6 +2,7 @@ import { Command } from "commander";
 {% set hasLocationMethod = false %}
 {% set hasFileParam = false %}
 {% set hasObjectParam = false %}
+{% set hasGraphQLInput = false %}
 {% set hasQueryParam = service | hasCliQueryParam %}
 {% set enumNames = [] %}
 {% for method in service.methods %}
@@ -12,7 +13,9 @@ import { Command } from "commander";
 {% if parameter.type == 'file' %}
 {% set hasFileParam = true %}
 {% endif %}
-{% if parameter.type == 'object' %}
+{% if cliIsGraphQLInput(parameter, method, service) %}
+{% set hasGraphQLInput = true %}
+{% elseif parameter.type == 'object' %}
 {% set hasObjectParam = true %}
 {% endif %}
 {% if parameter.enumName is defined and parameter.enumName not in enumNames %}
@@ -59,6 +62,9 @@ import {
   parseInteger,
 {% if hasObjectParam %}
   parseJsonObject,
+{% endif %}
+{% if hasGraphQLInput %}
+  parseGraphQLParams,
 {% endif %}
 {% if service.name == 'teams' %}
   hint,
@@ -153,10 +159,10 @@ export const {{ target.var }} = new Command(`{{ commandName }}`)
 const {{ target.var }} = {{ service.name | caseCamel }}
   .command(`{{ commandName }}`{% if target.hidden %}, { hidden: true }{% endif %})
 {% endif %}
-  .description(`{{ method.description | stripMarkdown | replace({'`': '\\`'}) | raw }}`)
+  .description(`{{ cliMethodDescription(method, service) | stripMarkdown | replace({'`': '\\`'}) | raw }}`)
 {% for parameter in method.parameters.all %}
 {% set opt = getCliOption(parameter) %}
-{% set optDescription = parameter.description | stripMarkdown | replace({'`': '\\`'}) %}
+{% set optDescription = cliParameterDescription(parameter, method, service) | stripMarkdown | replace({'`': '\\`'}) %}
 {% if parameter.name == 'queries' and parameter.type == 'array' %}
 {% set optDescription = query.rawDescriptionPrefix ~ ' ' ~ optDescription %}
 {% endif %}
@@ -216,7 +222,7 @@ const {{ target.var }} = {{ service.name | caseCamel }}
 {% if parameter.name == 'queries' and parameter.type == 'array' %}
 {% set argExpressions = argExpressions|merge(['buildQueries({ ' ~ query.builderParams | join(', ') ~ ' })']) %}
 {% else %}
-{% set argExpressions = argExpressions|merge([getCliArgExpression(parameter)]) %}
+{% set argExpressions = argExpressions|merge([getCliArgExpression(parameter, method, service)]) %}
 {% endif %}
 {% endfor %}
 {% if method.type == 'location' %}

--- a/templates/cli/lib/parser.ts
+++ b/templates/cli/lib/parser.ts
@@ -1005,6 +1005,46 @@ export const parseJsonObject = (
   throw new InvalidArgumentError(`${optionName} must be a valid JSON object.`);
 };
 
+export const parseGraphQLRequest = (
+  value: string,
+  optionName: string,
+): Record<string, unknown> | unknown[] => {
+  if (value.trim() === "") {
+    throw new InvalidArgumentError(
+      `${optionName} must be a GraphQL document or JSON request object or array.`,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value) as unknown;
+  } catch {
+    return { query: value };
+  }
+
+  if (typeof parsed === "string") {
+    return { query: parsed };
+  }
+  if (parsed && typeof parsed === "object") {
+    return parsed as Record<string, unknown> | unknown[];
+  }
+
+  throw new InvalidArgumentError(
+    `${optionName} must be a GraphQL document or JSON request object or array.`,
+  );
+};
+
+// The TypeScript SDK supports object-style method arguments. GraphQL request
+// envelopes themselves contain a `query` key, so passing one positionally is
+// ambiguous and the SDK mistakes it for its own outer params object. Supplying
+// that outer object explicitly preserves the envelope on the wire.
+export const parseGraphQLParams = (
+  value: string,
+  optionName: string,
+): { query: Record<string, unknown> | unknown[] } => ({
+  query: parseGraphQLRequest(value, optionName),
+});
+
 export const log = (message?: string): void => {
   console.log(`${chalk.cyan.bold("ℹ Info:")} ${chalk.cyan(message ?? "")}`);
 };

--- a/templates/go-cli/internal/app/convert.go
+++ b/templates/go-cli/internal/app/convert.go
@@ -35,6 +35,36 @@ func JSONObject(raw string) (interface{}, error) {
 	return value, nil
 }
 
+// GraphQLRequest accepts the document users naturally type at --query while
+// preserving the SDK's existing JSON request-object contract. A request object
+// carries variables and an operation name; an array carries a batch.
+func GraphQLRequest(raw string) (interface{}, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, fmt.Errorf("--query must be a GraphQL document or JSON request object or array")
+	}
+
+	if !json.Valid([]byte(raw)) {
+		return map[string]interface{}{"query": raw}, nil
+	}
+
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.UseNumber()
+
+	var value interface{}
+	if err := decoder.Decode(&value); err != nil {
+		return nil, fmt.Errorf("invalid GraphQL JSON request: %w", err)
+	}
+
+	switch value := value.(type) {
+	case string:
+		return map[string]interface{}{"query": value}, nil
+	case map[string]interface{}, []interface{}:
+		return value, nil
+	default:
+		return nil, fmt.Errorf("--query must be a GraphQL document or JSON request object or array")
+	}
+}
+
 // WriteFile saves a downloaded file.
 //
 // `location` methods return the bytes rather than a URL, so there is nothing to

--- a/templates/go-cli/internal/app/render_test.go
+++ b/templates/go-cli/internal/app/render_test.go
@@ -2,12 +2,64 @@ package app
 
 import (
 	"bytes"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/output"
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/sdk"
 )
+
+func TestGraphQLRequestAcceptsDocumentsEnvelopesAndBatches(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want interface{}
+	}{
+		{
+			name: "document",
+			raw:  "query { __typename }",
+			want: map[string]interface{}{"query": "query { __typename }"},
+		},
+		{
+			name: "envelope",
+			raw:  `{"query":"query Named($id: ID!) { node(id: $id) { id } }","variables":{"id":"one"},"operationName":"Named"}`,
+			want: map[string]interface{}{
+				"query":         "query Named($id: ID!) { node(id: $id) { id } }",
+				"variables":     map[string]interface{}{"id": "one"},
+				"operationName": "Named",
+			},
+		},
+		{
+			name: "batch",
+			raw:  `[{"query":"query { __typename }"},{"query":"query { __typename }"}]`,
+			want: []interface{}{
+				map[string]interface{}{"query": "query { __typename }"},
+				map[string]interface{}{"query": "query { __typename }"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := GraphQLRequest(test.raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("GraphQLRequest() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestGraphQLRequestRejectsEmptyAndScalarJSON(t *testing.T) {
+	for _, raw := range []string{"", "true", "42", "null"} {
+		if _, err := GraphQLRequest(raw); err == nil {
+			t.Errorf("GraphQLRequest(%q) succeeded", raw)
+		}
+	}
+}
 
 // The captured response, not the typed struct, is what --raw and --json show.
 //

--- a/templates/go-cli/internal/cmd/help_test.go
+++ b/templates/go-cli/internal/cmd/help_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 // These assert the layout rather than a byte golden: the command set comes from
@@ -239,6 +241,35 @@ func TestInitSkillDocumentsHeadlessFlags(t *testing.T) {
 		}
 		if flag.Hidden {
 			t.Errorf("`init skill --%s` is hidden", name)
+		}
+	}
+}
+
+func TestGraphQLHelpDescribesDocumentsAndJSONRequests(t *testing.T) {
+	root := NewRootCommand()
+	query := resolveCommand(root, "graphql query")
+	mutation := resolveCommand(root, "graphql mutation")
+	if query == nil || mutation == nil {
+		t.Skip("the generation spec does not include GraphQL commands")
+	}
+
+	if query.Short != "Execute a GraphQL query." {
+		t.Errorf("query description = %q", query.Short)
+	}
+	if mutation.Short != "Execute a GraphQL mutation." {
+		t.Errorf("mutation description = %q", mutation.Short)
+	}
+
+	for _, command := range []*cobra.Command{query, mutation} {
+		flag := command.Flags().Lookup("query")
+		if flag == nil {
+			t.Errorf("`%s` has no --query flag", command.CommandPath())
+			continue
+		}
+		for _, token := range []string{"Raw GraphQL document", "JSON request object or array", "batching"} {
+			if !strings.Contains(flag.Usage, token) {
+				t.Errorf("`%s --query` help does not mention %q: %s", command.CommandPath(), token, flag.Usage)
+			}
 		}
 	}
 }

--- a/templates/go-cli/internal/cmd/services/service.go.twig
+++ b/templates/go-cli/internal/cmd/services/service.go.twig
@@ -146,7 +146,7 @@ func new{{ service.name | caseUcfirst }}{{ method.name | caseUcfirst }}Command()
 {% set commandKeyFormat = isTopLevel ? '%-8s' : '%-7s' %}
 	cmd := &cobra.Command{
 		{{ commandKeyFormat|format('Use:') }}"{{ method.name | caseKebab }}",
-		{{ commandKeyFormat|format('Short:') }}{{ method.description | stripMarkdown | goString | raw }},
+		{{ commandKeyFormat|format('Short:') }}{{ cliMethodDescription(method, service) | stripMarkdown | goString | raw }},
 {% if isTopLevel %}
 		{{ commandKeyFormat|format('Hidden:') }}true,
 {% endif %}
@@ -279,7 +279,7 @@ func new{{ service.name | caseUcfirst }}{{ method.name | caseUcfirst }}Command()
 
 {% for parameter in method.parameters.all %}
 {% set opt = getGoCliOption(parameter) %}
-	cmd.Flags().{{ opt.register }}Var(&{{ opt.var }}, "{{ opt.flag }}", {% if opt.goType == '[]string' %}nil{% elseif opt.goType == 'bool' %}false{% elseif opt.goType == 'int' %}0{% elseif opt.goType == 'float64' %}0{% else %}""{% endif %}, {{ parameter.description | stripMarkdown | goString | raw }})
+	cmd.Flags().{{ opt.register }}Var(&{{ opt.var }}, "{{ opt.flag }}", {% if opt.goType == '[]string' %}nil{% elseif opt.goType == 'bool' %}false{% elseif opt.goType == 'int' %}0{% elseif opt.goType == 'float64' %}0{% else %}""{% endif %}, {{ cliParameterDescription(parameter, method, service) | stripMarkdown | goString | raw }})
 {% if opt.noOptDefault %}
 	cmd.Flags().Lookup("{{ opt.flag }}").NoOptDefVal = "{{ opt.noOptDefault }}"
 {% endif %}

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -18,7 +18,11 @@ process.on("exit", () => {
 const Client = require("./lib/client.ts").default;
 const { localConfig } = require("./lib/config.ts");
 const { types } = require("./lib/commands/types.ts");
-const { parse } = require("./lib/parser.ts");
+const {
+  parse,
+  parseGraphQLParams,
+  parseGraphQLRequest,
+} = require("./lib/parser.ts");
 const {
   openRuntimesVersion,
   systemTools,
@@ -101,6 +105,37 @@ const inquirerModule = require("inquirer");
 const inquirer = inquirerModule.default ?? inquirerModule;
 
 assert.ok(globalConfig.path.startsWith(sandboxHome));
+assert.deepEqual(parseGraphQLRequest("query { __typename }", "--query"), {
+  query: "query { __typename }",
+});
+assert.deepEqual(parseGraphQLParams("query { __typename }", "--query"), {
+  query: { query: "query { __typename }" },
+});
+assert.deepEqual(
+  parseGraphQLRequest(
+    '{"query":"query Named($id: ID!) { node(id: $id) { id } }","variables":{"id":"one"},"operationName":"Named"}',
+    "--query",
+  ),
+  {
+    query: "query Named($id: ID!) { node(id: $id) { id } }",
+    variables: { id: "one" },
+    operationName: "Named",
+  },
+);
+assert.deepEqual(
+  parseGraphQLRequest(
+    '[{"query":"query { __typename }"},{"query":"query { __typename }"}]',
+    "--query",
+  ),
+  [
+    { query: "query { __typename }" },
+    { query: "query { __typename }" },
+  ],
+);
+assert.throws(
+  () => parseGraphQLRequest("true", "--query"),
+  /GraphQL document or JSON request object or array/,
+);
 const sandboxKeyringTokens = new Map();
 setRefreshTokenEntryFactoryForTests((_service, account) => ({
   setPassword: (password) => sandboxKeyringTokens.set(account, password),


### PR DESCRIPTION
## What changed

Both generated CLIs now accept the raw GraphQL document users naturally pass to `--query` while preserving the existing JSON request contract:

- raw query and mutation documents are wrapped in the SDK request envelope;
- JSON request objects still support variables and operation names;
- JSON arrays still support batched requests;
- the TypeScript CLI supplies the explicit outer SDK parameter object so the inner GraphQL `query` field is not mistaken for the SDK's object-style arguments;
- shared CLI help now describes query and mutation commands accurately and documents every accepted input form.

The input detection and help contract live in the shared CLI command surface so the generated Go and TypeScript CLIs cannot drift.

## Before

The installed CLI rejects the documented-looking raw input before making a request:

```console
$ appwrite graphql query --query 'query { __typename }' --raw
✗ Error: expected JSON, got "query { __typename }": invalid character 'q' looking for beginning of value
```

Query help also identifies the command as a mutation:

```console
$ appwrite graphql query --help
Execute a GraphQL mutation.
```

## After

The same raw query succeeds against staging with both generated CLIs:

```console
$ appwrite graphql query --query 'query { __typename }' --raw
{
  "data": {
    "__typename": "Query"
  }
}
```

Raw mutations work as well:

```console
$ appwrite graphql mutation --query 'mutation { __typename }' --raw
{
  "data": {
    "__typename": "Mutation"
  }
}
```

The corrected help documents the full contract:

```console
$ appwrite graphql query --help
Execute a GraphQL query.

--query string   Raw GraphQL document, or a JSON request object or array for variables, operation names, or batching.
```

Existing JSON inputs remain supported:

```console
$ appwrite graphql query --query '{"query":"query { __typename }"}' --raw
{
  "data": {
    "__typename": "Query"
  }
}
```

## Verification

- Regenerated both `cli` and `go-cli` outputs.
- Built both generated CLIs and exercised them against the logged-in staging session.
- Confirmed raw query, raw mutation, JSON envelope, and two-request JSON batch behavior in both CLIs.
- Generated Go CLI build, vet, and all tests pass.
- Go CLI Docker E2E passes with 5,047 assertions.
- TypeScript CLI build passes; Bun 1.0, 1.1, and 1.3 Docker E2E suites each pass with 2,256 assertions.
- PHP unit tests pass with 125 assertions.
- Rector and all 591 Twig lint checks pass.

Addresses finding 7 in #1746.
