### PR TITLE
Support portable OpenAPI generation profiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,14 +202,17 @@ Pass as first argument to generate only that SDK:
 - **Silent no-op:** A new `.twig` file with no `getFiles()` entry — generation runs successfully but the file is never created
 - **Wrong scope:** Using `default` scope when you need `service` scope means your template can't access `{{ service.name }}`
 - **Copy scope surprises:** A `copy`-scoped file with Twig syntax — the syntax is output literally, not rendered
-- **Spec fetch failure:** `example.php` requires internet access to fetch the live spec from GitHub; generation fails with an exception if the fetch returns empty. Spec URL pattern (prefix is `open-api3` or `swagger2` depending on the format):
+- **Spec fetch failure:** `example.php` requires internet access to fetch the live spec and SDK generation profile from GitHub. Unified OpenAPI releases use:
   ```
-  https://raw.githubusercontent.com/appwrite/specs/main/specs/{version}/open-api3-{version}-{platform}.json
+  https://raw.githubusercontent.com/appwrite/specs/main/specs/{version}/open-api3-{version}.json
+  https://raw.githubusercontent.com/appwrite/specs/main/specs/{version}/sdk-generation-profile-{version}.json
   ```
+  Older releases automatically fall back to `open-api3-{version}-{platform}.json`.
 - **Spec formats:** `example.php` parses OpenAPI 3 specs by default (`Appwrite\Spec\OpenAPI3`). Swagger 2 (`Appwrite\Spec\Swagger2`) is still fully supported; both formats produce identical SDKs. Pass the format as the third argument:
   ```bash
   php example.php <sdk> <platform> swagger2             # use Swagger 2 spec
   SDK_GEN_SPEC_FILE=/path/to/spec.json php example.php  # use a local spec file
+  SDK_GEN_SPEC_FILE=/path/to/spec.json SDK_GEN_PROFILE_FILE=/path/to/profile.json php example.php web client
   ```
 - **Platform mismatch:** Pass the right platform (`console`, `client`, `server`) as second arg — different platforms expose different API services
 - **Child language gaps:** Adding a file to a parent's `getFiles()` but the child language needs a different template — child classes can override `getFiles()` to replace or remove entries

--- a/README.md
+++ b/README.md
@@ -43,10 +43,15 @@ use Appwrite\Spec\OpenAPI3;
 use Appwrite\SDK\SDK;
 use Appwrite\SDK\Language\PHP;
 
-// Read API specification file (OpenAPI 3) and create spec instance
+// Read the portable OpenAPI document and SDK generation profile.
 $version = '1.9.x';
 $platform = 'server';
-$spec = new OpenAPI3(file_get_contents("https://raw.githubusercontent.com/appwrite/specs/main/specs/{$version}/open-api3-{$version}-{$platform}.json"));
+$base = "https://raw.githubusercontent.com/appwrite/specs/main/specs/{$version}";
+$spec = new OpenAPI3(
+    file_get_contents("{$base}/open-api3-{$version}.json"),
+    $platform,
+    file_get_contents("{$base}/sdk-generation-profile-{$version}.json"),
+);
 
 // Swagger 2 specs are supported as well:
 // use Appwrite\Spec\Swagger2;
