### PR TITLE
Add native OpenAPI reader models

### DIFF
--- a/src/Spec/Model/Document.php
+++ b/src/Spec/Model/Document.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Appwrite\Spec\Model;
+
+final readonly class Document
+{
+    /**
+     * @param array<string, Service> $services
+     * @param array<string, array<string, mixed>> $schemas
+     * @param array<string, array<string, mixed>> $securitySchemes
+     * @param list<SecurityRequirement> $security
+     */
+    public function __construct(
+        public string $title,
+        public string $description,
+        public string $version,
+        public string $endpoint,
+        public array $services,
+        public array $schemas,
+        public array $securitySchemes,
+        public array $security,
+    ) {
+    }
+}

--- a/src/Spec/Model/Operation.php
+++ b/src/Spec/Model/Operation.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Appwrite\Spec\Model;
+
+final readonly class Operation
+{
+    /**
+     * @param list<string> $tags
+     * @param list<array<string, mixed>> $parameters
+     * @param array<string, mixed>|null $requestBody
+     * @param array<int|string, array<string, mixed>> $responses
+     * @param list<SecurityRequirement> $security
+     */
+    public function __construct(
+        public string $id,
+        public string $method,
+        public string $path,
+        public array $tags,
+        public string $summary,
+        public string $description,
+        public bool $deprecated,
+        public array $parameters,
+        public ?array $requestBody,
+        public array $responses,
+        public array $security,
+    ) {
+    }
+}

--- a/src/Spec/Model/SecurityRequirement.php
+++ b/src/Spec/Model/SecurityRequirement.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Appwrite\Spec\Model;
+
+final readonly class SecurityRequirement
+{
+    /**
+     * @param array<string, list<string>> $schemes
+     */
+    public function __construct(public array $schemes)
+    {
+    }
+}

--- a/src/Spec/Model/Service.php
+++ b/src/Spec/Model/Service.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Appwrite\Spec\Model;
+
+final readonly class Service
+{
+    /**
+     * @param list<Operation> $operations
+     */
+    public function __construct(
+        public string $name,
+        public string $description,
+        public array $operations,
+    ) {
+    }
+}

--- a/src/Spec/OpenAPI3Reader.php
+++ b/src/Spec/OpenAPI3Reader.php
@@ -142,14 +142,45 @@ final class OpenAPI3Reader
         $parameters = [];
 
         foreach ([...$pathParameters, ...$operationParameters] as $parameter) {
-            $reference = $parameter['$ref'] ?? null;
-            $key = \is_string($reference)
-                ? $reference
-                : ($parameter['in'] ?? '') . "\0" . ($parameter['name'] ?? '');
-            $parameters[$key] = $parameter;
+            $parameters[$this->getParameterKey($parameter)] = $parameter;
         }
 
         return \array_values($parameters);
+    }
+
+    /** @param array<string, mixed> $parameter */
+    private function getParameterKey(array $parameter): string
+    {
+        $reference = $parameter['$ref'] ?? null;
+        if (\is_string($reference)) {
+            $resolved = $this->resolveLocalReference($reference);
+            if ($resolved !== null) {
+                return $this->getParameterKey($resolved);
+            }
+
+            return $reference;
+        }
+
+        return ($parameter['in'] ?? '') . "\0" . ($parameter['name'] ?? '');
+    }
+
+    /** @return array<string, mixed>|null */
+    private function resolveLocalReference(string $reference): ?array
+    {
+        if (!\str_starts_with($reference, '#/')) {
+            return null;
+        }
+
+        $value = $this->document;
+        foreach (\explode('/', \substr($reference, 2)) as $segment) {
+            $segment = \str_replace(['~1', '~0'], ['/', '~'], $segment);
+            if (!\is_array($value) || !\array_key_exists($segment, $value)) {
+                return null;
+            }
+            $value = $value[$segment];
+        }
+
+        return \is_array($value) ? $value : null;
     }
 
     /** @return list<SecurityRequirement> */

