### PR TITLE
Add Utopia OpenAPI adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,22 @@ The SDK Generator uses predefined language settings as [Twig templates](https://
 
 Both OpenAPI 3.0 and Swagger 2.0 specs are supported and produce identical SDKs, including services, methods, models, enums, and union types.
 
+A migration adapter is also available for the planned `utopia-php/openapi` canonical model. It lets SDK Generator consume `Utopia\OpenAPI\Specification` while delegating template fields that have not migrated yet to the existing parser:
+
+```php
+use Appwrite\Spec\OpenAPI3;
+use Appwrite\Spec\UtopiaAdapter;
+use Utopia\OpenAPI\Parser;
+
+$input = file_get_contents('openapi.json');
+$spec = new UtopiaAdapter(
+    specification: Parser::parse($input),
+    compatibility: new OpenAPI3($input),
+);
+```
+
+The compatibility parser is optional once the canonical model provides every field required by the selected templates.
+
 ## Getting Started
 
 Install using composer:

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,9 @@
         "rector/rector": "^2.4",
         "squizlabs/php_codesniffer": "^4"
     },
+    "suggest": {
+        "utopia-php/openapi": "Required when using UtopiaAdapter with the canonical OpenAPI specification model."
+    },
     "config": {
         "sort-packages": true,
         "platform": {

--- a/src/Spec/UtopiaAdapter.php
+++ b/src/Spec/UtopiaAdapter.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Appwrite\Spec;
+
+use Override;
+use Utopia\OpenAPI\Model\HttpMethod;
+use Utopia\OpenAPI\Model\Operation;
+use Utopia\OpenAPI\Specification;
+
+/**
+ * Adapts the canonical Utopia OpenAPI model to SDK Generator's existing Spec
+ * contract. Compatibility policy stays here while templates migrate to the
+ * canonical model.
+ */
+final class UtopiaAdapter extends Spec
+{
+    public function __construct(
+        private readonly Specification $specification,
+        private readonly ?Spec $compatibility = null,
+    ) {
+        parent::__construct('{}');
+    }
+
+    #[Override]
+    public function getTitle(): string
+    {
+        return $this->specification->info->title;
+    }
+
+    #[Override]
+    public function getDescription(): string
+    {
+        return $this->specification->info->description;
+    }
+
+    #[Override]
+    public function getNamespace(): string
+    {
+        return $this->compatibility?->getNamespace() ?? $this->getTitle();
+    }
+
+    #[Override]
+    public function getVersion(): string
+    {
+        return $this->specification->info->version;
+    }
+
+    #[Override]
+    public function getEndpoint(): string
+    {
+        return $this->specification->servers[0]->url ?? 'https://example.com';
+    }
+
+    #[Override]
+    public function getEndpointDocs(): string
+    {
+        if ($this->compatibility instanceof Spec) {
+            return $this->compatibility->getEndpointDocs();
+        }
+
+        $endpoint = $this->getEndpoint();
+
+        return \preg_replace_callback(
+            '/\{([^}]+)\}/',
+            fn(array $matches): string => '<' . \strtoupper($matches[1]) . '>',
+            $endpoint,
+        ) ?? '';
+    }
+
+    #[Override]
+    public function getLicenseName(): string
+    {
+        return $this->specification->info->license?->name ?? '';
+    }
+
+    #[Override]
+    public function getLicenseURL(): string
+    {
+        return $this->specification->info->license?->url ?? '';
+    }
+
+    #[Override]
+    public function getContactName(): string
+    {
+        return $this->specification->info->contact?->name ?? '';
+    }
+
+    #[Override]
+    public function getContactURL(): string
+    {
+        return $this->specification->info->contact?->url ?? '';
+    }
+
+    #[Override]
+    public function getContactEmail(): string
+    {
+        return $this->specification->info->contact?->email ?? '';
+    }
+
+    #[Override]
+    public function getServices(): array
+    {
+        if ($this->compatibility instanceof Spec) {
+            $services = [];
+            $legacy = $this->compatibility->getServices();
+
+            foreach ($this->getOperations() as $operation) {
+                foreach ($operation->tags as $tag) {
+                    if (!isset($legacy[$tag])) {
+                        continue;
+                    }
+
+                    $services[$tag] = $legacy[$tag];
+                }
+            }
+
+            return $services;
+        }
+
+        $services = [];
+
+        foreach ($this->getOperations() as $operation) {
+            foreach ($operation->tags as $tag) {
+                $services[$tag] ??= [
+                    'name' => $tag,
+                    'description' => $this->specification->tags[$tag]->description ?? '',
+                    'methods' => [],
+                ];
+            }
+        }
+
+        foreach (\array_keys($services) as $name) {
+            $services[$name]['methods'] = $this->getMethods($name);
+        }
+
+        return $services;
+    }
+
+    #[Override]
+    public function getMethods($service): array
+    {
+        if ($this->compatibility instanceof Spec) {
+            return $this->compatibility->getMethods($service);
+        }
+
+        $methods = [];
+
+        foreach ($this->getOperations() as $operation) {
+            if (!\in_array($service, $operation->tags, true)) {
+                continue;
+            }
+
+            $methods[] = $this->mapOperation($operation, (string) $service);
+        }
+
+        return $methods;
+    }
+
+    #[Override]
+    public function getGlobalHeaders(): array
+    {
+        return $this->compatibility?->getGlobalHeaders() ?? [];
+    }
+
+    #[Override]
+    public function getDefinitions(): array
+    {
+        return $this->compatibility?->getDefinitions() ?? [];
+    }
+
+    #[Override]
+    public function getRequestModels(): array
+    {
+        return $this->compatibility?->getRequestModels() ?? [];
+    }
+
+    #[Override]
+    public function getRequestEnums(): array
+    {
+        return $this->compatibility?->getRequestEnums() ?? [];
+    }
+
+    #[Override]
+    public function getResponseEnums(): array
+    {
+        return $this->compatibility?->getResponseEnums() ?? [];
+    }
+
+    #[Override]
+    public function getRequestModelEnums(): array
+    {
+        return $this->compatibility?->getRequestModelEnums() ?? [];
+    }
+
+    #[Override]
+    public function getAllEnums(): array
+    {
+        return $this->compatibility?->getAllEnums() ?? [];
+    }
+
+    /** @return list<Operation> */
+    private function getOperations(): array
+    {
+        $operations = [];
+
+        foreach ($this->specification->paths as $path) {
+            foreach ($path->operations as $operation) {
+                $operations[] = $operation;
+            }
+        }
+
+        return $operations;
+    }
+
+    /** @return array<string, mixed> */
+    private function mapOperation(Operation $operation, string $service): array
+    {
+        return [
+            'method' => $operation->method instanceof HttpMethod
+                ? $operation->method->value
+                : (string) $operation->method,
+            'path' => $operation->path,
+            'fullPath' => (\parse_url($this->getEndpoint(), PHP_URL_PATH) ?: '') . $operation->path,
+            'name' => $this->getMethodName($operation, $service),
+            'packaging' => false,
+            'title' => $operation->summary,
+            'description' => $operation->description,
+            'auth' => [],
+            'security' => [],
+            'securityHeaders' => [],
+            'securityQueries' => [],
+            'securityPathParams' => [],
+            'consumes' => [],
+            'produces' => [],
+            'cookies' => false,
+            'platforms' => [],
+            'consoleOnly' => false,
+            'type' => false,
+            'deprecated' => $operation->deprecated,
+            'headers' => [],
+            'parameters' => [
+                'all' => [],
+                'header' => [],
+                'path' => [],
+                'query' => [],
+                'body' => [],
+            ],
+            'emptyResponse' => true,
+            'responseModel' => '',
+            'responseModels' => [],
+            'responseDiscriminator' => [],
+        ];
+    }
+
+    private function getMethodName(Operation $operation, string $service): string
+    {
+        if (!\str_starts_with(\strtolower($operation->id), \strtolower($service))) {
+            return $operation->id;
+        }
+
+        $name = \substr($operation->id, \strlen($service));
+
+        return $name === '' ? $operation->id : \lcfirst($name);
+    }
+}

--- a/tests/fixtures/utopia-openapi-contract/Utopia/OpenAPI/Model/Contact.php
+++ b/tests/fixtures/utopia-openapi-contract/Utopia/OpenAPI/Model/Contact.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utopia\OpenAPI\Model;
+
+final readonly class Contact
+{
+    public function __construct(public ?string $name, public ?string $url, public ?string $email)
+    {
+    }
+}

--- a/tests/fixtures/utopia-openapi-contract/Utopia/OpenAPI/Model/HttpMethod.php
+++ b/tests/fixtures/utopia-openapi-contract/Utopia/OpenAPI/Model/HttpMethod.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utopia\OpenAPI\Model;
+
+enum HttpMethod: string
+{
+    case GET = 'get';
+    case POST = 'post';
+    case PUT = 'put';
+    case PATCH = 'patch';
+    case DELETE = 'delete';
+    case HEAD = 'head';
+    case OPTIONS = 'options';
+    case TRACE = 'trace';
+}

--- a/tests/fixtures/utopia-openapi-contract/Utopia/OpenAPI/Model/Info.php
+++ b/tests/fixtures/utopia-openapi-contract/Utopia/OpenAPI/Model/Info.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utopia\OpenAPI\Model;
+
+final readonly class Info
+{
+    public function __construct(public string $title, public string $description, public string $version, public ?string $termsOfService, public ?Contact $contact, public ?License $license, public array $extensions = [])
+    {
+    }
+}

--- a/tests/fixtures/utopia-openapi-contract/Utopia/OpenAPI/Model/License.php
+++ b/tests/fixtures/utopia-openapi-contract/Utopia/OpenAPI/Model/License.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utopia\OpenAPI\Model;
+
+final readonly class License
+{
+    public function __construct(public ?string $name, public ?string $url)
+    {
+    }
+}

--- a/tests/fixtures/utopia-openapi-contract/Utopia/OpenAPI/Model/Operation.php
+++ b/tests/fixtures/utopia-openapi-contract/Utopia/OpenAPI/Model/Operation.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utopia\OpenAPI\Model;
+
+final readonly class Operation
+{
+    public function __construct(public string $id, public HttpMethod $method, public string $path, public array $tags, public string $summary, public string $description, public bool $deprecated, public array $parameters, public mixed $requestBody, public array $responses, public array $security, public array $extensions = [])
+    {
+    }
+}

--- a/tests/fixtures/utopia-openapi-contract/Utopia/OpenAPI/Model/PathItem.php
+++ b/tests/fixtures/utopia-openapi-contract/Utopia/OpenAPI/Model/PathItem.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utopia\OpenAPI\Model;
+
+final readonly class PathItem
+{
+    public function __construct(public string $path, public array $operations, public array $parameters, public array $extensions = [])
+    {
+    }
+}

--- a/tests/fixtures/utopia-openapi-contract/Utopia/OpenAPI/Model/Server.php
+++ b/tests/fixtures/utopia-openapi-contract/Utopia/OpenAPI/Model/Server.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utopia\OpenAPI\Model;
+
+final readonly class Server
+{
+    public function __construct(public string $url)
+    {
+    }
+}

--- a/tests/fixtures/utopia-openapi-contract/Utopia/OpenAPI/Model/Tag.php
+++ b/tests/fixtures/utopia-openapi-contract/Utopia/OpenAPI/Model/Tag.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utopia\OpenAPI\Model;
+
+final readonly class Tag
+{
+    public function __construct(public string $name, public string $description)
+    {
+    }
+}

--- a/tests/fixtures/utopia-openapi-contract/Utopia/OpenAPI/Specification.php
+++ b/tests/fixtures/utopia-openapi-contract/Utopia/OpenAPI/Specification.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utopia\OpenAPI;
+
+final readonly class Specification
+{
+    public function __construct(public Version $version, public object $info, public array $servers, public array $tags, public array $paths, public array $schemas, public array $securitySchemes, public array $security, public array $extensions = [])
+    {
+    }
+}

--- a/tests/fixtures/utopia-openapi-contract/Utopia/OpenAPI/Version.php
+++ b/tests/fixtures/utopia-openapi-contract/Utopia/OpenAPI/Version.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utopia\OpenAPI;
+
+enum Version: string
+{
+    case V2 = '2.0';
+    case V3_0 = '3.0';
+    case V3_1 = '3.1';
+}

--- a/tests/fixtures/utopia-openapi-contract/bootstrap.php
+++ b/tests/fixtures/utopia-openapi-contract/bootstrap.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+\spl_autoload_register(static function (string $class): void {
+    if (!\str_starts_with($class, 'Utopia\\OpenAPI\\')) {
+        return;
+    }
+
+    $file = __DIR__ . '/' . \str_replace('\\', '/', $class) . '.php';
+    if (\is_file($file)) {
+        require $file;
+    }
+});

--- a/tests/unit/UtopiaAdapterTest.php
+++ b/tests/unit/UtopiaAdapterTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+require_once __DIR__ . '/../fixtures/utopia-openapi-contract/bootstrap.php';
+
+use Appwrite\Spec\OpenAPI3;
+use Appwrite\Spec\UtopiaAdapter;
+use PHPUnit\Framework\TestCase;
+use Utopia\OpenAPI\Model\Contact;
+use Utopia\OpenAPI\Model\HttpMethod;
+use Utopia\OpenAPI\Model\Info;
+use Utopia\OpenAPI\Model\License;
+use Utopia\OpenAPI\Model\Operation;
+use Utopia\OpenAPI\Model\PathItem;
+use Utopia\OpenAPI\Model\Server;
+use Utopia\OpenAPI\Model\Tag;
+use Utopia\OpenAPI\Specification;
+use Utopia\OpenAPI\Version;
+
+final class UtopiaAdapterTest extends TestCase
+{
+    public function testAdaptsCanonicalMetadata(): void
+    {
+        $adapter = new UtopiaAdapter($this->createSpecification());
+
+        $this->assertSame('Example', $adapter->getTitle());
+        $this->assertSame('Example API', $adapter->getDescription());
+        $this->assertSame('Example', $adapter->getNamespace());
+        $this->assertSame('1.0.0', $adapter->getVersion());
+        $this->assertSame('https://{region}.example.com/v1', $adapter->getEndpoint());
+        $this->assertSame('https://<REGION>.example.com/v1', $adapter->getEndpointDocs());
+        $this->assertSame('MIT', $adapter->getLicenseName());
+        $this->assertSame('https://example.com/license', $adapter->getLicenseURL());
+        $this->assertSame('Utopia', $adapter->getContactName());
+        $this->assertSame('https://example.com', $adapter->getContactURL());
+        $this->assertSame('team@example.com', $adapter->getContactEmail());
+    }
+
+    public function testGroupsOperationsByOfficialTags(): void
+    {
+        $adapter = new UtopiaAdapter($this->createSpecification());
+        $services = $adapter->getServices();
+
+        $this->assertSame(['account'], \array_keys($services));
+        $this->assertSame('Account API', $services['account']['description']);
+        $this->assertCount(1, $services['account']['methods']);
+    }
+
+    public function testMapsOfficialOperationFieldsToLegacyContract(): void
+    {
+        $adapter = new UtopiaAdapter($this->createSpecification());
+        $method = $adapter->getMethods('account')[0];
+
+        $this->assertSame('get', $method['method']);
+        $this->assertSame('/account', $method['path']);
+        $this->assertSame('/v1/account', $method['fullPath']);
+        $this->assertSame('get', $method['name']);
+        $this->assertSame('Get account', $method['title']);
+        $this->assertSame('Returns the current account.', $method['description']);
+        $this->assertTrue($method['deprecated']);
+    }
+
+    public function testDelegatesUnmigratedContractToCompatibilityParser(): void
+    {
+        $legacy = $this->createMock(OpenAPI3::class);
+        $legacy->expects($this->once())->method('getDefinitions')->willReturn([
+            'account' => ['name' => 'account'],
+        ]);
+        $legacy->expects($this->once())->method('getMethods')->with('account')->willReturn([
+            ['name' => 'legacyGet'],
+        ]);
+
+        $adapter = new UtopiaAdapter($this->createSpecification(), $legacy);
+
+        $this->assertSame(['account' => ['name' => 'account']], $adapter->getDefinitions());
+        $this->assertSame([['name' => 'legacyGet']], $adapter->getMethods('account'));
+    }
+
+    private function createSpecification(): Specification
+    {
+        $operation = new Operation(
+            id: 'accountGet',
+            method: HttpMethod::GET,
+            path: '/account',
+            tags: ['account'],
+            summary: 'Get account',
+            description: 'Returns the current account.',
+            deprecated: true,
+            parameters: [],
+            requestBody: null,
+            responses: [],
+            security: [],
+        );
+
+        return new Specification(
+            version: Version::V3_1,
+            info: new Info(
+                title: 'Example',
+                description: 'Example API',
+                version: '1.0.0',
+                termsOfService: null,
+                contact: new Contact(
+                    name: 'Utopia',
+                    url: 'https://example.com',
+                    email: 'team@example.com',
+                ),
+                license: new License(
+                    name: 'MIT',
+                    url: 'https://example.com/license',
+                ),
+            ),
+            servers: [new Server(url: 'https://{region}.example.com/v1')],
+            tags: [
+                'account' => new Tag(
+                    name: 'account',
+                    description: 'Account API',
+                ),
+            ],
+            paths: [
+                '/account' => new PathItem(
+                    path: '/account',
+                    operations: [HttpMethod::GET->value => $operation],
+                    parameters: [],
+                ),
+            ],
+            schemas: [],
+            securitySchemes: [],
+            security: [],
+        );
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Drafts SDK Generator's consumer boundary for the planned `utopia-php/openapi` contract.

```text
Utopia\OpenAPI\Specification
            ↓
      UtopiaAdapter
            ↓
existing Spec contract and templates
```

- Maps canonical metadata, tags, and operations into the existing `Spec` contract.
- Accepts the current parser as an optional compatibility delegate for methods, schemas, enums, and authentication that have not migrated yet.
- Keeps all Appwrite and SDK compatibility policy outside `utopia-php/openapi`.
- Uses contract fixtures because the Utopia package currently contains only its design plan and is not published yet.

This PR intentionally does not add the Composer dependency or switch generation entrypoints. Those changes follow after the Utopia package publishes the contract represented by the fixtures.

## Test plan

```text
vendor/bin/phpunit --testsuite Unit
composer refactor:check
composer lint
composer lint-twig
composer validate --no-check-lock
git diff --check
```
