### PR TITLE
Format generated Go SDKs and update CLI to Go SDK 7.1.0

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -279,6 +279,12 @@ jobs:
               ;;
             go)
               go mod tidy || true
+              unformatted=$(gofmt -l .)
+              if [ -n "$unformatted" ]; then
+                echo "Not gofmt-clean:"
+                echo "$unformatted"
+                exit 1
+              fi
               go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
               govulncheck ./...
               go build ./...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,19 @@ Lock file templates (`package-lock.json.twig`) contain Twig expressions that get
 
 The script strips Twig expressions before running `npm install`, then restores them automatically. Never copy a raw lock file over a lock template or edit one by hand.
 
+### Rule 7: Go templates must generate formatted source
+
+Formatting is currently enforced only for the generated Go SDK; other SDKs will adopt formatter checks later. Keep Go templates accurate enough that their generated `.go` files are already `gofmt`-clean. Do not add a post-generation formatting step or run `gofmt` to fix the generated output in place—the fix belongs in the Twig template.
+
+After changing Go templates, regenerate the affected platform and verify formatting:
+
+```bash
+php example.php go <platform>
+test -z "$(gofmt -l examples/go)"
+```
+
+Because `CLI` inherits from `Go`, regenerate it after shared Go template changes and verify its generated Go files too.
+
 ## Repository at a Glance
 
 - **Purpose:** Generate Appwrite SDKs and tooling targets for 20+ languages/platforms from Swagger/OpenAPI specs using Twig templates