--- a/src/Spec/OpenAPI3Reader.php
+++ b/src/Spec/OpenAPI3Reader.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Appwrite\Spec;
+
+use Appwrite\Spec\Model\Document;
+use Appwrite\Spec\Model\Operation;
+use Appwrite\Spec\Model\SecurityRequirement;
+use Appwrite\Spec\Model\Service;
+use InvalidArgumentException;
+use JsonException;
+
+/**
+ * Reads an OpenAPI document into format-independent SDK generator models.
+ *
+ * This reader intentionally consumes only official OpenAPI fields. Legacy
+ * vendor-extension behavior remains in OpenAPI3 until each concern migrates to
+ * these models.
+ */
+final class OpenAPI3Reader
+{
+    private const array HTTP_METHODS = [
+        'delete',
+        'get',
+        'head',
+        'options',
+        'patch',
+        'post',
+        'put',
+        'trace',
+    ];
+
+    /** @var array<string, mixed> */
+    private array $document;
+
+    /**
+     * @param array<string, mixed>|string $input
+     * @throws JsonException
+     */
+    public function __construct(array|string $input)
+    {
+        $this->document = \is_string($input)
+            ? \json_decode($input, true, 512, JSON_THROW_ON_ERROR)
+            : $input;
+
+        if (!\is_string($this->document['openapi'] ?? null)) {
+            throw new InvalidArgumentException('The document must declare an OpenAPI version.');
+        }
+    }
+
+    public function read(): Document
+    {
+        $info = $this->document['info'] ?? [];
+        $operations = $this->readOperations();
+        $descriptions = [];
+
+        foreach ($this->document['tags'] ?? [] as $tag) {
+            if (\is_array($tag) && \is_string($tag['name'] ?? null)) {
+                $descriptions[$tag['name']] = (string) ($tag['description'] ?? '');
+            }
+        }
+
+        $services = [];
+        foreach ($operations as $operation) {
+            foreach ($operation->tags as $tag) {
+                $services[$tag] ??= new Service($tag, $descriptions[$tag] ?? '', []);
+                $services[$tag] = new Service(
+                    $tag,
+                    $services[$tag]->description,
+                    [...$services[$tag]->operations, $operation],
+                );
+            }
+        }
+
+        return new Document(
+            title: (string) ($info['title'] ?? ''),
+            description: (string) ($info['description'] ?? ''),
+            version: (string) ($info['version'] ?? ''),
+            endpoint: (string) ($this->document['servers'][0]['url'] ?? 'https://example.com'),
+            services: $services,
+            schemas: $this->readMap($this->document['components']['schemas'] ?? []),
+            securitySchemes: $this->readMap($this->document['components']['securitySchemes'] ?? []),
+            security: $this->readSecurity($this->document['security'] ?? []),
+        );
+    }
+
+    /** @return list<Operation> */
+    private function readOperations(): array
+    {
+        $operations = [];
+
+        foreach ($this->document['paths'] ?? [] as $path => $pathItem) {
+            if (!\is_string($path) || !\is_array($pathItem)) {
+                continue;
+            }
+
+            $pathParameters = $this->readList($pathItem['parameters'] ?? []);
+
+            foreach (self::HTTP_METHODS as $method) {
+                $operation = $pathItem[$method] ?? null;
+                if (!\is_array($operation)) {
+                    continue;
+                }
+
+                $security = \array_key_exists('security', $operation)
+                    ? $operation['security']
+                    : ($this->document['security'] ?? []);
+
+                $operations[] = new Operation(
+                    id: (string) ($operation['operationId'] ?? ''),
+                    method: $method,
+                    path: $path,
+                    tags: \array_values(\array_filter($operation['tags'] ?? [], \is_string(...))),
+                    summary: (string) ($operation['summary'] ?? ''),
+                    description: (string) ($operation['description'] ?? ''),
+                    deprecated: ($operation['deprecated'] ?? false) === true,
+                    parameters: [...$pathParameters, ...$this->readList($operation['parameters'] ?? [])],
+                    requestBody: \is_array($operation['requestBody'] ?? null) ? $operation['requestBody'] : null,
+                    responses: $this->readMap($operation['responses'] ?? []),
+                    security: $this->readSecurity($security),
+                );
+            }
+        }
+
+        return $operations;
+    }
+
+    /** @return list<SecurityRequirement> */
+    private function readSecurity(mixed $requirements): array
+    {
+        if (!\is_array($requirements)) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($requirements as $requirement) {
+            if (!\is_array($requirement)) {
+                continue;
+            }
+
+            $schemes = [];
+            foreach ($requirement as $name => $scopes) {
+                if (!\is_string($name) || !\is_array($scopes)) {
+                    continue;
+                }
+                $schemes[$name] = \array_values(\array_filter($scopes, \is_string(...)));
+            }
+            $result[] = new SecurityRequirement($schemes);
+        }
+
+        return $result;
+    }
+
+    /** @return list<array<string, mixed>> */
+    private function readList(mixed $value): array
+    {
+        return \is_array($value)
+            ? \array_values(\array_filter($value, \is_array(...)))
+            : [];
+    }
+
+    /** @return array<int|string, array<string, mixed>> */
+    private function readMap(mixed $value): array
+    {
+        if (!\is_array($value)) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($value as $key => $item) {
+            if (\is_array($item)) {
+                $result[$key] = $item;
+            }
+        }
+        return $result;
+    }
+}

