### PR TITLE
Skip update notice for CLI update command

### DIFF
--- a/templates/cli/cli.ts.twig
+++ b/templates/cli/cli.ts.twig
@@ -24,6 +24,7 @@ import {
     createCompletionCommand,
     isCompletionCommand,
     isCompletionInvocation,
+    isTopLevelCommandInvocation,
 } from './lib/completions.js';
 
 import { client } from './lib/commands/generic.js';
@@ -125,7 +126,10 @@ if (process.argv.includes('-v') || process.argv.includes('--version')) {
     })();
 } else {
     void (async () => {
-        if (!isCompletionInvocation()) {
+        if (
+            !isCompletionInvocation() &&
+            !isTopLevelCommandInvocation('update')
+        ) {
             await maybeShowUpdateNotice();
         }
 

--- a/templates/cli/lib/completions.ts
+++ b/templates/cli/lib/completions.ts
@@ -479,7 +479,11 @@ function installCompletion(
 }
 
 export function isCompletionInvocation(): boolean {
-  return findTopLevelCommandArg(process.argv.slice(2)) === "completion";
+  return isTopLevelCommandInvocation("completion");
+}
+
+export function isTopLevelCommandInvocation(commandName: string): boolean {
+  return findTopLevelCommandArg(process.argv.slice(2)) === commandName;
 }
 
 function findTopLevelCommandArg(args: string[]): string | undefined {

--- a/templates/go-cli/internal/cmd/help_test.go
+++ b/templates/go-cli/internal/cmd/help_test.go
@@ -77,6 +77,25 @@ func TestHelpSectionsAppearInOrder(t *testing.T) {
 	}
 }
 
+func TestUpdateNoticeSkipsOnlyTheRootUpdateCommand(t *testing.T) {
+	root := &cobra.Command{Use: "appwrite"}
+	updateCommand := &cobra.Command{Use: "update"}
+	root.AddCommand(updateCommand)
+
+	if !isRootUpdateCommand(updateCommand) {
+		t.Error("the root update command would show a notice recommending itself")
+	}
+
+	service := &cobra.Command{Use: "service"}
+	serviceUpdate := &cobra.Command{Use: "update"}
+	root.AddCommand(service)
+	service.AddCommand(serviceUpdate)
+
+	if isRootUpdateCommand(serviceUpdate) {
+		t.Error("a nested command named update was mistaken for the CLI updater")
+	}
+}
+
 func TestHelpListsGroupedCommandsWithTheirSummaries(t *testing.T) {
 	root := NewRootCommand()
 	screen := RenderMainHelp(root)

--- a/templates/go-cli/internal/cmd/root.go.twig
+++ b/templates/go-cli/internal/cmd/root.go.twig
@@ -87,6 +87,12 @@ func NewRootCommand() *cobra.Command {
 // network once a day, because the whole point of this binary is that it starts
 // in single-digit milliseconds.
 func noticeUpdateAvailable(command *cobra.Command) {
+	// The update command is already acting on this information. Recommending
+	// that the user run it again only adds noise before the updater's output.
+	if isRootUpdateCommand(command) {
+		return
+	}
+
 	checker := app.UpdateChecker()
 	if checker == nil {
 		return
@@ -105,4 +111,8 @@ func noticeUpdateAvailable(command *cobra.Command) {
 	}
 
 	fmt.Fprint(writer, update.Notice(app.ExecutableName, app.Version, latest))
+}
+
+func isRootUpdateCommand(command *cobra.Command) bool {
+	return command.Name() == "update" && command.Parent() == command.Root()
 }

--- a/tests/e2e/languages/cli/test.js
+++ b/tests/e2e/languages/cli/test.js
@@ -38,7 +38,10 @@ const {
   resolveSkillSelection,
 } = require("./lib/utils.ts");
 const { EXECUTABLE_NAME } = require("./lib/constants.ts");
-const { isCompletionInvocation } = require("./lib/completions.ts");
+const {
+  isCompletionInvocation,
+  isTopLevelCommandInvocation,
+} = require("./lib/completions.ts");
 const {
   decodeIdToken,
   isAuthorizationPendingError,
@@ -369,6 +372,20 @@ if (withArgv(["--id", "completion"], isCompletionInvocation)) {
 
 if (!withArgv(["--id=foo", "completion"], isCompletionInvocation)) {
   throw new Error("Expected completion command after --id=foo to be detected.");
+}
+
+const isUpdateInvocation = () => isTopLevelCommandInvocation("update");
+
+if (!withArgv(["--json", "update"], isUpdateInvocation)) {
+  throw new Error(
+    "Expected the root update command to be detected after global flags.",
+  );
+}
+
+if (withArgv(["--id", "update"], isUpdateInvocation)) {
+  throw new Error(
+    "Expected --id update to be parsed as an id value, not the update command.",
+  );
 }
 
 const completionHome = fs.mkdtempSync(


### PR DESCRIPTION
## What changed

Generated Go and TypeScript CLIs now suppress the global update-available notice when the user is already running the root `update` command.

The Go CLI checks that the executing command is specifically the root updater, so a nested service command named `update` would continue to receive normal update notifications. The TypeScript CLI reuses its top-level argument parser, preserving correct handling when global flags precede the command or when `update` is a value passed to the variadic `--id` option.

All other commands continue to show the cached update notice as before.

## Before

```console
$ appwrite update

⚠️  A newer version is available: 26.0.0-rc.1 → 26.0.0-rc.2
💡 Run 'appwrite update' to update to the latest version.

Updating via npm...

changed 2 packages in 2s
Updated to version 26.0.0-rc.2.
```

The command recommended the same action the user was already performing.

## After

```console
$ appwrite update
Updating via npm...

changed 2 packages in 2s
Updated to version 26.0.0-rc.2.
```

## Verification

- Regenerated both `cli` and `go-cli` outputs.
- Generated Go CLI build, vet, and all tests pass.
- Go CLI Docker E2E passes with 5,047 assertions.
- Generated TypeScript CLI type-check and bundle pass.
- TypeScript CLI Docker E2E passes with 2,256 assertions.
- PHP unit tests pass with 125 assertions.
- Rector and all 591 Twig lint checks pass.
