### PR TITLE
Fix Go CLI optional boolean flag rewrite

### DIFF
--- a/templates/go-cli/internal/cmd/flags.go
+++ b/templates/go-cli/internal/cmd/flags.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -38,11 +39,22 @@ func boolLiteral(token string) bool {
 	return err == nil
 }
 
-// booleanFlag returns the boolean flag a token names, or nil.
+// optionalBoolLiteral reports whether token can be a value for flag.
+func optionalBoolLiteral(flag *pflag.Flag, token string) bool {
+	if flag.Value.Type() == "bool" {
+		return boolLiteral(token)
+	}
+
+	_, err := parseFlagBool(token)
+
+	return err == nil
+}
+
+// optionalBooleanFlag returns the optional boolean flag a token names, or nil.
 //
 // A token that already carries `=` is left alone: pflag parses it correctly and
 // rewriting it would corrupt values containing an equals sign.
-func booleanFlag(command *cobra.Command, token string) *pflag.Flag {
+func optionalBooleanFlag(command *cobra.Command, token string) *pflag.Flag {
 	if strings.Contains(token, "=") {
 		return nil
 	}
@@ -67,11 +79,17 @@ func booleanFlag(command *cobra.Command, token string) *pflag.Flag {
 		return nil
 	}
 
-	if flag == nil || flag.Value.Type() != "bool" {
+	if flag == nil {
 		return nil
 	}
+	if flag.Value.Type() == "bool" {
+		return flag
+	}
+	if flag.Value.Type() == "string" && flag.NoOptDefVal != "" {
+		return flag
+	}
 
-	return flag
+	return nil
 }
 
 // RewriteBooleanValues joins `--flag value` into `--flag=value` for boolean
@@ -97,18 +115,34 @@ func RewriteBooleanValues(root *cobra.Command, args []string) []string {
 			break
 		}
 
-		if index+1 < len(args) && boolLiteral(args[index+1]) &&
-			booleanFlag(target, token) != nil {
-			rewritten = append(rewritten, token+"="+args[index+1])
-			index++
+		if index+1 < len(args) {
+			flag := optionalBooleanFlag(target, token)
+			if flag != nil && optionalBoolLiteral(flag, args[index+1]) {
+				rewritten = append(rewritten, token+"="+args[index+1])
+				index++
 
-			continue
+				continue
+			}
 		}
 
 		rewritten = append(rewritten, token)
 	}
 
 	return rewritten
+}
+
+// parseFlagBool reads a boolean flag value.
+//
+// A bare optional boolean is true; anything else has to say so.
+func parseFlagBool(value string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "true", "1", "yes", "y":
+		return true, nil
+	case "false", "0", "no", "n":
+		return false, nil
+	}
+
+	return false, fmt.Errorf("invalid boolean value %q", value)
 }
 
 // negatableBool registers name (defaulting on) together with its `--no-name`