--- a/src/Spec/OpenAPI3Reader.php
+++ b/src/Spec/OpenAPI3Reader.php
@@ -148,14 +148,22 @@ final class OpenAPI3Reader
         return \array_values($parameters);
     }
 
-    /** @param array<string, mixed> $parameter */
-    private function getParameterKey(array $parameter): string
+    /**
+     * @param array<string, mixed> $parameter
+     * @param array<string, true> $visited
+     */
+    private function getParameterKey(array $parameter, array $visited = []): string
     {
         $reference = $parameter['$ref'] ?? null;
         if (\is_string($reference)) {
+            if (isset($visited[$reference])) {
+                throw new InvalidArgumentException("Cyclic parameter reference: $reference");
+            }
+
             $resolved = $this->resolveLocalReference($reference);
             if ($resolved !== null) {
-                return $this->getParameterKey($resolved);
+                $visited[$reference] = true;
+                return $this->getParameterKey($resolved, $visited);
             }
 
             return $reference;

--- a/src/Spec/OpenAPI3Reader.php
+++ b/src/Spec/OpenAPI3Reader.php
@@ -115,7 +115,10 @@ final class OpenAPI3Reader
                     summary: (string) ($operation['summary'] ?? ''),
                     description: (string) ($operation['description'] ?? ''),
                     deprecated: ($operation['deprecated'] ?? false) === true,
-                    parameters: [...$pathParameters, ...$this->readList($operation['parameters'] ?? [])],
+                    parameters: $this->mergeParameters(
+                        $pathParameters,
+                        $this->readList($operation['parameters'] ?? []),
+                    ),
                     requestBody: \is_array($operation['requestBody'] ?? null) ? $operation['requestBody'] : null,
                     responses: $this->readMap($operation['responses'] ?? []),
                     security: $this->readSecurity($security),
@@ -124,6 +127,29 @@ final class OpenAPI3Reader
         }
 
         return $operations;
+    }
+
+    /**
+     * Operation parameters override path parameters with the same name and
+     * location, as required by OpenAPI.
+     *
+     * @param list<array<string, mixed>> $pathParameters
+     * @param list<array<string, mixed>> $operationParameters
+     * @return list<array<string, mixed>>
+     */
+    private function mergeParameters(array $pathParameters, array $operationParameters): array
+    {
+        $parameters = [];
+
+        foreach ([...$pathParameters, ...$operationParameters] as $parameter) {
+            $reference = $parameter['$ref'] ?? null;
+            $key = \is_string($reference)
+                ? $reference
+                : ($parameter['in'] ?? '') . "\0" . ($parameter['name'] ?? '');
+            $parameters[$key] = $parameter;
+        }
+
+        return \array_values($parameters);
     }
 
     /** @return list<SecurityRequirement> */

