### PR TITLE
Fix GraphQL JSON output filtering

### DIFF
--- a/templates/cli/lib/parser.ts
+++ b/templates/cli/lib/parser.ts
@@ -265,7 +265,36 @@ const applyDisplayFilter = (rows: JsonObject[]): JsonObject[] => {
   });
 };
 
+const GRAPHQL_RESPONSE_KEYS = new Set(["data", "errors", "extensions"]);
+
+const isGraphQLResponseObject = (value: unknown): boolean => {
+  const object = toJsonObject(value);
+  if (!object) return false;
+
+  const keys = Object.keys(object).filter(
+    (key) => typeof object[key] !== "function",
+  );
+
+  return (
+    keys.length > 0 &&
+    keys.every((key) => GRAPHQL_RESPONSE_KEYS.has(key)) &&
+    keys.some((key) => key === "data" || key === "errors")
+  );
+};
+
+const isGraphQLResponse = (value: unknown): boolean => {
+  if (Array.isArray(value)) {
+    return value.length > 0 && value.every(isGraphQLResponseObject);
+  }
+
+  return isGraphQLResponseObject(value);
+};
+
 const filterData = (data: JsonObject): JsonObject => {
+  if (isGraphQLResponseObject(data)) {
+    return data;
+  }
+
   const result: JsonObject = {};
   for (const key of Object.keys(data)) {
     const value = data[key];
@@ -310,7 +339,11 @@ export const parse = (data: unknown): void => {
 
     if (cliConfig.json) {
       const sanitizedData = maskSensitiveData(data) as JsonObject;
-      drawJSON(filterData(sanitizedData));
+      drawJSON(
+        isGraphQLResponse(sanitizedData)
+          ? sanitizedData
+          : filterData(sanitizedData),
+      );
       return;
     }
 

--- a/templates/go-cli/internal/output/filter.go
+++ b/templates/go-cli/internal/output/filter.go
@@ -104,13 +104,68 @@ func FilterObject(object *jsonx.Object) *jsonx.Object {
 	return result
 }
 
+var graphQLResponseKeys = map[string]bool{
+	"data":       true,
+	"errors":     true,
+	"extensions": true,
+}
+
+func isGraphQLResponse(value any) bool {
+	switch typed := value.(type) {
+	case *jsonx.Object:
+		return isGraphQLResponseObject(typed)
+	case []any:
+		if len(typed) == 0 {
+			return false
+		}
+		for _, item := range typed {
+			object, ok := item.(*jsonx.Object)
+			if !ok || !isGraphQLResponseObject(object) {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	return false
+}
+
+func isGraphQLResponseObject(object *jsonx.Object) bool {
+	keys := object.Keys()
+	if len(keys) == 0 {
+		return false
+	}
+
+	hasPayload := false
+	for _, key := range keys {
+		if !graphQLResponseKeys[key] {
+			return false
+		}
+		if key == "data" || key == "errors" {
+			hasPayload = true
+		}
+	}
+
+	return hasPayload
+}
+
 // FilterData prepares a response for --json.
 //
 // Scalars survive. Arrays survive with their object elements flattened by
 // FilterObject. Nested objects, nulls and blank strings are dropped. Integers
 // past 2^53 become strings, matching what json-bigint hands the TypeScript;
 // see renderedAsString.
+//
+// GraphQL is the exception: its response envelope is user-selected data under
+// `data` and/or `errors`, so flattening would erase successful responses.
 func FilterData(data *jsonx.Object) *jsonx.Object {
+	if isGraphQLResponseObject(data) {
+		filtered, _ := quoteBigIntegers(data).(*jsonx.Object)
+
+		return filtered
+	}
+
 	result := jsonx.NewObject()
 
 	for _, key := range data.Keys() {

--- a/templates/go-cli/internal/output/filter.go
+++ b/templates/go-cli/internal/output/filter.go
@@ -114,13 +114,14 @@ func isGraphQLResponse(value any) bool {
 	switch typed := value.(type) {
 	case *jsonx.Object:
 		return isGraphQLResponseObject(typed)
+	case map[string]any:
+		return isGraphQLResponseMap(typed)
 	case []any:
 		if len(typed) == 0 {
 			return false
 		}
 		for _, item := range typed {
-			object, ok := item.(*jsonx.Object)
-			if !ok || !isGraphQLResponseObject(object) {
+			if !isGraphQLResponse(item) {
 				return false
 			}
 		}
@@ -132,7 +133,19 @@ func isGraphQLResponse(value any) bool {
 }
 
 func isGraphQLResponseObject(object *jsonx.Object) bool {
-	keys := object.Keys()
+	return isGraphQLResponseKeys(object.Keys())
+}
+
+func isGraphQLResponseMap(object map[string]any) bool {
+	keys := make([]string, 0, len(object))
+	for key := range object {
+		keys = append(keys, key)
+	}
+
+	return isGraphQLResponseKeys(keys)
+}
+
+func isGraphQLResponseKeys(keys []string) bool {
 	if len(keys) == 0 {
 		return false
 	}
@@ -227,6 +240,13 @@ func quoteBigIntegers(value any) any {
 		for _, key := range typed.Keys() {
 			nested, _ := typed.Get(key)
 			result.Set(key, quoteBigIntegers(nested))
+		}
+
+		return result
+	case map[string]any:
+		result := make(map[string]any, len(typed))
+		for key, nested := range typed {
+			result[key] = quoteBigIntegers(nested)
 		}
 
 		return result

--- a/templates/go-cli/internal/output/filter_test.go
+++ b/templates/go-cli/internal/output/filter_test.go
@@ -199,12 +199,17 @@ func TestFilterDataPreservesGraphQLResponseEnvelope(t *testing.T) {
 }
 
 func TestJSONModePreservesGraphQLBatchResponses(t *testing.T) {
-	first := decode(t, `{"data":{"id":9007199254740993}}`)
-	second := decode(t, `{"errors":[{"message":"bad","extensions":{"code":"x"}}]}`)
+	input, err := DecodeOrdered([]byte(`[
+		{"data":{"id":9007199254740993}},
+		{"errors":[{"message":"bad","extensions":{"code":"x"}}]}
+	]`))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	buffer := &bytes.Buffer{}
 	renderer := &Renderer{Mode: ModeJSON, Writer: buffer}
-	if err := renderer.Render([]any{first, second}); err != nil {
+	if err := renderer.Render(input); err != nil {
 		t.Fatal(err)
 	}
 

--- a/templates/go-cli/internal/output/filter_test.go
+++ b/templates/go-cli/internal/output/filter_test.go
@@ -174,6 +174,64 @@ func TestFilterDataAppliesTheNumberRuleInsideArrays(t *testing.T) {
 	}
 }
 
+func TestFilterDataPreservesGraphQLResponseEnvelope(t *testing.T) {
+	input := decode(t, `{
+		"data": {
+			"localeGet": {
+				"countryCode": "in"
+			}
+		}
+	}`)
+
+	got := render(t, FilterData(input))
+	want := `{
+  "data": {
+    "localeGet": {
+      "countryCode": "in"
+    }
+  }
+}
+`
+
+	if got != want {
+		t.Errorf("FilterData GraphQL output.\n--- want ---\n%s\n--- got ---\n%s", want, got)
+	}
+}
+
+func TestJSONModePreservesGraphQLBatchResponses(t *testing.T) {
+	first := decode(t, `{"data":{"id":9007199254740993}}`)
+	second := decode(t, `{"errors":[{"message":"bad","extensions":{"code":"x"}}]}`)
+
+	buffer := &bytes.Buffer{}
+	renderer := &Renderer{Mode: ModeJSON, Writer: buffer}
+	if err := renderer.Render([]any{first, second}); err != nil {
+		t.Fatal(err)
+	}
+
+	want := `[
+  {
+    "data": {
+      "id": "9007199254740993"
+    }
+  },
+  {
+    "errors": [
+      {
+        "message": "bad",
+        "extensions": {
+          "code": "x"
+        }
+      }
+    ]
+  }
+]
+`
+
+	if got := buffer.String(); got != want {
+		t.Errorf("GraphQL batch output.\n--- want ---\n%s\n--- got ---\n%s", want, got)
+	}
+}
+
 // --raw keeps every field, including ones no generated model declares -- that
 // is what "raw" means and why the body is captured rather than re-encoded from
 // the struct. Big integers are still quoted, because the TypeScript's

--- a/templates/go-cli/internal/output/json.go
+++ b/templates/go-cli/internal/output/json.go
@@ -60,33 +60,15 @@ func RenderJSON(writer io.Writer, value any) error {
 //
 // Responses must go through this rather than encoding/json's default
 // map[string]any: a map would re-emit keys sorted, which --json consumers would
-// see as the field order changing between the two CLIs.
+// see as the field order changing between the two CLIs. Arrays use the same
+// ordered decoder because GraphQL batches put response objects at the top level.
 func DecodeOrdered(payload []byte) (any, error) {
 	trimmed := strings.TrimSpace(string(payload))
 	if trimmed == "" {
 		return nil, nil
 	}
 
-	// Only objects carry key order worth preserving; arrays and scalars decode
-	// normally, with UseNumber so integers keep their digits.
-	if strings.HasPrefix(trimmed, "{") {
-		object := jsonx.NewObject()
-		if err := object.UnmarshalJSON([]byte(trimmed)); err != nil {
-			return nil, err
-		}
-
-		return object, nil
-	}
-
-	decoder := json.NewDecoder(strings.NewReader(trimmed))
-	decoder.UseNumber()
-
-	var value any
-	if err := decoder.Decode(&value); err != nil {
-		return nil, err
-	}
-
-	return value, nil
+	return jsonx.DecodeValue([]byte(trimmed))
 }
 
 // MarshalOrdered encodes a value to JSON for re-decoding through DecodeOrdered.

--- a/templates/go-cli/internal/output/render.go
+++ b/templates/go-cli/internal/output/render.go
@@ -48,6 +48,9 @@ func (r *Renderer) Render(value any) error {
 		return RenderJSON(writer, quoteBigIntegers(redactor.Mask(value, "")))
 	case ModeJSON:
 		masked := redactor.Mask(value, "")
+		if isGraphQLResponse(masked) {
+			return RenderJSON(writer, quoteBigIntegers(masked))
+		}
 		if object, ok := masked.(*jsonx.Object); ok {
 			return RenderJSON(writer, FilterData(object))
 		}


### PR DESCRIPTION
## Summary

Fixes #1764.

Preserves GraphQL response envelopes in CLI `--json` output instead of applying the generic nested-object filter that collapsed valid GraphQL responses to `{}`.

```json
// before --json
{}

// after --json
{
  "data": {
    "localeGet": {
      "countryCode": "in"
    }
  }
}
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation

## What changed

- Detect GraphQL envelopes containing `data`, `errors`, and/or `extensions`.
- Preserve those envelopes for TypeScript CLI and Go CLI JSON rendering.
- Keep existing filtered JSON behavior for normal REST responses.
- Add Go CLI regression coverage for single and batched GraphQL responses.

## Test plan

```text
php example.php go-cli
php example.php cli
cd examples/go-cli && go test ./...
cd examples/go-cli && go build ./... && go vet ./...
cd examples/cli && npm run build:types
cd examples/cli && npm run build:runtime
composer lint-twig
composer refactor:check
```