--- a/templates/go-cli/internal/cmd/flags_test.go
+++ b/templates/go-cli/internal/cmd/flags_test.go
@@ -88,7 +88,7 @@ func TestBooleanFlagTakesASpaceSeparatedValue(t *testing.T) {
 		{"--verified=false"},
 		{"-v", "false"},
 	} {
-		verified, root := booleanCommand()
+		verified, _, root := booleanCommand()
 
 		root.SetArgs(RewriteBooleanValues(root, append([]string{"probe"}, spelling...)))
 		if err := root.Execute(); err != nil {
@@ -100,10 +100,25 @@ func TestBooleanFlagTakesASpaceSeparatedValue(t *testing.T) {
 	}
 }
 
+// `push site --activate true` is registered as a string optional flag because
+// it accepts commander's yes/no forms. It still needs the same rewrite, or true
+// is rejected as a stray positional argument.
+func TestStringOptionalBooleanFlagTakesASpaceSeparatedValue(t *testing.T) {
+	_, activate, root := booleanCommand()
+
+	root.SetArgs(RewriteBooleanValues(root, []string{"probe", "--activate", "yes"}))
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if *activate != "yes" {
+		t.Errorf("activate = %q", *activate)
+	}
+}
+
 // The bare spelling still means true -- that is what NoOptDefVal is for, and
 // commander's `--flag [value]` behaves the same way.
 func TestBareBooleanFlagIsStillTrue(t *testing.T) {
-	verified, root := booleanCommand()
+	verified, _, root := booleanCommand()
 
 	root.SetArgs(RewriteBooleanValues(root, []string{"probe", "--verified"}))
 	if err := root.Execute(); err != nil {
@@ -117,7 +132,7 @@ func TestBareBooleanFlagIsStillTrue(t *testing.T) {
 // Only a boolean literal is claimed. A path following a boolean flag is a
 // positional argument, and joining it would break `types --strict ./out`.
 func TestBooleanRewriteLeavesPositionalsAlone(t *testing.T) {
-	_, root := booleanCommand()
+	_, _, root := booleanCommand()
 
 	got := RewriteBooleanValues(root, []string{"probe", "--verified", "./out"})
 	want := []string{"probe", "--verified", "./out"}
@@ -130,7 +145,7 @@ func TestBooleanRewriteLeavesPositionalsAlone(t *testing.T) {
 // A non-boolean flag's value must never be joined, or `--name false` would
 // become a flag nobody registered.
 func TestBooleanRewriteIgnoresNonBooleanFlags(t *testing.T) {
-	_, root := booleanCommand()
+	_, _, root := booleanCommand()
 
 	got := RewriteBooleanValues(root, []string{"probe", "--name", "false"})
 	if len(got) != 3 || got[1] != "--name" || got[2] != "false" {
@@ -140,7 +155,7 @@ func TestBooleanRewriteIgnoresNonBooleanFlags(t *testing.T) {
 
 // Everything after `--` is positional, including a word that looks like a flag.
 func TestBooleanRewriteStopsAtTheTerminator(t *testing.T) {
-	_, root := booleanCommand()
+	_, _, root := booleanCommand()
 
 	got := RewriteBooleanValues(root, []string{"probe", "--", "--verified", "false"})
 	if len(got) != 4 || got[2] != "--verified" || got[3] != "false" {
@@ -150,9 +165,10 @@ func TestBooleanRewriteStopsAtTheTerminator(t *testing.T) {
 
 // booleanCommand builds a root with one subcommand carrying an optional
 // boolean, registered the way the generated service commands register theirs.
-func booleanCommand() (*bool, *cobra.Command) {
+func booleanCommand() (*bool, *string, *cobra.Command) {
 	var (
 		verified bool
+		activate string
 		name     string
 	)
 
@@ -163,12 +179,14 @@ func booleanCommand() (*bool, *cobra.Command) {
 	}
 	probe.Flags().BoolVarP(&verified, "verified", "v", false, "Verified")
 	probe.Flags().Lookup("verified").NoOptDefVal = "true"
+	probe.Flags().StringVar(&activate, "activate", "", "Activate")
+	probe.Flags().Lookup("activate").NoOptDefVal = "true"
 	probe.Flags().StringVar(&name, "name", "", "Name")
 
 	root := &cobra.Command{Use: "appwrite", SilenceUsage: true, SilenceErrors: true}
 	root.AddCommand(probe)
 
-	return &verified, root
+	return &verified, &activate, root
 }
 
 func negatableCommand(code *bool) *cobra.Command {

--- a/templates/go-cli/internal/cmd/pushdeploy.go
+++ b/templates/go-cli/internal/cmd/pushdeploy.go
@@ -605,20 +605,6 @@ func newPushDeployableCommand(resource deployable) *cobra.Command {
 	return command
 }
 
-// parseFlagBool reads the value of `--activate [value]`.
-//
-// A bare `--activate` is true; anything else has to say so.
-func parseFlagBool(value string) (bool, error) {
-	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "", "true", "1", "yes", "y":
-		return true, nil
-	case "false", "0", "no", "n":
-		return false, nil
-	}
-
-	return false, fmt.Errorf("invalid boolean value %q", value)
-}
-
 func runPushDeployable(
 	command *cobra.Command,
 	resource deployable,


### PR DESCRIPTION
## What does this PR do?

Fixes Go CLI compatibility for optional boolean flags registered as string flags, specifically `appwrite push <deployable> --activate true`.

The Go CLI already rewrites space-separated boolean flag values before pflag parses them, but it only recognized native bool flags. `push --activate` is string-backed so it can accept the TypeScript CLI boolean forms (`yes`/`no`), which meant `true` was left as a positional argument and rejected by push argument validation.

Before this PR, the space-separated form failed:

```sh
appwrite push site --activate true
```

```text
`appwrite push site` takes no arguments except `all`, and was given `true`.
Run `appwrite push site all` to push every one, or `appwrite push site` on its own to choose from a list
```

Only the equals form worked:

```sh
appwrite push site --activate=true
```

After this PR, both forms work:

```sh
appwrite push site --activate true
appwrite push site --activate=true
```

This updates the rewrite to also handle optional string flags with `NoOptDefVal`, and shares `parseFlagBool` between the rewrite and push deploy parsing.

## Test Plan

- `php example.php go-cli`
- `cd examples/go-cli && go test -mod=mod ./...`

## Related Issue

#XXXX
