### PR TITLE
Fix Go CLI generated query flags

### DIFF
--- a/src/SDK/Language/GoCLI.php
+++ b/src/SDK/Language/GoCLI.php
@@ -701,6 +701,11 @@ class GoCLI extends Go
                 'template'      => 'go-cli/internal/app/flags.go',
             ],
             [
+                'scope'         => 'copy',
+                'destination'   => 'internal/app/flags_test.go',
+                'template'      => 'go-cli/internal/app/flags_test.go',
+            ],
+            [
                 'scope'         => 'default',
                 'destination'   => 'internal/app/version.go',
                 'template'      => 'go-cli/internal/app/version.go.twig',

--- a/templates/go-cli/internal/app/flags.go
+++ b/templates/go-cli/internal/app/flags.go
@@ -25,3 +25,16 @@ func FlagString(command *cobra.Command, name string, value string) *string {
 
 	return &value
 }
+
+// AnyFlagChanged reports whether any registered flag in names was set by the
+// user. Unknown names are ignored so generated call sites can share one query
+// flag list across commands with different query surfaces.
+func AnyFlagChanged(command *cobra.Command, names ...string) bool {
+	for _, name := range names {
+		if flag := command.Flags().Lookup(name); flag != nil && command.Flags().Changed(name) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/templates/go-cli/internal/app/flags_test.go
+++ b/templates/go-cli/internal/app/flags_test.go
@@ -1,0 +1,49 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestAnyFlagChangedReturnsTrueForChangedFlag(t *testing.T) {
+	command := queryFlagCommand()
+	command.SetArgs([]string{"--filter", "title=Bulk One"})
+
+	if err := command.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !AnyFlagChanged(command, "queries", "filter", "missing") {
+		t.Error("expected changed --filter to be reported")
+	}
+}
+
+func TestAnyFlagChangedReturnsFalseWhenOnlyUnknownFlagsAreNamed(t *testing.T) {
+	command := queryFlagCommand()
+	command.SetArgs([]string{"--filter", "title=Bulk One"})
+
+	if err := command.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if AnyFlagChanged(command, "missing") {
+		t.Error("unknown flags should be ignored")
+	}
+}
+
+func queryFlagCommand() *cobra.Command {
+	var filter []string
+	var queries []string
+
+	command := &cobra.Command{
+		Use: "probe",
+		RunE: func(command *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+	command.Flags().StringArrayVar(&filter, "filter", nil, "Filter")
+	command.Flags().StringArrayVar(&queries, "queries", nil, "Queries")
+
+	return command
+}

--- a/templates/go-cli/internal/cmd/services/service.go.twig
+++ b/templates/go-cli/internal/cmd/services/service.go.twig
@@ -240,9 +240,15 @@ func new{{ service.name | caseUcfirst }}{{ method.name | caseUcfirst }}Command()
 			// TypeScript passes undefined and the SDK drops it.
 			options := []{{ plan.package }}.{{ plan.optionType }}{}
 {% for option in plan.optional %}
+{% if option.flag == 'queries' and query.hasQueries %}
+			if app.AnyFlagChanged(cmd, "queries", "filter", "where", "sort-asc", "sort-desc", "limit", "offset", "cursor-after", "cursor-before", "select") {
+				options = append(options, service.{{ option.setter }}({{ option.expression }}))
+			}
+{% else %}
 			if cmd.Flags().Changed("{{ option.flag }}") {
 				options = append(options, service.{{ option.setter }}({{ option.expression }}))
 			}
+{% endif %}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
## What changed

Fixes #1762.

The generated Go CLI now treats any generated query flag as a reason to pass the built `queries` option into the SDK call, not only raw `--queries`.

```text
before: --filter title=Bulk One -> queries built -> With*Queries omitted
after:  --filter title=Bulk One -> queries built -> With*Queries sent
```

## Why

Bulk commands like `tablesdb update-rows` and `delete-rows` parsed `--filter`, but then silently dropped the resulting query list because only `cmd.Flags().Changed("queries")` gated the SDK option.

## Tests

```text
php example.php go-cli
composer lint-twig
composer refactor:check
cd examples/go-cli && go build -mod=mod ./... && go vet ./... && go test ./...
```
