### PR TITLE
Fix Go CLI positional argument validation

### DIFF
--- a/templates/go-cli/internal/cmd/pull.go
+++ b/templates/go-cli/internal/cmd/pull.go
@@ -50,6 +50,7 @@ func newPullCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "pull",
 		Short: "Pull your Appwrite project resources into appwrite.config.json",
+		Args:  cobra.NoArgs,
 		RunE: func(command *cobra.Command, args []string) error {
 			// The TypeScript's bare `pull` runs pullResources (pull.ts:1129),
 			// the same picker `pull all` used to reach -- it does not print

--- a/templates/go-cli/internal/cmd/pushcommon.go
+++ b/templates/go-cli/internal/cmd/pushcommon.go
@@ -430,6 +430,7 @@ func newPushCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "push",
 		Short: "Push your Appwrite project resources from appwrite.config.json",
+		Args:  cobra.NoArgs,
 		// Not Help(). The TypeScript's `push` has an action of its own
 		// (push.ts:4280) that pushes -- prompting for one resource, or
 		// everything under --all. Showing help instead made `push --all` a

--- a/templates/go-cli/internal/cmd/services/service.go.twig
+++ b/templates/go-cli/internal/cmd/services/service.go.twig
@@ -41,6 +41,10 @@ func New{{ service.name | caseUcfirst }}Command() *cobra.Command {
 		{{ serviceKeyFormat|format('Aliases:') }}[]string{"tables-db"},
 {% endif %}
 		{{ serviceKeyFormat|format('Short:') }}{{ service.description | default('') | stripMarkdown | goString | raw }},
+		{{ serviceKeyFormat|format('Args:') }}cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
 	}
 
 {% set seenCommands = [] %}
@@ -150,6 +154,7 @@ func new{{ service.name | caseUcfirst }}{{ method.name | caseUcfirst }}Command()
 {% if isTopLevel %}
 		{{ commandKeyFormat|format('Hidden:') }}true,
 {% endif %}
+		{{ commandKeyFormat|format('Args:') }}cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 {% set plan = getGoCallPlan(method, service) %}
 {% if sdk.test %}

--- a/templates/go-cli/internal/cmd/shorthand_test.go
+++ b/templates/go-cli/internal/cmd/shorthand_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -36,6 +37,32 @@ func TestNoCommandHasAShorthandCollision(t *testing.T) {
 	}
 
 	walk(root)
+}
+
+func TestNoArgCommandsRejectExtraArguments(t *testing.T) {
+	tests := [][]string{
+		{"users", "definitely-not-a-command"},
+		{"users", "list", "definitely-not-an-argument"},
+		{"pull", "definitely-not-a-command"},
+		{"push", "definitely-not-a-command"},
+	}
+
+	for _, args := range tests {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			root := NewRootCommand()
+			root.SetArgs(args)
+			root.SetOut(&bytes.Buffer{})
+			root.SetErr(&bytes.Buffer{})
+
+			err := root.Execute()
+			if err == nil {
+				t.Fatal("command accepted an unexpected positional argument")
+			}
+			if !strings.Contains(err.Error(), "unknown command") {
+				t.Fatalf("error = %q, want an unknown command error", err)
+			}
+		})
+	}
 }
 
 // commandPath is cobra's CommandPath without the binary name, which makes a


### PR DESCRIPTION
## What does this PR do?

Fixes generated Go CLI commands so unexpected positional arguments are rejected instead of being ignored.

- Adds `cobra.NoArgs` to generated service parent commands and leaf commands
- Keeps bare service parent commands showing help by adding a help `RunE`
- Adds `cobra.NoArgs` to `pull` and `push` parent commands
- Adds regression tests for generated service parents, generated leaf commands, `pull`, and `push`

Closes #1765

## Test Plan

- `php example.php go-cli`
- `cd examples/go-cli && go mod tidy && go test ./internal/cmd -count=1`
- `composer lint-twig`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Checklist

- [x] I regenerated the affected SDK output
- [x] I added or updated tests
- [x] I ran relevant tests and linters
