### PR TITLE
Name the Swift package product in the README

### DIFF
--- a/templates/swift/README.md.twig
+++ b/templates/swift/README.md.twig
@@ -50,7 +50,7 @@ Then add it to your target:
         .target(
             name: "YourAppTarget",
             dependencies: [
-                .product(name: "{{ spec.name | caseUcfirst }}", package: "{{ sdk.gitRepoName }}")
+                .product(name: "{{ spec.title | caseUcfirst }}", package: "{{ sdk.gitRepoName }}")
             ]
         ),
 ```


### PR DESCRIPTION
The install instructions in the Swift and Apple SDK READMEs render:

```swift
.product(name: "", package: "sdk-for-swift")
```

SPM rejects this — no product is named `""` — so anyone following the README of the published SDK cannot resolve the package.

## Cause

The line reads `spec.name`, which is not a key on the specification, so it has always rendered as an empty string. `Package.swift.twig` declares the library with `spec.title`, and the README has to name that same product, so it now uses the same expression.

## Verified

Published `sdk-for-swift` and `sdk-for-apple` both declare:

```swift
.library(
    name: "Appwrite",
```

while both READMEs say `.product(name: "")`. After this change the generated README names the product that `Package.swift` actually declares:

```
examples/swift/README.md:45:   .product(name: "Appwrite", package: "reponame")
examples/apple/README.md:45:   .product(name: "Appwrite", package: "reponame")
examples/swift/Package.swift:15:   name: "Appwrite",
```

(`reponame` is the placeholder `example.php` uses for `gitRepoName`; real generation emits `sdk-for-swift` / `sdk-for-apple`.)

`Apple::getFiles()` points at `swift/README.md.twig`, so this one change covers both SDKs. Only the README line changes — no other generated output is affected.