### PR TITLE
Stream local function runtime logs in the CLI

### DIFF
--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -974,6 +974,16 @@ class CLI extends Go
             ],
             [
                 'scope'         => 'copy',
+                'destination'   => 'internal/docker/logs.go',
+                'template'      => 'cli/internal/docker/logs.go',
+            ],
+            [
+                'scope'         => 'copy',
+                'destination'   => 'internal/docker/logs_test.go',
+                'template'      => 'cli/internal/docker/logs_test.go',
+            ],
+            [
+                'scope'         => 'copy',
                 'destination'   => 'internal/docker/queue.go',
                 'template'      => 'cli/internal/docker/queue.go',
             ],

--- a/templates/cli/internal/cmd/run.go
+++ b/templates/cli/internal/cmd/run.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -147,6 +148,8 @@ func runFunction(command *cobra.Command, options runOptions) error {
 	ctx, stop := signal.NotifyContext(command.Context(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	go printRuntimeLogs(ctx, out, emulator.Directory)
+
 	keys, variables := collectVariables(command, local, function, options)
 
 	// The credentials collectVariables minted last an hour. A run outliving
@@ -203,6 +206,21 @@ func runFunction(command *cobra.Command, options runOptions) error {
 	queue.Unlock()
 
 	return serve(ctx, command, emulator, tool, queue, port, keys, variables, wait)
+}
+
+// printRuntimeLogs restores the live context.log() and context.error() output
+// that local functions had before the Go CLI. Both streams share stdout to
+// preserve that command's output contract; the heading is delayed so a function
+// that does not log leaves no empty section behind.
+func printRuntimeLogs(ctx context.Context, out io.Writer, functionDirectory string) {
+	shownHeading := false
+	docker.FollowRuntimeLogs(ctx, functionDirectory, func(line string) {
+		if !shownHeading {
+			output.Log(out, "Runtime logs:")
+			shownHeading = true
+		}
+		fmt.Fprintln(out, line)
+	})
 }
 
 // watchExit reports a container's own exit, once. Buffered by one so the

--- a/templates/cli/internal/docker/logs.go
+++ b/templates/cli/internal/docker/logs.go
@@ -3,6 +3,8 @@ package docker
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"hash"
 	"io"
 	"os"
 	"path/filepath"
@@ -12,20 +14,16 @@ import (
 // runtimeLogPollInterval bounds how long a function log waits before it is
 // shown. Polling keeps this portable and avoids holding the files open while
 // cleanup removes .appwrite on Windows.
-const (
-	runtimeLogPollInterval = 50 * time.Millisecond
-	runtimeLogBookmarkSize = 256
-)
+const runtimeLogPollInterval = 50 * time.Millisecond
 
 // followedLogFile remembers how much of one runtime log has been emitted. The
-// bookmark detects a truncate-and-regrow that happens entirely between polls.
+// digest detects a truncate-and-regrow that happens entirely between polls.
 type followedLogFile struct {
-	path           string
-	info           os.FileInfo
-	offset         int64
-	pending        []byte
-	bookmark       []byte
-	bookmarkOffset int64
+	path    string
+	info    os.FileInfo
+	offset  int64
+	pending []byte
+	digest  [sha256.Size]byte
 }
 
 // FollowRuntimeLogs emits complete lines appended to the runtime's stdout and
@@ -81,30 +79,36 @@ func (f *followedLogFile) read(emit func(string)) {
 	defer file.Close()
 
 	reset := f.info != nil && (!os.SameFile(f.info, info) || info.Size() < f.offset)
-	if !reset && f.info != nil && info.Size() == f.offset {
-		// The file changed without growing, so it was rewritten in place.
-		reset = true
-	}
+	hasher := sha256.New()
 	if !reset && f.offset > 0 {
-		reset = !f.bookmarkMatches(file)
+		var matches bool
+		hasher, matches = f.prefixMatches(file)
+		reset = !matches
 	}
 	if reset {
 		f.offset = 0
 		f.pending = nil
-		f.bookmark = nil
-		f.bookmarkOffset = 0
-	}
-
-	if _, err := file.Seek(f.offset, io.SeekStart); err != nil {
-		return
+		hasher = sha256.New()
+		if _, err := file.Seek(0, io.SeekStart); err != nil {
+			return
+		}
 	}
 
 	appended, err := io.ReadAll(file)
-	if err != nil || len(appended) == 0 {
+	if err != nil {
+		return
+	}
+	if len(appended) == 0 {
+		if latest, err := file.Stat(); err == nil {
+			f.info = latest
+		} else {
+			f.info = info
+		}
 		return
 	}
 	f.offset += int64(len(appended))
-	f.refreshBookmark(appended)
+	_, _ = hasher.Write(appended)
+	copy(f.digest[:], hasher.Sum(nil))
 	f.pending = append(f.pending, appended...)
 	if latest, err := file.Stat(); err == nil {
 		f.info = latest
@@ -124,28 +128,15 @@ func (f *followedLogFile) read(emit func(string)) {
 	}
 }
 
-func (f *followedLogFile) bookmarkMatches(file *os.File) bool {
-	if len(f.bookmark) == 0 {
-		return true
+// prefixMatches verifies every byte already emitted and leaves the hasher and
+// file positioned at the old offset. A bounded tail sample is insufficient: a
+// restarted runtime can reproduce that sample after replacing an earlier line.
+func (f *followedLogFile) prefixMatches(file *os.File) (hash.Hash, bool) {
+	hasher := sha256.New()
+	copied, err := io.CopyN(hasher, file, f.offset)
+	if err != nil || copied != f.offset {
+		return hasher, false
 	}
 
-	actual := make([]byte, len(f.bookmark))
-	if _, err := file.ReadAt(actual, f.bookmarkOffset); err != nil {
-		return false
-	}
-
-	return bytes.Equal(actual, f.bookmark)
-}
-
-func (f *followedLogFile) refreshBookmark(appended []byte) {
-	if len(appended) >= runtimeLogBookmarkSize {
-		f.bookmark = append(f.bookmark[:0], appended[len(appended)-runtimeLogBookmarkSize:]...)
-	} else {
-		keep := min(len(f.bookmark), runtimeLogBookmarkSize-len(appended))
-		bookmark := make([]byte, 0, keep+len(appended))
-		bookmark = append(bookmark, f.bookmark[len(f.bookmark)-keep:]...)
-		f.bookmark = append(bookmark, appended...)
-	}
-
-	f.bookmarkOffset = f.offset - int64(len(f.bookmark))
+	return hasher, bytes.Equal(hasher.Sum(nil), f.digest[:])
 }

--- a/templates/cli/internal/docker/logs.go
+++ b/templates/cli/internal/docker/logs.go
@@ -14,16 +14,20 @@ import (
 // runtimeLogPollInterval bounds how long a function log waits before it is
 // shown. Polling keeps this portable and avoids holding the files open while
 // cleanup removes .appwrite on Windows.
-const runtimeLogPollInterval = 50 * time.Millisecond
+const (
+	runtimeLogPollInterval      = 50 * time.Millisecond
+	runtimeLogIntegrityInterval = time.Second
+)
 
 // followedLogFile remembers how much of one runtime log has been emitted. The
 // digest detects a truncate-and-regrow that happens entirely between polls.
 type followedLogFile struct {
-	path    string
-	info    os.FileInfo
-	offset  int64
-	pending []byte
-	digest  [sha256.Size]byte
+	path        string
+	info        os.FileInfo
+	offset      int64
+	pending     []byte
+	digest      [sha256.Size]byte
+	validatedAt time.Time
 }
 
 // FollowRuntimeLogs emits complete lines appended to the runtime's stdout and
@@ -67,8 +71,12 @@ func (f *followedLogFile) read(emit func(string)) {
 	if err != nil {
 		return
 	}
-	if f.info != nil && info.Size() == f.offset &&
-		os.SameFile(f.info, info) && info.ModTime().Equal(f.info.ModTime()) {
+	// Size and mtime make ordinary idle polls cheap. The periodic digest is the
+	// fallback for coarse-timestamp filesystems where a same-size rewrite can
+	// leave both values unchanged.
+	metadataUnchanged := f.info != nil && info.Size() == f.offset &&
+		os.SameFile(f.info, info) && info.ModTime().Equal(f.info.ModTime())
+	if metadataUnchanged && time.Since(f.validatedAt) < runtimeLogIntegrityInterval {
 		return
 	}
 
@@ -104,6 +112,7 @@ func (f *followedLogFile) read(emit func(string)) {
 		} else {
 			f.info = info
 		}
+		f.validatedAt = time.Now()
 		return
 	}
 	f.offset += int64(len(appended))
@@ -115,6 +124,7 @@ func (f *followedLogFile) read(emit func(string)) {
 	} else {
 		f.info = info
 	}
+	f.validatedAt = time.Now()
 
 	for {
 		newline := bytes.IndexByte(f.pending, '\n')

--- a/templates/cli/internal/docker/logs.go
+++ b/templates/cli/internal/docker/logs.go
@@ -1,0 +1,106 @@
+package docker
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// runtimeLogPollInterval bounds how long a function log waits before it is
+// shown. Polling keeps this portable and avoids holding the files open while
+// cleanup removes .appwrite on Windows.
+const runtimeLogPollInterval = 50 * time.Millisecond
+
+// followedLogFile remembers how much of one runtime log has been emitted.
+type followedLogFile struct {
+	path    string
+	info    os.FileInfo
+	offset  int64
+	pending []byte
+}
+
+// FollowRuntimeLogs emits complete lines appended to the runtime's stdout and
+// stderr files until the context is cancelled.
+//
+// Open Runtimes writes context.log() and context.error() to bind-mounted files,
+// not the container's stdout or stderr, so docker logs cannot expose them. The
+// files are checked in stdout/stderr order to keep output deterministic when
+// both change between polls.
+func FollowRuntimeLogs(ctx context.Context, functionDirectory string, emit func(string)) {
+	files := []*followedLogFile{
+		{path: filepath.Join(functionDirectory, AppwriteDirectory, "logs.txt")},
+		{path: filepath.Join(functionDirectory, AppwriteDirectory, "errors.txt")},
+	}
+
+	read := func() {
+		for _, file := range files {
+			file.read(emit)
+		}
+	}
+
+	// Catch output written between the container starting and this goroutine
+	// being scheduled.
+	read()
+
+	ticker := time.NewTicker(runtimeLogPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			read()
+		}
+	}
+}
+
+func (f *followedLogFile) read(emit func(string)) {
+	info, err := os.Stat(f.path)
+	if err != nil {
+		return
+	}
+
+	// A reload normally appends to the same files, but reset if a runtime or a
+	// user replaces or truncates one of them.
+	if f.info != nil && (!os.SameFile(f.info, info) || info.Size() < f.offset) {
+		f.offset = 0
+		f.pending = nil
+	}
+	f.info = info
+
+	if info.Size() == f.offset {
+		return
+	}
+
+	file, err := os.Open(f.path)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	if _, err := file.Seek(f.offset, io.SeekStart); err != nil {
+		return
+	}
+
+	appended, err := io.ReadAll(file)
+	if err != nil || len(appended) == 0 {
+		return
+	}
+	f.offset += int64(len(appended))
+	f.pending = append(f.pending, appended...)
+
+	for {
+		newline := bytes.IndexByte(f.pending, '\n')
+		if newline < 0 {
+			return
+		}
+
+		line := bytes.TrimSuffix(f.pending[:newline], []byte{'\r'})
+		emit(string(line))
+		f.pending = f.pending[newline+1:]
+	}
+}

--- a/templates/cli/internal/docker/logs.go
+++ b/templates/cli/internal/docker/logs.go
@@ -12,14 +12,20 @@ import (
 // runtimeLogPollInterval bounds how long a function log waits before it is
 // shown. Polling keeps this portable and avoids holding the files open while
 // cleanup removes .appwrite on Windows.
-const runtimeLogPollInterval = 50 * time.Millisecond
+const (
+	runtimeLogPollInterval = 50 * time.Millisecond
+	runtimeLogBookmarkSize = 256
+)
 
-// followedLogFile remembers how much of one runtime log has been emitted.
+// followedLogFile remembers how much of one runtime log has been emitted. The
+// bookmark detects a truncate-and-regrow that happens entirely between polls.
 type followedLogFile struct {
-	path    string
-	info    os.FileInfo
-	offset  int64
-	pending []byte
+	path           string
+	info           os.FileInfo
+	offset         int64
+	pending        []byte
+	bookmark       []byte
+	bookmarkOffset int64
 }
 
 // FollowRuntimeLogs emits complete lines appended to the runtime's stdout and
@@ -63,16 +69,8 @@ func (f *followedLogFile) read(emit func(string)) {
 	if err != nil {
 		return
 	}
-
-	// A reload normally appends to the same files, but reset if a runtime or a
-	// user replaces or truncates one of them.
-	if f.info != nil && (!os.SameFile(f.info, info) || info.Size() < f.offset) {
-		f.offset = 0
-		f.pending = nil
-	}
-	f.info = info
-
-	if info.Size() == f.offset {
+	if f.info != nil && info.Size() == f.offset &&
+		os.SameFile(f.info, info) && info.ModTime().Equal(f.info.ModTime()) {
 		return
 	}
 
@@ -81,6 +79,21 @@ func (f *followedLogFile) read(emit func(string)) {
 		return
 	}
 	defer file.Close()
+
+	reset := f.info != nil && (!os.SameFile(f.info, info) || info.Size() < f.offset)
+	if !reset && f.info != nil && info.Size() == f.offset {
+		// The file changed without growing, so it was rewritten in place.
+		reset = true
+	}
+	if !reset && f.offset > 0 {
+		reset = !f.bookmarkMatches(file)
+	}
+	if reset {
+		f.offset = 0
+		f.pending = nil
+		f.bookmark = nil
+		f.bookmarkOffset = 0
+	}
 
 	if _, err := file.Seek(f.offset, io.SeekStart); err != nil {
 		return
@@ -91,7 +104,13 @@ func (f *followedLogFile) read(emit func(string)) {
 		return
 	}
 	f.offset += int64(len(appended))
+	f.refreshBookmark(appended)
 	f.pending = append(f.pending, appended...)
+	if latest, err := file.Stat(); err == nil {
+		f.info = latest
+	} else {
+		f.info = info
+	}
 
 	for {
 		newline := bytes.IndexByte(f.pending, '\n')
@@ -103,4 +122,30 @@ func (f *followedLogFile) read(emit func(string)) {
 		emit(string(line))
 		f.pending = f.pending[newline+1:]
 	}
+}
+
+func (f *followedLogFile) bookmarkMatches(file *os.File) bool {
+	if len(f.bookmark) == 0 {
+		return true
+	}
+
+	actual := make([]byte, len(f.bookmark))
+	if _, err := file.ReadAt(actual, f.bookmarkOffset); err != nil {
+		return false
+	}
+
+	return bytes.Equal(actual, f.bookmark)
+}
+
+func (f *followedLogFile) refreshBookmark(appended []byte) {
+	if len(appended) >= runtimeLogBookmarkSize {
+		f.bookmark = append(f.bookmark[:0], appended[len(appended)-runtimeLogBookmarkSize:]...)
+	} else {
+		keep := min(len(f.bookmark), runtimeLogBookmarkSize-len(appended))
+		bookmark := make([]byte, 0, keep+len(appended))
+		bookmark = append(bookmark, f.bookmark[len(f.bookmark)-keep:]...)
+		f.bookmark = append(bookmark, appended...)
+	}
+
+	f.bookmarkOffset = f.offset - int64(len(f.bookmark))
 }

--- a/templates/cli/internal/docker/logs_test.go
+++ b/templates/cli/internal/docker/logs_test.go
@@ -1,0 +1,117 @@
+package docker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestFollowedLogFileEmitsAppendedLinesOnce(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "logs.txt")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	file := &followedLogFile{path: path}
+	var lines []string
+	emit := func(line string) { lines = append(lines, line) }
+
+	appendFile(t, path, "first\nsecond\r\npartial")
+	file.read(emit)
+	file.read(emit)
+	appendFile(t, path, " line\n")
+	file.read(emit)
+
+	want := []string{"first", "second", "partial line"}
+	if !reflect.DeepEqual(lines, want) {
+		t.Fatalf("lines = %#v, want %#v", lines, want)
+	}
+}
+
+func TestFollowedLogFileResetsAfterTruncateOrReplace(t *testing.T) {
+	directory := t.TempDir()
+	path := filepath.Join(directory, "logs.txt")
+	if err := os.WriteFile(path, []byte("before\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	file := &followedLogFile{path: path}
+	var lines []string
+	emit := func(line string) { lines = append(lines, line) }
+	file.read(emit)
+
+	if err := os.WriteFile(path, []byte("short\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file.read(emit)
+
+	replacement := filepath.Join(directory, "replacement.txt")
+	if err := os.WriteFile(replacement, []byte("replacement\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(replacement, path); err != nil {
+		t.Fatal(err)
+	}
+	file.read(emit)
+
+	want := []string{"before", "short", "replacement"}
+	if !reflect.DeepEqual(lines, want) {
+		t.Fatalf("lines = %#v, want %#v", lines, want)
+	}
+}
+
+func TestFollowRuntimeLogsStreamsStdoutAndStderr(t *testing.T) {
+	directory := t.TempDir()
+	scratch := filepath.Join(directory, AppwriteDirectory)
+	if err := os.MkdirAll(scratch, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout := filepath.Join(scratch, "logs.txt")
+	stderr := filepath.Join(scratch, "errors.txt")
+	for _, path := range []string{stdout, stderr} {
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	lines := make(chan string, 2)
+	go FollowRuntimeLogs(ctx, directory, func(line string) { lines <- line })
+
+	appendFile(t, stdout, "from log\n")
+	appendFile(t, stderr, "from error\n")
+
+	for _, want := range []string{"from log", "from error"} {
+		select {
+		case got := <-lines:
+			if got != want {
+				t.Fatalf("line = %q, want %q", got, want)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for %q", want)
+		}
+	}
+}
+
+func appendFile(t *testing.T, path, contents string) {
+	t.Helper()
+
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	if _, err := file.WriteString(contents); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/templates/cli/internal/docker/logs_test.go
+++ b/templates/cli/internal/docker/logs_test.go
@@ -66,6 +66,31 @@ func TestFollowedLogFileResetsAfterTruncateOrReplace(t *testing.T) {
 	}
 }
 
+func TestFollowedLogFileDetectsTruncateAndRegrowBetweenReads(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "logs.txt")
+	if err := os.WriteFile(path, []byte("old first\nold second\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	file := &followedLogFile{path: path}
+	var lines []string
+	emit := func(line string) { lines = append(lines, line) }
+	file.read(emit)
+
+	// This replacement is larger than the old offset. A size-only follower
+	// mistakes it for an append and starts in the middle of "new second".
+	regrown := []byte("new first\nnew second\nnew third\n")
+	if err := os.WriteFile(path, regrown, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file.read(emit)
+
+	want := []string{"old first", "old second", "new first", "new second", "new third"}
+	if !reflect.DeepEqual(lines, want) {
+		t.Fatalf("lines = %#v, want %#v", lines, want)
+	}
+}
+
 func TestFollowRuntimeLogsStreamsStdoutAndStderr(t *testing.T) {
 	directory := t.TempDir()
 	scratch := filepath.Join(directory, AppwriteDirectory)

--- a/templates/cli/internal/docker/logs_test.go
+++ b/templates/cli/internal/docker/logs_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -86,6 +87,33 @@ func TestFollowedLogFileDetectsTruncateAndRegrowBetweenReads(t *testing.T) {
 	file.read(emit)
 
 	want := []string{"old first", "old second", "new first", "new second", "new third"}
+	if !reflect.DeepEqual(lines, want) {
+		t.Fatalf("lines = %#v, want %#v", lines, want)
+	}
+}
+
+func TestFollowedLogFileChecksTheWholePrefixAfterRegrowth(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "logs.txt")
+	sharedTail := strings.Repeat("x", 256)
+	oldLine := strings.Repeat("a", 300) + sharedTail
+	if err := os.WriteFile(path, []byte(oldLine+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	file := &followedLogFile{path: path}
+	var lines []string
+	emit := func(line string) { lines = append(lines, line) }
+	file.read(emit)
+
+	// The final 256 bytes before the old offset are unchanged, but the prefix
+	// before them belongs to the new runtime and must not be skipped.
+	newLine := strings.Repeat("b", 300) + sharedTail
+	if err := os.WriteFile(path, []byte(newLine+"\nnew suffix\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	file.read(emit)
+
+	want := []string{oldLine, newLine, "new suffix"}
 	if !reflect.DeepEqual(lines, want) {
 		t.Fatalf("lines = %#v, want %#v", lines, want)
 	}

--- a/templates/cli/internal/docker/logs_test.go
+++ b/templates/cli/internal/docker/logs_test.go
@@ -119,6 +119,35 @@ func TestFollowedLogFileChecksTheWholePrefixAfterRegrowth(t *testing.T) {
 	}
 }
 
+func TestFollowedLogFilePeriodicallyChecksUnchangedMetadata(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "logs.txt")
+	if err := os.WriteFile(path, []byte("old line\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	file := &followedLogFile{path: path}
+	var lines []string
+	emit := func(line string) { lines = append(lines, line) }
+	file.read(emit)
+	oldModTime := file.info.ModTime()
+
+	// Simulate a coarse-timestamp filesystem: the content changes in place but
+	// size, identity and modification time all remain unchanged.
+	if err := os.WriteFile(path, []byte("new line\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, oldModTime, oldModTime); err != nil {
+		t.Fatal(err)
+	}
+	file.validatedAt = time.Now().Add(-runtimeLogIntegrityInterval)
+	file.read(emit)
+
+	want := []string{"old line", "new line"}
+	if !reflect.DeepEqual(lines, want) {
+		t.Fatalf("lines = %#v, want %#v", lines, want)
+	}
+}
+
 func TestFollowRuntimeLogsStreamsStdoutAndStderr(t *testing.T) {
 	directory := t.TempDir()
 	scratch := filepath.Join(directory, AppwriteDirectory)


### PR DESCRIPTION
`appwrite run function` still bind-mounted the Open Runtimes log files after the Go migration, but no longer followed them. Function `log()` and `error()` calls were written to `.appwrite/logs.txt` and `.appwrite/errors.txt` without reaching the terminal.

## Reproduction

Run a local Node function that writes to both runtime streams:

```js
export default async ({ res, log, error }) => {
  log("REPRO_STDOUT: visible in real time");
  error("REPRO_STDERR: visible in real time");
  return res.text("ok");
};
```

```sh
appwrite run function --function-id cli-log-repro --port 3099 --no-reload
curl -X POST http://127.0.0.1:3099/ \
  -H 'content-type: application/json' \
  --data '{"body":"","headers":{},"method":"GET","path":"/"}'
```

### Before

The function returned `ok`, but the CLI only showed the server startup. Waiting did not print either runtime message:

```text
✓ Success: Visit http://localhost:3099/ to execute your function.
HTTP server successfully started!
```

Both messages were present in the mounted files:

```text
$ cat functions/fn/.appwrite/logs.txt
REPRO_STDOUT: visible in real time

$ cat functions/fn/.appwrite/errors.txt
REPRO_STDERR: visible in real time
```

### After

The same request prints both messages immediately under one lazy heading:

```text
✓ Success: Visit http://localhost:3099/ to execute your function.
HTTP server successfully started!
ℹ Info: Runtime logs:
REPRO_STDOUT: visible in real time
REPRO_STDERR: visible in real time
```

This adds a portable follower for both files. It preserves partial lines, handles truncation and replacement, stops with the run context, and avoids holding files open during Windows cleanup.

## Test plan

- [x] `php example.php cli`
- [x] `cd examples/cli && go test ./... && go vet ./... && go build ./...`
- [x] `cd examples/cli && go test -race ./internal/docker ./internal/cmd`
- [x] `composer lint`
- [x] `composer refactor:check`
- [x] `composer lint-twig`
- [x] Run the reproduction above and verify `log()` and `error()` appear immediately under one `Runtime logs:` heading
