### PR TITLE
fix(python): honour include and exclude in generic model serializers

### DIFF
--- a/templates/python/package/models/model.py.twig
+++ b/templates/python/package/models/model.py.twig
@@ -2,7 +2,7 @@
 {% set isGeneric = definition.additionalProperties or hasGenericProperty %}
 from typing import Any, Dict, List, Optional, Union, cast{% if isGeneric %}, Generic, TypeVar, Type{% endif %}
 
-from pydantic import Field, PrivateAttr{{ definition.additionalProperties ? ', model_serializer' : '' }}
+from pydantic import Field, PrivateAttr{{ definition.additionalProperties ? ', TypeAdapter, model_serializer' : '' }}
 
 from .base_model import AppwriteModel
 {% set added = [] %}
@@ -30,6 +30,10 @@ from .{{ subSchema | caseSnake }} import {{ subSchema | caseUcfirst }}
 {% if isGeneric %}
 
 T = TypeVar('T')
+{% endif %}
+{% if definition.additionalProperties %}
+
+_PAYLOAD_ADAPTER = TypeAdapter(Dict[str, Any])
 {% endif %}
 
 class {{ definition.name | caseUcfirst }}(AppwriteModel{% if isGeneric %}, Generic[T]{% endif %}):
@@ -126,11 +130,16 @@ class {{ definition.name | caseUcfirst }}(AppwriteModel{% if isGeneric %}, Gener
             )
 
         if isinstance(self._{{ 'data' | caseSnake | removeDollarSign }}, dict) and (include is not None or exclude is not None):
-            keys = [key for key in self._{{ 'data' | caseSnake | removeDollarSign }} if include is None or key in include]
-            if exclude is not None:
-                keys = [key for key in keys if key not in exclude]
-
-            return {key: self._{{ 'data' | caseSnake | removeDollarSign }}[key] for key in keys}
+            return _PAYLOAD_ADAPTER.dump_python(
+                self._{{ 'data' | caseSnake | removeDollarSign }},
+                mode=info.mode,
+                by_alias=info.by_alias,
+                exclude_unset=info.exclude_unset,
+                exclude_defaults=info.exclude_defaults,
+                exclude_none=info.exclude_none,
+                include=include,
+                exclude=exclude,
+            )
 
         return self._{{ 'data' | caseSnake | removeDollarSign }}
 {% if definition.properties | length > 0 %}

--- a/templates/python/package/models/model.py.twig
+++ b/templates/python/package/models/model.py.twig
@@ -113,7 +113,7 @@ class {{ definition.name | caseUcfirst }}(AppwriteModel{% if isGeneric %}, Gener
     def {{ 'data' | caseSnake | removeDollarSign }}(self, value: T) -> None:
         object.__setattr__(self, '_{{ 'data' | caseSnake | removeDollarSign }}', value)
 
-    def _serialize_data(self, info):
+    def _serialize_data(self, info, include=None, exclude=None):
         if hasattr(self._{{ 'data' | caseSnake | removeDollarSign }}, 'model_dump'):
             return self._{{ 'data' | caseSnake | removeDollarSign }}.model_dump(
                 mode=info.mode,
@@ -121,18 +121,58 @@ class {{ definition.name | caseUcfirst }}(AppwriteModel{% if isGeneric %}, Gener
                 exclude_unset=info.exclude_unset,
                 exclude_defaults=info.exclude_defaults,
                 exclude_none=info.exclude_none,
+                include=include,
+                exclude=exclude,
             )
 
+        if isinstance(self._{{ 'data' | caseSnake | removeDollarSign }}, dict) and (include is not None or exclude is not None):
+            keys = [key for key in self._{{ 'data' | caseSnake | removeDollarSign }} if include is None or key in include]
+            if exclude is not None:
+                keys = [key for key in keys if key not in exclude]
+
+            return {key: self._{{ 'data' | caseSnake | removeDollarSign }}[key] for key in keys}
+
         return self._{{ 'data' | caseSnake | removeDollarSign }}
+{% if definition.properties | length > 0 %}
+
+    @staticmethod
+    def _select_data(selector):
+        """
+        Resolves a pydantic include/exclude selector against the '{{ 'data' }}' key, which is
+        serialized here rather than declared as a field. Returns whether the key was
+        named, and any nested selector to apply within it.
+        """
+        if selector is None:
+            return False, None
+
+        if isinstance(selector, dict):
+            if '{{ 'data' }}' not in selector:
+                return False, None
+
+            nested = selector['{{ 'data' }}']
+
+            return True, nested if isinstance(nested, (dict, set, frozenset, list, tuple)) else None
+
+        return '{{ 'data' }}' in selector, None
+{% endif %}
 
     @model_serializer(mode='wrap')
     def _serialize_model(self, handler, info):
         result = handler(self)
-        data = self._serialize_data(info)
 {% if definition.properties | length > 0 %}
-        result['{{ 'data' }}'] = data
+        included, include_fields = self._select_data(info.include)
+        excluded, exclude_fields = self._select_data(info.exclude)
+
+        if info.include is not None and not included:
+            return result
+
+        if excluded and exclude_fields is None:
+            return result
+
+        result['{{ 'data' }}'] = self._serialize_data(info, include_fields, exclude_fields)
         return result
 {% else %}
+        data = self._serialize_data(info, info.include, info.exclude)
         if isinstance(result, dict) and isinstance(data, dict):
             return {**result, **data}
 


### PR DESCRIPTION
Follow-up to #1776/#1777, from review on appwrite/sdk-for-console-python#7.

Models with additional properties serialize their payload from a `@model_serializer(mode='wrap')`, because the payload lives in a private attribute rather than a declared field. The serializer wrote that key *after* pydantic had applied `include`/`exclude`, so field selection could not see it. On the published SDK:

```python
doc.model_dump(exclude={'data'})
# {'id': 'a', ..., 'data': {'title': 'hello', 'body': 'x'}}   <- exclude ignored

doc.model_dump(include={'id'})
# {'id': 'a', 'data': {'title': 'hello', 'body': 'x'}}        <- data not asked for
```

Nested selection could not reach the payload either: `include={'data': {'title'}}` returned the whole payload, and for a typed payload nothing was propagated into its own `model_dump`.

The serializer now resolves the selector against the synthetic key before writing it, and passes any nested selector down — to `model_dump` when the payload is a model, or by filtering keys when it is a plain dict. `SerializationInfo` exposes `include`/`exclude`, so this needs no override of `model_dump`.

For payload-only models such as `Preferences`, whose keys merge at the top level, the selector applies to those keys directly.

## After

```
plain             {'id': 'a', ..., 'data': {'title': 'hello', 'body': 'x'}}
exclude={'data'}  data absent
include={'id'}    {'id': 'a'}
include={'data'}  {'data': {'title': 'hello', 'body': 'x'}}
include={'data': {'title'}}   {'data': {'title': 'hello'}}
exclude={'data': {'title'}}   {'data': {'body': 'x'}}
exclude={'id'}    data still present
prefs include={'theme'}       {'theme': 'dark'}
```

Same results whether the payload is a plain dict or a typed model. `to_dict()` is unchanged.

## Verification

Regenerated the Console Python SDK and exercised every case above against the built package, for dict and typed payloads. The 1053 generated tests still pass, `composer lint-twig` is clean, and the only files that change in a regenerated SDK are the three generic models (`document`, `row`, `preferences`).