### PR TITLE
Fix CLI login endpoint and logout messaging

### DIFF
--- a/templates/cli/lib/auth/login.ts
+++ b/templates/cli/lib/auth/login.ts
@@ -558,7 +558,7 @@ export const loginCommand = async ({
   }
 
   const configEndpoint = normalizeCloudConsoleEndpoint(
-    (endpoint ?? globalConfig.getEndpoint()) || DEFAULT_ENDPOINT,
+    endpoint || DEFAULT_ENDPOINT,
   );
 
   if (endpoint && isRegionalCloudEndpoint(endpoint)) {
@@ -605,7 +605,9 @@ export const loginCommand = async ({
       }
 
       if (!email && !password && !endpoint && !switchAccount && !newAccount) {
-        success("Already logged in as " + account.email);
+        success(
+          `Already logged in as ${account.email} (${globalConfig.getEndpoint()})`,
+        );
         hint(`Use '${EXECUTABLE_NAME} login --new' to add another account`);
         return;
       }

--- a/templates/cli/lib/commands/generic.ts
+++ b/templates/cli/lib/commands/generic.ts
@@ -62,6 +62,28 @@ const hintSignedInAccounts = (): void => {
   log(`Run '${EXECUTABLE_NAME} login --switch' to select one.`);
 };
 
+const formatSessionLabel = (session: {
+  id?: string;
+  email?: string;
+  endpoint?: string;
+}): string => {
+  const who = session.email || session.id || "unknown session";
+  return session.endpoint ? `${who} (${session.endpoint})` : who;
+};
+
+const announceActiveSession = (): void => {
+  const currentSession = globalConfig
+    .getSessions()
+    .find((session) => session.id === globalConfig.getCurrentSession());
+
+  if (currentSession?.email) {
+    log(`Now using ${formatSessionLabel(currentSession)}.`);
+    return;
+  }
+
+  log("No active session.");
+};
+
 const warnDetachedAuthenticatedSession = (previousSessionId: string): void => {
   if (!previousSessionId || !isAuthenticatedSession(previousSessionId)) {
     return;
@@ -172,7 +194,8 @@ export const logout = new Command("logout")
         } else {
           globalConfig.setCurrentSession("");
         }
-        success(logMessages.logoutSuccess);
+        success(`Signed out of ${formatSessionLabel(accounts[0])}.`);
+        announceActiveSession();
 
         return;
       }
@@ -204,15 +227,23 @@ export const logout = new Command("logout")
           remainingSessions[0];
         globalConfig.setCurrentSession(nextSession.id);
 
-        if (!logoutFailed && nextSession.email) {
-          success(`Switched to ${nextSession.email}`);
-        }
       } else if (remainingSessions.length === 0) {
         globalConfig.setCurrentSession("");
       }
 
       if (!logoutFailed) {
-        success(logMessages.logoutSuccess);
+        const signedOutAccounts = accounts.filter((account) =>
+          (answers.accounts as string[] | undefined)?.includes(account.id),
+        );
+        if (signedOutAccounts.length > 0) {
+          success(`Signed out of ${signedOutAccounts.length} account(s):`);
+          for (const account of signedOutAccounts) {
+            log(`  ${formatSessionLabel(account)}`);
+          }
+        } else {
+          success(logMessages.logoutSuccess);
+        }
+        announceActiveSession();
       }
     }),
   );

--- a/templates/go-cli/internal/cmd/login.go
+++ b/templates/go-cli/internal/cmd/login.go
@@ -92,14 +92,7 @@ func runLogin(command *cobra.Command, options loginOptions) error {
 		return switchAccount(command, global, previous, options.Endpoint, options.Email)
 	}
 
