### PR TITLE
Fix Homebrew formula release updates

### DIFF
--- a/templates/cli/.github/workflows/publish.yml
+++ b/templates/cli/.github/workflows/publish.yml
@@ -205,13 +205,14 @@ jobs:
 
           text = File.read(formula_path)
 
-          unless text.sub!(/^(\s*version ")([^"]+)(")$/) { "#{$1}#{release_tag}#{$3}" }
-            abort("Failed to update formula version")
-          end
-
           checksums.each do |artifact, checksum|
-            pattern = /(#{Regexp.escape(artifact)}"\n\s+sha256 ")([0-9a-f]{64})(")/
-            unless text.sub!(pattern) { "#{$1}#{checksum}#{$3}" }
+            url_pattern = %r{(releases/download/)[^/"]+(/#{Regexp.escape(artifact)}")}
+            unless text.sub!(url_pattern) { "#{$1}#{release_tag}#{$2}" }
+              abort("Failed to update release URL for #{artifact}")
+            end
+
+            checksum_pattern = /(#{Regexp.escape(artifact)}"\n\s+sha256 ")([0-9a-f]{64})(")/
+            unless text.sub!(checksum_pattern) { "#{$1}#{checksum}#{$3}" }
               abort("Failed to update checksum for #{artifact}")
             end
           end

--- a/templates/go-cli/.github/workflows/publish.yml.twig
+++ b/templates/go-cli/.github/workflows/publish.yml.twig
@@ -282,13 +282,14 @@ jobs:
 
           text = File.read(formula_path)
 
-          unless text.sub!(/^(\s*version ")([^"]+)(")$/) { "#{$1}#{release_tag}#{$3}" }
-            abort("failed to update the formula version")
-          end
-
           checksums.each do |artifact, checksum|
-            pattern = /(#{Regexp.escape(artifact)}"\n\s+sha256 ")([0-9a-f]{64})(")/
-            unless text.sub!(pattern) { "#{$1}#{checksum}#{$3}" }
+            url_pattern = %r{(releases/download/)[^/"]+(/#{Regexp.escape(artifact)}")}
+            unless text.sub!(url_pattern) { "#{$1}#{release_tag}#{$2}" }
+              abort("failed to update the release URL for #{artifact}")
+            end
+
+            checksum_pattern = /(#{Regexp.escape(artifact)}"\n\s+sha256 ")([0-9a-f]{64})(")/
+            unless text.sub!(checksum_pattern) { "#{$1}#{checksum}#{$3}" }
               abort("failed to update the checksum for #{artifact}")
             end
           end


### PR DESCRIPTION
## Summary

Fix the generated CLI and Go CLI release workflows after the Homebrew formula stopped declaring an explicit `version`.

The release bot now updates each platform asset URL directly, then updates its checksum:

```text
before: version "26.1.0" + releases/download/#{version}/...
after:  releases/download/26.2.0/... + matching SHA256
```

This prevents the next CLI release from failing while updating [`appwrite/homebrew-appwrite`](https://github.com/appwrite/homebrew-appwrite/pull/34).

## Tests

- `php example.php cli`
- `php example.php go-cli`
- Exercised both generated Ruby updaters against the current Homebrew formula fixture
- `composer lint-twig`
- `composer refactor:check`
- `vendor/bin/phpunit --testsuite Unit`
