### PR TITLE
perf(go): avoid JSON response string copies

### DIFF
--- a/templates/go/base/requests/api.twig
+++ b/templates/go/base/requests/api.twig
@@ -3,7 +3,10 @@
 		return nil, err
 	}
 	if strings.HasPrefix(resp.Type, "application/json") {
-		bytes := []byte(resp.Result.(string))
+		bytes, err := client.ResponseBody(resp)
+		if err != nil {
+			return nil, err
+		}
 
 {%~ if method | returnType(spec, spec.title | caseLower) == 'models.Model' %}
 {% set hasResponseDiscriminator = method.responseDiscriminator is defined and method.responseDiscriminator is not empty %}

--- a/templates/go/base/requests/file.twig
+++ b/templates/go/base/requests/file.twig
@@ -17,18 +17,22 @@
 		return nil, err
 	}
 	if strings.HasPrefix(resp.Type, "application/json") {
+		bytes, err := client.ResponseBody(resp)
+		if err != nil {
+			return nil, err
+		}
 {% if method | returnType(spec, spec.title | caseLower) == 'models.Model' %}
 {% set hasResponseDiscriminator = method.responseDiscriminator is defined and method.responseDiscriminator is not empty %}
 {% set responseDiscriminator = method.responseDiscriminator ?? {} %}
 {% if hasResponseDiscriminator %}
 		var response map[string]interface{}
-		if err := json.Unmarshal([]byte(resp.Result.(string)), &response); err != nil {
+		if err := json.Unmarshal(bytes, &response); err != nil {
 			return nil, err
 		}
 {% for modelName, conditions in responseDiscriminator %}
 		if {% for field, expectedValue in conditions %}fmt.Sprint(response["{{ field }}"]) == "{{ expectedValue }}"{% if not loop.last %} && {% endif %}{% endfor %} {
-			parsed := models.{{ modelName | caseUcfirst }}{}.New([]byte(resp.Result.(string)))
-			if err := json.Unmarshal([]byte(resp.Result.(string)), parsed); err != nil {
+			parsed := models.{{ modelName | caseUcfirst }}{}.New(bytes)
+			if err := json.Unmarshal(bytes, parsed); err != nil {
 				return nil, err
 			}
 			return parsed, nil
@@ -36,15 +40,15 @@
 {% endfor %}
 		return nil, errors.New("unable to match response to any expected response model")
 {% else %}
-		parsed := models.{{ method.responseModel | caseUcfirst }}{}.New([]byte(resp.Result.(string)))
-		if err := json.Unmarshal([]byte(resp.Result.(string)), parsed); err != nil {
+		parsed := models.{{ method.responseModel | caseUcfirst }}{}.New(bytes)
+		if err := json.Unmarshal(bytes, parsed); err != nil {
 			return nil, err
 		}
 		return parsed, nil
 {% endif %}
 {% else %}
 		var parsed {{ method | returnType(spec, spec.title | caseLower) }}
-		err = json.Unmarshal([]byte(resp.Result.(string)), &parsed)
+		err = json.Unmarshal(bytes, &parsed)
 		if err != nil {
 			return nil, err
 		}

--- a/templates/go/client.go.twig
+++ b/templates/go/client.go.twig
@@ -243,10 +243,8 @@ func (client *Client) FileUpload(url string, headers map[string]interface{}, par
 		if err == nil {
 			result = resp
 			var result map[string]interface{}
-			if resStr, ok := resp.Result.(string); ok {
-				_ = json.Unmarshal([]byte(resStr), &result)
-			} else {
-				result, _ = resp.Result.(map[string]interface{})
+			if body, bodyErr := ResponseBody(resp); bodyErr == nil {
+				_ = json.Unmarshal(body, &result)
 			}
 			if result != nil && result["chunksUploaded"] != nil {
 				currentChunk = int64(result["chunksUploaded"].(float64))
@@ -272,9 +270,12 @@ func (client *Client) FileUpload(url string, headers map[string]interface{}, par
 
 		var parsed map[string]interface{}
 		if strings.HasPrefix(result.Type, "application/json") {
-			err = json.Unmarshal([]byte(result.Result.(string)), &parsed)
-			if err == nil {
-				uploadId, _ = parsed["$id"].(string)
+			body, bodyErr := ResponseBody(result)
+			if bodyErr == nil {
+				err = json.Unmarshal(body, &parsed)
+				if err == nil {
+					uploadId, _ = parsed["$id"].(string)
+				}
 			}
 		}
 
@@ -284,9 +285,12 @@ func (client *Client) FileUpload(url string, headers map[string]interface{}, par
 	parseUploadId := func(resp *ClientResponse) string {
 		var parsed map[string]interface{}
 		if resp != nil && strings.HasPrefix(resp.Type, "application/json") {
-			if unmarshalErr := json.Unmarshal([]byte(resp.Result.(string)), &parsed); unmarshalErr == nil {
-				id, _ := parsed["$id"].(string)
-				return id
+			body, bodyErr := ResponseBody(resp)
+			if bodyErr == nil {
+				if unmarshalErr := json.Unmarshal(body, &parsed); unmarshalErr == nil {
+					id, _ := parsed["$id"].(string)
+					return id
+				}
 			}
 		}
 		return ""
@@ -298,10 +302,8 @@ func (client *Client) FileUpload(url string, headers map[string]interface{}, par
 		}
 
 		var parsed map[string]interface{}
-		if resStr, ok := resp.Result.(string); ok {
-			_ = json.Unmarshal([]byte(resStr), &parsed)
-		} else {
-			parsed, _ = resp.Result.(map[string]interface{})
+		if body, bodyErr := ResponseBody(resp); bodyErr == nil {
+			_ = json.Unmarshal(body, &parsed)
 		}
 		if parsed == nil || parsed["chunksUploaded"] == nil {
 			return false
@@ -574,7 +576,7 @@ func (client *Client) Call(method string, path string, headers map[string]interf
 			Status:     resp.Status,
 			StatusCode: resp.StatusCode,
 			Header:     resp.Header,
-			Result:     string(responseData),
+			Result:     responseData,
 			Type:	   contentType,
 		}, nil
 	}
@@ -593,6 +595,22 @@ func (client *Client) Call(method string, path string, headers map[string]interf
 		Result:     responseData,
 		Type:	   contentType,
 	}, nil
+}
+
+// ResponseBody returns the raw response body bytes.
+func ResponseBody(resp *ClientResponse) ([]byte, error) {
+	if resp == nil {
+		return nil, errors.New("response is nil")
+	}
+
+	switch body := resp.Result.(type) {
+	case []byte:
+		return body, nil
+	case string:
+		return []byte(body), nil
+	default:
+		return nil, errors.New("unexpected response body type")
+	}
 }
 
 // AddQueryParam writes one query parameter into q.


### PR DESCRIPTION
## What does this PR do?

Avoids an extra string copy for successful JSON responses in the generated Go SDK.

```text
before: []byte response -> string copy -> []byte copy -> json.Unmarshal
after:  []byte response ----------------> json.Unmarshal
```

`client.Call()` now keeps JSON response bodies as `[]byte`. Generated service parsers read them through `client.ResponseBody()`, which keeps a string fallback for compatibility with manual `ClientResponse` values.

## Test Plan

```text
php example.php go
cd examples/go && go test ./...
composer lint-twig
```

## Related PRs and Issues

- N/A

## Checklist

- [ ] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [ ] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs?
