### PR TITLE
fix(react-native): make expo-file-system a peer dependency

### DIFF
--- a/src/SDK/Language/ReactNative.php
+++ b/src/SDK/Language/ReactNative.php
@@ -38,6 +38,11 @@ class ReactNative extends Web
             ],
             [
                 'scope'         => 'default',
+                'destination'   => 'src/expo-file-system-shim.d.ts',
+                'template'      => 'react-native/src/expo-file-system-shim.d.ts.twig',
+            ],
+            [
+                'scope'         => 'default',
                 'destination'   => 'src/service.ts',
                 'template'      => 'react-native/src/service.ts.twig',
             ],

--- a/templates/react-native/package-lock.json.twig
+++ b/templates/react-native/package-lock.json.twig
@@ -9,7 +9,6 @@
       "version": "{{ sdk.version }}",
       "license": "{{ sdk.license }}",
       "dependencies": {
-        "expo-file-system": "18.*.*",
         "json-bigint": "1.0.0"
       },
       "devDependencies": {
@@ -26,6 +25,7 @@
       },
       "peerDependencies": {
         "expo": "*",
+        "expo-file-system": ">=18.0.0",
         "react-native": ">=0.76.7 <1.0.0"
       },
       "overrides": {
@@ -3655,6 +3655,7 @@
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.1.11.tgz",
       "integrity": "sha512-HJw/m0nVOKeqeRjPjGdvm+zBi5/NxcdPf8M8P3G2JFvH5Z8vBWqVDic2O58jnT1OFEy0XXzoH9UqFu7cHg9DTQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"

--- a/templates/react-native/package.json.twig
+++ b/templates/react-native/package.json.twig
@@ -41,11 +41,11 @@
     "typescript": "5.9.3"
   },
   "dependencies": {
-    "expo-file-system": "18.*.*",
     "json-bigint": "1.0.0"
   },
   "peerDependencies": {
     "expo": "*",
+    "expo-file-system": ">=18.0.0",
     "react-native": ">=0.76.7 <1.0.0"
   },
   "overrides": {

--- a/templates/react-native/src/expo-file-system-shim.d.ts.twig
+++ b/templates/react-native/src/expo-file-system-shim.d.ts.twig
@@ -1,0 +1,22 @@
+declare module 'expo-file-system' {
+    export enum EncodingType {
+        UTF8 = 'utf8',
+        Base64 = 'base64',
+    }
+    export const cacheDirectory: string;
+    export function readAsStringAsync(
+        fileUri: string,
+        options?: {
+            encoding?: EncodingType;
+            position?: number;
+            length?: number;
+        }
+    ): Promise<string>;
+    export function writeAsStringAsync(
+        fileUri: string,
+        contents: string,
+        options?: {
+            encoding?: EncodingType;
+        }
+    ): Promise<void>;
+}


### PR DESCRIPTION
## What does this PR do?

Moves the React Native SDK's `expo-file-system` dependency from a hard pin (`"18.*.*"`) to a peer dependency (`">=18.0.0"`), and adds an ambient type shim so the generated SDK still builds when peers are omitted.

Fixes appwrite/sdk-for-react-native#114.

## Why

`react-native-appwrite` currently declares:

```json
"dependencies": { "expo-file-system": "18.*.*" }
```

Apps on Expo SDK 54+ ship `expo-file-system` 19.x or newer, so npm installs a second, nested copy of 18.x under `node_modules/react-native-appwrite/`. Expo autolinking then mixes the two versions' native code and the app crashes at launch:

```
java.lang.NoClassDefFoundError: Failed resolution of: Lexpo/modules/filesystem/FilePermissionModule;
```

With a peer dependency, the host app owns the version and only one copy is ever installed. `">=18.0.0"` deliberately has no upper bound — an upper bound would recreate this exact problem on the next Expo SDK release. Apps on older Expo SDKs are unaffected (their 18.x satisfies the range), and npm 7+ auto-installs missing peers for apps that do not list `expo-file-system` themselves.

## Changes

- `templates/react-native/package.json.twig` — `expo-file-system` moved from `dependencies` to `peerDependencies` as `">=18.0.0"`.
- `templates/react-native/src/expo-file-system-shim.d.ts.twig` (new) — ambient module declaration covering exactly the API surface the SDK uses (`readAsStringAsync`, `writeAsStringAsync`, `EncodingType`, `cacheDirectory`). Same pattern as the existing `react-native-shim.d.ts.twig`: without it, `npm ci --omit=peer && npm run build` (as run in `validation.yml`) could no longer resolve the import. Like the react-native shim it is not part of the published `files`, so consumers keep getting real types from their own `expo-file-system` install.
- `src/SDK/Language/ReactNative.php` — registers the new template file.
- `templates/react-native/package-lock.json.twig` — regenerated with `npm install --package-lock-only`; the diff is exactly the moved dependency plus the `"peer": true` marker on the existing entry.

## Verification

- The template's `FileSystem` usage (mirroring `services/template.ts.twig` lines 200–208) typechecks against the shim alone with `tsc --strict` 5.9.3 and **no** `expo-file-system` installed — the situation `npm ci --omit=peer` produces.
- Real-world confirmation of the underlying bug: our production Expo SDK 57 app needs an npm `overrides` entry to force a single `expo-file-system` copy; without it, `expo-doctor` flags the duplicate and a native Android build crashes at launch exactly as described in #114.

## Related

appwrite/sdk-for-react-native#112 is adjacent but separate: the SDK calls the legacy FileSystem API, which newer `expo-file-system` versions expose via `expo-file-system/legacy`. This PR does not change runtime behavior — it only stops the forced second native copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
