### PR TITLE
Show CLI update reminders for version checks

### DIFF
--- a/templates/cli/internal/cmd/help_test.go
+++ b/templates/cli/internal/cmd/help_test.go
@@ -77,6 +77,35 @@ func TestHelpSectionsAppearInOrder(t *testing.T) {
 	}
 }
 
+type fixedUpdateChecker string
+
+func (checker fixedUpdateChecker) UpdateAvailable() string { return string(checker) }
+
+// Cobra handles --version before PersistentPreRun, so Execute catches it.
+func TestVersionChecksForUpdates(t *testing.T) {
+	original := newUpdateChecker
+	newUpdateChecker = func() updateAvailabilityChecker {
+		return fixedUpdateChecker("27.0.0")
+	}
+	t.Cleanup(func() { newUpdateChecker = original })
+
+	root := NewRootCommand()
+	root.SetArgs([]string{"--version"})
+	printed := &bytes.Buffer{}
+	root.SetOut(printed)
+	root.SetErr(printed)
+
+	if _, err := Execute(root); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{"appwrite version", "A newer version is available", "27.0.0"} {
+		if !strings.Contains(printed.String(), want) {
+			t.Errorf("--version output is missing %q:\n%s", want, printed.String())
+		}
+	}
+}
+
 func TestUpdateNoticeSkipsOnlyTheRootUpdateCommand(t *testing.T) {
 	root := &cobra.Command{Use: "appwrite"}
 	updateCommand := &cobra.Command{Use: "update"}

--- a/templates/cli/internal/cmd/root.go.twig
+++ b/templates/cli/internal/cmd/root.go.twig
@@ -13,6 +13,21 @@ import (
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/update"
 )
 
+const updateNoticeCheckedAnnotation = "appwrite.io/update-notice-checked"
+
+type updateAvailabilityChecker interface {
+	UpdateAvailable() string
+}
+
+var newUpdateChecker = func() updateAvailabilityChecker {
+	checker := app.UpdateChecker()
+	if checker == nil {
+		return nil
+	}
+
+	return checker
+}
+
 // NewRootCommand builds the full command tree.
 //
 // Registration is deliberately eager: the complete tree measures at 5.0ms, so
@@ -81,19 +96,37 @@ func NewRootCommand() *cobra.Command {
 	return root
 }
 
+// Execute runs the root command and checks early exits skipped by PersistentPreRun.
+func Execute(root *cobra.Command) (*cobra.Command, error) {
+	executed, err := root.ExecuteC()
+	if err == nil && executed != nil {
+		noticeUpdateAvailable(executed)
+	}
+
+	return executed, err
+}
+
 // noticeUpdateAvailable tells the user when a newer version exists.
 //
-// Reads a cache and only reaches the
-// network once a day, because the whole point of this binary is that it starts
-// in single-digit milliseconds.
+// Reads a cache and only reaches the network once a day. The root annotation
+// prevents Execute from repeating a check made by PersistentPreRun.
 func noticeUpdateAvailable(command *cobra.Command) {
+	root := command.Root()
+	if root.Annotations != nil && root.Annotations[updateNoticeCheckedAnnotation] == "true" {
+		return
+	}
+	if root.Annotations == nil {
+		root.Annotations = map[string]string{}
+	}
+	root.Annotations[updateNoticeCheckedAnnotation] = "true"
+
 	// The update command is already acting on this information. Recommending
 	// that the user run it again only adds noise before the updater's output.
 	if isRootUpdateCommand(command) {
 		return
 	}
 
-	checker := app.UpdateChecker()
+	checker := newUpdateChecker()
 	if checker == nil {
 		return
 	}

--- a/templates/cli/internal/cmd/update.go.twig
+++ b/templates/cli/internal/cmd/update.go.twig
@@ -44,6 +44,10 @@ func releaseAssetURL(version, asset string) string {
 	return fmt.Sprintf("%s/download/%s/%s", releasesPageURL, strings.TrimPrefix(version, "v"), asset)
 }
 
+func releaseNotesURL(version string) string {
+	return fmt.Sprintf("%s/tag/%s", releasesPageURL, strings.TrimPrefix(version, "v"))
+}
+
 // resolveReleaseVersion is the version a standalone update would install, or
 // "" when the registry cannot be reached.
 func resolveReleaseVersion() string {
@@ -227,6 +231,7 @@ func runUpdater(command *cobra.Command, version, name string, args ...string) er
 	}
 
 	command.Printf("Updated to version %s.\n", version)
+	command.Printf("Release notes: %s\n", releaseNotesURL(version))
 
 	return nil
 }
@@ -315,6 +320,7 @@ func updateStandalone(command *cobra.Command, force bool) error {
 	}
 
 	command.Printf("Updated %s.\n", target)
+	command.Printf("Release notes: %s\n", releaseNotesURL(version))
 
 	return nil
 }

