### PR TITLE
Build the Go SDK with 1.26.6

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -183,7 +183,7 @@ jobs:
         if: matrix.sdk == 'go' || matrix.sdk == 'go-cli' || matrix.sdk == 'dart' || matrix.sdk == 'flutter'
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Install OSV Scanner
         if: matrix.sdk == 'dart' || matrix.sdk == 'flutter'


### PR DESCRIPTION
The `go (server)` job fails at `govulncheck`, blocking CI. All four advisories are in the **Go standard library** — none are in the generated SDK or anything it imports:

| Advisory | Package |
|---|---|
| GO-2026-6218 | `net/url` |
| GO-2026-6090 | `crypto/tls` |
| GO-2026-5972 | `encoding/asn1` |
| GO-2026-5026 | `net/http` |

Each is reported as `Found in: …@go1.26.5` / `Fixed in: …@go1.26.6`, so the toolchain pinned in `setup-go` is the entire cause and the entire fix.

## Verification

Reproduced locally on Go 1.26.5, which is the same version CI pins:

```
$ govulncheck ./...
Your code is affected by 4 vulnerabilities from the Go standard library.
```

And with only the toolchain changed:

```
$ GOTOOLCHAIN=go1.26.6 govulncheck ./...
No vulnerabilities found.
```

`go build ./...`, `go vet ./...` and `go test ./...` pass on the generated SDK either way.

## Why the go.mod templates are untouched

`templates/go/go.mod.twig` and `templates/go-cli/go.mod.twig` also say `go 1.26.5`, but that directive declares a *minimum* language version — govulncheck resolves the standard library from the toolchain that actually performs the build. Raising it would change the published `sdk-for-go` and `sdk-for-cli` output for no security benefit, so it is left alone.

`go-cli` does not run `govulncheck`; it shares the same `setup-go` step, so it simply builds on the newer patch release.