--- a/tests/unit/OpenAPI3ReaderTest.php
+++ b/tests/unit/OpenAPI3ReaderTest.php
@@ -83,11 +83,20 @@ final class OpenAPI3ReaderTest extends TestCase
                     'get' => [
                         'operationId' => 'usersGet',
                         'tags' => ['users'],
-                        'parameters' => [[
-                            'name' => 'queries',
-                            'in' => 'query',
-                            'schema' => ['type' => 'array'],
-                        ]],
+                        'parameters' => [
+                            [
+                                'name' => 'userId',
+                                'in' => 'path',
+                                'required' => true,
+                                'description' => 'Operation override.',
+                                'schema' => ['type' => 'string'],
+                            ],
+                            [
+                                'name' => 'queries',
+                                'in' => 'query',
+                                'schema' => ['type' => 'array'],
+                            ],
+                        ],
                         'responses' => ['200' => ['description' => 'OK']],
                     ],
                 ],
@@ -97,6 +106,7 @@ final class OpenAPI3ReaderTest extends TestCase
         $parameters = $document->services['users']->operations[0]->parameters;
 
         $this->assertSame(['userId', 'queries'], \array_column($parameters, 'name'));
+        $this->assertSame('Operation override.', $parameters[0]['description']);
     }
 
     public function testRequiresAnOpenAPIVersion(): void

--- a/tests/unit/OpenAPI3ReaderTest.php
+++ b/tests/unit/OpenAPI3ReaderTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Appwrite\Spec\Model\Operation;
+use Appwrite\Spec\OpenAPI3Reader;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+final class OpenAPI3ReaderTest extends TestCase
+{
+    public function testReadsOfficialOpenAPIFieldsIntoNativeModels(): void
+    {
+        $document = new OpenAPI3Reader(\file_get_contents(__DIR__ . '/../resources/spec-openapi3.json'))->read();
+
+        $this->assertSame('Appwrite', $document->title);
+        $this->assertSame('1.4.2', $document->version);
+        $this->assertSame('http://mockapi/v1', $document->endpoint);
+        $this->assertArrayHasKey('general', $document->services);
+        $this->assertArrayHasKey('mock', $document->schemas);
+        $this->assertArrayHasKey('Project', $document->securitySchemes);
+
+        $operation = $this->getOperation($document->services['general']->operations, 'generalCreatePlayer');
+
+        $this->assertSame('post', $operation->method);
+        $this->assertSame('/mock/tests/general/models', $operation->path);
+        $this->assertSame(['general'], $operation->tags);
+        $this->assertNotNull($operation->requestBody);
+        $this->assertArrayHasKey(200, $operation->responses);
+        $this->assertSame(['Project', 'Key', 'JWT'], \array_keys($operation->security[0]->schemes));
+    }
+
+    public function testKeepsSecurityAlternativesSeparate(): void
+    {
+        $document = new OpenAPI3Reader([
+            'openapi' => '3.1.0',
+            'info' => ['title' => 'Example', 'version' => '1.0.0'],
+            'security' => [
+                ['Project' => [], 'Session' => []],
+                ['Project' => [], 'JWT' => []],
+            ],
+            'paths' => [
+                '/account' => [
+                    'get' => [
+                        'operationId' => 'accountGet',
+                        'tags' => ['account'],
+                        'responses' => ['200' => ['description' => 'OK']],
+                    ],
+                ],
+                '/health' => [
+                    'get' => [
+                        'operationId' => 'healthGet',
+                        'tags' => ['health'],
+                        'security' => [],
+                        'responses' => ['200' => ['description' => 'OK']],
+                    ],
+                ],
+            ],
+        ])->read();
+
+        $account = $document->services['account']->operations[0];
+        $this->assertCount(2, $account->security);
+        $this->assertSame(['Project', 'Session'], \array_keys($account->security[0]->schemes));
+        $this->assertSame(['Project', 'JWT'], \array_keys($account->security[1]->schemes));
+        $this->assertSame([], $document->services['health']->operations[0]->security);
+    }
+
+    public function testIncludesPathLevelParametersOnOperations(): void
+    {
+        $document = new OpenAPI3Reader([
+            'openapi' => '3.1.0',
+            'info' => ['title' => 'Example', 'version' => '1.0.0'],
+            'paths' => [
+                '/users/{userId}' => [
+                    'parameters' => [[
+                        'name' => 'userId',
+                        'in' => 'path',
+                        'required' => true,
+                        'schema' => ['type' => 'string'],
+                    ]],
+                    'get' => [
+                        'operationId' => 'usersGet',
+                        'tags' => ['users'],
+                        'parameters' => [[
+                            'name' => 'queries',
+                            'in' => 'query',
+                            'schema' => ['type' => 'array'],
+                        ]],
+                        'responses' => ['200' => ['description' => 'OK']],
+                    ],
+                ],
+            ],
+        ])->read();
+
+        $parameters = $document->services['users']->operations[0]->parameters;
+
+        $this->assertSame(['userId', 'queries'], \array_column($parameters, 'name'));
+    }
+
+    public function testRequiresAnOpenAPIVersion(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new OpenAPI3Reader([
+            'info' => ['title' => 'Example', 'version' => '1.0.0'],
+            'paths' => [],
+        ]);
+    }
+
+    /**
+     * @param list<Operation> $operations
+     */
+    private function getOperation(array $operations, string $id): Operation
+    {
+        foreach ($operations as $operation) {
+            if ($operation->id === $id) {
+                return $operation;
+            }
+        }
+
+        $this->fail("Operation $id not found");
+    }
+}