--- a/templates/cli/internal/cmd/updateasset_test.go
+++ b/templates/cli/internal/cmd/updateasset_test.go
@@ -38,6 +38,15 @@ func TestReleaseAssetURLUsesTheBareTag(t *testing.T) {
 	}
 }
 
+func TestReleaseNotesURLUsesTheBareTag(t *testing.T) {
+	for _, version := range []string{"27.0.0", "v27.0.0"} {
+		want := releasesPageURL + "/tag/27.0.0"
+		if got := releaseNotesURL(version); got != want {
+			t.Errorf("releaseNotesURL(%q) = %q, want %q", version, got, want)
+		}
+	}
+}
+
 // The asset has to survive verbatim: it is the release asset name, and the
 // installer scripts and goreleaser derive the same string independently.
 func TestReleaseAssetURLKeepsTheAssetName(t *testing.T) {

--- a/templates/cli/internal/output/filter.go
+++ b/templates/cli/internal/output/filter.go
@@ -58,6 +58,7 @@ func filteredNumber(number json.Number) any {
 var normalViewHiddenKeys = map[string]bool{
 	"onboarding":    true,
 	"billingPlanId": true,
+	"prefs":         true,
 }
 
 // IsNormalViewHiddenKey reports whether a field is hidden from the table view.

--- a/templates/cli/internal/output/filter_test.go
+++ b/templates/cli/internal/output/filter_test.go
@@ -30,7 +30,7 @@ func render(t *testing.T, value any) string {
 }
 
 func TestIsNormalViewHiddenKey(t *testing.T) {
-	hidden := []string{"$createdAt", "$updatedAt", "$permissions", "onboarding", "billingPlanId"}
+	hidden := []string{"$createdAt", "$updatedAt", "$permissions", "onboarding", "billingPlanId", "prefs"}
 	for _, key := range hidden {
 		if !IsNormalViewHiddenKey(key) {
 			t.Errorf("IsNormalViewHiddenKey(%q) = false, want true", key)
@@ -245,6 +245,7 @@ func TestRawModeKeepsEverythingAndQuotesBigIntegers(t *testing.T) {
 		"total": 42,
 		"undeclared": "kept",
 		"nested": {"big": 9007199254740993, "small": 7},
+		"prefs": {"console.internal": true},
 		"rows": [9007199254740993, 7],
 		"big": 9007199254740993
 	}`)
@@ -261,6 +262,9 @@ func TestRawModeKeepsEverythingAndQuotesBigIntegers(t *testing.T) {
   "nested": {
     "big": "9007199254740993",
     "small": 7
+  },
+  "prefs": {
+    "console.internal": true
   },
   "rows": [
     "9007199254740993",

--- a/templates/cli/main.go.twig
+++ b/templates/cli/main.go.twig
@@ -12,9 +12,8 @@ func main() {
 	// RewriteBooleanValues.
 	root.SetArgs(cmd.RewriteBooleanValues(root, os.Args[1:]))
 
-	// ExecuteC rather than Execute: it returns the command that ran, which is
-	// what names the command in a cancellation notice.
-	executed, err := root.ExecuteC()
+	// cmd.Execute returns the command that ran for cancellation notices.
+	executed, err := cmd.Execute(root)
 	if err == nil {
 		return
 	}


### PR DESCRIPTION
## Summary

- run the CLI update check after Cobra handles early exits such as `--version` and `--help`
- avoid repeating the check for commands that already ran `PersistentPreRun`
- link the installed version's GitHub release notes after a successful update
- hide account `prefs` from human-readable output while retaining them under `--raw`
- add regression coverage for these behaviors

```text
before: appwrite -v -> appwrite version 26.1.0
after:  appwrite -v -> appwrite version 26.1.0 + 27.0.0 update reminder

update: Updated to version 27.0.0.
        Release notes: https://github.com/appwrite/sdk-for-cli/releases/tag/27.0.0
```

## Test plan

- [x] `php example.php cli`
- [x] `cd examples/cli && go mod tidy && go build ./... && go vet ./... && go test ./...`
- [x] `test -z "$(gofmt -l examples/cli)"`
- [x] `composer lint-twig`
- [x] `composer refactor:check`
- [x] Build a `26.1.0` CLI and verify `appwrite -v` reports the `27.0.0` update
