### PR TITLE
fix(go): document that ClientResponse.Result holds bytes, and pin the type

### DIFF
--- a/templates/go/client.go.twig
+++ b/templates/go/client.go.twig
@@ -40,6 +40,11 @@ type ClientResponse struct {
 	Status     string
 	StatusCode int
 	Header     http.Header
+	// Result holds the raw response body as []byte, for a JSON response and a
+	// non-JSON one alike. It carried a string for JSON responses until v6.5.0,
+	// so a `Result.(string)` assertion that used to succeed now fails, and an
+	// unchecked one panics. Read it through ResponseBody, which accepts either
+	// and so keeps working across the change.
 	Result     interface{}
 	Type	   string
 }

--- a/templates/go/client_test.go.twig
+++ b/templates/go/client_test.go.twig
@@ -196,4 +196,80 @@ func TestAddQueryParam(t *testing.T) {
 		t.Errorf("Expected %q, got %q", expected.Encode(), q.Encode())
 	}
 }
+
+// Result is []byte for a JSON response as much as for a non-JSON one. It held a
+// string for JSON until v6.5.0, and the two branches disagreeing is what made a
+// `Result.(string)` assertion work against one endpoint and panic against
+// another. Pinned in both directions: reintroducing the string copy is a silent
+// break for anything written against the current type, exactly as dropping it
+// was for anything written against the old one.
+func TestCallReturnsTheBodyAsBytes(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		contentType string
+		body        string
+	}{
+		{name: "json", contentType: "application/json", body: `{"$id":"abc"}`},
+		{name: "not json", contentType: "text/plain", body: "abc"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("content-type", test.contentType)
+				w.Write([]byte(test.body))
+			}))
+			defer server.Close()
+
+			c := New()
+			c.Endpoint = server.URL
+
+			resp, err := c.Call(http.MethodGet, "/", nil, nil)
+			if err != nil {
+				t.Fatalf("Expected the call to succeed, got %v", err)
+			}
+
+			if _, ok := resp.Result.([]byte); !ok {
+				t.Errorf("Expected Result to hold []byte, got %T", resp.Result)
+			}
+
+			body, err := ResponseBody(resp)
+			if err != nil {
+				t.Fatalf("Expected ResponseBody to read the body, got %v", err)
+			}
+			if string(body) != test.body {
+				t.Errorf("Expected %q, got %q", test.body, string(body))
+			}
+		})
+	}
+}
+
+// ResponseBody is the accessor consumers are pointed at when Result's type
+// changes under them, so it has to read the type it used to hold too.
+func TestResponseBodyReadsEitherType(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		result interface{}
+	}{
+		{name: "bytes", result: []byte(`{"$id":"abc"}`)},
+		{name: "string", result: `{"$id":"abc"}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			body, err := ResponseBody(&ClientResponse{Result: test.result})
+			if err != nil {
+				t.Fatalf("Expected ResponseBody to read the body, got %v", err)
+			}
+			if string(body) != `{"$id":"abc"}` {
+				t.Errorf("Expected the body, got %q", string(body))
+			}
+		})
+	}
+}
+
+func TestResponseBodyRejectsAnotherType(t *testing.T) {
+	if _, err := ResponseBody(&ClientResponse{Result: 42}); err == nil {
+		t.Error("Expected an error for a body that is neither []byte nor string")
+	}
+	if _, err := ResponseBody(nil); err == nil {
+		t.Error("Expected an error for a nil response")
+	}
+}
 {% endautoescape %}


### PR DESCRIPTION
`perf(go): avoid JSON response string copies` (07bc9c37) stopped materializing a string for JSON responses. That is worth having, and it also removed a real inconsistency: `ClientResponse.Result` now holds `[]byte` for a JSON response and a non-JSON one alike, where the two branches used to disagree.

What it did not do is say so anywhere. A consumer of the exported `Client.Call` that reads `Result` as a string gets a failed assertion on a checked one and a panic on an unchecked one, on an otherwise successful response — and nothing in the generated code or the changelog told them the type moved. That silence is the defect this fixes, not the `[]byte` itself.

`ResponseBody` already accepts either type, so it is the accessor to point consumers at. It is now named on the field, alongside the version the type changed in.

## What's Changed

* Added: a doc comment on `ClientResponse.Result` recording that it holds `[]byte`, that it held a string for JSON before v6.5.0, and that `ResponseBody` reads either
* Added: `TestCallReturnsTheBodyAsBytes`, covering the JSON and non-JSON branches
* Added: `TestResponseBodyReadsEitherType` and `TestResponseBodyRejectsAnotherType`

The type is pinned in **both** directions deliberately. Reintroducing the string copy is now a silent break for anything written against the current type, exactly as dropping it was for anything written against the old one, so neither edge is safe to leave uncovered.

## Verification

Both edits are Twig-free, so they were validated on the generated Go tree: `go test ./client/...` passes, and the new test was seen red by flipping the JSON branch back to `string(responseData)` — it fails on the JSON case with `Expected Result to hold []byte, got string`.

Needed by the `sdk-for-go` v6.5.0 release (appwrite/sdk-for-go#68), which is where the type change first reaches a published SDK.