### PR TITLE
Fix Python payload-only model serialization

### DIFF
--- a/src/SDK/Language/Python.php
+++ b/src/SDK/Language/Python.php
@@ -781,7 +781,7 @@ class Python extends Language
         $modelDef = $spec['definitions'][$model];
         $lines = [];
 
-        if (!empty($modelDef['additionalProperties'])) {
+        if (!empty($modelDef['additionalProperties']) && !empty($modelDef['properties'] ?? [])) {
             $lines[] = $target . "['data'] = {}";
         }
 

--- a/templates/python/package/models/model.py.twig
+++ b/templates/python/package/models/model.py.twig
@@ -128,6 +128,14 @@ class {{ definition.name | caseUcfirst }}(AppwriteModel{% if isGeneric %}, Gener
     @model_serializer(mode='wrap')
     def _serialize_model(self, handler, info):
         result = handler(self)
-        result['{{ 'data' }}'] = self._serialize_data(info)
+        data = self._serialize_data(info)
+{% if definition.properties | length > 0 %}
+        result['{{ 'data' }}'] = data
         return result
+{% else %}
+        if isinstance(result, dict) and isinstance(data, dict):
+            return {**result, **data}
+
+        return data
+{% endif %}
 {% endif %}

--- a/templates/python/package/service.py.twig
+++ b/templates/python/package/service.py.twig
@@ -46,5 +46,6 @@ class Service:
             return model.model_validate(response)
         except ValidationError as error:
             raise AppwriteException(
-                f'Unable to parse response into {model.__name__}: {error}'
+                f'Unable to parse response into {model.__name__}: {error}',
+                response=response,
             ) from error


### PR DESCRIPTION
## Summary

Fixes two Python SDK generator edge cases:

- preserve the raw response body on Pydantic hydration failures via `AppwriteException.response`
- keep payload-only `additionalProperties` models flattened when serialized

```python
# Preferences keeps typed access
prefs.data == {"theme": "dark"}

# but serializes back to the REST shape
prefs.to_dict() == {"theme": "dark"}
```

Models with declared fields plus dynamic payload, like `Document` and `Row`, still serialize dynamic data under `data`.

## Testing

```text
php example.php python
composer lint-twig
composer refactor:check
cd examples/python && uv run --with requests --with requests_mock --with 'pydantic>=2,<3' python -m unittest discover -s test
```
