### PR TITLE
Migrate workflows to RunsOn runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   tests:
     name: Tests / ${{ matrix.sdk }}
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/family=c7/extras=otel
     strategy:
       fail-fast: false
       matrix:
@@ -90,7 +90,7 @@ jobs:
 
   unit:
     name: Tests / Unit
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/family=c7/extras=otel
 
     steps:
       - name: Checkout code
@@ -110,7 +110,7 @@ jobs:
 
   lint:
     name: Checks / Lint
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/family=c7/extras=otel
 
     steps:
       - name: Checkout code
@@ -130,7 +130,7 @@ jobs:
 
   refactor:
     name: Checks / Refactor
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/family=c7/extras=otel
 
     steps:
       - name: Checkout code
@@ -150,7 +150,7 @@ jobs:
 
   twig-lint:
     name: Checks / Twig
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/family=c7/extras=otel
 
     steps:
       - name: Checkout code
@@ -165,7 +165,7 @@ jobs:
 
   max-line-length:
     name: Checks / Twig line length
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/family=c7/extras=otel
 
     steps:
       - name: Checkout code

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   renovate:
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/family=c7/extras=otel
     steps:
       - name: generate app token
         id: app-token

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -9,7 +9,7 @@ on: [pull_request]
 jobs:
   generate-and-build:
     name: ${{ matrix.sdk }} (${{ matrix.platform }})
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/family=c7/extras=otel
     env:
       # Bun 1.3.12 has a sig_size calculation bug in macho.zig that truncates the
       # LC_CODE_SIGNATURE blob on cross-compiled Darwin binaries (oven-sh/bun#29120).
@@ -417,7 +417,7 @@ jobs:
 
   validate-tooling-plugins:
     name: Tooling plugins
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/family=c7/extras=otel
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## What does this PR do?

Migrates every GitHub Actions job from GitHub-hosted runners to RunsOn.

```yaml
# before
runs-on: ubuntu-latest

# after
runs-on: runs-on=${{ github.run_id }}/runner=4cpu-linux-x64/family=c7/extras=otel
```

The runner is specified inline, so a `.github/runs-on.yml` profile is not required.

## Test plan

- `git diff --check`
- `actionlint -shellcheck= .github/workflows/*.yml`
