### PR TITLE
Fix Python nested model serialization

### DIFF
--- a/src/SDK/Language/Python.php
+++ b/src/SDK/Language/Python.php
@@ -772,6 +772,46 @@ class Python extends Language
         return false;
     }
 
+    protected function getAdditionalPropertiesExpectationLines(?string $model, array $spec, string $target): array
+    {
+        if (!$model || !array_key_exists($model, $spec['definitions'] ?? [])) {
+            return [];
+        }
+
+        $modelDef = $spec['definitions'][$model];
+        $lines = [];
+
+        if (!empty($modelDef['additionalProperties'])) {
+            $lines[] = $target . "['data'] = {}";
+        }
+
+        foreach ($modelDef['properties'] ?? [] as $property) {
+            if (!($property['required'] ?? false) || empty($property['sub_schema']) || ($property['type'] ?? '') === self::TYPE_ARRAY) {
+                continue;
+            }
+
+            $propertyName = str_replace(["\\", "'"], ["\\\\", "\\'"], (string) $property['name']);
+            $lines = [
+                ...$lines,
+                ...$this->getAdditionalPropertiesExpectationLines(
+                    $property['sub_schema'],
+                    $spec,
+                    $target . "['" . $propertyName . "']"
+                ),
+            ];
+        }
+
+        return $lines;
+    }
+
+    protected function getAdditionalPropertiesExpectations(?string $model, array $spec, string $target): string
+    {
+        return implode("\n", array_map(
+            fn(string $line): string => '        ' . $line,
+            $this->getAdditionalPropertiesExpectationLines($model, $spec, $target)
+        ));
+    }
+
     /**
      * Creates an example for a response model with the given name
      *
@@ -877,7 +917,8 @@ class Python extends Language
                 $json = json_encode($result, JSON_PRETTY_PRINT | JSON_PRESERVE_ZERO_FRACTION);
 
                 return str_replace([ 'true', 'false', 'null' ], [ "True", "False", "None" ], $json);
-            })
+            }),
+            new TwigFilter('additionalPropertiesExpectations', fn(string $model, array $spec, string $target): string => $this->getAdditionalPropertiesExpectations($model, $spec, $target))
         ];
     }
 }

--- a/templates/python/package/models/model.py.twig
+++ b/templates/python/package/models/model.py.twig
@@ -2,7 +2,7 @@
 {% set isGeneric = definition.additionalProperties or hasGenericProperty %}
 from typing import Any, Dict, List, Optional, Union, cast{% if isGeneric %}, Generic, TypeVar, Type{% endif %}
 
-from pydantic import Field, PrivateAttr
+from pydantic import Field, PrivateAttr{% if definition.additionalProperties %}, model_serializer{% endif %}
 
 from .base_model import AppwriteModel
 {% set added = [] %}
@@ -113,25 +113,21 @@ class {{ definition.name | caseUcfirst }}(AppwriteModel{% if isGeneric %}, Gener
     def {{ 'data' | caseSnake | removeDollarSign }}(self, value: T) -> None:
         object.__setattr__(self, '_{{ 'data' | caseSnake | removeDollarSign }}', value)
 
-    def model_dump(self, **kwargs) -> Dict[str, Any]:
-        result = super().model_dump(**kwargs)
-        if hasattr(self, '_{{ 'data' | caseSnake | removeDollarSign }}'):
-            if isinstance(self._{{ 'data' | caseSnake | removeDollarSign }}, dict):
-                result['{{ 'data' }}'] = self._{{ 'data' | caseSnake | removeDollarSign }}
-            elif hasattr(self._{{ 'data' | caseSnake | removeDollarSign }}, 'model_dump'):
-                result['{{ 'data' }}'] = self._{{ 'data' | caseSnake | removeDollarSign }}.model_dump(**kwargs)
-            else:
-                result['{{ 'data' }}'] = self._{{ 'data' | caseSnake | removeDollarSign }}
-        return result
+    def _serialize_data(self, info):
+        if hasattr(self._{{ 'data' | caseSnake | removeDollarSign }}, 'model_dump'):
+            return self._{{ 'data' | caseSnake | removeDollarSign }}.model_dump(
+                mode=info.mode,
+                by_alias=info.by_alias,
+                exclude_unset=info.exclude_unset,
+                exclude_defaults=info.exclude_defaults,
+                exclude_none=info.exclude_none,
+            )
 
-    def to_dict(self) -> Dict[str, Any]:
-        result = super().to_dict()
-        if hasattr(self, '_{{ 'data' | caseSnake | removeDollarSign }}'):
-            if isinstance(self._{{ 'data' | caseSnake | removeDollarSign }}, dict):
-                result['{{ 'data' }}'] = self._{{ 'data' | caseSnake | removeDollarSign }}
-            elif hasattr(self._{{ 'data' | caseSnake | removeDollarSign }}, 'model_dump'):
-                result['{{ 'data' }}'] = self._{{ 'data' | caseSnake | removeDollarSign }}.model_dump(mode='json')
-            else:
-                result['{{ 'data' }}'] = self._{{ 'data' | caseSnake | removeDollarSign }}
+        return self._{{ 'data' | caseSnake | removeDollarSign }}
+
+    @model_serializer(mode='wrap')
+    def _serialize_model(self, handler, info):
+        result = handler(self)
+        result['{{ 'data' }}'] = self._serialize_data(info)
         return result
 {% endif %}

--- a/templates/python/test/services/test_service.py.twig
+++ b/templates/python/test/services/test_service.py.twig
@@ -35,9 +35,7 @@ class {{ service.name | caseUcfirst }}ServiceTest(unittest.TestCase):
         )
 
         {%~ if method.type != 'webAuth' and method.type != 'location' and method.responseModel and method.responseModel != 'any' %}
-        {%~ if spec.definitions[method.responseModel].additionalProperties %}
-        data['{{ 'data' }}'] = {}
-        {%~ endif  %}
+{{ method.responseModel | additionalPropertiesExpectations(spec, 'data') | raw }}
         self.assertEqual(response.to_dict(), data)
         {%~ else %}
         self.assertEqual(response, data)


### PR DESCRIPTION
## What does this PR do?

Fixes Python SDK serialization for generated `additionalProperties` models by replacing `model_dump()` / `to_dict()` overrides with a Pydantic v2 `@model_serializer`.

This keeps the existing `data` envelope used for generic payload type-safety, but makes it work when the model is nested and serialized by pydantic-core:

```text
before: RowList.to_dict() -> rows: [{"$id": "b01", ...}]
after:  RowList.to_dict() -> rows: [{"$id": "b01", ..., "data": {"title": "T"}}]
```

The same applies to nested preferences:

```text
before: UserList.to_dict() -> users: [{..., "prefs": {}}]
after:  UserList.to_dict() -> users: [{..., "prefs": {"data": {"theme": "dark"}}}]
```

## Test Plan

```text
php example.php python
composer lint-twig
composer refactor:check
vendor/bin/phpunit --testsuite Unit
```

Also verified the regenerated Python SDK with a local Pydantic v2 reproducer for `RowList`, `UserList`, typed row data, and `Preferences`.

## Related PRs and Issues

- #XXXX

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?
- [x] If the PR includes a change to an API's metadata (desc, label, params, etc.), does it also include updated API specs and example docs? N/A