--- a/tests/unit/OpenAPI3ReaderTest.php
+++ b/tests/unit/OpenAPI3ReaderTest.php
@@ -75,10 +75,7 @@ final class OpenAPI3ReaderTest extends TestCase
             'paths' => [
                 '/users/{userId}' => [
                     'parameters' => [[
-                        'name' => 'userId',
-                        'in' => 'path',
-                        'required' => true,
-                        'schema' => ['type' => 'string'],
+                        '$ref' => '#/components/parameters/UserId',
                     ]],
                     'get' => [
                         'operationId' => 'usersGet',
@@ -98,6 +95,16 @@ final class OpenAPI3ReaderTest extends TestCase
                             ],
                         ],
                         'responses' => ['200' => ['description' => 'OK']],
+                    ],
+                ],
+            ],
+            'components' => [
+                'parameters' => [
+                    'UserId' => [
+                        'name' => 'userId',
+                        'in' => 'path',
+                        'required' => true,
+                        'schema' => ['type' => 'string'],
                     ],
                 ],
             ],

--- a/tests/unit/OpenAPI3ReaderTest.php
+++ b/tests/unit/OpenAPI3ReaderTest.php
@@ -116,6 +116,33 @@ final class OpenAPI3ReaderTest extends TestCase
         $this->assertSame('Operation override.', $parameters[0]['description']);
     }
 