--- a/example.php
+++ b/example.php
@@ -328,6 +328,7 @@ try {
         ['service' => 'account', 'name' => 'updatePushTarget'],
         ['service' => 'account', 'name' => 'deletePushTarget'],
         ['service' => 'account', 'name' => 'createOAuth2Session'],
+        ['service' => 'account', 'name' => 'createJWT'],
         ['service' => 'account', 'name' => 'delete'],
         // OIDC logout.
         ['service' => 'oauth2', 'name' => 'logout'],
@@ -348,6 +349,7 @@ try {
         ['service' => 'presences', 'name' => 'update'],
         // Usage and log reporting.
         ['service' => 'presences', 'name' => 'getUsage'],
+        ['service' => 'project', 'name' => 'createKey'],
         ['service' => 'project', 'name' => 'getUsage'],
         ['service' => 'users', 'name' => 'getUsage'],
         ['service' => 'teams', 'name' => 'listLogs'],

--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -25,7 +25,7 @@ class CLI extends Go
      * requires from v2 on, so it moves in lockstep with the version pinned in
      * templates/cli/go.mod.twig.
      */
-    public const string SDK_MODULE = 'github.com/appwrite/sdk-for-go/v6';
+    public const string SDK_MODULE = 'github.com/appwrite/sdk-for-go/v7';
 
     /**
      * @var array

--- a/src/SDK/Language/Go.php
+++ b/src/SDK/Language/Go.php
@@ -357,7 +357,10 @@ class Go extends Language
                 $value = explode("\n", $value);
                 $indent = \str_repeat(' ', $indent);
                 foreach ($value as $key => $line) {
-                    $value[$key] = "// " . wordwrap(trim($line), 75, "\n" . $indent . "// ");
+                    $line = trim($line);
+                    $value[$key] = $line === ''
+                        ? '//'
+                        : "// " . wordwrap($line, 75, "\n" . $indent . "// ");
                 }
                 return implode("\n" . $indent, $value);
             }, ['is_safe' => ['html']]),

--- a/templates/cli/go.mod.twig
+++ b/templates/cli/go.mod.twig
@@ -7,7 +7,7 @@ go 1.26.5
 // so anything added by hand to the generated file is lost on the next run.
 require (
 {% if not sdk.test %}
-	github.com/appwrite/sdk-for-go/v6 v6.5.0
+	github.com/appwrite/sdk-for-go/v7 v7.1.0
 {% endif %}
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/templates/cli/internal/sdk/ambient_js.go
+++ b/templates/cli/internal/sdk/ambient_js.go
@@ -5,7 +5,7 @@ package sdk
 import (
 	"os"
 
-	sdkclient "github.com/appwrite/sdk-for-go/v6/client"
+	sdkclient "github.com/appwrite/sdk-for-go/v7/client"
 
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/config"
 )

--- a/templates/cli/internal/sdk/ambient_native.go
+++ b/templates/cli/internal/sdk/ambient_native.go
@@ -2,7 +2,7 @@
 
 package sdk
 
-import sdkclient "github.com/appwrite/sdk-for-go/v6/client"
+import sdkclient "github.com/appwrite/sdk-for-go/v7/client"
 
 // The native half of the pair in ambient_js.go. A host has no session of its
 // own to lend the CLI: the credential is whatever `login` stored, and a command

--- a/templates/go/appwrite.go.twig
+++ b/templates/go/appwrite.go.twig
@@ -1,10 +1,12 @@
+{% set sortedServices = services | sort((a, b) => a.name <=> b.name) -%}
 package appwrite
 
 import (
 	"time"
 
 	"{{ sdk | goPackagePath }}/client"
-{% for key,service in services %}
+
+{% for service in sortedServices %}
 	"{{ sdk | goPackagePath }}/{{ service.name | caseLower }}"
 {% endfor %}
 )
@@ -62,7 +64,7 @@ func WithChunkSize(size int64) client.ClientOption {
 {% for headerKey, header in globalHeaders %}
 // Helper method to construct NewClient()
 {% if header.description %}
-// 
+//
 // {{header.description}}
 {% endif %}
 func With{{headerKey | caseUcfirst}}(value string) client.ClientOption {
@@ -74,4 +76,5 @@ func With{{headerKey | caseUcfirst}}(value string) client.ClientOption {
 		return nil
 	}
 }
+{% if not loop.last %}{{ "\n" -}}{% endif %}
 {% endfor %}

--- a/templates/go/base/params.twig
+++ b/templates/go/base/params.twig
@@ -14,17 +14,16 @@
 	}
 {% endif %}
 {% endfor %}
-	headers := map[string]interface{}{
+	headers := map[string]interface{}{}
 {%~ for key, security in (method | securityHeaders) %}
-		"{{ security.name }}": srv.client.Config["{{ key | caseLower }}"],
+	headers["{{ security.name }}"] = srv.client.Config["{{ key | caseLower }}"]
 {%~ endfor %}
 {% for key, header in (method | methodHeaders) %}
-		"{{ key }}": "{{ header }}",
+	headers["{{ key }}"] = "{{ header }}"
 {% endfor %}
 {%~ for parameter in (method | parameters('header')) | filter(v => v.required) %}
-		"{{ parameter.name }}": {{ parameter.name | caseUcfirst }},
+	headers["{{ parameter.name }}"] = {{ parameter.name | caseUcfirst }}
 {%~ endfor %}
-	}
 {% for parameter in (method | parameters('header')) | filter(v => not v.required) %}
 	if options.enabledSetters["{{ parameter.name | caseUcfirst }}"] {
 		headers["{{ parameter.name }}"] = options.{{ parameter.name | caseUcfirst }}

--- a/templates/go/base/requests/file.twig
+++ b/templates/go/base/requests/file.twig
@@ -1,14 +1,10 @@
-{% for parameter in (method | parameters('all')) %}
-{% if (parameter | schemaType) == 'file' %}
-    paramName := "{{ parameter.name }}"
+{% set fileParameter = (method | parameters('all')) | filter(p => (p | schemaType) == 'file') | last %}
+	paramName := "{{ fileParameter.name }}"
 
-{% endif %}
-{% endfor %}
-
-    uploadId := ""
+	uploadId := ""
 {% for parameter in (method | parameters('all')) %}
 {% if (parameter | extension('x-upload-id', false)) %}
-    uploadId = {{ parameter.name | escapeKeyword | caseUcfirst }}
+	uploadId = {{ parameter.name | escapeKeyword | caseUcfirst }}
 {% endif %}
 {% endfor %}
 

--- a/templates/go/client.go.twig
+++ b/templates/go/client.go.twig
@@ -14,10 +14,10 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
-	"runtime"
 
 	"{{ sdk | goPackagePath }}/file"
 )
@@ -45,8 +45,8 @@ type ClientResponse struct {
 	// so a `Result.(string)` assertion that used to succeed now fails, and an
 	// unchecked one panics. Read it through ResponseBody, which accepts either
 	// and so keeps working across the change.
-	Result     interface{}
-	Type	   string
+	Result interface{}
+	Type   string
 }
 
 func (ce *{{ spec.info.title | caseUcfirst }}Error) Error() string {
@@ -78,16 +78,15 @@ type Client struct {
 
 // Initialize a new {{ spec.info.title | caseUcfirst }} client with a given timeout
 func New(optionalSetters ...ClientOption) Client {
-	headers := map[string]string{
+	headers := map[string]string{}
 {% for key,header in defaultHeaders %}
-		"{{key}}" : "{{header}}",
-		"user-agent" : fmt.Sprintf("{{spec.info.title | caseUcfirst}}{{ language.name | caseUcfirst }}SDK/{{ sdk.version }} (%s; %s)", runtime.GOOS, runtime.GOARCH),
-		"x-sdk-name": "{{ sdk.name }}",
-		"x-sdk-platform": "{{ sdk.platform }}",
-		"x-sdk-language": "{{ language.name | caseLower }}",
-		"x-sdk-version": "{{ sdk.version }}",
+	headers["{{key}}"] = "{{header}}"
+	headers["user-agent"] = fmt.Sprintf("{{spec.info.title | caseUcfirst}}{{ language.name | caseUcfirst }}SDK/{{ sdk.version }} (%s; %s)", runtime.GOOS, runtime.GOARCH)
+	headers["x-sdk-name"] = "{{ sdk.name }}"
+	headers["x-sdk-platform"] = "{{ sdk.platform }}"
+	headers["x-sdk-language"] = "{{ language.name | caseLower }}"
+	headers["x-sdk-version"] = "{{ sdk.version }}"
 {% endfor %}
-	}
 	httpClient, err := GetDefaultClient(defaultTimeout)
 	if err != nil {
 		panic(err)
@@ -582,7 +581,7 @@ func (client *Client) Call(method string, path string, headers map[string]interf
 			StatusCode: resp.StatusCode,
 			Header:     resp.Header,
 			Result:     responseData,
-			Type:	   contentType,
+			Type:       contentType,
 		}, nil
 	}
 
@@ -598,7 +597,7 @@ func (client *Client) Call(method string, path string, headers map[string]interf
 		StatusCode: resp.StatusCode,
 		Header:     resp.Header,
 		Result:     responseData,
-		Type:	   contentType,
+		Type:       contentType,
 	}, nil
 }
 
@@ -747,11 +746,11 @@ func flatten(params interface{}, prefix string, result *map[string]string) error
 				return err
 			}
 		}
-		default:
-			if prefix == "" {
-				return fmt.Errorf("prefix is empty for %s", params)
-			}
-			(*result)[prefix] = toString(params)
+	default:
+		if prefix == "" {
+			return fmt.Errorf("prefix is empty for %s", params)
+		}
+		(*result)[prefix] = toString(params)
 	}
 	return nil
 }

--- a/templates/go/id.go.twig
+++ b/templates/go/id.go.twig
@@ -1,13 +1,13 @@
 package id
 
 import (
-    "time"
-    "strconv"
-    "math/rand"
+	"math/rand"
+	"strconv"
+	"time"
 )
 
 func Custom(id string) string {
-    return id
+	return id
 }
 
 func Unique() string {

--- a/templates/go/models/model.go.twig
+++ b/templates/go/models/model.go.twig
@@ -1,38 +1,38 @@
 package models
 
 import (
-    "encoding/json"
-    "errors"
+	"encoding/json"
+	"errors"
 )
 
 {{ ((definition.description | caseUcfirst) ~ " Model") | godocComment }}
 type {{ definitionName | caseUcfirst }} struct {
-    {%~ for property in definition.properties %}
-    {{ property.description | godocComment(4) }}
-    {{ (property | schemaName) | caseUcfirst | escapeKeyword }} {{ property | propertyType(spec) }} `json:"{{ (property | schemaName) }}"`
-    {%~ endfor %}
+	{%~ for property in definition.properties %}
+	{{ property.description | godocComment | replace({"\n": "\n\t"}) }}
+	{{ (property | schemaName) | caseUcfirst | escapeKeyword }} {{ property | propertyType(spec) }} `json:"{{ (property | schemaName) }}"`
+	{%~ endfor %}
 
-    // Used by Decode() method
-    data []byte
+	// Used by Decode() method
+	data []byte
 }
 
 func (model {{ definitionName | caseUcfirst }}) New(data []byte) *{{ definitionName | caseUcfirst }} {
-    model.data = data
-    return &model
+	model.data = data
+	return &model
 }
 
 {%~ if definition.additionalProperties %}
 // Use this method to get response in desired type
 {%~ endif %}
 func (model *{{ definitionName | caseUcfirst }}) Decode(value interface{}) error {
-    if len(model.data) <= 0 {
-        return errors.New("method Decode() cannot be used on nested struct")
-    }
+	if len(model.data) <= 0 {
+		return errors.New("method Decode() cannot be used on nested struct")
+	}
 
-    err := json.Unmarshal(model.data, value)
-    if err != nil {
-        return err
-    }
+	err := json.Unmarshal(model.data, value)
+	if err != nil {
+		return err
+	}
 
-    return nil
+	return nil
 }

--- a/templates/go/models/model_test.go.twig
+++ b/templates/go/models/model_test.go.twig
@@ -1,73 +1,61 @@
 {% autoescape false %}
 {%- macro render_property_value(definitions, property, spec) -%}
-    {%- if (property | schemaModel) and definitions[(property | schemaModel)] -%}
-        {%- if (property | schemaType) == 'array' -%}
-            []{{ (property | schemaModel) | caseUcfirst }}{
-                {{- _self.render_struct_init(definitions, definitions[(property | schemaModel)], spec) -}},
-            }
-        {%- else -%}
-            {{- _self.render_struct_init(definitions, definitions[(property | schemaModel)], spec) -}}
-        {%- endif -%}
-    {%- else -%}
-        {%- if (property | schemaType) == 'object' -%}
-            map[string]interface{}{}
-        {%- elseif (property | schemaType) == 'array' -%}
-            {{ (property | typeName) }}{
-                {%- if (property | arraySchema | schemaType) == 'string' -%}
-                    "{{ (property | arraySchema | schemaExample) | default('test') | replace({'\\': '\\\\', '"': '\\"'}) | raw }}"
-                {%- elseif (property | arraySchema | schemaType) == 'integer' -%}
-                    1
-                {%- endif -%}
-            }
-        {%- elseif (property | schemaType) == 'string' -%}
-            "{{ ((property | schemaExample) | default('string')) | replace({'\\': '\\\\', '"': '\\"'}) | raw }}"
-        {%- elseif (property | schemaType) == 'boolean' -%}
-            true
-        {%- elseif (property | schemaType) == 'integer' -%}
-            {{ (property | schemaExample) | default(1) }}
-        {%- elseif (property | schemaType) == 'number' -%}
-            {{ (property | schemaExample) | default(1.0) }}
-        {%- else -%}
-            nil
-        {%- endif -%}
-    {%- endif -%}
+{%- if (property | schemaModel) and definitions[(property | schemaModel)] -%}
+{%- if (property | schemaType) == 'array' -%}
+[]{{ (property | schemaModel) | caseUcfirst }}{ {{- _self.render_struct_init(definitions, definitions[(property | schemaModel)], spec) -}} }
+{%- else -%}
+{{ _self.render_struct_init(definitions, definitions[(property | schemaModel)], spec) }}
+{%- endif -%}
+{%- elseif (property | schemaType) == 'object' -%}
+map[string]interface{}{}
+{%- elseif (property | schemaType) == 'array' -%}
+{{ property | typeName }}{%- if (property | arraySchema | schemaType) == 'string' -%}{"{{ (property | arraySchema | schemaExample) | default('test') | replace({'\\': '\\\\', '"': '\\"'}) | raw }}"}{%- elseif (property | arraySchema | schemaType) == 'integer' -%}{1}{%- else -%}{}{%- endif -%}
+{%- elseif (property | schemaType) == 'string' -%}
+"{{ ((property | schemaExample) | default('string')) | replace({'\\': '\\\\', '"': '\\"'}) | raw }}"
+{%- elseif (property | schemaType) == 'boolean' -%}
+true
+{%- elseif (property | schemaType) == 'integer' -%}
+{{ (property | schemaExample) | default(1) }}
+{%- elseif (property | schemaType) == 'number' -%}
+{{ (property | schemaExample) | default(1.0) }}
+{%- else -%}
+nil
+{%- endif -%}
 {%- endmacro -%}
 
 {%- macro render_struct_init(definitions, definition, spec) -%}
-    {{ (definition | schemaName) | caseUcfirst }}{
-        {%- for property in definition.properties | filter(p => p | schemaRequired) %}
-        {{ (property | schemaName) | caseUcfirst | escapeKeyword }}: {{ _self.render_property_value(definitions, property, spec) }},
-        {%- endfor %}
-    }
-{%- endmacro -%}
+{{ (definition | schemaName) | caseUcfirst }}{
+{%- for property in definition.properties | filter(p => p | schemaRequired) -%}
+{{ (property | schemaName) | caseUcfirst | escapeKeyword }}: {{ _self.render_property_value(definitions, property, spec) }}{% if not loop.last %}, {% endif %}
+{%- endfor -%}
+}
+{%- endmacro %}
 package models
 
 import (
-    "encoding/json"
-    "testing"
+	"encoding/json"
+	"testing"
 )
 
 func Test{{ definitionName | caseUcfirst }}Model(t *testing.T) {
-    model := {{ _self.render_struct_init(definitions, definition, spec) }}
+	model := {{ _self.render_struct_init(definitions, definition, spec) }}
 
-    data, err := json.Marshal(model)
-    if err != nil {
-        t.Fatal(err)
-    }
+	data, err := json.Marshal(model)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-    var result {{ definitionName | caseUcfirst }}
-    err = json.Unmarshal(data, &result)
-    if err != nil {
-        t.Fatal(err)
-    }
-
-    {%- for property in definition.properties | filter(p => p | schemaRequired) %}
-    {%- if (property | schemaType) != 'object' and (property | schemaType) != 'array' %}
-
-    if result.{{ (property | schemaName) | caseUcfirst | escapeKeyword }} != model.{{ (property | schemaName) | caseUcfirst | escapeKeyword }} {
-        t.Errorf("Expected {{ (property | schemaName) | caseUcfirst | escapeKeyword }} %v, got %v", model.{{ (property | schemaName) | caseUcfirst | escapeKeyword }}, result.{{ (property | schemaName) | caseUcfirst | escapeKeyword }})
-    }
-    {%- endif %}
-    {%- endfor %}
+	var result {{ definitionName | caseUcfirst }}
+	err = json.Unmarshal(data, &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+{% for property in definition.properties | filter(p => p | schemaRequired) %}
+{% if (property | schemaType) != 'object' and (property | schemaType) != 'array' %}
+	if result.{{ (property | schemaName) | caseUcfirst | escapeKeyword }} != model.{{ (property | schemaName) | caseUcfirst | escapeKeyword }} {
+		t.Errorf("Expected {{ (property | schemaName) | caseUcfirst | escapeKeyword }} %v, got %v", model.{{ (property | schemaName) | caseUcfirst | escapeKeyword }}, result.{{ (property | schemaName) | caseUcfirst | escapeKeyword }})
+	}
+{% endif %}
+{% endfor %}
 }
 {% endautoescape %}

--- a/templates/go/models/request_model.go.twig
+++ b/templates/go/models/request_model.go.twig
@@ -1,26 +1,26 @@
 package models
 
 import (
-    "encoding/json"
+	"encoding/json"
 )
 
 {{ ((requestModel.description | caseUcfirst) ~ " Request Model") | godocComment }}
 type {{ requestModelName | caseUcfirst }} struct {
-    {%~ for property in requestModel.properties %}
-    {{ property.description | godocComment(4) }}
-    {{ (property | schemaName) | caseUcfirst | escapeKeyword }} {{ property | propertyType(spec) }}{% if not (property | schemaRequired) %} `json:"{{ (property | schemaName) }},omitempty"`{% else %} `json:"{{ (property | schemaName) }}"`{% endif %}
+	{%~ for property in requestModel.properties %}
+	{{ property.description | godocComment | replace({"\n": "\n\t"}) }}
+	{{ (property | schemaName) | caseUcfirst | escapeKeyword }} {{ property | propertyType(spec) }}{% if not (property | schemaRequired) %} `json:"{{ (property | schemaName) }},omitempty"`{% else %} `json:"{{ (property | schemaName) }}"`{% endif %}
 
-    {%~ endfor %}
+	{%~ endfor %}
 }
 
 func (model {{ requestModelName | caseUcfirst }}) ToMap() map[string]interface{} {
-    return map[string]interface{}{
-        {%~ for property in requestModel.properties %}
-        "{{ (property | schemaName) }}": model.{{ (property | schemaName) | caseUcfirst | escapeKeyword }},
-        {%~ endfor %}
-    }
+	values := map[string]interface{}{}
+	{%~ for property in requestModel.properties %}
+	values["{{ (property | schemaName) }}"] = model.{{ (property | schemaName) | caseUcfirst | escapeKeyword }}
+	{%~ endfor %}
+	return values
 }
 
 func (model {{ requestModelName | caseUcfirst }}) ToJson() ([]byte, error) {
-    return json.Marshal(model.ToMap())
+	return json.Marshal(model.ToMap())
 }

--- a/templates/go/operator.go.twig
+++ b/templates/go/operator.go.twig
@@ -9,15 +9,15 @@ import (
 type Condition string
 
 const (
-	ConditionEqual              Condition = "equal"
-	ConditionNotEqual           Condition = "notEqual"
-	ConditionGreaterThan        Condition = "greaterThan"
-	ConditionGreaterThanEqual   Condition = "greaterThanEqual"
-	ConditionLessThan           Condition = "lessThan"
-	ConditionLessThanEqual      Condition = "lessThanEqual"
-	ConditionContains           Condition = "contains"
-	ConditionIsNull             Condition = "isNull"
-	ConditionIsNotNull          Condition = "isNotNull"
+	ConditionEqual            Condition = "equal"
+	ConditionNotEqual         Condition = "notEqual"
+	ConditionGreaterThan      Condition = "greaterThan"
+	ConditionGreaterThanEqual Condition = "greaterThanEqual"
+	ConditionLessThan         Condition = "lessThan"
+	ConditionLessThanEqual    Condition = "lessThanEqual"
+	ConditionContains         Condition = "contains"
+	ConditionIsNull           Condition = "isNull"
+	ConditionIsNotNull        Condition = "isNotNull"
 )
 
 type operatorOptions struct {

--- a/templates/go/query.go.twig
+++ b/templates/go/query.go.twig
@@ -27,7 +27,7 @@ func parseQuery(options queryOptions) string {
 		Attribute string        `json:"attribute,omitempty"`
 		Values    []interface{} `json:"values,omitempty"`
 	}{
-		Method:    options.Method,
+		Method: options.Method,
 	}
 
 	if options.Attribute != nil {
@@ -282,32 +282,32 @@ func OrderRandom() string {
 func CursorBefore(documentId interface{}) string {
 	values := toArray(documentId)
 	return parseQuery(queryOptions{
-		Method:    "cursorBefore",
-		Values:    &values,
+		Method: "cursorBefore",
+		Values: &values,
 	})
 }
 
 func CursorAfter(documentId string) string {
 	values := toArray(documentId)
 	return parseQuery(queryOptions{
-		Method:    "cursorAfter",
-		Values:    &values,
+		Method: "cursorAfter",
+		Values: &values,
 	})
 }
 
 func Limit(limit int) string {
 	values := toArray(limit)
 	return parseQuery(queryOptions{
-		Method:    "limit",
-		Values:    &values,
+		Method: "limit",
+		Values: &values,
 	})
 }
 
 func Offset(offset int) string {
 	values := toArray(offset)
 	return parseQuery(queryOptions{
-		Method:    "offset",
-		Values:    &values,
+		Method: "offset",
+		Values: &values,
 	})
 }
 

--- a/templates/go/role.go.twig
+++ b/templates/go/role.go.twig
@@ -1,42 +1,42 @@
 package role
 
 import (
-    "fmt"
+	"fmt"
 )
 
 func Any() string {
-    return "any"
+	return "any"
 }
 
 func User(id, status string) string {
-    if status != "" {
-        return fmt.Sprintf("user:%s/%s", id, status)
-    }
-    return fmt.Sprintf("user:%s", id)
+	if status != "" {
+		return fmt.Sprintf("user:%s/%s", id, status)
+	}
+	return fmt.Sprintf("user:%s", id)
 }
 
-func Users(status string) string{
-    if status != "" {
-        return fmt.Sprintf("users/%s", status)
-    }
-    return "users"
+func Users(status string) string {
+	if status != "" {
+		return fmt.Sprintf("users/%s", status)
+	}
+	return "users"
 }
 
 func Guests() string {
-    return "guests"
+	return "guests"
 }
 
 func Team(id, role string) string {
-    if role != "" {
-        return fmt.Sprintf("team:%s/%s", id, role)
-    }
-    return fmt.Sprintf("team:%s", id)
+	if role != "" {
+		return fmt.Sprintf("team:%s/%s", id, role)
+	}
+	return fmt.Sprintf("team:%s", id)
 }
 
 func Member(id string) string {
-    return fmt.Sprintf("member:%s", id)
+	return fmt.Sprintf("member:%s", id)
 }
 
 func Label(id string) string {
-    return fmt.Sprintf("label:%s", id)
+	return fmt.Sprintf("label:%s", id)
 }

--- a/templates/go/services/service.go.twig
+++ b/templates/go/services/service.go.twig
@@ -12,7 +12,8 @@
 {% set hasDiscriminatedUnionResponses = true %}
 {% endif %}
 {% endfor %}
-{%- for method in (service | operations) -%}
+{%- set methods = service | operations -%}
+{%- for method in methods -%}
 {%- if (method | returnType(spec, spec.info.title | caseLower)) starts with "models" -%}
 		{%- set requireModelsPkg = true -%}
 	{%- endif -%}
@@ -30,20 +31,21 @@ package {{ service.name | caseLower }}
 import (
 	"encoding/json"
 	"errors"
-	"{{ sdk | goPackagePath }}/client"
-{% if requireModelsPkg %}
-	"{{ sdk | goPackagePath }}/models"
-{% endif %}
-{% if requireFilesPkg %}
-	"{{ sdk | goPackagePath }}/file"
+{% if hasDiscriminatedUnionResponses %}
+	"fmt"
 {% endif %}
 {% if requireUrlPkg %}
 	"net/url"
 {% endif %}
-{% if hasDiscriminatedUnionResponses %}
-	"fmt"
-{% endif %}
 	"strings"
+
+	"{{ sdk | goPackagePath }}/client"
+{% if requireFilesPkg %}
+	"{{ sdk | goPackagePath }}/file"
+{% endif %}
+{% if requireModelsPkg %}
+	"{{ sdk | goPackagePath }}/models"
+{% endif %}
 )
 
 {{ ((service.name | caseUcfirst) ~ " service") | godocComment }}
@@ -55,30 +57,35 @@ func New(clt client.Client) *{{ service.name | caseUcfirst }} {
 	return &{{ service.name | caseUcfirst }}{
 		client: clt,
 	}
+}{%- set firstMethod = methods | first -%}
+{%- if (firstMethod | parameters('all')) | filter(v => not v.required) | length > 0 -%}
+{{ "\n\n" -}}
+{%- else -%}
+{{ "\n" -}}
+{%- endif -%}
+{% for method in methods -%}
+{% if (method | parameters('all'))|filter(v => not v.required)|length > 0 %}
+{% set optionalParameters = (method | parameters('all')) | filter(v => not v.required) %}
+{% set optionFieldWidth = (optionalParameters | map(p => ((p.name | caseUcfirst) | length)) | merge([14]) | sort | last) %}
+type {{ ((method | methodName) ~ "Options") | caseUcfirst }} struct {
+{% for parameter in optionalParameters %}
+	{{ ('%-' ~ optionFieldWidth ~ 's %s') | format(parameter.name | caseUcfirst, parameter | typeName) }}
+{% endfor %}
+	{{ ('%-' ~ optionFieldWidth ~ 's %s') | format('enabledSetters', 'map[string]bool') }}
 }
 
-{% for method in (service | operations) %}
-{% if (method | parameters('all'))|filter(v => not v.required)|length > 0 %}
-type {{ ((method | methodName) ~ "Options") | caseUcfirst }} struct {
-{% for parameter in (method | parameters('all')) %}
-{% if not parameter.required %}
-	{{ parameter.name | caseUcfirst }} {{ (parameter | typeName) }}
-{% endif %}
-{% endfor %}
-	enabledSetters map[string]bool
-}
 func (options {{ ((method | methodName) ~ "Options") | caseUcfirst }}) New() *{{ ((method | methodName) ~ "Options") | caseUcfirst }} {
-	options.enabledSetters = map[string]bool{
-{% for parameter in (method | parameters('all')) %}
-{% if not parameter.required %}
-		"{{ parameter.name | caseUcfirst }}": false,
-{% endif %}
-{% endfor %}
-	}
+	options.enabledSetters = map[string]bool{{ '{' -}}
+{%- for parameter in optionalParameters -%}
+"{{ parameter.name | caseUcfirst }}": false{% if not loop.last %}, {% endif %}
+{%- endfor -%}
+{{ '}' }}
 	return &options
 }
+
 type {{ ((method | methodName) ~ "Option" ) | caseUcfirst }} func(*{{ ((method | methodName) ~ "Options") | caseUcfirst }})
-{% for parameter in (method | parameters('all'))|filter(v => not v.required) %}
+
+{% for parameter in optionalParameters %}
 func (srv *{{ service.name | caseUcfirst }}) With{{ (method | methodName) | caseUcfirst }}{{ parameter.name | caseUcfirst }}(v {{ (parameter | typeName) }}) {{ ((method | methodName) ~ "Option") | caseUcfirst }} {
 	return func(o *{{ ((method | methodName) ~ "Options") | caseUcfirst }}) {
 		o.{{ parameter.name | caseUcfirst }} = v
@@ -86,23 +93,23 @@ func (srv *{{ service.name | caseUcfirst }}) With{{ (method | methodName) | case
 	}
 }
 {% endfor %}
-{% endif %}
-{% set params="" %}
-{% if (method | parameters('all'))|filter(v => v.required)|length > 0 %}
-{% for parameter in (method | parameters('all'))|filter(v => v.required) %}
-	{% set params = params ~ (parameter.name | caseUcfirst) ~ " " ~ (parameter | typeName) %}
-{% if not loop.last %}
-	{% set params = params ~ ", " %}
-{% endif %}
-{% endfor %}
-{% if (method | parameters('all'))|filter(v => not v.required)|length > 0 %}
-	{% set params = params ~ ", " %}
-{% endif %}
-{% endif %}
-{% if (method | parameters('all'))|filter(v => not v.required)|length > 0 %}
-	{% set params = params ~ "optionalSetters ..." ~ (((method | methodName) ~ "Option") | caseUcfirst) %}
-{% endif %}
-
+{%- endif -%}
+{%- set params="" -%}
+{%- if (method | parameters('all'))|filter(v => v.required)|length > 0 -%}
+{%- for parameter in (method | parameters('all'))|filter(v => v.required) -%}
+{%- set params = params ~ (parameter.name | caseUcfirst) ~ " " ~ (parameter | typeName) -%}
+{%- if not loop.last -%}
+{%- set params = params ~ ", " -%}
+{%- endif -%}
+{%- endfor -%}
+{%- if (method | parameters('all'))|filter(v => not v.required)|length > 0 -%}
+{%- set params = params ~ ", " -%}
+{%- endif -%}
+{%- endif -%}
+{%- if (method | parameters('all'))|filter(v => not v.required)|length > 0 -%}
+{%- set params = params ~ "optionalSetters ..." ~ (((method | methodName) ~ "Option") | caseUcfirst) -%}
+{%- endif -%}
+{{ "\n" -}}
 {% if method.description %}
 {{ (((method | methodName) | caseUcfirst) ~ ' ' ~ method.description | caseLcfirst) | godocComment }}
 {% else %}
@@ -117,7 +124,7 @@ func (srv *{{ service.name | caseUcfirst }}) With{{ (method | methodName) | case
 {%~ endif %}
 {% endif %}
 {% set returnType = method | returnType(spec, spec.info.title | caseLower) %}
-func (srv *{{ service.name | caseUcfirst }}) {{ (method | methodName) | caseUcfirst }}({{ params }})({% if returnType == 'models.Model' %}{{ returnType }}{% else %}*{{ returnType }}{% endif %}, error) {
+func (srv *{{ service.name | caseUcfirst }}) {{ (method | methodName) | caseUcfirst }}({{ params }}) ({% if returnType == 'models.Model' %}{{ returnType }}{% else %}*{{ returnType }}{% endif %}, error) {
 {% if (method | parameters('path'))|length > 0 %}
 	r := strings.NewReplacer({% for parameter in (method | parameters('path')) %}"{{ '{' }}{{ parameter.name }}{{ '}' }}", client.EncodePath({% if (parameter.extensions['x-sdk-source']|default('')) == 'security' %}srv.client.Config["{{ parameter.extensions['x-sdk-config'] | caseLower }}"]{% else %}{{ parameter.name | caseUcfirst }}{% endif %}){% if not loop.last %}, {% endif %}{% endfor %})
 	path := r.Replace("{{ method.path }}")
@@ -135,6 +142,7 @@ func (srv *{{ service.name | caseUcfirst }}) {{ (method | methodName) | caseUcfi
 {% endif %}
 }
 {% if (method | methodType) == 'location' %}
+{{ "\n" -}}
 {% if method.description %}
 {{ (((method | methodName) | caseUcfirst) ~ 'URL ' ~ method.description | caseLcfirst) | godocComment }}
 {% else %}
@@ -180,4 +188,5 @@ func (srv *{{ service.name | caseUcfirst }}) {{ (method | methodName) | caseUcfi
 	return &result, nil
 }
 {% endif %}
+{% if not loop.last and ((methods[loop.index0 + 1] | parameters('all')) | filter(v => not v.required) | length > 0) %}{{ "\n" -}}{% endif %}
 {% endfor %}

--- a/templates/go/services/service_test.go.twig
+++ b/templates/go/services/service_test.go.twig
@@ -56,15 +56,18 @@ package {{ service.name | caseLower }}
 import (
 	"net/http"
 	"net/http/httptest"
-	"testing"
-{% if requireOsPkg %}	"os"
+{% if requireOsPkg %}
+	"os"
 {% endif %}
+	"testing"
 
 	"{{ sdk | goPackagePath }}/client"
-{% if requireModelsPkg %}	"{{ sdk | goPackagePath }}/models"
+{% if requireFilesPkg %}
+	"{{ sdk | goPackagePath }}/file"
 {% endif %}
-{% if requireFilesPkg %}	"{{ sdk | goPackagePath }}/file"
-{%- endif %}
+{% if requireModelsPkg %}
+	"{{ sdk | goPackagePath }}/models"
+{% endif %}
 )
 
 func Test{{ service.name | caseUcfirst }}(t *testing.T) {


### PR DESCRIPTION
## Summary

- make Go templates emit `gofmt`-clean source without post-generation formatting
- fail Go SDK validation when generated files are not formatted
- update the CLI from Appwrite Go SDK `v6.5.0` to `v7.1.0`
- exclude console endpoints absent from the released v7 SDK so the generated CLI compiles

```text
before: generate Go SDK -> gofmt reports generated files

after:  generate Go SDK -> gofmt -l . produces no output
```

## Test plan

- [x] Generate Go console and server SDKs and run `gofmt -l .`
- [x] `cd examples/go && go test ./...`
- [x] `vendor/bin/phpunit tests/e2e/Go118Test.php`
- [x] Regenerate CLI from a clean output directory
- [x] `cd examples/cli && go mod tidy && go build ./... && go vet ./... && go test ./...`
- [x] `composer lint-twig`
- [x] `composer refactor:check`