-	endpoint := options.Endpoint
-	if endpoint == "" {
-		endpoint = global.CurrentValue(config.PreferenceEndpoint)
-	}
-	if endpoint == "" {
-		endpoint = config.DefaultEndpoint
-	}
-	configEndpoint := config.NormalizeCloudConsoleEndpoint(endpoint)
+	configEndpoint := resolveLoginEndpoint(options.Endpoint)
 
 	if options.Endpoint != "" && config.IsRegionalCloudEndpoint(options.Endpoint) {
 		output.Warn(out, "Regional Cloud endpoints are for project API calls, so "+
@@ -133,7 +126,8 @@ func runLogin(command *cobra.Command, options loginOptions) error {
 			// rather than starting a flow they did not ask for.
 			if options.Email == "" && options.Password == "" &&
 				options.Endpoint == "" && !options.Switch {
-				output.Success(out, "Already logged in as %s", account.GetString("email"))
+				output.Success(out, "Already logged in as %s (%s)",
+					account.GetString("email"), global.CurrentValue(config.PreferenceEndpoint))
 				output.Hint(out, "Use '%s login --new' to add another account",
 					app.ExecutableName)
 
@@ -512,6 +506,14 @@ func isInvalidCredentials(err error) bool {
 
 // loginWithDevice signs in through the browser. Ports loginWithOAuthDevice
 // (login.ts:333).
+func resolveLoginEndpoint(endpoint string) string {
+	if endpoint == "" {
+		endpoint = config.DefaultEndpoint
+	}
+
+	return config.NormalizeCloudConsoleEndpoint(endpoint)
+}
+
 func loginWithDevice(command *cobra.Command, endpoint string) error {
 	global, err := preferences()
 	if err != nil {

--- a/templates/go-cli/internal/cmd/login_test.go
+++ b/templates/go-cli/internal/cmd/login_test.go
@@ -144,6 +144,27 @@ func TestSwitchWithoutSelectorsIsActionableWhenHeadless(t *testing.T) {
 
 // Cloud sign-in happens in a browser, so an email and password given for it
 // would be silently ignored. Saying so beats appearing to accept them.
+func TestLoginDefaultsToProductionCloudEvenWhenAnotherEndpointIsCurrent(t *testing.T) {
+	preferencesWith(t, `{
+  "current": "staging",
+  "staging": {
+    "endpoint": "https://cloud.staging.appwrite.io/v1",
+    "email": "a@example.com",
+    "accessToken": "token"
+  }
+}`)
+
+	if got := resolveLoginEndpoint(""); got != "https://cloud.appwrite.io/v1" {
+		t.Errorf("endpoint = %q, want production Cloud", got)
+	}
+}
+
+func TestLoginHonorsExplicitEndpoint(t *testing.T) {
+	if got := resolveLoginEndpoint("https://cloud.staging.appwrite.io/v1"); got != "https://cloud.staging.appwrite.io/v1" {
+		t.Errorf("endpoint = %q, want the explicit endpoint", got)
+	}
+}
+
 func TestLoginRejectsPasswordOptionsAgainstCloud(t *testing.T) {
 	err := runLogin(newLoginCommand(), loginOptions{
 		Endpoint: "https://cloud.appwrite.io/v1",

--- a/templates/go-cli/internal/cmd/logout_test.go
+++ b/templates/go-cli/internal/cmd/logout_test.go
@@ -124,6 +124,26 @@ func TestLogoutRevokesEachSessionAtItsOwnEndpoint(t *testing.T) {
 	}
 }
 
+func TestLogoutSessionLabelsShowAccountAndEndpoint(t *testing.T) {
+	session := config.Session{
+		ID:       "session-id",
+		Email:    "person@example.com",
+		Endpoint: "https://cloud.appwrite.io/v1",
+	}
+
+	if got := formatSessionLabel(session); got != "person@example.com (https://cloud.appwrite.io/v1)" {
+		t.Errorf("label = %q", got)
+	}
+}
+
+func TestLogoutSessionLabelsFallbackToID(t *testing.T) {
+	session := config.Session{ID: "session-id"}
+
+	if got := formatSessionLabel(session); got != "session-id" {
+		t.Errorf("label = %q", got)
+	}
+}
+
 // preferencesWith writes a prefs file and loads it, with HOME pointed at a
 // temporary directory so the real one is never touched.
 func preferencesWith(t *testing.T, contents string) *config.Global {

--- a/templates/go-cli/internal/cmd/session.go
+++ b/templates/go-cli/internal/cmd/session.go
@@ -223,6 +223,11 @@ func newLogoutCommand() *cobra.Command {
 				return nil
 			}
 
+			// Capture labels before revocation deletes the local entries. Without
+			// them, logout can only say a count, and users cannot tell which account
+			// was removed or which remaining account became active.
+			signedOutSessions := sessionsForIDs(global, targets)
+
 			// Revoked at the server first. Deleting the local entry alone
 			// left the credential working until it expired on its own.
 			result := logoutSessions(global, targets)
@@ -231,7 +236,16 @@ func newLogoutCommand() *cobra.Command {
 			}
 
 			if len(result.SignedOut) > 0 {
-				command.Printf("Signed out of %d session(s).\n", len(result.SignedOut))
+				command.Printf("Signed out of %d session(s):\n", len(result.SignedOut))
+				for _, session := range sessionsForIDsFromList(signedOutSessions, result.SignedOut) {
+					command.Printf("  %s\n", formatSessionLabel(session))
+				}
+
+				if current, ok := global.Session(global.CurrentSessionID()); ok {
+					command.Printf("Now using:\n  %s\n", formatSessionLabel(current))
+				} else if !app.Flags().All {
+					command.Println("No active session.")
+				}
 			}
 			if len(result.Failed) > 0 {
 				// Kept, not removed: a live server session with no local record
@@ -244,6 +258,47 @@ func newLogoutCommand() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func sessionsForIDs(global *config.Global, ids []string) []config.Session {
+	sessions := make([]config.Session, 0, len(ids))
+	for _, id := range ids {
+		if session, ok := global.Session(id); ok {
+			sessions = append(sessions, session)
+		}
+	}
+
+	return sessions
+}
+
+func sessionsForIDsFromList(sessions []config.Session, ids []string) []config.Session {
+	byID := make(map[string]config.Session, len(sessions))
+	for _, session := range sessions {
+		byID[session.ID] = session
+	}
+
+	matched := make([]config.Session, 0, len(ids))
+	for _, id := range ids {
+		if session, ok := byID[id]; ok {
+			matched = append(matched, session)
+		}
+	}
+
+	return matched
+}
+
+func formatSessionLabel(session config.Session) string {
+	parts := []string{}
+	if session.Email != "" {
+		parts = append(parts, session.Email)
+	} else {
+		parts = append(parts, session.ID)
+	}
+	if session.Endpoint != "" {
+		parts = append(parts, "("+session.Endpoint+")")
+	}
+
+	return strings.Join(parts, " ")
 }
 
 // bannerStyle is the dim grey the CLI uses for context lines.


### PR DESCRIPTION
## What

Fixes two CLI auth UX issues:

- `logout` now names the account/endpoint that was signed out and the account that is active afterwards.
- `login` / `login --new` no longer inherit the currently configured endpoint; they default to production Cloud unless `--endpoint` is passed.

```text
before: appwrite login --new -> uses current endpoint, e.g. cloud.staging.appwrite.io
after:  appwrite login --new -> uses https://cloud.appwrite.io/v1
        appwrite login --new --endpoint <url> -> uses explicit endpoint
```

```text
before: Signed out of 1 session(s).
after:  Signed out of 1 session(s):
          user@example.com (https://cloud.staging.appwrite.io/v1)
        Now using:
          other@example.com (https://cloud.appwrite.io/v1)
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor

## Testing

```text
php example.php go-cli
php example.php cli
cd examples/go-cli && go build -mod=mod ./... && go test -mod=mod ./...
cd examples/cli && npm run build
composer lint-twig
```