+    public function testRejectsCyclicParameterReferences(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cyclic parameter reference');
+
+        new OpenAPI3Reader([
+            'openapi' => '3.1.0',
+            'info' => ['title' => 'Example', 'version' => '1.0.0'],
+            'paths' => [
+                '/users' => [
+                    'parameters' => [['$ref' => '#/components/parameters/First']],
+                    'get' => [
+                        'operationId' => 'usersList',
+                        'tags' => ['users'],
+                        'responses' => ['200' => ['description' => 'OK']],
+                    ],
+                ],
+            ],
+            'components' => [
+                'parameters' => [
+                    'First' => ['$ref' => '#/components/parameters/Second'],
+                    'Second' => ['$ref' => '#/components/parameters/First'],
+                ],
+            ],
+        ])->read();
+    }
+
     public function testRequiresAnOpenAPIVersion(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/unit/SpecCompatibilityTest.php
+++ b/tests/unit/SpecCompatibilityTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Appwrite\Spec\OpenAPI3;
+use Appwrite\Spec\Spec;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Locks the internal data contract consumed by SDK templates while the OpenAPI
+ * reader is migrated section by section. Update a checksum only when the
+ * generated SDK contract is intentionally changed.
+ */
+final class SpecCompatibilityTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function sections(): iterable
+    {
+        yield 'metadata' => ['metadata', 'b803aa7490ab743b2ecfeaf6fa4bd4b9ca1b59c28f3a51b5ddbf7f4cbe38e971'];
+        yield 'global headers' => ['globalHeaders', '23ef0093268009ffbe39d51f8c84ede4be0c9f2c8f4f2bbb2822b9d2d6a135bd'];
+        yield 'services and methods' => ['services', '1202fe251708541957e60fce68a627f839b03a31c8675bc6e9b390fa6d239f1a'];
+        yield 'definitions' => ['definitions', '738ca45812d551c53f087eb2fb2109d24e5d84043860d96559c2864a30aa27bb'];
+        yield 'request models' => ['requestModels', '6a29bef58c3ca072f3084ab0e48dfca31252f0c6d673a5cb36c1e432a86ee0cb'];
+        yield 'request enums' => ['requestEnums', 'bac17d969659d6a179d06cccc7f3d0455e5e32db44f33910a123faa4e7797b39'];
+        yield 'response enums' => ['responseEnums', 'ce8d286f76b79fc46e5b112b32785dc5afbd7b1269a2efe270d4444f4aaf3ba2'];
+        yield 'request model enums' => ['requestModelEnums', '4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945'];
+        yield 'all enums' => ['allEnums', '965f6a8fba9b38aa3cb60f5c891789f816966130fa4fa350590ec1aa677a9750'];
+    }
+
+    #[DataProvider('sections')]
+    public function testInternalGeneratorContractRemainsCompatible(string $section, string $checksum): void
+    {
+        $spec = new OpenAPI3(\file_get_contents(__DIR__ . '/../resources/spec-openapi3.json'));
+        $contract = $this->dumpContract($spec);
+
+        $this->assertSame(
+            $checksum,
+            \hash('sha256', \json_encode($contract[$section], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_PRESERVE_ZERO_FRACTION)),
+        );
+    }
+
+    /** @return array<string, mixed> */
+    private function dumpContract(Spec $spec): array
+    {
+        $services = [];
+        foreach ($spec->getServices() as $name => $service) {
+            $service['methods'] = $spec->getMethods($name);
+            $services[$name] = $service;
+        }
+
+        return [
+            'metadata' => [
+                'title' => $spec->getTitle(),
+                'description' => $spec->getDescription(),
+                'namespace' => $spec->getNamespace(),
+                'version' => $spec->getVersion(),
+                'endpoint' => $spec->getEndpoint(),
+                'endpointDocs' => $spec->getEndpointDocs(),
+                'licenseName' => $spec->getLicenseName(),
+                'licenseURL' => $spec->getLicenseURL(),
+                'contactName' => $spec->getContactName(),
+                'contactURL' => $spec->getContactURL(),
+                'contactEmail' => $spec->getContactEmail(),
+            ],
+            'globalHeaders' => $spec->getGlobalHeaders(),
+            'services' => $services,
+            'definitions' => $spec->getDefinitions(),
+            'requestModels' => $spec->getRequestModels(),
+            'requestEnums' => $spec->getRequestEnums(),
+            'responseEnums' => $spec->getResponseEnums(),
+            'requestModelEnums' => $spec->getRequestModelEnums(),
+            'allEnums' => $spec->getAllEnums(),
+        ];
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Starts the native OpenAPI migration without converting the specification into another JSON shape.

- Adds typed `Document`, `Service`, `Operation`, and `SecurityRequirement` models.
- Adds `OpenAPI3Reader`, which reads official OpenAPI fields directly.
- Preserves OpenAPI security alternatives instead of flattening them.
- Adds section-level compatibility checksums for the current template contract.

```text
OpenAPI document -> OpenAPI3Reader -> typed generator models
```

The existing generator path is unchanged. Follow-up PRs can migrate schemas, operations, parameters, responses, and security to these models independently.

## Test plan

```text
vendor/bin/phpunit --testsuite Unit
composer lint
composer lint-twig
composer refactor:check
git diff --check
```
