### PR TITLE
fix: stop python templates emitting stray blank lines

### DIFF
--- a/templates/python/package/models/model.py.twig
+++ b/templates/python/package/models/model.py.twig
@@ -2,7 +2,7 @@
 {% set isGeneric = definition.additionalProperties or hasGenericProperty %}
 from typing import Any, Dict, List, Optional, Union, cast{% if isGeneric %}, Generic, TypeVar, Type{% endif %}
 
-from pydantic import Field, PrivateAttr{% if definition.additionalProperties %}, model_serializer{% endif %}
+from pydantic import Field, PrivateAttr{{ definition.additionalProperties ? ', model_serializer' : '' }}
 
 from .base_model import AppwriteModel
 {% set added = [] %}

--- a/templates/python/test/services/test_service.py.twig
+++ b/templates/python/test/services/test_service.py.twig
@@ -35,7 +35,10 @@ class {{ service.name | caseUcfirst }}ServiceTest(unittest.TestCase):
         )
 
         {%~ if method.type != 'webAuth' and method.type != 'location' and method.responseModel and method.responseModel != 'any' %}
-{{ method.responseModel | additionalPropertiesExpectations(spec, 'data') | raw }}
+        {%~ set expectations = method.responseModel | additionalPropertiesExpectations(spec, 'data') %}
+        {%~ if expectations is not empty %}
+{{ expectations | raw }}
+        {%~ endif %}
         self.assertEqual(response.to_dict(), data)
         {%~ else %}
         self.assertEqual(response, data)


### PR DESCRIPTION
Regenerating a Python SDK against 2.11.3 rewrites every model file and every test file. None of it is a behaviour change — it is two whitespace regressions from the serialization fixes in #1776 and #1777.

Twig drops the newline that immediately follows a block tag. `model.py.twig` grew a conditional `, model_serializer` import, which put an `{% endif %}` at the end of the pydantic import line, so that line ate the blank line separating it from the `base_model` import — in all ~250 model files:

```diff
 from typing import Any, Dict, List, Optional, Union, cast
 from pydantic import Field, PrivateAttr
-
 from .base_model import AppwriteModel
```

Using an expression tag instead keeps the newline, since the rule applies to `{% %}`, not `{{ }}`.

In `test_service.py.twig`, the `additionalPropertiesExpectations` line sits at column 0 so its output lands unindented. The filter returns an empty string for any response model without additional properties — the overwhelming majority — and the line then emits a blank one, in every test file:

```diff
         response = self.locale.get(
         )
 
+
         self.assertEqual(response.to_dict(), data)
```

Guarding it on a non-empty result keeps the expectations for models that have them and emits nothing otherwise.

## Verification

Generated the Console Python SDK before and after. The diff against the published SDK drops from 57 changed files to 26, and what remains is the actual release: the new `targetDatabaseId` parameter, `sourceDatabaseId`, the serializer rewrites from #1776/#1777, and the version bump. The 1053 generated tests pass either way, and `composer lint-twig` is clean.