### PR TITLE
chore(go-cli): pin sdk-for-go v6.5.0

### DIFF
--- a/templates/go-cli/go.mod.twig
+++ b/templates/go-cli/go.mod.twig
@@ -7,7 +7,7 @@ go 1.26.5
 // so anything added by hand to the generated file is lost on the next run.
 require (
 {% if not sdk.test %}
-	github.com/appwrite/sdk-for-go/v6 v6.4.0
+	github.com/appwrite/sdk-for-go/v6 v6.5.0
 {% endif %}
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0


### PR DESCRIPTION
The Go CLI generates its commands from the console spec but calls the **published** `sdk-for-go`, so a spec that moves ahead of a Go SDK release fails the CLI build. Against v6.4.0 the generated CLI does not compile:

- `project.UpdateMFAFactorsPolicy` — undefined
- `tablesdb.CutoverMigration` — undefined
- `project.WithUpdateOAuth2ServerInstallationScopes` — undefined

The third is why this is a pin bump rather than an exclusion. The first two are new methods and could have been dropped via `exclude.methods`, but `installationScopes` is a new **parameter** on an existing method, and `excludeRules` reaches only services, methods and definitions — there is no parameter-level exclusion, and dropping `projectUpdateOAuth2Server` wholesale would remove a shipping command.

[sdk-for-go v6.5.0](https://github.com/appwrite/sdk-for-go/releases/tag/v6.5.0) carries all three.

`SDK_MODULE` in `GoCLI.php` stays on `/v6`: v6.5.0 is a minor, so the module path is unchanged.

## Verification

The generated CLI was built against v6.5.0 before this was raised — `go build ./...`, `go vet ./...` and `go test ./...` are all clean, the latter across all 20 packages.