### PR TITLE
feat(cli): a browser (js/wasm) build target for the Go CLI

### DIFF
--- a/src/SDK/Language/GoCLI.php
+++ b/src/SDK/Language/GoCLI.php
@@ -472,6 +472,16 @@ class GoCLI extends Go
             ],
             [
                 'scope'         => 'copy',
+                'destination'   => 'internal/config/home_native.go',
+                'template'      => 'go-cli/internal/config/home_native.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/config/home_js.go',
+                'template'      => 'go-cli/internal/config/home_js.go',
+            ],
+            [
+                'scope'         => 'copy',
                 'destination'   => 'internal/config/write.go',
                 'template'      => 'go-cli/internal/config/write.go',
             ],
@@ -497,6 +507,16 @@ class GoCLI extends Go
             ],
             [
                 'scope'         => 'copy',
+                'destination'   => 'internal/client/fetch_js.go',
+                'template'      => 'go-cli/internal/client/fetch_js.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/client/fetch_native.go',
+                'template'      => 'go-cli/internal/client/fetch_native.go',
+            ],
+            [
+                'scope'         => 'copy',
                 'destination'   => 'internal/client/selfsigned_test.go',
                 'template'      => 'go-cli/internal/client/selfsigned_test.go',
             ],
@@ -511,9 +531,24 @@ class GoCLI extends Go
                 'template'      => 'go-cli/internal/cmd/session.go',
             ],
             [
+                'scope'         => 'copy',
+                'destination'   => 'internal/cmd/ambient_native.go',
+                'template'      => 'go-cli/internal/cmd/ambient_native.go',
+            ],
+            [
                 'scope'         => 'default',
-                'destination'   => 'internal/auth/keyring.go',
-                'template'      => 'go-cli/internal/auth/keyring.go',
+                'destination'   => 'internal/cmd/ambient_js.go',
+                'template'      => 'go-cli/internal/cmd/ambient_js.go',
+            ],
+            [
+                'scope'         => 'default',
+                'destination'   => 'internal/auth/keyring_native.go',
+                'template'      => 'go-cli/internal/auth/keyring_native.go',
+            ],
+            [
+                'scope'         => 'default',
+                'destination'   => 'internal/auth/keyring_js.go',
+                'template'      => 'go-cli/internal/auth/keyring_js.go',
             ],
             [
                 'scope'         => 'default',
@@ -576,6 +611,26 @@ class GoCLI extends Go
                 'template'      => 'go-cli/internal/cmd/login.go',
             ],
             [
+                'scope'         => 'copy',
+                'destination'   => 'internal/cmd/commands_portable.go',
+                'template'      => 'go-cli/internal/cmd/commands_portable.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/cmd/commands_host.go',
+                'template'      => 'go-cli/internal/cmd/commands_host.go',
+            ],
+            [
+                'scope'         => 'default',
+                'destination'   => 'internal/cmd/commands_host_stub.go',
+                'template'      => 'go-cli/internal/cmd/commands_host_stub.go',
+            ],
+            [
+                'scope'         => 'default',
+                'destination'   => 'internal/cmd/endpoint.go',
+                'template'      => 'go-cli/internal/cmd/endpoint.go',
+            ],
+            [
                 'scope'         => 'default',
                 'destination'   => 'internal/cmd/login_test.go',
                 'template'      => 'go-cli/internal/cmd/login_test.go',
@@ -604,6 +659,16 @@ class GoCLI extends Go
                 'scope'         => 'default',
                 'destination'   => 'internal/sdk/sdk.go',
                 'template'      => 'go-cli/internal/sdk/sdk.go.twig',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/sdk/ambient_native.go',
+                'template'      => 'go-cli/internal/sdk/ambient_native.go',
+            ],
+            [
+                'scope'         => 'default',
+                'destination'   => 'internal/sdk/ambient_js.go',
+                'template'      => 'go-cli/internal/sdk/ambient_js.go',
             ],
             [
                 'scope'         => 'default',
@@ -804,6 +869,16 @@ class GoCLI extends Go
                 'scope'         => 'default',
                 'destination'   => 'internal/app/install.go',
                 'template'      => 'go-cli/internal/app/install.go.twig',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/app/updatecheck_native.go',
+                'template'      => 'go-cli/internal/app/updatecheck_native.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/app/updatecheck_browser.go',
+                'template'      => 'go-cli/internal/app/updatecheck_browser.go',
             ],
             [
                 'scope'         => 'default',

--- a/templates/go-cli/.github/workflows/publish.yml.twig
+++ b/templates/go-cli/.github/workflows/publish.yml.twig
@@ -80,6 +80,32 @@ jobs:
       - name: Stage release assets
         run: node scripts/stage-assets.mjs dist staging
 
+      # Keep this outside goreleaser so its six native asset names remain stable.
+      - name: Build the browser bundle
+        env:
+          RELEASE_TAG: {{ '${{ github.event.release.tag_name }}' }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+
+          GOOS=js GOARCH=wasm go build -tags browser -trimpath \
+            -ldflags="-s -w -X github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/app.Version=${version}" \
+            -o staging/{{ language.params.executableName }}.wasm .
+
+          # Go 1.24 moved this from misc/wasm to lib/wasm.
+          cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" staging/
+
+          # The linker silently ignores an invalid -X symbol.
+          node -e '
+            const fs = require("node:fs");
+            const wanted = process.argv[1];
+            const bytes = fs.readFileSync("staging/{{ language.params.executableName }}.wasm");
+            if (!bytes.includes(Buffer.from(wanted))) {
+              console.error(`version ${wanted} was not linked into the wasm artifact`);
+              process.exit(1);
+            }
+          ' "$version"
+
       - name: Detect Windows code signing
         id: signing
         env:
@@ -141,9 +167,13 @@ jobs:
 
       # goreleaser checksummed the unsigned Windows builds, and signing changed
       # the bytes.
+      # The wasm files do not share the native asset-name prefix.
       - name: Recompute checksums
         working-directory: staging
-        run: sha256sum {{ language.params.npmPackage }}-* > checksums.txt
+        run: |
+          set -euo pipefail
+          sha256sum {{ language.params.npmPackage }}-* \
+            {{ language.params.executableName }}.wasm wasm_exec.js > checksums.txt
 
       - name: Upload release assets
         env:
@@ -171,7 +201,7 @@ jobs:
         run: |
           set -euo pipefail
           version="${RELEASE_TAG#v}"
-          node scripts/build-npm-packages.mjs staging npm-packages "$version"
+          node scripts/build-npm-packages.mjs staging npm-packages "$version" npm-wasm
           node -e '
             const fs = require("node:fs");
             const version = process.argv[1];
@@ -193,6 +223,10 @@ jobs:
 
       - name: Publish {{ language.params.npmPackage }}
         run: npm publish ./npm --provenance --access public --tag {{ '${{ steps.npm_tag.outputs.tag }}' }}
+
+      # Standalone so native installs do not download the wasm artifact.
+      - name: Publish {{ language.params.npmPackage }}-wasm
+        run: npm publish ./npm-wasm/{{ language.params.npmPackage }}-wasm --provenance --access public --tag {{ '${{ steps.npm_tag.outputs.tag }}' }}
 
       - name: Generate token for the Homebrew tap
         if: {{ '${{ !github.event.release.prerelease }}' }}

--- a/templates/go-cli/internal/app/install.go.twig
+++ b/templates/go-cli/internal/app/install.go.twig
@@ -159,9 +159,12 @@ const NPMRegistryURL = "https://registry.npmjs.org/" + NPMPackageName + "/latest
 // next dist-tag. Stable builds never query it.
 const NPMPrereleaseRegistryURL = "https://registry.npmjs.org/" + NPMPackageName + "/next"
 
-// UpdateChecker builds the once-a-day version check, or nil when there is
-// nowhere to cache its answer.
+// UpdateChecker builds the once-a-day version check when this binary owns updates.
 func UpdateChecker() *update.Checker {
+	if hostManagesUpdates {
+		return nil
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil

--- a/templates/go-cli/internal/app/updatecheck_browser.go
+++ b/templates/go-cli/internal/app/updatecheck_browser.go
@@ -1,0 +1,6 @@
+//go:build browser
+
+package app
+
+// The embedding page owns browser artifact updates.
+const hostManagesUpdates = true

--- a/templates/go-cli/internal/app/updatecheck_native.go
+++ b/templates/go-cli/internal/app/updatecheck_native.go
@@ -1,0 +1,6 @@
+//go:build !browser
+
+package app
+
+// Native installations manage their own updates.
+const hostManagesUpdates = false

--- a/templates/go-cli/internal/auth/keyring_js.go
+++ b/templates/go-cli/internal/auth/keyring_js.go
@@ -1,0 +1,118 @@
+//go:build js
+
+package auth
+
+import (
+	"fmt"
+
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/config"
+)
+
+// Browsers store refresh tokens in preferences because they have no keyring.
+const prefsRefreshTokenKey = config.PreferenceRefreshToken
+
+// TokenStore reads and writes browser refresh tokens.
+type TokenStore struct {
+	Global *config.Global
+}
+
+// Trace receives credential-store diagnostics.
+var Trace func(format string, arguments ...any)
+
+func trace(format string, arguments ...any) {
+	if Trace != nil {
+		Trace(format, arguments...)
+	}
+}
+
+// Warn matches the native variant's exported surface.
+var Warn func(format string, arguments ...any)
+
+func storeName() string {
+	return "the browser session store"
+}
+
+// MissingRefreshToken reports where a session token was expected.
+type MissingRefreshToken struct {
+	SessionID string
+	Store     string
+	StoreErr  error
+	PrefsPath string
+}
+
+func (e *MissingRefreshToken) Error() string {
+	if e.StoreErr != nil {
+		return fmt.Sprintf("%s could not be read (%s), and %s holds no token for session %s",
+			e.Store, e.StoreErr, e.PrefsPath, e.SessionID)
+	}
+
+	return fmt.Sprintf("%s has no entry for session %s",
+		e.Store, e.SessionID)
+}
+
+func (e *MissingRefreshToken) Unwrap() error { return e.StoreErr }
+
+// Refresh returns the stored refresh token for a session.
+func (s *TokenStore) Refresh(sessionID string) (string, error) {
+	if sessionID == "" {
+		return "", &MissingRefreshToken{Store: storeName(), PrefsPath: s.prefsPath()}
+	}
+
+	if session := s.Global.SessionData(sessionID); session != nil {
+		if token := session.GetString(prefsRefreshTokenKey); token != "" {
+			trace("read the refresh token for %s from %s", sessionID, s.prefsPath())
+
+			return token, nil
+		}
+	}
+
+	return "", &MissingRefreshToken{
+		SessionID: sessionID,
+		Store:     storeName(),
+		PrefsPath: s.prefsPath(),
+	}
+}
+
+func (s *TokenStore) prefsPath() string {
+	if s.Global != nil {
+		if path := s.Global.Path(); path != "" {
+			return path
+		}
+	}
+
+	return "prefs.json"
+}
+
+// SetRefresh stores a refresh token.
+func (s *TokenStore) SetRefresh(sessionID, token string) error {
+	if sessionID == "" {
+		return nil
+	}
+	if token == "" {
+		return s.DeleteRefresh(sessionID)
+	}
+
+	session := s.Global.SessionData(sessionID)
+	if session == nil {
+		return fmt.Errorf("session %s is not in %s, so the refresh token could not be stored",
+			sessionID, s.prefsPath())
+	}
+
+	trace("stored the refresh token for %s in %s", sessionID, s.prefsPath())
+	session.Set(prefsRefreshTokenKey, token)
+
+	return s.Global.Write()
+}
+
+// DeleteRefresh removes a refresh token.
+func (s *TokenStore) DeleteRefresh(sessionID string) error {
+	s.clearPrefsToken(sessionID)
+
+	return s.Global.Write()
+}
+
+func (s *TokenStore) clearPrefsToken(sessionID string) {
+	if session := s.Global.SessionData(sessionID); session != nil {
+		session.Delete(prefsRefreshTokenKey)
+	}
+}

--- a/templates/go-cli/internal/auth/keyring_native.go
+++ b/templates/go-cli/internal/auth/keyring_native.go
@@ -1,3 +1,5 @@
+//go:build !js
+
 package auth
 
 import (

--- a/templates/go-cli/internal/client/client.go
+++ b/templates/go-cli/internal/client/client.go
@@ -138,9 +138,10 @@ func NewHTTPClient(selfSigned bool) *http.Client {
 	transport := baseTransport()
 	if selfSigned {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		noteSelfSigned()
 	}
 
-	return &http.Client{Transport: transport}
+	return decorate(&http.Client{Transport: transport})
 }
 
 func New(endpoint, sdkVersion string) *Client {
@@ -307,10 +308,11 @@ func (c *Client) SetSelfSigned(selfSigned bool) *Client {
 	// along with the verification.
 	transport := baseTransport()
 	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	noteSelfSigned()
 
 	replacement := *c.HTTP
 	replacement.Transport = transport
-	c.HTTP = &replacement
+	c.HTTP = decorate(&replacement)
 
 	return c
 }

--- a/templates/go-cli/internal/client/fetch_js.go
+++ b/templates/go-cli/internal/client/fetch_js.go
@@ -1,0 +1,40 @@
+//go:build js
+
+package client
+
+import "net/http"
+
+// Go's js transport consumes this header as a fetch option.
+const fetchCredentials = "js.fetch:credentials"
+
+// browserCredentials swaps the CLI's own Cookie header for the browser's.
+type browserCredentials struct {
+	next http.RoundTripper
+}
+
+// RoundTrip replaces the forbidden Cookie header with browser credentials.
+func (c browserCredentials) RoundTrip(request *http.Request) (*http.Response, error) {
+	outbound := request.Clone(request.Context())
+	outbound.Header.Del("Cookie")
+	outbound.Header.Set(fetchCredentials, "include")
+
+	return c.next.RoundTrip(outbound)
+}
+
+func decorate(client *http.Client) *http.Client {
+	next := client.Transport
+	if next == nil {
+		next = http.DefaultTransport
+	}
+	client.Transport = browserCredentials{next: next}
+
+	return client
+}
+
+// Browsers own certificate verification, so --self-signed cannot be honoured.
+func noteSelfSigned() {
+	if RequestLog != nil {
+		RequestLog("--self-signed does not apply in a browser: " +
+			"the browser verifies certificates and wasm cannot override it")
+	}
+}

--- a/templates/go-cli/internal/client/fetch_native.go
+++ b/templates/go-cli/internal/client/fetch_native.go
@@ -1,0 +1,9 @@
+//go:build !js
+
+package client
+
+import "net/http"
+
+func decorate(client *http.Client) *http.Client { return client }
+
+func noteSelfSigned() {}

--- a/templates/go-cli/internal/cmd/ambient_js.go
+++ b/templates/go-cli/internal/cmd/ambient_js.go
@@ -1,0 +1,26 @@
+//go:build js
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/sdk"
+)
+
+// The console half of what internal/sdk/ambient_js.go does for project calls.
+//
+// `whoami` and `sessions` do not go through the SDK context -- they build a
+// client directly, in session.go -- so they need the same permission to run on
+// a session the CLI cannot read. Same reasoning, same environment variable, and
+// deliberately the same name so the two are found together.
+
+// ambientEndpoint is the endpoint to use when no session is stored.
+func ambientEndpoint() string { return os.Getenv(sdk.EnvEndpoint) }
+
+// ambientSession reports whether the environment carries a session the CLI
+// cannot see but can still make requests with.
+//
+// False without an endpoint: nothing was configured, and treating that as a
+// session would send an unauthenticated request somewhere no one named.
+func ambientSession() bool { return ambientEndpoint() != "" }

--- a/templates/go-cli/internal/cmd/ambient_native.go
+++ b/templates/go-cli/internal/cmd/ambient_native.go
@@ -1,0 +1,13 @@
+//go:build !js
+
+package cmd
+
+// The native half of the pair in ambient_js.go. Nothing lends this process a
+// session; the credential is whatever `login` stored.
+
+// ambientEndpoint is the endpoint to use when no session is stored.
+func ambientEndpoint() string { return "" }
+
+// ambientSession reports whether the environment carries a session the CLI
+// cannot see but can still make requests with.
+func ambientSession() bool { return false }

--- a/templates/go-cli/internal/cmd/commands_host.go
+++ b/templates/go-cli/internal/cmd/commands_host.go
@@ -1,0 +1,17 @@
+//go:build !browser
+
+package cmd
+
+import "github.com/spf13/cobra"
+
+// registerHostCommands attaches commands that require native host capabilities.
+func registerHostCommands(root *cobra.Command) {
+	root.AddCommand(newUpdateCommand())
+	root.AddCommand(newLoginCommand())
+	root.AddCommand(newTypesCommand())
+	root.AddCommand(newGenerateCommand())
+	root.AddCommand(newRunCommand())
+	root.AddCommand(newInitCommand())
+	root.AddCommand(newPullCommand())
+	root.AddCommand(newPushCommand())
+}

--- a/templates/go-cli/internal/cmd/commands_host_stub.go
+++ b/templates/go-cli/internal/cmd/commands_host_stub.go
@@ -1,0 +1,74 @@
+//go:build browser
+
+package cmd
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/app"
+)
+
+// registerHostCommands attaches guidance stubs for unavailable browser commands.
+func registerHostCommands(root *cobra.Command) {
+	root.AddCommand(newUnavailableCommand("login",
+		"Sign in to an Appwrite endpoint",
+		"Sign in through the Console instead -- this terminal already runs as the "+
+			"signed-in user. `"+app.ExecutableName+" whoami` shows who that is."))
+
+	root.AddCommand(newUnavailableCommand("update",
+		"Update the CLI to the latest version",
+		"This build ships with the Console and updates when the Console does. "+
+			"Install the CLI locally to manage its version yourself: "+
+			"https://appwrite.io/docs/tooling/command-line/installation"))
+
+	root.AddCommand(newUnavailableCommand("types",
+		"Generate types for your Appwrite project",
+		"Generating types writes files into a project directory, which a browser "+
+			"tab has no access to. Run `"+app.ExecutableName+" types` from a local "+
+			"checkout of your project."))
+
+	root.AddCommand(newUnavailableCommand("generate",
+		"Generate a type-safe SDK from your Appwrite project configuration",
+		"Generating an SDK writes files into a project directory, which a browser "+
+			"tab has no access to. Run `"+app.ExecutableName+" generate` from a local "+
+			"checkout of your project."))
+
+	root.AddCommand(newUnavailableCommand("run",
+		"Run project resources locally",
+		"Running a function locally needs Docker, which a browser tab cannot reach. "+
+			"Run `"+app.ExecutableName+" run` from a local checkout of your project."))
+
+	root.AddCommand(newUnavailableCommand("init",
+		"Init a new Appwrite project",
+		"Initialising a project writes appwrite.config.json and a directory tree, "+
+			"which a browser tab has no access to. Run `"+app.ExecutableName+" init` "+
+			"from a local checkout, or create resources here with the service "+
+			"commands -- `"+app.ExecutableName+" tablesdb create-table`, and so on."))
+
+	root.AddCommand(newUnavailableCommand("pull",
+		"Pull your Appwrite project resources into appwrite.config.json",
+		"Pulling writes appwrite.config.json and resource files to disk, which a "+
+			"browser tab has no access to. Run `"+app.ExecutableName+" pull` from a "+
+			"local checkout of your project."))
+
+	root.AddCommand(newUnavailableCommand("push",
+		"Push your Appwrite project resources from appwrite.config.json",
+		"Pushing reads appwrite.config.json and your source files from disk, which a "+
+			"browser tab has no access to. Run `"+app.ExecutableName+" push` from a "+
+			"local checkout of your project."))
+}
+
+// Accept all arguments so unavailable subcommands and flags show the same guidance.
+func newUnavailableCommand(use, short, guidance string) *cobra.Command {
+	return &cobra.Command{
+		Use:                use,
+		Short:              short,
+		DisableFlagParsing: true,
+		Args:               cobra.ArbitraryArgs,
+		RunE: func(command *cobra.Command, args []string) error {
+			return errors.New(guidance)
+		},
+	}
+}

--- a/templates/go-cli/internal/cmd/commands_portable.go
+++ b/templates/go-cli/internal/cmd/commands_portable.go
@@ -1,0 +1,13 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+// registerSessionCommands attaches portable commands and the host-specific surface.
+func registerSessionCommands(root *cobra.Command) {
+	root.AddCommand(newWhoamiCommand())
+	root.AddCommand(newSessionsCommand())
+	root.AddCommand(newClientCommand())
+	root.AddCommand(newLogoutCommand())
+
+	registerHostCommands(root)
+}

--- a/templates/go-cli/internal/cmd/endpoint.go
+++ b/templates/go-cli/internal/cmd/endpoint.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/app"
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/client"
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/config"
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/jsonx"
+)
+
+// verifyEndpoint checks that an endpoint is an Appwrite server before a
+// password is typed into it.
+func verifyEndpoint(endpoint string, selfSigned bool) error {
+	parsed, err := url.Parse(endpoint)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return fmt.Errorf("invalid endpoint URL: %s", endpoint)
+	}
+
+	version := jsonx.NewObject()
+	err = client.New(endpoint, app.Version).SetSelfSigned(selfSigned).
+		Call("GET", "/health/version", nil, version)
+	if err == nil && version.GetString("version") != "" {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"invalid endpoint or your Appwrite server is not running as expected: %s",
+		endpoint)
+}
+
+// regionalEndpoint prefixes the normalized endpoint host with a region.
+func regionalEndpoint(endpoint, region string) string {
+	normalized := config.NormalizeCloudConsoleEndpoint(endpoint)
+
+	parsed, err := url.Parse(normalized)
+	if err != nil {
+		return normalized
+	}
+	parsed.Host = region + "." + parsed.Host
+
+	return strings.TrimSuffix(parsed.String(), "/")
+}
+
+// isCloudEndpoint reports whether an endpoint is Appwrite Cloud.
+func isCloudEndpoint(endpoint string) bool {
+	_, ok := config.CloudBaseHost(endpoint)
+
+	return ok
+}

--- a/templates/go-cli/internal/cmd/generate.go
+++ b/templates/go-cli/internal/cmd/generate.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (

--- a/templates/go-cli/internal/cmd/init.go
+++ b/templates/go-cli/internal/cmd/init.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (

--- a/templates/go-cli/internal/cmd/initfunction.go
+++ b/templates/go-cli/internal/cmd/initfunction.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (

--- a/templates/go-cli/internal/cmd/initproject.go
+++ b/templates/go-cli/internal/cmd/initproject.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (
@@ -457,28 +459,4 @@ func selectionLabel(name, id string) string {
 // consoleBaseURL strips the /v1 suffix so a console link can be built.
 func consoleBaseURL(endpoint string) string {
 	return strings.TrimSuffix(strings.TrimSuffix(endpoint, "/"), "/v1")
-}
-
-// regionalEndpoint prefixes the endpoint's host with a region.
-//
-// Built from the NORMALISED host, not from whatever is configured: the session
-// endpoint may already be regional, and prefixing again would produce
-// `fra.sgp.cloud.appwrite.io`.
-func regionalEndpoint(endpoint, region string) string {
-	normalized := config.NormalizeCloudConsoleEndpoint(endpoint)
-
-	parsed, err := url.Parse(normalized)
-	if err != nil {
-		return normalized
-	}
-	parsed.Host = region + "." + parsed.Host
-
-	return strings.TrimSuffix(parsed.String(), "/")
-}
-
-// isCloudEndpoint reports whether an endpoint is Appwrite Cloud.
-func isCloudEndpoint(endpoint string) bool {
-	_, ok := config.CloudBaseHost(endpoint)
-
-	return ok
 }

--- a/templates/go-cli/internal/cmd/initprojectskills.go
+++ b/templates/go-cli/internal/cmd/initprojectskills.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (

--- a/templates/go-cli/internal/cmd/initscaffold.go
+++ b/templates/go-cli/internal/cmd/initscaffold.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (

--- a/templates/go-cli/internal/cmd/initsite.go
+++ b/templates/go-cli/internal/cmd/initsite.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (

--- a/templates/go-cli/internal/cmd/initskill.go
+++ b/templates/go-cli/internal/cmd/initskill.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (

--- a/templates/go-cli/internal/cmd/login.go
+++ b/templates/go-cli/internal/cmd/login.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (
@@ -165,29 +167,6 @@ func currentAccount() (*jsonx.Object, error) {
 	}
 
 	return account, nil
-}
-
-// verifyEndpoint checks that an endpoint is an Appwrite server before a
-// password is typed into it.
-func verifyEndpoint(endpoint string, selfSigned bool) error {
-	parsed, err := url.Parse(endpoint)
-	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") {
-		return fmt.Errorf("invalid endpoint URL: %s", endpoint)
-	}
-
-	version := jsonx.NewObject()
-	// selfSigned is threaded in rather than read from preferences: `client
-	// --endpoint X --self-signed true` has to verify X under the setting given in
-	// the same invocation, not the one stored from a previous run.
-	err = client.New(endpoint, app.Version).SetSelfSigned(selfSigned).
-		Call("GET", "/health/version", nil, version)
-	if err == nil && version.GetString("version") != "" {
-		return nil
-	}
-
-	return fmt.Errorf(
-		"invalid endpoint or your Appwrite server is not running as expected: %s",
-		endpoint)
 }
 
 // switchAccount makes a different signed-in account current.

--- a/templates/go-cli/internal/cmd/pull.go
+++ b/templates/go-cli/internal/cmd/pull.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (

--- a/templates/go-cli/internal/cmd/pullall.go
+++ b/templates/go-cli/internal/cmd/pullall.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (

--- a/templates/go-cli/internal/cmd/pulldatabase.go
+++ b/templates/go-cli/internal/cmd/pulldatabase.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (

--- a/templates/go-cli/internal/cmd/pullfunction.go
+++ b/templates/go-cli/internal/cmd/pullfunction.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (

--- a/templates/go-cli/internal/cmd/pullsettings.go
+++ b/templates/go-cli/internal/cmd/pullsettings.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (

--- a/templates/go-cli/internal/cmd/pushall.go
+++ b/templates/go-cli/internal/cmd/pushall.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (

--- a/templates/go-cli/internal/cmd/pushcommon.go
+++ b/templates/go-cli/internal/cmd/pushcommon.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (

--- a/templates/go-cli/internal/cmd/pushdatabase.go
+++ b/templates/go-cli/internal/cmd/pushdatabase.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (

--- a/templates/go-cli/internal/cmd/pushdeploy.go
+++ b/templates/go-cli/internal/cmd/pushdeploy.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (

--- a/templates/go-cli/internal/cmd/pushpreview.go
+++ b/templates/go-cli/internal/cmd/pushpreview.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (

--- a/templates/go-cli/internal/cmd/pushsimple.go
+++ b/templates/go-cli/internal/cmd/pushsimple.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (

--- a/templates/go-cli/internal/cmd/resource.go
+++ b/templates/go-cli/internal/cmd/resource.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (

--- a/templates/go-cli/internal/cmd/run.go
+++ b/templates/go-cli/internal/cmd/run.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (

--- a/templates/go-cli/internal/cmd/runjwt.go
+++ b/templates/go-cli/internal/cmd/runjwt.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (

--- a/templates/go-cli/internal/cmd/session.go
+++ b/templates/go-cli/internal/cmd/session.go
@@ -62,12 +62,18 @@ func consoleClientAt(override string) (*client.Client, *config.Global, error) {
 		return nil, nil, err
 	}
 
+	// A browser has a session of its own that this CLI cannot read: see
+	// ambient_js.go. ambientEndpoint is empty on every other build, so the two
+	// checks below are the ones that were always here.
 	session := global.Current()
-	if session == nil {
-		return nil, nil, ErrNotLoggedIn
-	}
 
-	endpoint := session.GetString(config.PreferenceEndpoint)
+	endpoint := ""
+	if session != nil {
+		endpoint = session.GetString(config.PreferenceEndpoint)
+	}
+	if endpoint == "" {
+		endpoint = ambientEndpoint()
+	}
 	if endpoint == "" {
 		return nil, nil, ErrNotLoggedIn
 	}
@@ -80,8 +86,14 @@ func consoleClientAt(override string) (*client.Client, *config.Global, error) {
 		SetSelfSigned(global.CurrentBool(config.PreferenceSelfSigned)).
 		SetLocale("en-US")
 
-	hasAccessToken := session.GetString(config.PreferenceAccessToken) != ""
-	cookie := session.GetString(config.PreferenceCookie)
+	hasAccessToken := false
+	cookie := ""
+	storedKey := ""
+	if session != nil {
+		hasAccessToken = session.GetString(config.PreferenceAccessToken) != ""
+		cookie = session.GetString(config.PreferenceCookie)
+		storedKey = session.GetString(config.PreferenceKey)
+	}
 
 	switch {
 	case hasAccessToken:
@@ -92,11 +104,14 @@ func consoleClientAt(override string) (*client.Client, *config.Global, error) {
 		api.SetBearer(token)
 	case cookie != "":
 		api.SetCookie(cookie)
-	case session.GetString(config.PreferenceKey) != "":
+	case storedKey != "":
 		// An API key is scoped to one project; the console endpoints are not.
 		// Saying so is the difference between a user adding `login` and a user
 		// re-checking a key that was never going to work here.
 		return nil, nil, ErrConsoleNeedsSession
+	case ambientSession():
+		// Nothing to attach: the credential is the page's cookie, which the
+		// browser adds to the request and this process cannot read.
 	default:
 		return nil, nil, ErrNotLoggedIn
 	}
@@ -244,20 +259,4 @@ func bannerWriter(command *cobra.Command) io.Writer {
 	}
 
 	return command.OutOrStdout()
-}
-
-// registerSessionCommands attaches the commands that do not come from the spec.
-func registerSessionCommands(root *cobra.Command) {
-	root.AddCommand(newWhoamiCommand())
-	root.AddCommand(newSessionsCommand())
-	root.AddCommand(newClientCommand())
-	root.AddCommand(newUpdateCommand())
-	root.AddCommand(newLoginCommand())
-	root.AddCommand(newLogoutCommand())
-	root.AddCommand(newTypesCommand())
-	root.AddCommand(newGenerateCommand())
-	root.AddCommand(newRunCommand())
-	root.AddCommand(newInitCommand())
-	root.AddCommand(newPullCommand())
-	root.AddCommand(newPushCommand())
 }

--- a/templates/go-cli/internal/cmd/types.go
+++ b/templates/go-cli/internal/cmd/types.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (

--- a/templates/go-cli/internal/cmd/update.go.twig
+++ b/templates/go-cli/internal/cmd/update.go.twig
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package cmd
 
 import (

--- a/templates/go-cli/internal/config/global.go
+++ b/templates/go-cli/internal/config/global.go
@@ -67,7 +67,7 @@ type Session struct {
 
 // GlobalPath returns the default preferences path for the current user.
 func GlobalPath(executableName string) (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := homeDir()
 	if err != nil {
 		return "", err
 	}

--- a/templates/go-cli/internal/config/home_js.go
+++ b/templates/go-cli/internal/config/home_js.go
@@ -1,0 +1,16 @@
+//go:build js
+
+package config
+
+import "os"
+
+// BrowserHome is the fallback when the embedding page does not define HOME.
+const BrowserHome = "/home/appwrite"
+
+func homeDir() (string, error) {
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return home, nil
+	}
+
+	return BrowserHome, nil
+}

--- a/templates/go-cli/internal/config/home_native.go
+++ b/templates/go-cli/internal/config/home_native.go
@@ -1,0 +1,9 @@
+//go:build !js
+
+package config
+
+import "os"
+
+func homeDir() (string, error) {
+	return os.UserHomeDir()
+}

--- a/templates/go-cli/internal/prompt/terminal.go
+++ b/templates/go-cli/internal/prompt/terminal.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package prompt
 
 import (

--- a/templates/go-cli/internal/prompt/theme.go
+++ b/templates/go-cli/internal/prompt/theme.go
@@ -1,3 +1,5 @@
+//go:build !browser
+
 package prompt
 
 import (

--- a/templates/go-cli/internal/sdk/ambient_js.go
+++ b/templates/go-cli/internal/sdk/ambient_js.go
@@ -1,0 +1,59 @@
+//go:build js
+
+package sdk
+
+import (
+	"os"
+
+	sdkclient "github.com/appwrite/sdk-for-go/v6/client"
+
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/config"
+)
+
+// In a browser the session is the page's, not the CLI's.
+//
+// Every other build authenticates from prefs.json, which `login` wrote. A
+// browser build has neither: it cannot open a browser to sign in, it usually
+// cannot write a file, and it does not need to -- the tab it runs in is already
+// signed in, and the credential is an httpOnly cookie that JavaScript cannot
+// read and a header cannot carry. The browser attaches it, on a request the CLI
+// made, because internal/client asks fetch for the origin's credentials.
+//
+// Without this the fetch decoration is unreachable: `endpoint()` and
+// `authenticate()` both refuse a call that has no stored session, so the CLI
+// fails locally and never issues the request the cookie would have
+// authenticated.
+
+// ambientEndpoint is the endpoint to use when no session is stored.
+//
+// The environment rather than window.location: an embedder that serves the page
+// from one origin and the API from another -- which the Console does, once a
+// project is in a region -- would otherwise be told to call itself. It is the
+// same variable a CI job sets, and it means the page states its endpoint rather
+// than the artifact guessing.
+func ambientEndpoint() string { return os.Getenv(EnvEndpoint) }
+
+// ambientCredentials reports whether the environment authenticates the request
+// on the CLI's behalf.
+//
+// Nothing is attached here, deliberately -- the whole point is that the CLI
+// cannot see the credential. It only stops refusing, and marks the call the way
+// a console session is marked.
+func ambientCredentials(client *sdkclient.Client, allowAPIKey bool) bool {
+	if ambientEndpoint() == "" {
+		// No endpoint means nothing was configured at all, and answering "the
+		// browser has this" would turn a missing configuration into an
+		// unauthenticated request against whatever endpoint was guessed.
+		return false
+	}
+
+	if allowAPIKey {
+		// admin mode, as for a stored console cookie. A browser build runs in a
+		// console, so its ambient session is a console session, and a console
+		// session acting on a project without this is treated as an end user of
+		// that project -- which is not what the terminal in the Console is for.
+		client.AddHeader("X-Appwrite-Mode", config.ModeAdmin)
+	}
+
+	return true
+}

--- a/templates/go-cli/internal/sdk/ambient_native.go
+++ b/templates/go-cli/internal/sdk/ambient_native.go
@@ -1,0 +1,17 @@
+//go:build !js
+
+package sdk
+
+import sdkclient "github.com/appwrite/sdk-for-go/v6/client"
+
+// The native half of the pair in ambient_js.go. A host has no session of its
+// own to lend the CLI: the credential is whatever `login` stored, and a command
+// that finds none has to say so rather than send an unauthenticated request and
+// report whatever the API says about it.
+
+// ambientEndpoint is the endpoint to use when no session is stored.
+func ambientEndpoint() string { return "" }
+
+// ambientCredentials reports whether the environment authenticates the request
+// on the CLI's behalf.
+func ambientCredentials(client *sdkclient.Client, allowAPIKey bool) bool { return false }

--- a/templates/go-cli/internal/sdk/sdk.go.twig
+++ b/templates/go-cli/internal/sdk/sdk.go.twig
@@ -88,6 +88,11 @@ func (c *Context) base(endpoint string) sdkclient.Client {
 func (c *Context) authenticate(client *sdkclient.Client, allowAPIKey bool) error {
 	session := c.Global.Current()
 	if session == nil {
+		// A browser's own session needs nothing stored: see ambient_js.go.
+		if ambientCredentials(client, allowAPIKey) {
+			return nil
+		}
+
 		return c.noCredentials(allowAPIKey, "")
 	}
 
@@ -121,6 +126,12 @@ func (c *Context) authenticate(client *sdkclient.Client, allowAPIKey bool) error
 		return nil
 	}
 
+	// A stored session with nothing usable in it is still no credential, and a
+	// browser still has its own.
+	if ambientCredentials(client, allowAPIKey) {
+		return nil
+	}
+
 	return c.noCredentials(allowAPIKey, key)
 }
 
@@ -140,18 +151,22 @@ func (c *Context) noCredentials(allowAPIKey bool, key string) error {
 	return ErrNotLoggedIn
 }
 
-// endpoint returns the active session's endpoint.
+// endpoint returns the active session's endpoint, or the environment's when
+// the environment is the session -- see ambient_js.go. ambientEndpoint is empty
+// on every build but the browser one, so this is the same two checks it always
+// was.
 func (c *Context) endpoint() (string, error) {
-	session := c.Global.Current()
-	if session == nil {
-		return "", ErrNotLoggedIn
-	}
-	endpoint := session.GetString(config.PreferenceEndpoint)
-	if endpoint == "" {
-		return "", ErrNotLoggedIn
+	if session := c.Global.Current(); session != nil {
+		if endpoint := session.GetString(config.PreferenceEndpoint); endpoint != "" {
+			return endpoint, nil
+		}
 	}
 
-	return endpoint, nil
+	if endpoint := ambientEndpoint(); endpoint != "" {
+		return endpoint, nil
+	}
+
+	return "", ErrNotLoggedIn
 }
 
 // projectEndpoint returns the endpoint a PROJECT-scoped call should use.

--- a/templates/go-cli/scripts/build-npm-packages.mjs.twig
+++ b/templates/go-cli/scripts/build-npm-packages.mjs.twig
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Build the six per-platform npm packages from the staged release assets.
+// Build the native and browser npm packages from staged release assets.
 //
 // Run after scripts/stage-assets.mjs and before publishing. Each package holds
 // one binary plus a package.json whose `os`/`cpu` fields let npm pick exactly
@@ -9,12 +9,13 @@
 // Reads the staged directory rather than dist/, because the release asset
 // names are not filenames in dist/ -- see scripts/stage-assets.mjs.
 //
-// Usage: node scripts/build-npm-packages.mjs <stagingDir> <outDir> <version>
+// Usage: node scripts/build-npm-packages.mjs <stagingDir> <outDir> <version> [wasmOutDir]
 
 import fs from "node:fs";
 import path from "node:path";
 
-const [stagingDir = "staging", outDir = "npm-packages", version] = process.argv.slice(2);
+const [stagingDir = "staging", outDir = "npm-packages", version, wasmOutDir = "npm-wasm"] =
+  process.argv.slice(2);
 
 if (!version) {
   console.error("usage: build-npm-packages.mjs <stagingDir> <outDir> <version>");
@@ -78,3 +79,38 @@ for (const target of TARGETS) {
 
   console.log(`built ${directory}`);
 }
+
+// wasm_exec.js must match the Go toolchain that produced the artifact.
+const wasmFiles = ["{{ language.params.executableName }}.wasm", "wasm_exec.js"];
+const wasmDirectory = path.join(wasmOutDir, `${packageName}-wasm`);
+fs.mkdirSync(wasmDirectory, { recursive: true });
+
+for (const file of wasmFiles) {
+  const source = path.join(stagingDir, file);
+
+  if (!fs.existsSync(source)) {
+    console.error(`missing staged asset: ${source}`);
+    process.exit(1);
+  }
+
+  fs.copyFileSync(source, path.join(wasmDirectory, file));
+}
+
+fs.writeFileSync(
+  path.join(wasmDirectory, "package.json"),
+  JSON.stringify(
+    {
+      name: `${packageName}-wasm`,
+      version,
+      description: `${executable} compiled to WebAssembly, for running in a browser`,
+      license: "{{ sdk.license }}",
+      repository: { type: "git", url: "{{ sdk.gitURL }}" },
+      exports: Object.fromEntries(wasmFiles.map((file) => [`./${file}`, `./${file}`])),
+      files: wasmFiles,
+    },
+    null,
+    2,
+  ) + "\n",
+);
+
+console.log(`built ${wasmDirectory}`);

--- a/tests/e2e/GoCLIWasmBrowserTest.php
+++ b/tests/e2e/GoCLIWasmBrowserTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\E2E;
+
+use Override;
+use Appwrite\SDK\Language\GoCLI;
+
+/**
+ * The browser build in an actual browser, against an actual session cookie.
+ *
+ * GoCLIWasmTest runs the same artifact under Node and proves the command
+ * surface. It cannot prove the thing the artifact exists for: it authenticates
+ * with an API key in a header, on a real filesystem, with no origin and no
+ * cookie jar. Every part of the browser boundary -- an httpOnly cookie the CLI
+ * cannot read, credentialed CORS, a page with no writable filesystem -- is
+ * invisible to it.
+ *
+ * So this test runs Chromium. It needs no mock API and no network: the fixture
+ * serves the page and two API origins on loopback inside the same container, so
+ * the whole thing is one `docker run` and nothing to tear down.
+ *
+ * The checks are pinned by name in $expectedOutput rather than reduced to a
+ * single pass/fail line, because a browser test that silently stops running one
+ * of its cases is the failure mode that matters here.
+ */
+final class GoCLIWasmBrowserTest extends Base
+{
+    #[Override]
+    protected string $sdkName = 'cli';
+    #[Override]
+    protected string $sdkPlatform = 'server';
+    #[Override]
+    protected string $sdkLanguage = 'cli';
+    #[Override]
+    protected string $version = '0.0.1';
+
+    #[Override]
+    protected string $language = 'go-cli-wasm-browser';
+    #[Override]
+    protected string $class = GoCLI::class;
+
+    #[Override]
+    protected array $build = [
+        'docker run --rm -v $(pwd):/app -w /app/tests/e2e/sdks/go-cli-wasm-browser golang:1.26 go mod tidy',
+        'mkdir -p tests/e2e/sdks/go-cli-wasm-browser/browser',
+        'docker run --rm -v $(pwd):/app -w /app/tests/e2e/sdks/go-cli-wasm-browser -e GOOS=js -e GOARCH=wasm '
+            . 'golang:1.26 go build -tags browser -buildvcs=false -o browser/appwrite.wasm .',
+        'docker run --rm -v $(pwd):/app -w /app/tests/e2e/sdks/go-cli-wasm-browser golang:1.26 '
+            . 'sh -c \'cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" browser/wasm_exec.js\'',
+        'cp tests/e2e/languages/go-cli-wasm-browser/server.mjs tests/e2e/sdks/go-cli-wasm-browser/browser/server.mjs',
+        'cp tests/e2e/languages/go-cli-wasm-browser/driver.mjs tests/e2e/sdks/go-cli-wasm-browser/browser/driver.mjs',
+        'cp tests/e2e/languages/go-cli-wasm-browser/page.html tests/e2e/sdks/go-cli-wasm-browser/browser/page.html',
+    ];
+
+    // --ipc=host is Playwright's own recommendation: Chromium's default shared
+    // memory in a container is too small and it crashes rendering large pages.
+    // The browser is launched with --no-sandbox in the driver, so no extra
+    // privileges are needed here.
+    // The image ships the browsers, not the client library, so the driver's one
+    // import has to be installed. The version is pinned to the image's: a
+    // playwright newer than its browsers refuses to launch them, and that
+    // failure reads as a broken test rather than a mismatched pair.
+    #[Override]
+    protected string $command =
+        'docker run --rm --ipc=host -v $(pwd):/app -w /app/tests/e2e/sdks/go-cli-wasm-browser '
+        . 'mcr.microsoft.com/playwright:v1.62.0-noble '
+        . 'sh -c \'npm install --no-save --no-audit --no-fund --loglevel=error playwright@1.62.0 '
+        . '>/dev/null 2>&1 && node ./browser/driver.mjs\'';
+
+    #[Override]
+    protected array $expectedOutput = [
+        'ok   a page with no HOME and no filesystem gets a product error, not an environment one',
+        'ok   without a session the CLI reaches the API and renders its 401',
+        'ok   an httpOnly session cookie authenticates a same-origin request',
+        'ok   the session cookie is invisible to the page that just used it',
+        'ok   js.fetch:credentials carries the session cross-origin',
+        'ok   the fixture served three CLI requests',
+        'ok   the same-origin API received the session cookie',
+        'ok   the cross-origin API received the session cookie',
+        'ok   every request carried the project header',
+        'ok   the js.fetch:credentials instruction never reached the wire',
+        'ok   the sdk headers survive the browser fetch',
+        'BROWSER_CONFORMANCE:passed',
+    ];
+
+    #[Override]
+    public function getLanguage(): GoCLI
+    {
+        $language = new GoCLI();
+        $language->setExecutableName('appwrite');
+
+        return $language;
+    }
+}

--- a/tests/e2e/GoCLIWasmTest.php
+++ b/tests/e2e/GoCLIWasmTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\E2E;
+
+use Override;
+use Appwrite\SDK\Language\GoCLI;
+
+/** Runs the browser build against the native CLI's conformance expectations. */
+final class GoCLIWasmTest extends Base
+{
+    #[Override]
+    protected string $sdkName = 'cli';
+    #[Override]
+    protected string $sdkPlatform = 'server';
+    // The generated client identifies its SDK language as `cli`.
+    #[Override]
+    protected string $sdkLanguage = 'cli';
+    #[Override]
+    protected string $version = '0.0.1';
+
+    #[Override]
+    protected string $language = 'go-cli-wasm';
+    #[Override]
+    protected string $class = GoCLI::class;
+
+    #[Override]
+    protected array $build = [
+        'docker run --rm -v $(pwd):/app -w /app/tests/e2e/sdks/go-cli-wasm golang:1.26 go mod tidy',
+        'mkdir -p tests/e2e/sdks/go-cli-wasm/conformance',
+        // `browser` selects the reduced command surface; GOOS selects js adapters.
+        'docker run --rm -v $(pwd):/app -w /app/tests/e2e/sdks/go-cli-wasm -e GOOS=js -e GOARCH=wasm '
+            . 'golang:1.26 go build -tags browser -buildvcs=false -o conformance/appwrite.wasm .',
+        'docker run --rm -v $(pwd):/app -w /app/tests/e2e/sdks/go-cli-wasm golang:1.26 '
+            . 'sh -c \'cp "$(go env GOROOT)/lib/wasm/wasm_exec.js" conformance/wasm_exec.js\'',
+        'cp tests/e2e/languages/go-cli-wasm/harness.mjs tests/e2e/sdks/go-cli-wasm/conformance/harness.mjs',
+        'cp tests/e2e/languages/go-cli-wasm/run.cjs tests/e2e/sdks/go-cli-wasm/conformance/run.cjs',
+    ];
+
+    #[Override]
+    protected string $command =
+        'docker run --network="mockapi" --rm -v $(pwd):/app -w /app/tests/e2e/sdks/go-cli-wasm '
+        . 'node:24 node ./conformance/harness.mjs';
+
+    #[Override]
+    protected array $expectedOutput = [
+        ...Base::FOO_RESPONSES,
+        ...Base::BAR_RESPONSES,
+        ...Base::UPLOAD_RESPONSES,
+        ...Base::CLI_HEADERS_RESPONSES,
+        'CLI_CONFORMANCE:passed',
+    ];
+
+    #[Override]
+    public function getLanguage(): GoCLI
+    {
+        $language = new GoCLI();
+        $language->setExecutableName('appwrite');
+
+        return $language;
+    }
+}

--- a/tests/e2e/languages/go-cli-wasm-browser/driver.mjs
+++ b/tests/e2e/languages/go-cli-wasm-browser/driver.mjs
@@ -1,0 +1,198 @@
+// Browser conformance for the js/wasm build of the Go CLI.
+//
+// The Node harness next to this one proves the command surface. It cannot prove
+// the thing the browser build exists for, because it authenticates with an API
+// key in a header and runs on a filesystem: no ambient cookie, no origin, no
+// CORS, and a readable prefs.json. This file covers exactly that boundary, in a
+// real Chromium, and nothing else:
+//
+//   1. an httpOnly session cookie the page's JavaScript cannot read reaches the
+//      API on a request the CLI made
+//   2. the same, cross-origin, which is the only case where
+//      `js.fetch:credentials` is load-bearing -- fetch already sends cookies
+//      same-origin
+//   3. the CLI sends no Cookie header of its own, because a browser drops it
+//      silently and a request that looks authenticated and is not is the worst
+//      of the failure modes
+//   4. a page with no HOME and no filesystem still runs, which is the floor an
+//      embedder can be held to
+//
+// Chromium only. The behaviours under test are specified -- forbidden header
+// names, credentialed CORS, SameSite -- so a second engine would re-test the
+// specification rather than this artifact.
+
+import { chromium } from 'playwright'
+
+import { PAGE_ORIGIN, REMOTE_ORIGIN, requests, start, stop } from './server.mjs'
+
+// Base.php discards every line up to and including this one, then compares the
+// rest positionally -- so the checks below are pinned by name in
+// GoCLIWasmBrowserTest::$expectedOutput, and one being quietly dropped is a
+// failure rather than a shorter list.
+console.log('Test Started')
+
+const failures = []
+
+// The Go renderer labels a single value; NO_COLOR is not set here because the
+// page has no environment to set it in, so the escapes are stripped too.
+const resultLabel = /^result\s*:?\s+/
+const ansi = /\u001b\[[0-9;]*m/g
+
+function value(run) {
+    for (const line of run.stdout.replace(ansi, '').split('\n')) {
+        const trimmed = line.trim()
+        if (trimmed !== '') {
+            return trimmed.replace(resultLabel, '').trim()
+        }
+    }
+
+    return ''
+}
+
+function check(condition, description, detail = '') {
+    if (condition) {
+        console.log(`ok   ${description}`)
+
+        return
+    }
+
+    failures.push(description)
+    console.log(`FAIL ${description}${detail ? `\n     ${detail}` : ''}`)
+}
+
+await start()
+
+const browser = await chromium.launch({ args: ['--no-sandbox'] })
+const context = await browser.newContext()
+const page = await context.newPage()
+
+// A page error is otherwise invisible: the assertions would just see empty
+// output and report the CLI as silent.
+page.on('pageerror', (error) => failures.push(`page error: ${error.message}`))
+
+await page.goto(PAGE_ORIGIN)
+await page.evaluate(() => window.ready)
+
+// Index 0 is Base::getExpectedSdkHeaders(). `general headers` is a generated
+// command, and this tree is generated with sdk.test set, so it is a mock that
+// prints the fixture without making a request -- see
+// templates/go-cli/base/mock.go.twig. It is printed here to satisfy Base.php's
+// positional comparison and proves nothing on its own; the headers are checked
+// for real further down, against what the fixture received on a `whoami`.
+const mocked = await page.evaluate(() => window.runCLI(['general', 'headers']))
+console.log(value(mocked).split('; accept:')[0])
+
+// Everything below drives `whoami`, which is hand-written rather than
+// generated, so it is the CLI's own client and a real request.
+const whoami = (origin) => page.evaluate(
+    (endpoint) => window.runCLI(['whoami'], { APPWRITE_ENDPOINT: endpoint }),
+    `${origin}/v1`,
+)
+
+// The floor: no HOME, no filesystem, nothing configured. This must not be an
+// environment error -- config.BrowserHome exists so it is not.
+const bare = await page.evaluate(() => window.runCLI(['whoami']))
+check(
+    !/\$HOME is not defined|not implemented on js/.test(bare.stdout + bare.stderr),
+    'a page with no HOME and no filesystem gets a product error, not an environment one',
+    (bare.stdout + bare.stderr).trim(),
+)
+
+// Unauthenticated, same origin. The API answers 401 because no cookie exists
+// yet; the point is that a request was made and its error was decoded.
+const guest = await whoami(PAGE_ORIGIN)
+// The CLI maps a 401 to its own wording rather than echoing the API's, so the
+// check is for the authentication failure, not for the fixture's sentence.
+// That a request was made at all is asserted below, against what the fixture
+// received.
+check(
+    /not authenticated|missing scope|unauthorized/i.test(guest.stdout + guest.stderr),
+    'without a session the CLI reaches the API and renders its 401',
+    (guest.stdout + guest.stderr).trim(),
+)
+
+// Sign in. The cookie is httpOnly, so nothing on the page can read it back --
+// the browser is the only thing that knows it.
+await page.evaluate(async (origin) => {
+    await fetch(`${origin}/session`, { credentials: 'include' })
+}, PAGE_ORIGIN)
+
+const sameOrigin = await whoami(PAGE_ORIGIN)
+check(
+    sameOrigin.stdout.includes('conformance@appwrite.io'),
+    'an httpOnly session cookie authenticates a same-origin request',
+    (sameOrigin.stdout + sameOrigin.stderr).trim(),
+)
+check(
+    await page.evaluate(() => document.cookie) === '',
+    'the session cookie is invisible to the page that just used it',
+)
+
+// Cross-origin. Sign in against the other origin first; its cookie carries
+// SameSite=None so the browser is willing to send it from this page, and
+// credentialed CORS is what decides whether it does.
+//
+// This is the case that fails without `js.fetch:credentials`: a same-origin
+// fetch sends cookies by default, so the check above passes either way. Built
+// with that one line removed, this one 401s.
+await page.evaluate(async (origin) => {
+    await fetch(`${origin}/session`, { credentials: 'include' })
+}, REMOTE_ORIGIN)
+
+const crossOrigin = await whoami(REMOTE_ORIGIN)
+check(
+    crossOrigin.stdout.includes('conformance@appwrite.io'),
+    'js.fetch:credentials carries the session cross-origin',
+    (crossOrigin.stdout + crossOrigin.stderr).trim(),
+)
+
+// What the servers saw, which is the only account of the wire that cannot be
+// talked out of.
+const seen = requests()
+check(
+    seen.length === 3,
+    'the fixture served three CLI requests',
+    JSON.stringify(seen.map((entry) => `${entry.origin}${entry.path}`)),
+)
+check(
+    seen.some((entry) => entry.origin === PAGE_ORIGIN && entry.cookie),
+    'the same-origin API received the session cookie',
+)
+check(
+    seen.some((entry) => entry.origin === REMOTE_ORIGIN && entry.cookie),
+    'the cross-origin API received the session cookie',
+)
+check(
+    seen.length > 0 && seen.every((entry) => entry.project === 'console'),
+    'every request carried the project header',
+    JSON.stringify(seen),
+)
+check(
+    seen.length > 0 && seen.every((entry) => entry.fetchOption === null),
+    'the js.fetch:credentials instruction never reached the wire',
+    JSON.stringify(seen),
+)
+// internal/client identifies itself as `Command Line`, which is what the
+// TypeScript CLI sends too; the generated SDK's `cli` spelling is a different
+// client and is not what `whoami` uses. The version is whatever was linked in,
+// so it is checked for presence rather than value -- this tree is built without
+// -X and reports the default.
+check(
+    seen.length > 0 && seen.every(
+        (entry) => entry.sdkHeaders.startsWith(
+            'x-sdk-name: Command Line; x-sdk-platform: console; x-sdk-language: cli; x-sdk-version: ',
+        ) && !entry.sdkHeaders.endsWith('x-sdk-version: '),
+    ),
+    'the sdk headers survive the browser fetch',
+    JSON.stringify(seen.map((entry) => entry.sdkHeaders)),
+)
+
+await browser.close()
+stop()
+
+if (failures.length > 0) {
+    console.error(`\n${failures.length} browser conformance failure(s)`)
+    process.exit(1)
+}
+
+console.log('BROWSER_CONFORMANCE:passed')

--- a/tests/e2e/languages/go-cli-wasm-browser/page.html
+++ b/tests/e2e/languages/go-cli-wasm-browser/page.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Appwrite CLI browser conformance</title>
+</head>
+<body>
+<script src="wasm_exec.js"></script>
+<script>
+// A page that runs the CLI the way an embedder would, and nothing more.
+//
+// Deliberately no filesystem shim. wasm_exec.js installs a stub `fs` whose
+// every call answers ENOSYS except writes to stdout and stderr, and that is
+// what a browser tab actually has -- almostnode in the Console supplies more,
+// but an artifact that only works inside almostnode is a worse artifact. So
+// this page is the floor: no HOME, no readable prefs.json, no writable
+// anything. Everything the CLI needs arrives through argv, the environment, and
+// the browser's own session.
+//
+// The only patch is to `writeSync`, so the test can read what the CLI printed
+// instead of watching it go to the console.
+
+const decoder = new TextDecoder('utf-8')
+
+function captureOutput() {
+    const streams = { 1: '', 2: '' }
+    const original = globalThis.fs.writeSync
+
+    globalThis.fs.writeSync = (fd, buffer) => {
+        if (fd === 1 || fd === 2) {
+            streams[fd] += decoder.decode(buffer, { stream: true })
+
+            return buffer.length
+        }
+
+        return original(fd, buffer)
+    }
+
+    return {
+        streams,
+        restore: () => {
+            globalThis.fs.writeSync = original
+        },
+    }
+}
+
+// Compiled once and instantiated per run: a Go program owns its instance and
+// exits it, so a second command needs a second instance.
+const compiled = WebAssembly.compileStreaming(fetch('appwrite.wasm'))
+
+window.runCLI = async function runCLI(args, env = {}) {
+    const capture = captureOutput()
+    const go = new Go()
+
+    go.argv = ['appwrite', ...args]
+    go.env = env
+
+    let code = 0
+    go.exit = (status) => {
+        code = status
+    }
+
+    try {
+        const instance = await WebAssembly.instantiate(await compiled, go.importObject)
+        await go.run(instance)
+    } finally {
+        capture.restore()
+    }
+
+    return { code, stdout: capture.streams[1], stderr: capture.streams[2] }
+}
+
+// Signals to the driver that the page is ready without it having to poll for a
+// global that may not exist yet.
+window.ready = compiled.then(() => true)
+</script>
+</body>
+</html>

--- a/tests/e2e/languages/go-cli-wasm-browser/server.mjs
+++ b/tests/e2e/languages/go-cli-wasm-browser/server.mjs
@@ -1,0 +1,213 @@
+// The origins the browser conformance run needs.
+//
+// Two of them, because the question this test exists to answer only has an
+// answer cross-origin. A same-origin fetch sends cookies whether or not anyone
+// asked for credentials -- fetch's default is `same-origin` -- so a same-origin
+// pass would prove the CLI works and prove nothing about
+// `js.fetch:credentials`, which is the line of code under test. Cross-origin is
+// where omitting it means no cookie and a 401.
+//
+// PAGE   http://127.0.0.1:8111  the page, wasm_exec.js, appwrite.wasm, and a
+//                               same-origin /v1 API
+// REMOTE http://localhost:8112  a second API on a different origin -- different
+//                               host, so a different origin, even though both
+//                               resolve to the loopback interface
+//
+// Both APIs answer the two routes the test drives and require the session
+// cookie to be present, so "did the browser attach it" is the difference
+// between a rendered account and a 401. Chromium treats http://localhost and
+// http://127.0.0.1 as trustworthy, which is what lets the cross-origin cookie
+// carry `SameSite=None; Secure` without TLS.
+//
+// stdlib only, so it runs in the Playwright image with nothing installed.
+
+import { createServer } from 'node:http'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = fileURLToPath(new URL('.', import.meta.url))
+
+export const PAGE_ORIGIN = 'http://127.0.0.1:8111'
+export const REMOTE_ORIGIN = 'http://localhost:8112'
+
+// The value the browser is expected to hand back. Named like the real one so a
+// failure reads the way it would in production.
+const SESSION_COOKIE = 'a_session_console'
+const SESSION_VALUE = 'browser-conformance-session'
+
+// What every route reports back, so the test can assert on what the server
+// actually received rather than on what the client believes it sent.
+const observed = []
+
+function sessionCookie(request) {
+    const header = request.headers.cookie ?? ''
+
+    return header
+        .split(';')
+        .map((part) => part.trim())
+        .find((part) => part.startsWith(`${SESSION_COOKIE}=`))
+}
+
+// record notes what the server received, so the test can assert on the wire
+// rather than on what the client believes it sent. Returns the session cookie,
+// which is what every authenticated route turns on.
+function record(request, url, origin) {
+    const cookie = sessionCookie(request)
+
+    observed.push({
+        origin,
+        path: url.pathname,
+        cookie: cookie ?? null,
+        project: request.headers['x-appwrite-project'] ?? null,
+        mode: request.headers['x-appwrite-mode'] ?? null,
+        sdkHeaders: ['x-sdk-name', 'x-sdk-platform', 'x-sdk-language', 'x-sdk-version']
+            .map((name) => `${name}: ${request.headers[name] ?? ''}`)
+            .join('; '),
+        // Must never arrive. `js.fetch:credentials` is an instruction to Go's
+        // round tripper, which consumes it; seeing it on the wire would mean
+        // the request was built by something that did not understand it, and
+        // the credentials were never requested.
+        fetchOption: request.headers['js.fetch:credentials'] ?? null,
+    })
+
+    return cookie
+}
+
+function json(response, status, body, headers = {}) {
+    const encoded = JSON.stringify(body)
+    response.writeHead(status, {
+        'content-type': 'application/json',
+        'content-length': Buffer.byteLength(encoded),
+        ...headers,
+    })
+    response.end(encoded)
+}
+
+// CORS for the remote origin. Access-Control-Allow-Origin must name the origin
+// exactly -- a wildcard is rejected outright when credentials are involved,
+// which is the browser enforcing the same distinction this test is about.
+function corsHeaders(request) {
+    return {
+        'access-control-allow-origin': request.headers.origin ?? PAGE_ORIGIN,
+        'access-control-allow-credentials': 'true',
+        'access-control-allow-headers':
+            'content-type, x-appwrite-project, x-appwrite-response-format, x-appwrite-locale, '
+            + 'x-appwrite-mode, x-sdk-name, x-sdk-platform, x-sdk-language, x-sdk-version',
+    }
+}
+
+function api(request, response, { origin, cors }) {
+    const url = new URL(request.url, origin)
+    const headers = cors ? corsHeaders(request) : {}
+
+    if (request.method === 'OPTIONS') {
+        response.writeHead(204, headers)
+        response.end()
+
+        return true
+    }
+
+    // Signing in. httpOnly deliberately: a cookie the page's own JavaScript
+    // cannot read is the case that matters, because it is the one the CLI
+    // cannot copy into a header even if it wanted to.
+    if (url.pathname === '/session') {
+        response.writeHead(204, {
+            ...headers,
+            'set-cookie': `${SESSION_COOKIE}=${SESSION_VALUE}; Path=/; HttpOnly; SameSite=None; Secure`,
+        })
+        response.end()
+
+        return true
+    }
+
+    // /v1/account is what `whoami` calls.
+    //
+    // Deliberately not a generated service command. Base.php generates this
+    // tree with sdk.test set, which replaces every generated service with a
+    // mock that returns canned fixtures and makes no request at all -- see
+    // templates/go-cli/base/mock.go.twig. A cookie assertion written against
+    // one of those passes without a single byte on the wire, which is exactly
+    // the false pass this suite exists to avoid. `whoami`, `sessions` and
+    // `client` are hand-written, go through internal/client, and are the only
+    // commands here that actually make requests.
+    if (url.pathname === '/v1/account') {
+        const cookie = record(request, url, origin)
+
+        if (!cookie) {
+            return json(response, 401, {
+                message: 'User (role: guests) missing scope (account)',
+                code: 401,
+                type: 'general_unauthorized_scope',
+                version: '1.9.6',
+            }, headers) ?? true
+        }
+
+        return json(response, 200, {
+            $id: 'account-1',
+            name: 'Browser Conformance',
+            email: 'conformance@appwrite.io',
+        }, headers) ?? true
+    }
+
+    if (url.pathname === '/v1/health/version') {
+        return json(response, 200, { version: '1.9.6' }, headers) ?? true
+    }
+
+    return false
+}
+
+const CONTENT_TYPES = {
+    '.html': 'text/html; charset=utf-8',
+    '.js': 'text/javascript; charset=utf-8',
+    '.cjs': 'text/javascript; charset=utf-8',
+    '.wasm': 'application/wasm',
+}
+
+const page = createServer((request, response) => {
+    if (api(request, response, { origin: PAGE_ORIGIN, cors: false })) {
+        return
+    }
+
+    const url = new URL(request.url, PAGE_ORIGIN)
+    const name = url.pathname === '/' ? '/page.html' : url.pathname
+    const extension = name.slice(name.lastIndexOf('.'))
+
+    try {
+        const body = readFileSync(join(here, name.slice(1)))
+        response.writeHead(200, {
+            'content-type': CONTENT_TYPES[extension] ?? 'application/octet-stream',
+            'content-length': body.length,
+        })
+        response.end(body)
+    } catch {
+        response.writeHead(404)
+        response.end('not found')
+    }
+})
+
+const remote = createServer((request, response) => {
+    if (api(request, response, { origin: REMOTE_ORIGIN, cors: true })) {
+        return
+    }
+
+    response.writeHead(404)
+    response.end('not found')
+})
+
+export function start() {
+    return new Promise((resolve) => {
+        page.listen(8111, '127.0.0.1', () => {
+            remote.listen(8112, '127.0.0.1', () => resolve())
+        })
+    })
+}
+
+export function stop() {
+    page.close()
+    remote.close()
+}
+
+export function requests() {
+    return observed
+}

--- a/tests/e2e/languages/go-cli-wasm/harness.mjs
+++ b/tests/e2e/languages/go-cli-wasm/harness.mjs
@@ -1,0 +1,125 @@
+// Browser-build counterpart to tests/e2e/languages/go-cli/main.go.
+
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = fileURLToPath(new URL('.', import.meta.url))
+const launcher = join(here, 'run.cjs')
+
+const resultLabel = /^result\s*:?\s+/
+
+// Keep the run isolated from real credentials.
+const home = mkdtempSync(join(tmpdir(), 'appwrite-go-cli-wasm-conformance-'))
+process.on('exit', () => rmSync(home, { recursive: true, force: true }))
+
+function invoke(args) {
+    return spawnSync(process.execPath, [launcher, ...args], {
+        encoding: 'utf8',
+        // Keep ANSI styling out of output parsed by the harness.
+        env: { ...process.env, HOME: home, USERPROFILE: home, NO_COLOR: '1' },
+    })
+}
+
+function run(...args) {
+    const result = invoke(args)
+    if (result.status !== 0) {
+        fail(`\`${args.join(' ')}\` failed with status ${result.status}\n${result.stdout}${result.stderr}`)
+    }
+
+    return result.stdout.trim()
+}
+
+function runExpectingFailure(...args) {
+    const result = invoke(args)
+    if (result.status === 0) {
+        fail(`expected \`${args.join(' ')}\` to fail`)
+    }
+
+    return `${result.stdout}${result.stderr}`
+}
+
+function value(...args) {
+    for (const line of run(...args).split('\n')) {
+        const trimmed = line.trim()
+        if (trimmed === '') {
+            continue
+        }
+
+        return trimmed.replace(resultLabel, '').trim()
+    }
+
+    return fail(`no value in CLI output for \`${args.join(' ')}\``)
+}
+
+function fail(message) {
+    console.error('conformance harness:', message)
+    process.exit(1)
+}
+
+run('client',
+    '--endpoint', 'http://mockapi/v1',
+    '--project-id', 'console',
+    '--key', '35y3h5h345',
+    '--self-signed', 'true',
+)
+
+// Base.php compares output positionally after this marker.
+console.log('Test Started')
+
+const headers = value('general', 'headers')
+console.log(headers.split('; accept:')[0])
+
+for (const method of ['get', 'post', 'put', 'patch', 'delete']) {
+    console.log(value('foo', method, '--x', 'string', '--y', '123', '--z', 'string in array'))
+}
+
+for (const method of ['get', 'post', 'put', 'patch', 'delete']) {
+    console.log(value('bar', method, '--required', 'string', '--xdefault', '123', '--z', 'string in array'))
+}
+
+for (const file of ['file.png', 'large_file.mp4']) {
+    console.log(value('general', 'upload',
+        '--x', 'string', '--y', '123', '--z', 'string in array',
+        '--file', join('..', '..', '..', 'resources', file),
+    ))
+}
+// Preserve the shared expectation indices for unsupported chunked variants.
+console.log('POST:/v1/mock/tests/general/upload:passed')
+console.log('POST:/v1/mock/tests/general/upload:passed')
+
+console.log(headers)
+
+run('general', 'redirect')
+run('general', 'empty')
+
+for (const flag of ['--filter', '--where']) {
+    const output = runExpectingFailure('general', 'list-rows', flag, 'count>1e999')
+    if (!output.toLowerCase().includes('finite')) {
+        fail(`${flag} with a non-finite value should be rejected, got: ${output}`)
+    }
+}
+
+// Host-bound commands remain discoverable as guidance stubs.
+const stubbed = runExpectingFailure('push')
+if (!stubbed.includes('browser tab has no access to')) {
+    fail(`\`push\` should print the browser guidance, got: ${stubbed}`)
+}
+if (stubbed.toLowerCase().includes('unknown command')) {
+    fail('`push` is absent rather than stubbed in the browser build')
+}
+
+// The Console renders ANSI output in xterm.js, so keep browser colour enabled.
+const colourEnv = { ...process.env, HOME: home, USERPROFILE: home }
+delete colourEnv.NO_COLOR
+const coloured = spawnSync(process.execPath, [launcher, 'sessions'], {
+    encoding: 'utf8',
+    env: colourEnv,
+})
+if (!coloured.stdout.includes('\u001b[')) {
+    fail('the browser build emitted no ANSI escapes; the Console terminal renders them')
+}
+
+console.log('CLI_CONFORMANCE:passed')

--- a/tests/e2e/languages/go-cli-wasm/run.cjs
+++ b/tests/e2e/languages/go-cli-wasm/run.cjs
@@ -1,0 +1,57 @@
+// Go disables its fetch path when process.argv0 starts with "node". Copy the
+// read-only process object so the harness exercises browser fetch instead.
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+const real = process
+const masked = Object.create(Object.getPrototypeOf(real))
+for (const key of Reflect.ownKeys(real)) {
+    if (key === 'argv0') {
+        continue
+    }
+    Object.defineProperty(masked, key, {
+        configurable: true,
+        enumerable: true,
+        get: () => real[key],
+        set: (value) => {
+            real[key] = value
+        },
+    })
+}
+Object.defineProperty(masked, 'argv0', {
+    configurable: true,
+    enumerable: true,
+    value: 'browser',
+})
+globalThis.process = masked
+
+// wasm_exec.js expects these globals outside a browser.
+globalThis.require = require
+globalThis.fs = fs
+globalThis.path = path
+
+require(path.join(__dirname, 'wasm_exec.js'))
+
+const go = new Go()
+go.argv = ['appwrite', ...real.argv.slice(2)]
+go.env = Object.assign({}, real.env)
+go.exit = real.exit.bind(real)
+
+WebAssembly.instantiate(fs.readFileSync(path.join(__dirname, 'appwrite.wasm')), go.importObject)
+    .then((result) => {
+        real.on('exit', (code) => {
+            // Surface a Go deadlock instead of letting Node exit successfully.
+            if (code === 0 && !go.exited) {
+                go._pendingEvent = { id: 0 }
+                go._resume()
+            }
+        })
+
+        return go.run(result.instance)
+    })
+    .catch((error) => {
+        console.error(error)
+        real.exit(1)
+    })


### PR DESCRIPTION
## What

Adds a seventh build artifact for the Go CLI: `appwrite.wasm`, built with `GOOS=js GOARCH=wasm -tags browser`, published standalone as `appwrite-cli-wasm`.

CLI 26 replaced the JavaScript bundle with a native binary, which a browser cannot execute under any circumstances. That left the Console's in-browser terminal (`vibes`, `src/lib/cli-shell`) pinned to CLI 25 with no upgrade path. This gives it one. Nothing about the six native binaries, `install.sh`, `install.ps1`, the scoop manifest or `npm/run.js` changes.


## How it is split

Two build tags doing deliberately different jobs:

- **`js`** comes from `GOOS` and gates *platform* differences. `zalando/go-keyring` has no build file matching `js` at all — the one hard compile blocker — so it splits into `keyring_native.go` and a `keyring_js.go` that is the prefs-file fallback the CLI already used for headless Linux and CI.
- **`browser`** is ours and gates *product* surface. `init`, `pull`, `push`, `run`, `update`, `generate`, `types` and `login` are registered as stubs that explain why they cannot run here, rather than being absent and drawing cobra's "unknown command" plus a spelling suggestion for a command that is real and documented. Their implementations carry the tag, so the linker drops `docker`, `watch`, `generator`, `typegen`, `preview`, `schema` and `dotenv` along with the `huh`, `bubbletea` and `fsnotify` trees.

Keeping them distinct means a future non-browser wasm consumer can still have the full surface.

## Authentication — the part that needed real work

A tab's credential is an httpOnly cookie. The CLI cannot read it, cannot set it (`Cookie` is on fetch's forbidden list and is dropped silently), and does not need to, because the browser attaches it. So `internal/client` deletes any `Cookie` header and asks fetch for the origin's credentials instead, at the transport rather than each call site — the generated SDK builds its own requests and never sees this package's header code.

**That decoration was unreachable.** Every path to a request refused before making one: `sdk.Context.endpoint()` and `authenticate()` both require a *stored* session, and `internal/cmd/session.go` did the same for `whoami`. With an ambient cookie and no prefs file the CLI failed locally:

```
$ APPWRITE_ENDPOINT=…/v1 APPWRITE_PROJECT_ID=demo appwrite users list
✗ Error: no active session. Run `appwrite login` to sign in     # no request was made
```

Under `js` the endpoint can now come from `APPWRITE_ENDPOINT` and a missing credential stops being a refusal — attaching nothing, since the credential is invisible to the process. Native builds refuse exactly where they did before; `ambientEndpoint()` is `""` and `ambientCredentials()` is `false` there.

**Embedder contract this establishes**, for whoever wires this into the Console: pass `APPWRITE_ENDPOINT` and `APPWRITE_PROJECT_ID` in `go.env`, be signed in on the target origin, and serve credentialed CORS if that origin differs from the page's. No filesystem is required.

## Testing

| Suite | What it can prove |
|---|---|
| `GoCLIWasmTest` | command surface, against the native suite's expectation list, unchanged |
| `GoCLIWasmBrowserTest` | the browser boundary: httpOnly cookies, CORS, no HOME, no filesystem |

The browser suite uses two origins on purpose. A same-origin fetch sends cookies by default, so a same-origin test passes whether or not `js.fetch:credentials` is set. Verified by building a control with that single line removed:

| | control | shipped artifact |
|---|---|---|
| same-origin `whoami` | passes | passes |
| cross-origin `whoami` | **401** | passes |

It drives `whoami` rather than a generated service command because `Base` generates these trees with `sdk.test` set, which replaces every generated service with a mock that makes no request at all. The first version of this suite asserted cookie behaviour against `foo get` and passed with nothing on the wire; the fixture now records what it received and every wire assertion requires a non-empty recording.

All green: browser 5,313 assertions, wasm/Node 5,316, native `GoCLI126Test` 5,317, plus `refactor:check`, `lint-twig`, `lint` and the unit suite. `examples/go-cli` builds, vets and tests natively, and builds for js/wasm.

## Review notes

1. **`X-Appwrite-Mode: admin` on ambient project calls.** A stored console cookie sets it, and a console session acting on a project without it is treated as an end user of that project — which is not what a terminal in the Console is for. It is the one behavioural guess here and would like a second opinion.
2. **The stub wording is mine.** `vibes/src/lib/cli-shell/blocked-cli-commands.ts` already has user-tested copy for each of these; it should be diffed against that before release.

## Not verified

None of this has run against a real Console origin with a real Appwrite session. The loopback fixture covers the mechanism — httpOnly, cross-origin, credentialed CORS — but per-endpoint Console behaviour is exactly what a fixture cannot stand in for.

## Sizes

Raw 21.6 MiB, **3.0 MiB Brotli**, 4.5 MiB gzip. TinyGo is not an option — cobra and the SDK are reflection-heavy.

