### PR TITLE
Push selected functions in parallel

### DIFF
--- a/templates/cli/internal/cmd/pushdeploy.go
+++ b/templates/cli/internal/cmd/pushdeploy.go
@@ -26,13 +26,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Selected functions are packaged, uploaded and monitored in parallel. This
-// starts every deployment without waiting for the previous build to finish.
-// Project settings are deliberately different -- see applyEnabled. Build logs
+// Selected functions are packaged, uploaded and monitored with bounded
+// parallelism. This starts several deployments without waiting for the previous
+// build to finish. Project settings are deliberately different -- see
+// applyEnabled. Build logs
 // come from deployment polling rather than a realtime WebSocket, so a line
 // appears within one pollDebounce rather than the moment it is written.
 
 const (
+	// functionPushConcurrency bounds whole-resource pushes. Each deployment can
+	// already upload eight chunks concurrently, so an unbounded worker per
+	// configured function multiplies network, file and API pressure quickly.
+	functionPushConcurrency = 4
+
 	// pollDebounce is the gap between deployment status reads.
 	pollDebounce = 2 * time.Second
 
@@ -745,25 +751,34 @@ type deployRun struct {
 	LabelLogs     bool
 }
 
-// pushDeployablesInParallel starts one independent push per selected entry.
-// Each worker owns its summary so counters and failure slices never race. The
-// results are merged in config order after every worker has finished, keeping
-// the closing deployment links deterministic even when builds finish in a
-// different order.
+// pushDeployablesInParallel runs selected entries through a bounded worker
+// pool. Each entry owns its summary so counters and failure slices never race.
+// The results are merged in config order after every worker has finished,
+// keeping the closing deployment links deterministic even when builds finish
+// in a different order.
 func pushDeployablesInParallel(
 	entries []*jsonx.Object,
 	push func(*jsonx.Object, *pushSummary),
 ) pushSummary {
 	results := make([]pushSummary, len(entries))
+	jobs := make(chan int)
 
+	workerCount := min(functionPushConcurrency, len(entries))
 	var workers sync.WaitGroup
-	workers.Add(len(entries))
-	for index, entry := range entries {
-		go func(index int, entry *jsonx.Object) {
+	workers.Add(workerCount)
+	for range workerCount {
+		go func() {
 			defer workers.Done()
-			push(entry, &results[index])
-		}(index, entry)
+			for index := range jobs {
+				push(entries[index], &results[index])
+			}
+		}()
 	}
+
+	for index := range entries {
+		jobs <- index
+	}
+	close(jobs)
 	workers.Wait()
 
 	summary := pushSummary{}

--- a/templates/cli/internal/cmd/pushdeploy.go
+++ b/templates/cli/internal/cmd/pushdeploy.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/app"
@@ -25,11 +26,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Resources are pushed one at a time rather than concurrently, which keeps the
-// request sequence deterministic (the settings writes have a stronger reason --
-// see applyEnabled). Build logs come from the deployment poll rather than a
-// realtime WebSocket, so a line appears within one pollDebounce rather than the
-// moment it is written.
+// Selected functions are packaged, uploaded and monitored in parallel. This
+// starts every deployment without waiting for the previous build to finish.
+// Project settings are deliberately different -- see applyEnabled. Build logs
+// come from deployment polling rather than a realtime WebSocket, so a line
+// appears within one pollDebounce rather than the moment it is written.
 
 const (
 	// pollDebounce is the gap between deployment status reads.
@@ -696,20 +697,37 @@ func runPushDeployable(
 	output.Log(out, "Pushing %s ...", resource.Label)
 
 	started := time.Now()
-	summary := pushSummary{}
 
-	for _, entry := range entries {
-		context.pushDeployable(command, resource, entry, deployRun{
-			Async:         options.Async,
-			Code:          pushCode,
-			Activate:      activate,
-			WithVariables: options.WithVariables,
-			// An async push returns before the build starts, so there is no
-			// log to stream.
-			Logs: options.Logs && !options.Async,
-			// The label is only worth the width when two logs could interleave.
-			LabelLogs: len(entries) > 1,
-		}, &summary)
+	run := deployRun{
+		Async:         options.Async,
+		Code:          pushCode,
+		Activate:      activate,
+		WithVariables: options.WithVariables,
+		// An async push returns before the build starts, so there is no
+		// log to stream.
+		Logs: options.Logs && !options.Async,
+		// The label is only worth the width when two logs could interleave.
+		LabelLogs: len(entries) > 1,
+	}
+	push := func(entry *jsonx.Object, summary *pushSummary) {
+		context.pushDeployable(command, resource, entry, run, summary)
+	}
+
+	summary := pushSummary{}
+	if resource.Name == "function" && len(entries) > 1 {
+		// Individual spinners own one terminal row and cannot safely redraw the
+		// same row from several goroutines. A synchronized writer keeps every
+		// line intact and deliberately makes parallel progress use the spinner's
+		// plain-line fallback. Build log labels identify interleaved output.
+		command.SetOut(output.Synchronized(command.OutOrStdout()))
+		command.SetErr(output.Synchronized(command.ErrOrStderr()))
+		summary = pushDeployablesInParallel(entries, push)
+	} else {
+		// A single function keeps the animated status row. Sites remain ordered
+		// because their terminal preview cache is shared by the push context.
+		for _, entry := range entries {
+			push(entry, &summary)
+		}
 	}
 
 	summary.report(command, resource, options.Async, time.Since(started))
@@ -725,6 +743,37 @@ type deployRun struct {
 	WithVariables bool
 	Logs          bool
 	LabelLogs     bool
+}
+
+// pushDeployablesInParallel starts one independent push per selected entry.
+// Each worker owns its summary so counters and failure slices never race. The
+// results are merged in config order after every worker has finished, keeping
+// the closing deployment links deterministic even when builds finish in a
+// different order.
+func pushDeployablesInParallel(
+	entries []*jsonx.Object,
+	push func(*jsonx.Object, *pushSummary),
+) pushSummary {
+	results := make([]pushSummary, len(entries))
+
+	var workers sync.WaitGroup
+	workers.Add(len(entries))
+	for index, entry := range entries {
+		go func(index int, entry *jsonx.Object) {
+			defer workers.Done()
+			push(entry, &results[index])
+		}(index, entry)
+	}
+	workers.Wait()
+
+	summary := pushSummary{}
+	for _, result := range results {
+		summary.Pushed += result.Pushed
+		summary.Deployed += result.Deployed
+		summary.Failed = append(summary.Failed, result.Failed...)
+	}
+
+	return summary
 }
 
 // failedDeployment names a deployment that did not become ready.

--- a/templates/cli/internal/cmd/pushselect_test.go
+++ b/templates/cli/internal/cmd/pushselect_test.go
@@ -117,6 +117,55 @@ func TestSelectedDeploymentsStartInParallel(t *testing.T) {
 	}
 }
 
+// Packaging and uploading a large function can consume eight HTTP requests on
+// its own. Selecting a large project must not multiply that by every configured
+// function at once.
+func TestSelectedDeploymentConcurrencyIsBounded(t *testing.T) {
+	entries := make([]*jsonx.Object, functionPushConcurrency+2)
+	for index := range entries {
+		entries[index] = jsonx.NewObject()
+	}
+
+	started := make(chan struct{}, len(entries))
+	release := make(chan struct{})
+	finished := make(chan pushSummary, 1)
+
+	go func() {
+		finished <- pushDeployablesInParallel(entries,
+			func(_ *jsonx.Object, summary *pushSummary) {
+				started <- struct{}{}
+				<-release
+				summary.Pushed++
+			})
+	}()
+
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	for range functionPushConcurrency {
+		select {
+		case <-started:
+		case <-timer.C:
+			close(release)
+			t.Fatalf("only %d of %d deployment workers started",
+				len(started), functionPushConcurrency)
+		}
+	}
+
+	select {
+	case <-started:
+		close(release)
+		t.Fatalf("more than %d deployment workers ran concurrently",
+			functionPushConcurrency)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(release)
+
+	summary := <-finished
+	if summary.Pushed != len(entries) {
+		t.Errorf("summary counted %d pushes, want %d", summary.Pushed, len(entries))
+	}
+}
+
 // `appwrite push site all` prompted for a selection, because cobra accepts
 // surplus positionals by default and the word was thrown away. `push function
 // all` looked like it worked only because that project had no functions.

--- a/templates/cli/internal/cmd/pushselect_test.go
+++ b/templates/cli/internal/cmd/pushselect_test.go
@@ -5,9 +5,11 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/app"
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/config"
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/jsonx"
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/prompt"
 )
 
@@ -64,6 +66,54 @@ func TestPushSelectionKeepsTheChosenEntries(t *testing.T) {
 	}
 	if len(chosen) != 1 || chosen[0].GetString("$id") != "web" {
 		t.Errorf("chosen = %v, want the one site", chosen)
+	}
+}
+
+// Every selected deployment must start before any one of them finishes. The
+// sequential loop waited for a function's entire build before it even packaged
+// the next one, making a multi-function push take the sum of all build times.
+func TestSelectedDeploymentsStartInParallel(t *testing.T) {
+	entries := make([]*jsonx.Object, 2)
+	for index, id := range []string{"first", "second"} {
+		entry := jsonx.NewObject()
+		entry.Set("$id", id)
+		entries[index] = entry
+	}
+
+	started := make(chan string, len(entries))
+	release := make(chan struct{})
+	finished := make(chan pushSummary, 1)
+
+	go func() {
+		finished <- pushDeployablesInParallel(entries,
+			func(entry *jsonx.Object, summary *pushSummary) {
+				started <- entry.GetString("$id")
+				<-release
+				summary.Pushed++
+			})
+	}()
+
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+
+	seen := map[string]bool{}
+	for range entries {
+		select {
+		case id := <-started:
+			seen[id] = true
+		case <-timer.C:
+			close(release)
+			t.Fatal("a selected deployment waited for the previous one to finish")
+		}
+	}
+	close(release)
+
+	summary := <-finished
+	if len(seen) != len(entries) {
+		t.Errorf("started %v, want both selected deployments", seen)
+	}
+	if summary.Pushed != len(entries) {
+		t.Errorf("summary counted %d pushes, want %d", summary.Pushed, len(entries))
 	}
 }
 

--- a/templates/cli/internal/output/message.go
+++ b/templates/cli/internal/output/message.go
@@ -3,6 +3,7 @@ package output
 import (
 	"fmt"
 	"io"
+	"sync"
 
 	"github.com/charmbracelet/lipgloss"
 )
@@ -18,6 +19,31 @@ var (
 	failureStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
 	traceStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
 )
+
+// synchronizedWriter serializes whole writes to an underlying writer.
+type synchronizedWriter struct {
+	writer io.Writer
+	mutex  sync.Mutex
+}
+
+func (w *synchronizedWriter) Write(contents []byte) (int, error) {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	return w.writer.Write(contents)
+}
+
+// Synchronized returns a writer safe for concurrent status and build-log
+// lines. It intentionally hides whether the underlying writer is a terminal:
+// independent one-row spinners would otherwise redraw over each other, so a
+// parallel push falls back to plain progress lines.
+func Synchronized(writer io.Writer) io.Writer {
+	if _, ok := writer.(*synchronizedWriter); ok {
+		return writer
+	}
+
+	return &synchronizedWriter{writer: writer}
+}
 
 // Log writes an informational line.
 func Log(writer io.Writer, format string, arguments ...any) {


### PR DESCRIPTION
Closes #1794.

## Summary

- package, upload, and monitor selected functions with bounded concurrency
- keep worker summaries isolated, then merge them in config order
- serialize parallel status and build-log writes so terminal output stays intact
- preserve the existing animated spinner for single-function pushes

```text
before: function A upload + build -> function B upload + build
after:  function A upload + build
        function B upload + build  (in parallel)
```

## Implementation

The function push now sends every selected entry through the parallel worker while keeping sites and single-function pushes on the existing sequential path:

```go
run := deployRun{
    Async:         options.Async,
    Code:          pushCode,
    Activate:      activate,
    WithVariables: options.WithVariables,
    Logs:          options.Logs && !options.Async,
    LabelLogs:     len(entries) > 1,
}
push := func(entry *jsonx.Object, summary *pushSummary) {
    context.pushDeployable(command, resource, entry, run, summary)
}

summary := pushSummary{}
if resource.Name == "function" && len(entries) > 1 {
    command.SetOut(output.Synchronized(command.OutOrStdout()))
    command.SetErr(output.Synchronized(command.ErrOrStderr()))
    summary = pushDeployablesInParallel(entries, push)
} else {
    for _, entry := range entries {
        push(entry, &summary)
    }
}

summary.report(command, resource, options.Async, time.Since(started))
```

A four-worker pool bounds nested packaging and chunk-upload pressure. Each entry owns a summary, and results are merged in config order after all deployments finish:

```go
const functionPushConcurrency = 4

func pushDeployablesInParallel(
    entries []*jsonx.Object,
    push func(*jsonx.Object, *pushSummary),
) pushSummary {
    results := make([]pushSummary, len(entries))
    jobs := make(chan int)

    workerCount := min(functionPushConcurrency, len(entries))
    var workers sync.WaitGroup
    workers.Add(workerCount)
    for range workerCount {
        go func() {
            defer workers.Done()
            for index := range jobs {
                push(entries[index], &results[index])
            }
        }()
    }

    for index := range entries {
        jobs <- index
    }
    close(jobs)
    workers.Wait()

    summary := pushSummary{}
    for _, result := range results {
        summary.Pushed += result.Pushed
        summary.Deployed += result.Deployed
        summary.Failed = append(summary.Failed, result.Failed...)
    }

    return summary
}
```

Concurrent output is serialized. Hiding the underlying terminal also makes multi-function pushes use plain progress lines instead of multiple spinners redrawing the same row:

```go
type synchronizedWriter struct {
    writer io.Writer
    mutex  sync.Mutex
}

func (w *synchronizedWriter) Write(contents []byte) (int, error) {
    w.mutex.Lock()
    defer w.mutex.Unlock()

    return w.writer.Write(contents)
}

func Synchronized(writer io.Writer) io.Writer {
    if _, ok := writer.(*synchronizedWriter); ok {
        return writer
    }

    return &synchronizedWriter{writer: writer}
}
```

## Production verification

Built `examples/cli/appwrite` and pushed two disposable Node functions to `Main Project` in the SGP production region. The output shows both function pushes and deployment requests in flight together:

```text
ℹ Info: Pushing functions ...
ℹ Info: Pushing function SDK Generator 1794 First ( e2e-1794-first-221334 ) ...
ℹ Info: Pushing function SDK Generator 1794 Second ( e2e-1794-second-221334 ) ...
· GET /v1/functions/e2e-1794-second-221334 404 in 133ms
· GET /v1/functions/e2e-1794-first-221334 404 in 364ms
· POST /v1/functions 201 in 623ms
· POST /v1/functions 201 in 604ms
· GET /v1/proxy/rules 200 in 419ms
· GET /v1/proxy/rules 200 in 402ms
· POST /v1/proxy/rules/function 201 in 575ms
· POST /v1/proxy/rules/function 201 in 656ms
· POST /v1/functions/e2e-1794-first-221334/deployments 202 in 523ms
· POST /v1/functions/e2e-1794-second-221334/deployments 202 in 3.743s
✓ Success: Successfully pushed 2 functions.
```

The API recorded both deployments in the same second:

```text
first deployment:  2026-08-15T16:43:44.604Z
second deployment: 2026-08-15T16:43:44.853Z
difference:        249 ms
```

Both deployments reached `ready`. Both executions completed with HTTP 200 and returned their expected JSON responses:

```json
{"function":"e2e-1794-first-221334","ok":true}
{"function":"e2e-1794-second-221334","ok":true}
```

The test functions and their proxy rules were deleted afterward.

## Test plan

- [x] `php example.php cli`
- [x] `cd examples/cli && go mod tidy && go build ./... && go vet ./... && go test ./...`
- [x] `cd examples/cli && go test -race ./internal/cmd ./internal/output`
- [x] `vendor/bin/phpunit tests/e2e/CLIGo126Test.php`
- [x] `composer lint-twig`
- [x] `composer refactor:check`
- [x] Production SGP deployment and execution verification described above