@@ -72,6 +77,38 @@ $sdk
 $sdk->generate(__DIR__ . '/examples/php'); // Generate source code
 
 ```
+
+The OpenAPI document describes only the HTTP API. SDK-specific policy lives in
+a separate generation profile so the API document remains portable across
+standard OpenAPI tooling. A profile can select operations and security schemes,
+provide platform-specific security definitions, and retain compatibility
+metadata such as SDK method variants:
+
+```json
+{
+  "version": "1.0",
+  "platforms": {
+    "client": {
+      "securitySchemes": {
+        "Project": {},
+        "Session": {}
+      },
+      "include": ["accountGet"],
+      "operations": {
+        "accountGet": {
+          "name": "get",
+          "auth": ["Project"]
+        }
+      }
+    }
+  }
+}
+```
+
+Profiles are optional. Without one, services come from `tags`, method names come
+from `operationId`, and authentication comes from standard operation `security`
+requirements. Existing platform-specific specs with `x-appwrite` metadata remain
+supported.
 
 For generated artifacts that do not need an API specification, use `StaticSpec`:
 
@@ -139,6 +176,17 @@ php example.php <target> <platform> <format>
 `<platform>` can be `console`, `client`, or `server`. If omitted, it defaults to `console`.
 
 `<format>` can be `openapi3` or `swagger2`. If omitted, it defaults to `openapi3`. Both formats produce identical SDKs.
+
+For local unified-spec testing, set both input paths:
+
+```bash
+SDK_GEN_SPEC_FILE=/path/to/openapi.json \
+SDK_GEN_PROFILE_FILE=/path/to/sdk-generation-profile.json \
+php example.php web client
+```
+
+If the remote unified spec and profile are unavailable, `example.php` falls back
+to the legacy platform-specific specification URL.
 
 Examples:
 

--- a/example.php
+++ b/example.php
@@ -122,7 +122,23 @@ try {
     }
 
     function buildSpec(string $format, string $content): Spec {
-        return $format === 'swagger2' ? new Swagger2($content) : new OpenAPI3($content);
+        global $platform, $profile;
+
+        return $format === 'swagger2'
+            ? new Swagger2($content)
+            : new OpenAPI3($content, $platform, $profile);
+    }
+
+    function isJsonDocument(bool|string $content): bool {
+        if (!\is_string($content) || $content === '') {
+            return false;
+        }
+
+        try {
+            return \is_array(\json_decode($content, true, 512, JSON_THROW_ON_ERROR));
+        } catch (JsonException) {
+            return false;
+        }
     }
 
     function buildStaticSpec(): StaticSpec {
@@ -184,20 +200,33 @@ try {
     $speclessSDKs = ['skills', 'cursor-plugin', 'claude-plugin', 'codex-plugin', 'zed-extension'];
     $needsSpec = !$requestedSdk || !in_array($requestedSdk, $speclessSDKs);
     $spec = '';
+    $profile = null;
 
     if ($needsSpec) {
-        // Optional local spec file override, e.g. SDK_GEN_SPEC_FILE=/path/to/spec.json
+        // Optional local overrides for the portable spec and its SDK generation profile.
         $specFile = getenv('SDK_GEN_SPEC_FILE');
+        $profileFile = getenv('SDK_GEN_PROFILE_FILE');
 
         if ($specFile) {
             $spec = file_get_contents($specFile);
+            $profile = $profileFile ? file_get_contents($profileFile) : null;
+        } elseif ($specFormat === 'openapi3') {
+            $unified = getSSLPage(Config::SPECS_URL . "/{$version}/open-api3-{$version}.json");
+            $generationProfile = getSSLPage(Config::SPECS_URL . "/{$version}/sdk-generation-profile-{$version}.json");
+
+            if (isJsonDocument($unified) && isJsonDocument($generationProfile)) {
+                $spec = $unified;
+                $profile = $generationProfile;
+            } else {
+                // Older releases publish one OpenAPI document per platform.
+                $spec = getSSLPage(Config::SPECS_URL . "/{$version}/open-api3-{$version}-{$platform}.json");
+            }
         } else {
-            $specPrefix = $specFormat === 'swagger2' ? 'swagger2' : 'open-api3';
-            $spec = getSSLPage(Config::SPECS_URL . "/{$version}/{$specPrefix}-{$version}-{$platform}.json");
+            $spec = getSSLPage(Config::SPECS_URL . "/{$version}/swagger2-{$version}-{$platform}.json");
         }
 
-        if(empty($spec)) {
-            throw new Exception('Failed to fetch spec from Appwrite server');
+        if (!isJsonDocument($spec) || ($profile !== null && !isJsonDocument($profile))) {
+            throw new Exception('Failed to fetch spec or generation profile from Appwrite server');
         }
     }
 

--- a/src/Spec/GenerationProfile.php
+++ b/src/Spec/GenerationProfile.php
@@ -101,7 +101,7 @@ final class GenerationProfile
                 if (\is_array($operationConfig) && \is_array($platformOperation)) {
                     $operation = $this->applyOperation(
                         $operation,
-                        \array_replace_recursive($operationConfig, $platformOperation),
+                        $this->mergeConfig($operationConfig, $platformOperation),
                     );
                 }
 
@@ -292,6 +292,34 @@ final class GenerationProfile
         $operation['security'] = $requirements;
 
         return $operation;
+    }
+
+    /**
+     * Merge associative profile configuration while replacing lists. Platform
+     * lists are complete overrides, not positional patches of global lists.
+     *
+     * @param array<string, mixed> $base
+     * @param array<string, mixed> $override
+     * @return array<string, mixed>
+     */
+    private function mergeConfig(array $base, array $override): array
+    {
+        foreach ($override as $key => $value) {
+            if (
+                isset($base[$key])
+                && \is_array($base[$key])
+                && \is_array($value)
+                && !\array_is_list($base[$key])
+                && !\array_is_list($value)
+            ) {
+                $base[$key] = $this->mergeConfig($base[$key], $value);
+                continue;
+            }
+
+            $base[$key] = $value;
+        }
+
+        return $base;
     }
 
     /**

--- a/src/Spec/GenerationProfile.php
+++ b/src/Spec/GenerationProfile.php
@@ -1,0 +1,414 @@
+<?php
+
+namespace Appwrite\Spec;
+
+use InvalidArgumentException;
+use JsonException;
+
+/**
+ * Applies SDK-generation policy to a portable OpenAPI document.
+ *
+ * OpenAPI describes the HTTP API, while a generation profile describes which
+ * part of that API belongs in a particular SDK and preserves generator-only
+ * compatibility details such as method aliases. The source OpenAPI document
+ * remains free of vendor extensions.
+ */
+final class GenerationProfile
+{
+    private const array HTTP_METHODS = [
+        'delete',
+        'get',
+        'head',
+        'options',
+        'patch',
+        'post',
+        'put',
+        'trace',
+    ];
+
+    private array $profile;
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function __construct(array|string $profile)
+    {
+        if (\is_string($profile)) {
+            try {
+                $profile = \json_decode($profile, true, 512, JSON_THROW_ON_ERROR);
+            } catch (JsonException $exception) {
+                throw new InvalidArgumentException('Failed to parse generation profile: ' . $exception->getMessage(), previous: $exception);
+            }
+        }
+
+        if (($profile['version'] ?? null) !== '1.0') {
+            throw new InvalidArgumentException('Generation profile version must be 1.0.');
+        }
+
+        if (!isset($profile['platforms']) || !\is_array($profile['platforms'])) {
+            throw new InvalidArgumentException('Generation profile must define platforms.');
+        }
+
+        $this->profile = $profile;
+    }
+
+    /**
+     * @param array<string, mixed> $document
+     * @return array<string, mixed>
+     */
+    public function apply(array $document, string $platform): array
+    {
+        $config = $this->profile['platforms'][$platform] ?? null;
+        if (!\is_array($config)) {
+            throw new InvalidArgumentException("Generation profile does not define platform '{$platform}'.");
+        }
+
+        $document = $this->applySchemas($document, $this->profile['schemas'] ?? []);
+        $document = $this->selectSchemas($document, $config['schemas'] ?? null);
+        $document = $this->applySecuritySchemes($document, $config['securitySchemes'] ?? null);
+        $allowedSecurity = \array_fill_keys(\array_keys($document['components']['securitySchemes'] ?? []), true);
+        $include = $config['include'] ?? null;
+        $include = \is_array($include) ? \array_fill_keys($include, true) : null;
+        $operations = \is_array($this->profile['operations'] ?? null) ? $this->profile['operations'] : [];
+        $platformOperations = \is_array($config['operations'] ?? null) ? $config['operations'] : [];
+
+        foreach ($document['paths'] ?? [] as $path => $pathItem) {
+            if (!\is_array($pathItem)) {
+                continue;
+            }
+
+            foreach ($pathItem as $method => $operation) {
+                if (!\in_array(\strtolower((string) $method), self::HTTP_METHODS, true) || !\is_array($operation)) {
+                    continue;
+                }
+
+                $operationId = $operation['operationId'] ?? null;
+                if (!\is_string($operationId) || $operationId === '') {
+                    if ($include !== null) {
+                        unset($document['paths'][$path][$method]);
+                    }
+                    continue;
+                }
+
+                if ($include !== null && !isset($include[$operationId])) {
+                    unset($document['paths'][$path][$method]);
+                    continue;
+                }
+
+                $operation = $this->filterSecurity($operation, $allowedSecurity);
+                $operationConfig = $operations[$operationId] ?? [];
+                $platformOperation = $platformOperations[$operationId] ?? [];
+                if (\is_array($operationConfig) && \is_array($platformOperation)) {
+                    $operation = $this->applyOperation(
+                        $operation,
+                        \array_replace_recursive($operationConfig, $platformOperation),
+                    );
+                }
+
+                $document['paths'][$path][$method] = $operation;
+            }
+
+            if (empty($document['paths'][$path])) {
+                unset($document['paths'][$path]);
+            }
+        }
+
+        if ($include !== null) {
+            $document = $this->orderOperations($document, $include);
+        }
+
+        return $document;
+    }
+
+    /**
+     * @param array<string, mixed> $document
+     * @param array<string, int|bool> $include
+     * @return array<string, mixed>
+     */
+    private function orderOperations(array $document, array $include): array
+    {
+        $order = \array_flip(\array_keys($include));
+
+        foreach ($document['paths'] ?? [] as $path => $pathItem) {
+            if (!\is_array($pathItem)) {
+                continue;
+            }
+
+            \uksort($pathItem, function (string $left, string $right) use ($pathItem, $order): int {
+                $leftId = $pathItem[$left]['operationId'] ?? null;
+                $rightId = $pathItem[$right]['operationId'] ?? null;
+
+                return ($order[$leftId] ?? PHP_INT_MAX) <=> ($order[$rightId] ?? PHP_INT_MAX);
+            });
+            $document['paths'][$path] = $pathItem;
+        }
+
+        \uasort($document['paths'], function (array $left, array $right) use ($order): int {
+            $position = function (array $pathItem) use ($order): int {
+                $positions = [];
+                foreach ($pathItem as $operation) {
+                    if (\is_array($operation) && isset($operation['operationId'], $order[$operation['operationId']])) {
+                        $positions[] = $order[$operation['operationId']];
+                    }
+                }
+
+                return $positions === [] ? PHP_INT_MAX : \min($positions);
+            };
+
+            return $position($left) <=> $position($right);
+        });
+
+        return $document;
+    }
+
+    /**
+     * @param array<string, mixed> $document
+     * @param array<string, mixed> $schemas
+     * @return array<string, mixed>
+     */
+    private function applySchemas(array $document, array $schemas): array
+    {
+        foreach ($schemas as $name => $config) {
+            if (!\is_array($config) || !isset($document['components']['schemas'][$name])) {
+                continue;
+            }
+
+            if (($config['requestModel'] ?? false) === true) {
+                $document['components']['schemas'][$name]['x-request-model'] = true;
+            }
+
+            foreach ($config['properties'] ?? [] as $property => $metadata) {
+                if (!\is_array($metadata) || !isset($document['components']['schemas'][$name]['properties'][$property])) {
+                    continue;
+                }
+
+                $target = &$document['components']['schemas'][$name]['properties'][$property];
+                $this->applyParameterMetadata($target, $metadata);
+                unset($target);
+            }
+        }
+
+        return $document;
+    }
+
+    /**
+     * @param array<string, mixed> $document
+     * @return array<string, mixed>
+     */
+    private function selectSchemas(array $document, mixed $config): array
+    {
+        if (!\is_array($config)) {
+            return $document;
+        }
+
+        $schemas = $document['components']['schemas'] ?? [];
+        $selected = [];
+        foreach ($config as $name) {
+            if (\is_string($name) && isset($schemas[$name])) {
+                $selected[$name] = $schemas[$name];
+            }
+        }
+        $document['components']['schemas'] = $selected;
+
+        return $document;
+    }
+
+    /**
+     * @param array<string, mixed> $document
+     * @return array<string, mixed>
+     */
+    private function applySecuritySchemes(array $document, mixed $config): array
+    {
+        if (!\is_array($config)) {
+            return $document;
+        }
+
+        $schemes = $document['components']['securitySchemes'] ?? [];
+        $selected = [];
+
+        foreach ($config as $key => $value) {
+            $name = \is_int($key) ? $value : $key;
+            if (!\is_string($name) || !isset($schemes[$name]) || !\is_array($schemes[$name])) {
+                continue;
+            }
+
+            $profile = \is_array($value) ? $value : [];
+            $definition = $profile['definition'] ?? $schemes[$name];
+            if (!\is_array($definition)) {
+                continue;
+            }
+
+            $metadata = [];
+            if (isset($profile['setter']) && \is_string($profile['setter'])) {
+                $metadata['setter'] = $profile['setter'];
+            }
+            if (isset($profile['location']) && \is_array($profile['location'])) {
+                $metadata['location'] = $profile['location']['in'] ?? null;
+                $metadata['param'] = $profile['location']['parameter'] ?? null;
+                $metadata['config'] = $profile['location']['config'] ?? null;
+                $metadata = \array_filter($metadata, fn(mixed $value): bool => $value !== null);
+            }
+            foreach (['demo', 'optional'] as $key) {
+                if (\array_key_exists($key, $profile)) {
+                    $metadata[$key] = $profile[$key];
+                }
+            }
+
+            if ($metadata !== []) {
+                $definition['x-appwrite'] = \array_merge($definition['x-appwrite'] ?? [], $metadata);
+            }
+
+            $selected[$name] = $definition;
+        }
+
+        $document['components'] ??= [];
+        $document['components']['securitySchemes'] = $selected;
+
+        return $document;
+    }
+
+    /**
+     * @param array<string, mixed> $operation
+     * @param array<string, bool> $allowed
+     * @return array<string, mixed>
+     */
+    private function filterSecurity(array $operation, array $allowed): array
+    {
+        if (!isset($operation['security']) || !\is_array($operation['security'])) {
+            return $operation;
+        }
+
+        $requirements = [];
+        foreach ($operation['security'] as $requirement) {
+            if (!\is_array($requirement)) {
+                continue;
+            }
+
+            if ($requirement === [] || \array_diff_key($requirement, $allowed) === []) {
+                $requirements[] = $requirement;
+            }
+        }
+
+        $operation['security'] = $requirements;
+
+        return $operation;
+    }
+
+    /**
+     * @param array<string, mixed> $operation
+     * @param array<string, mixed> $config
+     * @return array<string, mixed>
+     */
+    private function applyOperation(array $operation, array $config): array
+    {
+        $metadata = [];
+
+        foreach (['packaging', 'cookies', 'type', 'consoleOnly', 'produces', 'platforms'] as $key) {
+            if (\array_key_exists($key, $config)) {
+                $metadata[$key] = $config[$key];
+            }
+        }
+
+        if (isset($config['name']) && \is_string($config['name'])) {
+            $metadata['method'] = $config['name'];
+        }
+
+        if (isset($config['auth']) && \is_array($config['auth'])) {
+            $metadata['auth'] = \array_fill_keys($config['auth'], []);
+        }
+
+        if (isset($config['security']) && \is_array($config['security'])) {
+            $operation['security'] = [\array_fill_keys($config['security'], [])];
+        }
+
+        if (isset($config['methods']) && \is_array($config['methods'])) {
+            $metadata['methods'] = \array_map(function (array $method): array {
+                if (isset($method['auth']) && \array_is_list($method['auth'])) {
+                    $method['auth'] = \array_fill_keys($method['auth'], []);
+                }
+
+                return $method;
+            }, $config['methods']);
+        }
+
+        if (isset($config['deprecation']) && \is_array($config['deprecation'])) {
+            $operation['deprecated'] = true;
+            $metadata['deprecated'] = $config['deprecation'];
+        }
+
+        foreach ($config['responseMetadata'] ?? [] as $code => $responseMetadata) {
+            if (!\is_array($responseMetadata) || !isset($operation['responses'][$code])) {
+                continue;
+            }
+
+            foreach ($operation['responses'][$code]['content'] ?? [] as $contentType => $media) {
+                if (isset($media['schema']) && \is_array($media['schema'])) {
+                    if (isset($responseMetadata['discriminator']) && \is_array($responseMetadata['discriminator'])) {
+                        $media['schema']['discriminator'] = $responseMetadata['discriminator'];
+                    }
+                    $operation['responses'][$code]['content'][$contentType] = $media;
+                }
+            }
+        }
+
+        foreach ($config['parameters'] ?? [] as $name => $parameterMetadata) {
+            if (!\is_array($parameterMetadata)) {
+                continue;
+            }
+
+            foreach ($operation['parameters'] ?? [] as $index => $parameter) {
+                if (($parameter['name'] ?? null) === $name) {
+                    if (isset($parameter['schema']) && \is_array($parameter['schema'])) {
+                        $this->applyParameterMetadata($parameter['schema'], $parameterMetadata);
+                    } else {
+                        $this->applyParameterMetadata($parameter, $parameterMetadata);
+                    }
+                    $operation['parameters'][$index] = $parameter;
+                }
+            }
+
+            foreach ($operation['requestBody']['content'] ?? [] as $contentType => $media) {
+                if (isset($media['schema']['properties'][$name])) {
+                    $this->applyParameterMetadata($media['schema']['properties'][$name], $parameterMetadata);
+                    $operation['requestBody']['content'][$contentType] = $media;
+                }
+            }
+        }
+
+        if (!empty($metadata)) {
+            $operation['x-appwrite'] = \array_merge($operation['x-appwrite'] ?? [], $metadata);
+        }
+
+        return $operation;
+    }
+
+    /**
+     * @param array<string, mixed> $target
+     * @param array<string, mixed> $metadata
+     */
+    private function applyParameterMetadata(array &$target, array $metadata): void
+    {
+        foreach (
+            [
+            'class' => 'x-class',
+            'uploadId' => 'x-upload-id',
+            'model' => 'x-model',
+            'enumName' => 'x-enum-name',
+            'enumKeys' => 'x-enum-keys',
+            ] as $key => $extension
+        ) {
+            if (\array_key_exists($key, $metadata)) {
+                $target[$extension] = $metadata[$key];
+            }
+        }
+
+        if (isset($metadata['discriminator']) && \is_array($metadata['discriminator'])) {
+            $target['discriminator'] = $metadata['discriminator'];
+        }
+
+        if (isset($metadata['items']) && \is_array($metadata['items'])) {
+            $target['items'] ??= [];
+            $this->applyParameterMetadata($target['items'], $metadata['items']);
+        }
+    }
+}

--- a/src/Spec/OpenAPI3.php
+++ b/src/Spec/OpenAPI3.php
@@ -148,16 +148,23 @@ class OpenAPI3 extends Spec
     protected function parseMethod(string $methodName, string $pathName, array $method): array
     {
         $security = $this->getAttribute('components.securitySchemes', []);
-        $methodSecurity = $this->mergeSecurityRequirements($method['security'] ?? []);
-        $methodAuth = $method['x-appwrite']['auth'] ?? $methodSecurity;
+        $methodRequirements = \array_values(\array_filter($method['security'] ?? [], \is_array(...)));
+        $methodSecurity = $methodRequirements[0] ?? [];
+        $methodAuthRequirements = isset($method['x-appwrite']['auth'])
+            ? [$method['x-appwrite']['auth']]
+            : $methodRequirements;
+        $methodAuthRequirements = $methodAuthRequirements === [] ? [[]] : $methodAuthRequirements;
 
-        foreach ($methodAuth as $i => $node) {
-            $authKey = $this->getAuthSetterKey((string) $i, $security[(string) $i] ?? []);
-            $methodAuth[$authKey] = (array_key_exists((string) $i, $security)) ? [...$security[$i], 'global' => $i !== 'Project'] : [];
-            if ($authKey !== (string) $i) {
-                unset($methodAuth[$i]);
+        $methodAuth = [];
+        foreach ($methodAuthRequirements as $requirement) {
+            $auth = [];
+            foreach ($requirement as $i => $node) {
+                $authKey = $this->getAuthSetterKey((string) $i, $security[(string) $i] ?? []);
+                $auth[$authKey] = (array_key_exists((string) $i, $security)) ? [...$security[$i], 'global' => $i !== 'Project'] : [];
             }
+            $methodAuth[] = $auth;
         }
+
         foreach ($methodSecurity as $i => $node) {
             $methodSecurity[$i] = (array_key_exists((string) $i, $security)) ? [...$security[$i], 'global' => $i !== 'Project'] : [];
         }
@@ -255,7 +262,7 @@ class OpenAPI3 extends Spec
             'packaging' => $method['x-appwrite']['packaging'] ?? false,
             'title' => $method['summary'] ?? '',
             'description' => $method['description'] ?? '',
-            'auth' => [$methodAuth] ?? [],
+            'auth' => $methodAuth,
             'security' => \array_keys($methodSecurity),
             'securityHeaders' => $methodSecurityHeaders,
             'securityQueries' => $methodSecurityQueries,
@@ -448,27 +455,6 @@ class OpenAPI3 extends Spec
         usort($output['parameters']['all'], fn(array $a, array $b): int => (int) $b['required'] - (int) $a['required']);
 
         return $output;
-    }
-
-    /**
-     * @param array<int, array<string, mixed>> $requirements
-     * @return array<string, mixed>
-     */
-    private function mergeSecurityRequirements(array $requirements): array
-    {
-        $security = [];
-
-        foreach ($requirements as $requirement) {
-            if (!\is_array($requirement)) {
-                continue;
-            }
-
-            foreach ($requirement as $name => $scopes) {
-                $security[$name] ??= $scopes;
-            }
-        }
-
-        return $security;
     }
 
     /**

--- a/src/Spec/OpenAPI3.php
+++ b/src/Spec/OpenAPI3.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\Spec;
 
+use InvalidArgumentException;
 use Override;
 use stdClass;
 
@@ -15,6 +16,19 @@ use stdClass;
 class OpenAPI3 extends Spec
 {
     protected const string DEFAULT_CONTENT_TYPE = 'application/json';
+
+    public function __construct($input, ?string $platform = null, array|string|null $profile = null)
+    {
+        parent::__construct($input);
+
+        if ($profile !== null) {
+            if ($platform === null || $platform === '') {
+                throw new InvalidArgumentException('A platform is required when using a generation profile.');
+            }
+
+            $this->exchangeArray(new GenerationProfile($profile)->apply($this->getArrayCopy(), $platform));
+        }
+    }
 
     #[Override]
     public function getTitle(): string
@@ -134,8 +148,8 @@ class OpenAPI3 extends Spec
     protected function parseMethod(string $methodName, string $pathName, array $method): array
     {
         $security = $this->getAttribute('components.securitySchemes', []);
-        $methodAuth = $method['x-appwrite']['auth'] ?? [];
-        $methodSecurity = $method['security'][0] ?? [];
+        $methodSecurity = $this->mergeSecurityRequirements($method['security'] ?? []);
+        $methodAuth = $method['x-appwrite']['auth'] ?? $methodSecurity;
 
         foreach ($methodAuth as $i => $node) {
             $authKey = $this->getAuthSetterKey((string) $i, $security[(string) $i] ?? []);
@@ -237,7 +251,7 @@ class OpenAPI3 extends Spec
             'method' => $methodName,
             'path' => $pathName,
             'fullPath' => parse_url($this->getEndpoint(), PHP_URL_PATH) . $pathName,
-            'name' => $method['x-appwrite']['method'] ?? ($method['operationId'] ?? ''),
+            'name' => $method['x-appwrite']['method'] ?? $this->getOperationName($method),
             'packaging' => $method['x-appwrite']['packaging'] ?? false,
             'title' => $method['summary'] ?? '',
             'description' => $method['description'] ?? '',
@@ -290,13 +304,13 @@ class OpenAPI3 extends Spec
 
             $param = [
                 'name' => $parameter['name'] ?? null,
-                'type' => $parameter['type'] ?? null,
+                'type' => $this->getSchemaType($parameter),
                 'class' => $parameter['x-class'] ?? null,
                 'description' => $parameter['description'] ?? '',
                 'required' => $parameter['required'] ?? false,
-                'nullable' => $parameter['x-nullable'] ?? false,
+                'nullable' => $this->isNullableSchema($parameter),
                 'default' => $parameter['default'] ?? null,
-                'example' => $parameter['x-example'] ?? null,
+                'example' => $parameter['example'] ?? $parameter['x-example'] ?? null,
                 'isUploadID' => $parameter['x-upload-id'] ?? false,
                 'format' => $parameter['format'] ?? null,
                 'array' => [
@@ -311,11 +325,11 @@ class OpenAPI3 extends Spec
             $param['default'] = (is_array($param['default']) || $param['default'] instanceof stdClass) ? json_encode($param['default']) : $param['default'];
             if (isset($parameter['enum'])) {
                 $param['enumValues'] = $parameter['enum'];
-                $param['enumName'] = $parameter['x-enum-name'] ?? $param['name'];
+                $param['enumName'] = $parameter['x-enum-name'] ?? $parameter['title'] ?? $param['name'];
                 $param['enumKeys'] = $parameter['x-enum-keys'] ?? [];
             } elseif (($param['type'] ?? null) === 'array' && isset($parameter['items']['enum'])) {
                 $param['enumValues'] = $parameter['items']['enum'];
-                $param['enumName'] = $parameter['items']['x-enum-name'] ?? $param['name'];
+                $param['enumName'] = $parameter['items']['x-enum-name'] ?? $parameter['items']['title'] ?? $param['name'];
                 $param['enumKeys'] = $parameter['items']['x-enum-keys'] ?? [];
             }
 
@@ -351,14 +365,13 @@ class OpenAPI3 extends Spec
             foreach ($bodyProperties as $key => $value) {
                 $param = [
                     'name' => $key,
-                    'type' => $value['type'] ?? null,
+                    'type' => $this->getSchemaType($value),
                     'class' => $value['x-class'] ?? null,
                     'description' => $value['description'] ?? '',
                     'required' => (in_array($key, $bodyRequired)),
-                    // Multipart parameters carry no nullability information
-                    'nullable' => false,
+                    'nullable' => $this->isNullableSchema($value),
                     'default' => $value['default'] ?? null,
-                    'example' => $value['x-example'] ?? null,
+                    'example' => $value['example'] ?? $value['x-example'] ?? null,
                     'isUploadID' => $value['x-upload-id'] ?? false,
                     'format' => $value['format'] ?? null,
                     'array' => [
@@ -379,11 +392,11 @@ class OpenAPI3 extends Spec
 
                 if (isset($value['enum'])) {
                     $param['enumValues'] = $value['enum'];
-                    $param['enumName'] = $value['x-enum-name'] ?? $param['name'];
+                    $param['enumName'] = $value['x-enum-name'] ?? $value['title'] ?? $param['name'];
                     $param['enumKeys'] = $value['x-enum-keys'] ?? [];
                 } elseif (($param['type'] ?? null) === 'array' && isset($value['items']['enum'])) {
                     $param['enumValues'] = $value['items']['enum'];
-                    $param['enumName'] = $value['items']['x-enum-name'] ?? $param['name'];
+                    $param['enumName'] = $value['items']['x-enum-name'] ?? $value['items']['title'] ?? $param['name'];
                     $param['enumKeys'] = $value['items']['x-enum-keys'] ?? [];
                 }
 
@@ -394,13 +407,13 @@ class OpenAPI3 extends Spec
             foreach ($bodyProperties as $key => $value) {
                 $bodyParam = [
                     'name' => $key,
-                    'type' => $value['type'] ?? null,
+                    'type' => $this->getSchemaType($value),
                     'class' => null,
                     'description' => $value['description'] ?? '',
                     'required' => (in_array($key, $bodyRequired)),
-                    'nullable' => $value['x-nullable'] ?? false,
+                    'nullable' => $this->isNullableSchema($value),
                     'default' => null,
-                    'example' => $value['x-example'] ?? null,
+                    'example' => $value['example'] ?? $value['x-example'] ?? null,
                     'isUploadID' => $value['x-upload-id'] ?? false,
                     'model' => $value['x-model'] ?? null,
                     'format' => $value['format'] ?? null,
@@ -417,11 +430,11 @@ class OpenAPI3 extends Spec
 
                 if (isset($value['enum'])) {
                     $bodyParam['enumValues'] = $value['enum'];
-                    $bodyParam['enumName'] = $value['x-enum-name'] ?? $bodyParam['name'];
+                    $bodyParam['enumName'] = $value['x-enum-name'] ?? $value['title'] ?? $bodyParam['name'];
                     $bodyParam['enumKeys'] = $value['x-enum-keys'] ?? [];
                 } elseif (($bodyParam['type'] ?? null) === 'array' && isset($value['items']['enum'])) {
                     $bodyParam['enumValues'] = $value['items']['enum'];
-                    $bodyParam['enumName'] = $value['items']['x-enum-name'] ?? $bodyParam['name'];
+                    $bodyParam['enumName'] = $value['items']['x-enum-name'] ?? $value['items']['title'] ?? $bodyParam['name'];
                     $bodyParam['enumKeys'] = $value['items']['x-enum-keys'] ?? [];
                 }
 
@@ -435,6 +448,106 @@ class OpenAPI3 extends Spec
         usort($output['parameters']['all'], fn(array $a, array $b): int => (int) $b['required'] - (int) $a['required']);
 
         return $output;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $requirements
+     * @return array<string, mixed>
+     */
+    private function mergeSecurityRequirements(array $requirements): array
+    {
+        $security = [];
+
+        foreach ($requirements as $requirement) {
+            if (!\is_array($requirement)) {
+                continue;
+            }
+
+            foreach ($requirement as $name => $scopes) {
+                $security[$name] ??= $scopes;
+            }
+        }
+
+        return $security;
+    }
+
+    /**
+     * Resolve the SDK method name from the standard operation ID. Appwrite
+     * operation IDs prefix the method with its service tag to remain globally
+     * unique, while SDK methods are scoped by that service.
+     */
+    private function getOperationName(array $method): string
+    {
+        $operationId = $method['operationId'] ?? '';
+        if (!\is_string($operationId) || $operationId === '') {
+            return '';
+        }
+
+        foreach ($method['tags'] ?? [] as $tag) {
+            if (!\is_string($tag) || !\str_starts_with(\strtolower($operationId), \strtolower($tag))) {
+                continue;
+            }
+
+            $name = \substr($operationId, \strlen($tag));
+            if ($name !== '') {
+                return \lcfirst($name);
+            }
+        }
+
+        return $operationId;
+    }
+
+    private function getSchemaType(array $schema): ?string
+    {
+        $type = $schema['type'] ?? null;
+        if (\is_string($type)) {
+            return $type;
+        }
+
+        if (\is_array($type)) {
+            foreach ($type as $candidate) {
+                if (\is_string($candidate) && $candidate !== 'null') {
+                    return $candidate;
+                }
+            }
+        }
+
+        foreach (['oneOf', 'anyOf'] as $union) {
+            foreach ($schema[$union] ?? [] as $candidate) {
+                if (!\is_array($candidate)) {
+                    continue;
+                }
+
+                $candidateType = $this->getSchemaType($candidate);
+                if ($candidateType !== null && $candidateType !== 'null') {
+                    return $candidateType;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function isNullableSchema(array $schema): bool
+    {
+        if (($schema['nullable'] ?? false) === true || ($schema['x-nullable'] ?? false) === true) {
+            return true;
+        }
+
+        $type = $schema['type'] ?? null;
+        if (\is_array($type) && \in_array('null', $type, true)) {
+            return true;
+        }
+
+        foreach (['oneOf', 'anyOf'] as $union) {
+            foreach ($schema[$union] ?? [] as $candidate) {
+                if (\is_array($candidate) && ($candidate['type'] ?? null) === 'null') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -719,6 +832,11 @@ class OpenAPI3 extends Spec
 
     private function getAuthSetterKey(string $key, array $security): string
     {
+        $setter = $security['x-appwrite']['setter'] ?? null;
+        if (\is_string($setter) && $setter !== '') {
+            return $setter;
+        }
+
         if (($security['x-appwrite']['location'] ?? '') !== 'path') {
             return $key;
         }
@@ -741,9 +859,35 @@ class OpenAPI3 extends Spec
      */
     protected function normalizeSchemaProperty(array $property): array
     {
-        if (isset($property['nullable'])) {
-            $property['x-nullable'] = $property['nullable'];
-            unset($property['nullable']);
+        if ($this->isNullableSchema($property)) {
+            $property['x-nullable'] = true;
+        }
+        unset($property['nullable']);
+
+        if (\array_key_exists('example', $property) && !\array_key_exists('x-example', $property)) {
+            $property['x-example'] = $property['example'];
+        }
+
+        foreach (['oneOf', 'anyOf'] as $union) {
+            $members = $property[$union] ?? null;
+            if (!\is_array($members)) {
+                continue;
+            }
+
+            $nonNull = \array_values(\array_filter(
+                $members,
+                fn(mixed $member): bool => !\is_array($member) || ($member['type'] ?? null) !== 'null',
+            ));
+
+            if (\count($nonNull) === 1 && \count($nonNull) !== \count($members) && \is_array($nonNull[0])) {
+                unset($property[$union]);
+                $property = \array_replace($nonNull[0], $property);
+            }
+        }
+
+        $type = $this->getSchemaType($property);
+        if ($type !== null) {
+            $property['type'] = $type;
         }
 
         // A union on an object property is wrapped in allOf
@@ -791,7 +935,7 @@ class OpenAPI3 extends Spec
 
             $def['name'] = $name;
             $def['description'] ??= '';
-            $def['example'] = $def['x-example'] ?? null;
+            $def['example'] ??= $def['x-example'] ?? null;
             $def['required'] = in_array($name, $model['required']);
 
             if (isset($def['$ref'])) {
@@ -833,11 +977,11 @@ class OpenAPI3 extends Spec
 
             if (isset($def['enum'])) {
                 // enum property
-                $def['enumName'] = $def['x-enum-name'] ?? ucfirst($key) . ucfirst((string) $name);
+                $def['enumName'] = $def['x-enum-name'] ?? $def['title'] ?? ucfirst($key) . ucfirst((string) $name);
                 $def['enumKeys'] = $def['x-enum-keys'] ?? [];
             } elseif (($def['type'] ?? null) === 'array' && isset($def['items']['enum'])) {
                 $def['enumValues'] = $def['items']['enum'];
-                $def['enumName'] = $def['items']['x-enum-name'] ?? ucfirst($key) . ucfirst((string) $name);
+                $def['enumName'] = $def['items']['x-enum-name'] ?? $def['items']['title'] ?? ucfirst($key) . ucfirst((string) $name);
                 $def['enumKeys'] = $def['items']['x-enum-keys'] ?? [];
             }
 
@@ -915,7 +1059,7 @@ class OpenAPI3 extends Spec
             if (isset($model['properties']) && is_array($model['properties'])) {
                 foreach ($model['properties'] as $propertyName => $property) {
                     if (isset($property['enum'])) {
-                        $enumName = $property['x-enum-name'] ?? ucfirst((string) $modelName) . ucfirst((string) $propertyName);
+                        $enumName = $property['x-enum-name'] ?? $property['title'] ?? ucfirst((string) $modelName) . ucfirst((string) $propertyName);
 
                         if (!isset($list[$enumName])) {
                             $list[$enumName] = [
@@ -929,6 +1073,7 @@ class OpenAPI3 extends Spec
                     // array of enums
                     if ((($property['type'] ?? null) === 'array') && isset($property['items']['enum'])) {
                         $enumName = $property['items']['x-enum-name']
+                            ?? $property['items']['title']
                             ?? $property['enumName']
                             ?? ucfirst((string) $modelName) . ucfirst((string) $propertyName);
 

--- a/tests/unit/GenerationProfileTest.php
+++ b/tests/unit/GenerationProfileTest.php
@@ -1,0 +1,317 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Appwrite\Spec\GenerationProfile;
+use Appwrite\Spec\OpenAPI3;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+final class GenerationProfileTest extends TestCase
+{
+    private array $document;
+    private array $profile;
+
+    protected function setUp(): void
+    {
+        $this->document = [
+            'openapi' => '3.1.0',
+            'info' => [
+                'title' => 'Example',
+                'version' => '1.0.0',
+            ],
+            'servers' => [
+                ['url' => 'https://example.com/v1'],
+            ],
+            'tags' => [
+                ['name' => 'account', 'description' => 'Account API'],
+                ['name' => 'users', 'description' => 'Users API'],
+            ],
+            'paths' => [
+                '/account' => [
+                    'get' => [
+                        'operationId' => 'accountGet',
+                        'summary' => 'Get account',
+                        'tags' => ['account'],
+                        'security' => [
+                            ['Project' => [], 'Session' => []],
+                            ['Project' => [], 'Key' => []],
+                        ],
+                        'parameters' => [
+                            [
+                                'name' => 'statuses',
+                                'in' => 'query',
+                                'schema' => [
+                                    'type' => 'array',
+                                    'items' => [
+                                        'type' => 'string',
+                                        'enum' => ['active', 'blocked'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        'responses' => [
+                            '200' => [
+                                'description' => 'OK',
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => [
+                                            'oneOf' => [
+                                                ['$ref' => '#/components/schemas/account'],
+                                            ],
+                                            'discriminator' => [
+                                                'propertyName' => 'status',
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                '/users' => [
+                    'get' => [
+                        'operationId' => 'usersList',
+                        'summary' => 'List users',
+                        'tags' => ['users'],
+                        'security' => [
+                            ['Project' => [], 'Key' => []],
+                        ],
+                        'responses' => [
+                            '200' => ['description' => 'OK'],
+                        ],
+                    ],
+                ],
+            ],
+            'components' => [
+                'schemas' => [
+                    'account' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'status' => [
+                                'type' => ['string', 'null'],
+                                'title' => 'AccountStatus',
+                                'enum' => ['active', 'blocked'],
+                                'example' => 'active',
+                            ],
+                        ],
+                    ],
+                ],
+                'securitySchemes' => [
+                    'Project' => [
+                        'type' => 'apiKey',
+                        'in' => 'header',
+                        'name' => 'X-Project',
+                        'description' => 'Project ID',
+                    ],
+                    'ProjectPath' => [
+                        'type' => 'apiKey',
+                        'in' => 'query',
+                        'name' => 'project',
+                        'description' => 'Project ID',
+                    ],
+                    'Session' => [
+                        'type' => 'apiKey',
+                        'in' => 'header',
+                        'name' => 'X-Session',
+                        'description' => 'Session',
+                    ],
+                    'Key' => [
+                        'type' => 'apiKey',
+                        'in' => 'header',
+                        'name' => 'X-Key',
+                        'description' => 'API key',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->profile = [
+            'version' => '1.0',
+            'schemas' => [
+                'account' => [
+                    'requestModel' => true,
+                    'properties' => [
+                        'status' => [
+                            'enumName' => 'Status',
+                            'enumKeys' => ['ACTIVE', 'BLOCKED'],
+                        ],
+                    ],
+                ],
+            ],
+            'operations' => [
+                'accountGet' => [
+                    'parameters' => [
+                        'statuses' => [
+                            'items' => [
+                                'enumName' => 'Status',
+                                'enumKeys' => ['ACTIVE', 'BLOCKED'],
+                            ],
+                        ],
+                    ],
+                    'responseMetadata' => [
+                        '200' => [
+                            'discriminator' => [
+                                'propertyName' => 'status',
+                                'x-mapping' => [
+                                    '#/components/schemas/account' => ['status' => 'active'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'platforms' => [
+                'client' => [
+                    'schemas' => ['account'],
+                    'securitySchemes' => [
+                        'Project' => [],
+                        'ProjectPath' => [
+                            'setter' => 'Project',
+                            'location' => [
+                                'in' => 'path',
+                                'parameter' => 'project_id',
+                                'config' => 'project',
+                            ],
+                            'demo' => '<PROJECT_ID>',
+                        ],
+                        'Session' => [],
+                    ],
+                    'include' => ['accountGet'],
+                    'operations' => [
+                        'accountGet' => [
+                            'name' => 'get',
+                            'auth' => ['Project'],
+                            'security' => ['Project', 'Session'],
+                            'cookies' => true,
+                            'methods' => [
+                                [
+                                    'name' => 'getLegacy',
+                                    'namespace' => 'account',
+                                    'auth' => ['Project'],
+                                    'parameters' => [],
+                                    'required' => [],
+                                    'responses' => [],
+                                    'description' => 'Legacy account method.',
+                                ],
+                                [
+                                    'name' => 'get',
+                                    'namespace' => 'account',
+                                    'auth' => ['Project'],
+                                    'parameters' => [],
+                                    'required' => [],
+                                    'responses' => [],
+                                    'description' => 'Get account.',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'server' => [
+                    'securitySchemes' => [
+                        'Project' => [],
+                        'Key' => [
+                            'definition' => [
+                                'type' => 'http',
+                                'scheme' => 'bearer',
+                                'bearerFormat' => 'JWT',
+                                'description' => 'Manager token',
+                            ],
+                        ],
+                    ],
+                    'include' => ['usersList'],
+                ],
+            ],
+        ];
+    }
+
+    public function testFiltersPortableDocumentForPlatform(): void
+    {
+        $projected = new GenerationProfile($this->profile)->apply($this->document, 'client');
+
+        $this->assertArrayHasKey('/account', $projected['paths']);
+        $this->assertArrayNotHasKey('/users', $projected['paths']);
+        $this->assertSame(['Project', 'ProjectPath', 'Session'], \array_keys($projected['components']['securitySchemes']));
+        $this->assertSame(
+            [['Project' => [], 'Session' => []]],
+            $projected['paths']['/account']['get']['security']
+        );
+        $this->assertSame('get', $projected['paths']['/account']['get']['x-appwrite']['method']);
+        $this->assertSame(['Project' => []], $projected['paths']['/account']['get']['x-appwrite']['auth']);
+        $this->assertSame('Project', $projected['components']['securitySchemes']['ProjectPath']['x-appwrite']['setter']);
+        $this->assertTrue($projected['components']['schemas']['account']['x-request-model']);
+        $this->assertSame('Status', $projected['components']['schemas']['account']['properties']['status']['x-enum-name']);
+        $this->assertSame(
+            'Status',
+            $projected['paths']['/account']['get']['parameters'][0]['schema']['items']['x-enum-name'],
+        );
+        $this->assertArrayHasKey(
+            'x-mapping',
+            $projected['paths']['/account']['get']['responses']['200']['content']['application/json']['schema']['discriminator'],
+        );
+        $this->assertArrayNotHasKey('x-appwrite', $this->document['paths']['/account']['get']);
+    }
+
+    public function testAppliesSecuritySchemeDefinitionOverride(): void
+    {
+        $projected = new GenerationProfile($this->profile)->apply($this->document, 'server');
+
+        $this->assertSame([
+            'type' => 'http',
+            'scheme' => 'bearer',
+            'bearerFormat' => 'JWT',
+            'description' => 'Manager token',
+        ], $projected['components']['securitySchemes']['Key']);
+    }
+
+    public function testOpenApiParserConsumesProfileWithoutChangingLegacyContract(): void
+    {
+        $spec = new OpenAPI3(
+            \json_encode($this->document, JSON_THROW_ON_ERROR),
+            'client',
+            $this->profile,
+        );
+        $methods = $spec->getMethods('account');
+
+        $this->assertCount(2, $methods);
+        $this->assertSame(['getLegacy', 'get'], \array_column($methods, 'name'));
+        $this->assertSame(['Project'], \array_keys($methods[1]['auth'][0]));
+        $this->assertSame(['Project', 'Session'], $methods[1]['security']);
+        $this->assertTrue($methods[1]['cookies']);
+        $this->assertSame(['account'], \array_keys($spec->getServices()));
+    }
+
+    public function testStandardOperationIdAndSecurityWorkWithoutProfile(): void
+    {
+        $spec = new OpenAPI3(\json_encode($this->document, JSON_THROW_ON_ERROR));
+        $method = $spec->getMethods('account')[0];
+
+        $this->assertSame('get', $method['name']);
+        $this->assertSame(['Project', 'Session', 'Key'], \array_keys($method['auth'][0]));
+        $this->assertSame(['Project', 'Session', 'Key'], $method['security']);
+
+        $property = $spec->getDefinitions()['account']['properties']['status'];
+        $this->assertSame('string', $property['type']);
+        $this->assertTrue($property['x-nullable']);
+        $this->assertSame('AccountStatus', $property['enumName']);
+        $this->assertSame('active', $property['example']);
+    }
+
+    public function testRejectsUnsupportedProfileVersion(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Generation profile version must be 1.0.');
+
+        new GenerationProfile(['version' => '2.0', 'platforms' => []]);
+    }
+
+    public function testRejectsUnknownPlatform(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Generation profile does not define platform 'console'.");
+
+        new GenerationProfile($this->profile)->apply($this->document, 'console');
+    }
+}

--- a/tests/unit/GenerationProfileTest.php
+++ b/tests/unit/GenerationProfileTest.php
@@ -186,6 +186,7 @@ final class GenerationProfileTest extends TestCase
                             'auth' => ['Project'],
                             'security' => ['Project', 'Session'],
                             'cookies' => true,
+                            'platforms' => ['client'],
                             'methods' => [
                                 [
                                     'name' => 'getLegacy',
@@ -279,6 +280,7 @@ final class GenerationProfileTest extends TestCase
         $this->assertSame(['getLegacy', 'get'], \array_column($methods, 'name'));
         $this->assertSame(['Project'], \array_keys($methods[1]['auth'][0]));
         $this->assertSame(['Project', 'Session'], $methods[1]['security']);
+        $this->assertSame(['client'], $methods[1]['platforms']);
         $this->assertTrue($methods[1]['cookies']);
         $this->assertSame(['account'], \array_keys($spec->getServices()));
     }
@@ -289,14 +291,39 @@ final class GenerationProfileTest extends TestCase
         $method = $spec->getMethods('account')[0];
 
         $this->assertSame('get', $method['name']);
-        $this->assertSame(['Project', 'Session', 'Key'], \array_keys($method['auth'][0]));
-        $this->assertSame(['Project', 'Session', 'Key'], $method['security']);
+        $this->assertCount(2, $method['auth']);
+        $this->assertSame(['Project', 'Session'], \array_keys($method['auth'][0]));
+        $this->assertSame(['Project', 'Key'], \array_keys($method['auth'][1]));
+        $this->assertSame(['Project', 'Session'], $method['security']);
 
         $property = $spec->getDefinitions()['account']['properties']['status'];
         $this->assertSame('string', $property['type']);
         $this->assertTrue($property['x-nullable']);
         $this->assertSame('AccountStatus', $property['enumName']);
         $this->assertSame('active', $property['example']);
+    }
+
+    public function testPlatformListsReplaceGlobalLists(): void
+    {
+        $profile = $this->profile;
+        $profile['operations']['accountGet']['auth'] = ['Project', 'Session'];
+        $profile['operations']['accountGet']['methods'] = [
+            ['name' => 'globalOne'],
+            ['name' => 'globalTwo'],
+        ];
+        $profile['operations']['accountGet']['platforms'] = ['client', 'server'];
+        $profile['platforms']['client']['operations']['accountGet']['auth'] = ['Project'];
+        $profile['platforms']['client']['operations']['accountGet']['methods'] = [
+            ['name' => 'clientOnly'],
+        ];
+        $profile['platforms']['client']['operations']['accountGet']['platforms'] = ['client'];
+
+        $projected = new GenerationProfile($profile)->apply($this->document, 'client');
+        $metadata = $projected['paths']['/account']['get']['x-appwrite'];
+
+        $this->assertSame(['Project'], \array_keys($metadata['auth']));
+        $this->assertSame(['clientOnly'], \array_column($metadata['methods'], 'name'));
+        $this->assertSame(['client'], $metadata['platforms']);
     }
 
     public function testRejectsUnsupportedProfileVersion(): void


### PR DESCRIPTION
## What does this PR do?

Adds support for generating platform SDKs from one portable OpenAPI document plus a separate SDK generation profile.

```text
open-api3-1.9.x.json
sdk-generation-profile-1.9.x.json
              │
              └── OpenAPI3(spec, platform, profile) → existing generator input
```

Standard OpenAPI fields now work without a profile: services use `tags`, method names use `operationId`, authentication uses operation `security`, examples use `example`, enum names can use schema `title`, and OpenAPI 3.1 nullable schemas are normalized. Legacy platform specs and `x-appwrite` metadata remain supported.

`example.php` prefers the unified spec/profile pair and falls back to the legacy platform-specific URL for older releases.

## Test Plan

```text
vendor/bin/phpunit --testsuite Unit
composer refactor:check
composer lint
composer lint-twig
```

Additional compatibility validation:

- Built a portable OpenAPI document and profile from the current client, server, and console specs.
- Compared the complete normalized generator input for all three platforms.
- Generated and recursively compared Web client, Node server, Web console, and PHP server SDKs; no output differences.
- Validated the portable OpenAPI document with `swagger-cli`.

## Related PRs and Issues

- Follow-up to appwrite/appwrite#13201; that PR will be reworked to emit the portable document and profile after this lands.
