### PR TITLE
Improve CLI project and organization discovery

### DIFF
--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -719,6 +719,11 @@ class CLI extends Go
             ],
             [
                 'scope'         => 'default',
+                'destination'   => 'internal/app/fallback_test.go',
+                'template'      => 'cli/internal/app/fallback_test.go.twig',
+            ],
+            [
+                'scope'         => 'default',
                 'destination'   => 'internal/app/inputfile.go',
                 'template'      => 'cli/internal/app/inputfile.go.twig',
             ],

--- a/src/SDK/Language/Concern/CliCommandSurface.php
+++ b/src/SDK/Language/Concern/CliCommandSurface.php
@@ -377,6 +377,14 @@ trait CliCommandSurface
 
     protected function getCliMethodDescription(Operation $method, Tag $service): string
     {
+        if ($service->name === 'oauth2') {
+            return match ($this->cliMethodName($method)) {
+                'listOrganizations' => 'List the organizations the current session can access.',
+                'listProjects' => 'List the projects the current session can access.',
+                default => $method->description,
+            };
+        }
+
         if ($service->name === 'graphql' && ($method->extensions['x-appwrite']['type'] ?? '') === 'graphql') {
             return match ($this->cliMethodName($method)) {
                 'query' => 'Execute a GraphQL query.',

--- a/templates/cli/internal/app/client.go.twig
+++ b/templates/cli/internal/app/client.go.twig
@@ -15,7 +15,7 @@ func ClientForConsole() (any, error) { return nil, errNoClientInTestBuild }
 func ClientForProject(string) (any, error) { return nil, errNoClientInTestBuild }
 
 // ClientForSessionProject is unavailable in the conformance build.
-func ClientForSessionProject(string) (any, error) { return nil, errNoClientInTestBuild }
+func ClientForSessionProject(string, string) (any, error) { return nil, errNoClientInTestBuild }
 
 // ClientForOrganization is unavailable in the conformance build.
 func ClientForOrganization(string) (any, error) { return nil, errNoClientInTestBuild }
@@ -61,16 +61,15 @@ func ClientForProject(projectID string) (sdkclient.Client, error) {
 	return ctx.ForProject(projectID)
 }
 
-// ClientForSessionProject builds a project client that ignores local project
-// configuration. It is used while enriching projects discovered from the
-// active session.
-func ClientForSessionProject(projectID string) (sdkclient.Client, error) {
+// ClientForSessionProject builds a project client from a discovered ID and
+// endpoint while ignoring unrelated local project configuration.
+func ClientForSessionProject(projectID, endpoint string) (sdkclient.Client, error) {
 	ctx, err := context()
 	if err != nil {
 		return sdkclient.Client{}, err
 	}
 
-	return ctx.ForSessionProject(projectID)
+	return ctx.ForSessionProject(projectID, endpoint)
 }
 
 // ClientForOrganization builds a console client scoped to an organization.

--- a/templates/cli/internal/app/client.go.twig
+++ b/templates/cli/internal/app/client.go.twig
@@ -14,6 +14,9 @@ func ClientForConsole() (any, error) { return nil, errNoClientInTestBuild }
 // ClientForProject is unavailable in the conformance build.
 func ClientForProject(string) (any, error) { return nil, errNoClientInTestBuild }
 
+// ClientForSessionProject is unavailable in the conformance build.
+func ClientForSessionProject(string) (any, error) { return nil, errNoClientInTestBuild }
+
 // ClientForOrganization is unavailable in the conformance build.
 func ClientForOrganization(string) (any, error) { return nil, errNoClientInTestBuild }
 {% else %}
@@ -56,6 +59,18 @@ func ClientForProject(projectID string) (sdkclient.Client, error) {
 	}
 
 	return ctx.ForProject(projectID)
+}
+
+// ClientForSessionProject builds a project client that ignores local project
+// configuration. It is used while enriching projects discovered from the
+// active session.
+func ClientForSessionProject(projectID string) (sdkclient.Client, error) {
+	ctx, err := context()
+	if err != nil {
+		return sdkclient.Client{}, err
+	}
+
+	return ctx.ForSessionProject(projectID)
 }
 
 // ClientForOrganization builds a console client scoped to an organization.

--- a/templates/cli/internal/app/fallback.go.twig
+++ b/templates/cli/internal/app/fallback.go.twig
@@ -2,36 +2,41 @@
 package app
 
 // Console fallbacks are omitted from the conformance build. The services they
-// cover (oauth2, organization, teams) are not in the test spec, so nothing
-// references them.
+// cover are not in the test spec, so nothing references them.
 {% else %}
 package app
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 
 	sdkclient "{{ language.params.sdkImportPath }}/client"
+	"{{ language.params.sdkImportPath }}/models"
 	"{{ language.params.sdkImportPath }}/oauth2"
 	"{{ language.params.sdkImportPath }}/organization"
+	"{{ language.params.sdkImportPath }}/project"
 	"{{ language.params.sdkImportPath }}/teams"
 
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/config"
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/output"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/term"
 )
 
-// Three OAuth2 endpoints only exist on Appwrite Cloud. On a self-hosted install
-// they 404, and the same answer has to be assembled from the console endpoints
-// that every install does serve. Without this, these commands work on Cloud and
-// fail everywhere else -- which is the whole reason the helpers exist.
+// The OAuth2 discovery endpoints only exist on Appwrite Cloud. Cookie sessions
+// and self-hosted logins use the console endpoints instead. Both paths are
+// normalized into the same summaries so authentication never changes what a
+// person sees.
 
 const (
-	defaultLimit  = 25
-	defaultOffset = 0
-	// pageSize is what the local fallback pages the console endpoints at while
-	// collecting every match.
-	pageSize = 100
+	defaultLimit          = 25
+	defaultOffset         = 0
+	pageSize              = 100
+	enrichmentConcurrency = 8
 )
 
 // isRouteMissing reports whether an error means the Cloud-only route is absent.
@@ -48,10 +53,7 @@ func isRouteMissing(err error) bool {
 	return strings.Contains(err.Error(), "general_route_not_found")
 }
 
-// applyWindow slices a locally-collected list the way the server would page it.
-//
-// The OAuth2 endpoints report `total` as every match while returning one page,
-// so the fallback counts before slicing to keep that contract.
+// applyWindow slices a locally collected list the way the server would page it.
 func applyWindow[T any](items []T, limit, offset *int) []T {
 	start := defaultOffset
 	if offset != nil {
@@ -73,10 +75,9 @@ func applyWindow[T any](items []T, limit, offset *int) []T {
 	return items[start:end]
 }
 
-// endpointForRegion returns the regional API endpoint for a project.
-//
-// Regions only have their own hostname on Cloud; anywhere else every project is
-// served from the configured endpoint. Ports endpointForRegion().
+// endpointForRegion returns the regional API endpoint for a project. Regions
+// only have their own hostname on Cloud; self-hosted projects all use the
+// configured endpoint.
 func endpointForRegion(endpoint, region string) string {
 	if endpoint == "" {
 		endpoint = config.DefaultEndpoint
@@ -99,7 +100,7 @@ func endpointForRegion(endpoint, region string) string {
 }
 
 // hasOAuth2Session reports whether the stored session uses an access token,
-// which is what the Cloud-only routes require.
+// which is what the Cloud-only discovery routes require.
 func hasOAuth2Session() bool {
 	ctx, err := context()
 	if err != nil {
@@ -113,28 +114,49 @@ func hasOAuth2Session() bool {
 	return session.GetString(config.PreferenceAccessToken) != ""
 }
 
-// OrganizationSummary is one entry of the organization list.
+// OrganizationSummary is one organization in the session-wide list.
 type OrganizationSummary struct {
-	ID string `json:"$id"`
+	ID      string `json:"$id"`
+	Name    string `json:"name"`
+	Members int    `json:"members"`
 }
 
-// OrganizationList mirrors the Cloud route's response shape.
+// OrganizationList is the stable response shape shared by every login type.
 type OrganizationList struct {
 	Total         int                   `json:"total"`
 	Organizations []OrganizationSummary `json:"organizations"`
 }
 
-// ListOrganizationsForSession lists the organizations the session can see.
-func ListOrganizationsForSession(limit, offset *int, search string) (any, error) {
+// ProjectSummary is one project in the session-wide list.
+type ProjectSummary struct {
+	ID               string `json:"$id"`
+	Name             string `json:"name"`
+	OrganizationID   string `json:"organizationId"`
+	OrganizationName string `json:"organization"`
+	Region           string `json:"region"`
+	Endpoint         string `json:"endpoint"`
+}
+
+// ProjectList is the stable response shape shared by every login type.
+type ProjectList struct {
+	Total    int              `json:"total"`
+	Projects []ProjectSummary `json:"projects"`
+}
+
+// ListOrganizationsForSession lists organizations with useful metadata for
+// OAuth2, cookie, and self-hosted sessions alike.
+func ListOrganizationsForSession(limit, offset *int, search string) (*OrganizationList, error) {
 	if hasOAuth2Session() {
 		client, err := ClientForConsole()
 		if err != nil {
 			return nil, err
 		}
 
-		result, err := callListOrganizations(client, limit, offset, search)
+		page, err := callListOrganizations(client, limit, offset, search)
 		if err == nil {
-			return result, nil
+			organizations := enrichOrganizationIDs(page.Organizations)
+
+			return &OrganizationList{Total: page.Total, Organizations: organizations}, nil
 		}
 		if !isRouteMissing(err) {
 			return nil, err
@@ -146,12 +168,13 @@ func ListOrganizationsForSession(limit, offset *int, search string) (any, error)
 		return nil, err
 	}
 
-	return OrganizationList{Total: len(all), Organizations: applyWindow(all, limit, offset)}, nil
+	return &OrganizationList{
+		Total: len(all), Organizations: applyWindow(all, limit, offset),
+	}, nil
 }
 
-func callListOrganizations(client sdkclient.Client, limit, offset *int, search string) (any, error) {
+func callListOrganizations(client sdkclient.Client, limit, offset *int, search string) (*models.Oauth2OrganizationList, error) {
 	service := oauth2.New(client)
-
 	options := []oauth2.ListOrganizationsOption{}
 	if limit != nil {
 		options = append(options, service.WithListOrganizationsLimit(*limit))
@@ -166,8 +189,33 @@ func callListOrganizations(client sdkclient.Client, limit, offset *int, search s
 	return service.ListOrganizations(options...)
 }
 
-// listAllOrganizations collects every organization the session can see, as
-// teams -- the console endpoint every install serves.
+// enrichOrganizationIDs fetches one page's display metadata concurrently. A
+// resource can disappear between list and get, so enrichment is best effort:
+// its ID remains useful even if its name cannot be loaded.
+func enrichOrganizationIDs(items []models.Oauth2Organization) []OrganizationSummary {
+	summaries := make([]OrganizationSummary, len(items))
+	group := errgroup.Group{}
+	group.SetLimit(enrichmentConcurrency)
+
+	for index, item := range items {
+		index, item := index, item
+		group.Go(func() error {
+			summary, err := getOrganizationSummary(item.Id)
+			if err != nil {
+				summary = OrganizationSummary{ID: item.Id}
+			}
+			summaries[index] = summary
+
+			return nil
+		})
+	}
+	_ = group.Wait()
+
+	return summaries
+}
+
+// listAllOrganizations collects every organization as the teams exposed by the
+// console endpoint available on Cloud and self-hosted installations.
 func listAllOrganizations(search string) ([]OrganizationSummary, error) {
 	client, err := ClientForConsole()
 	if err != nil {
@@ -178,9 +226,7 @@ func listAllOrganizations(search string) ([]OrganizationSummary, error) {
 	summaries := []OrganizationSummary{}
 	offset := 0
 	for {
-		options := []teams.ListOption{
-			service.WithListQueries(pageQueries(offset)),
-		}
+		options := []teams.ListOption{service.WithListQueries(pageQueries(offset))}
 		if search != "" {
 			options = append(options, service.WithListSearch(search))
 		}
@@ -190,7 +236,9 @@ func listAllOrganizations(search string) ([]OrganizationSummary, error) {
 			return nil, err
 		}
 		for _, team := range page.Teams {
-			summaries = append(summaries, OrganizationSummary{ID: team.Id})
+			summaries = append(summaries, OrganizationSummary{
+				ID: team.Id, Name: team.Name, Members: team.Total,
+			})
 		}
 		if len(page.Teams) < pageSize {
 			break
@@ -201,69 +249,207 @@ func listAllOrganizations(search string) ([]OrganizationSummary, error) {
 	return summaries, nil
 }
 
-// ProjectSummary is one entry of the project list.
-type ProjectSummary struct {
-	ID       string `json:"$id"`
-	Endpoint string `json:"endpoint"`
+func getOrganizationSummary(organizationID string) (OrganizationSummary, error) {
+	client, err := ClientForOrganization(organizationID)
+	if err != nil {
+		return OrganizationSummary{}, err
+	}
+
+	result, err := organization.New(client).Get()
+	if err == nil {
+		return OrganizationSummary{ID: result.Id, Name: result.Name, Members: result.Total}, nil
+	}
+	if !isRouteMissing(err) {
+		return OrganizationSummary{}, err
+	}
+
+	team, err := teams.New(client).Get(organizationID)
+	if err != nil {
+		return OrganizationSummary{}, err
+	}
+
+	return OrganizationSummary{ID: team.Id, Name: team.Name, Members: team.Total}, nil
 }
 
-// ProjectList mirrors the Cloud route's response shape.
-type ProjectList struct {
-	Total    int              `json:"total"`
-	Projects []ProjectSummary `json:"projects"`
-}
+// ListProjectsForSession lists projects across every accessible organization,
+// or only the explicitly requested organization.
+func ListProjectsForSession(organizationID string, limit, offset *int, search string) (*ProjectList, error) {
+	if organizationID != "" {
+		return listProjectsForOrganization(organizationID, limit, offset, search)
+	}
 
-// ListProjectsForSession lists the projects in an organization.
-func ListProjectsForSession(organizationID string, limit, offset *int, search string) (any, error) {
 	if hasOAuth2Session() {
 		client, err := ClientForConsole()
 		if err != nil {
 			return nil, err
 		}
 
-		service := oauth2.New(client)
-		options := []oauth2.ListProjectsOption{}
-		if limit != nil {
-			options = append(options, service.WithListProjectsLimit(*limit))
-		}
-		if offset != nil {
-			options = append(options, service.WithListProjectsOffset(*offset))
-		}
-		if search != "" {
-			options = append(options, service.WithListProjectsSearch(search))
-		}
-
-		result, err := service.ListProjects(options...)
+		page, err := callListProjects(client, limit, offset, search)
 		if err == nil {
-			return result, nil
+			projects := enrichOAuth2Projects(page.Projects)
+			enrichProjectOrganizationNames(projects)
+
+			return &ProjectList{Total: page.Total, Projects: projects}, nil
 		}
 		if !isRouteMissing(err) {
 			return nil, err
 		}
 	}
 
-	all, err := listAllProjects(organizationID, search)
+	return listAllProjectsForSession(limit, offset, search)
+}
+
+func callListProjects(client sdkclient.Client, limit, offset *int, search string) (*models.Oauth2ProjectList, error) {
+	service := oauth2.New(client)
+	options := []oauth2.ListProjectsOption{}
+	if limit != nil {
+		options = append(options, service.WithListProjectsLimit(*limit))
+	}
+	if offset != nil {
+		options = append(options, service.WithListProjectsOffset(*offset))
+	}
+	if search != "" {
+		options = append(options, service.WithListProjectsSearch(search))
+	}
+
+	return service.ListProjects(options...)
+}
+
+func enrichOAuth2Projects(items []models.Oauth2Project) []ProjectSummary {
+	summaries := make([]ProjectSummary, len(items))
+	group := errgroup.Group{}
+	group.SetLimit(enrichmentConcurrency)
+
+	for index, item := range items {
+		index, item := index, item
+		group.Go(func() error {
+			summary := ProjectSummary{
+				ID: item.Id, Region: item.Region, Endpoint: item.Endpoint,
+			}
+			client, err := ClientForSessionProject(item.Id)
+			if err == nil {
+				if details, getErr := project.New(client).Get(); getErr == nil {
+					summary.Name = details.Name
+					summary.OrganizationID = details.TeamId
+					if details.Region != "" {
+						summary.Region = details.Region
+					}
+				}
+			}
+			if summary.Endpoint == "" {
+				ctx, contextErr := context()
+				if contextErr == nil {
+					summary.Endpoint = endpointForRegion(
+						ctx.Global.CurrentValue(config.PreferenceEndpoint), summary.Region)
+				}
+			}
+			summaries[index] = summary
+
+			return nil
+		})
+	}
+	_ = group.Wait()
+
+	return summaries
+}
+
+func enrichProjectOrganizationNames(projects []ProjectSummary) {
+	ids := []string{}
+	seen := map[string]bool{}
+	for _, item := range projects {
+		if item.OrganizationID != "" && !seen[item.OrganizationID] {
+			seen[item.OrganizationID] = true
+			ids = append(ids, item.OrganizationID)
+		}
+	}
+
+	names := make([]string, len(ids))
+	group := errgroup.Group{}
+	group.SetLimit(enrichmentConcurrency)
+	for index, id := range ids {
+		index, id := index, id
+		group.Go(func() error {
+			if organization, err := getOrganizationSummary(id); err == nil {
+				names[index] = organization.Name
+			}
+
+			return nil
+		})
+	}
+	_ = group.Wait()
+
+	byID := map[string]string{}
+	for index, id := range ids {
+		byID[id] = names[index]
+	}
+	for index := range projects {
+		projects[index].OrganizationName = byID[projects[index].OrganizationID]
+	}
+}
+
+func listProjectsForOrganization(organizationID string, limit, offset *int, search string) (*ProjectList, error) {
+	organizationSummary, summaryErr := getOrganizationSummary(organizationID)
+	page, err := listProjectPage(organizationID, limit, offset, search)
 	if err != nil {
 		return nil, err
 	}
 
-	return ProjectList{Total: len(all), Projects: applyWindow(all, limit, offset)}, nil
+	summaries := summarizeProjects(page.Projects, organizationID, organizationSummary.Name)
+	if summaryErr != nil {
+		for index := range summaries {
+			summaries[index].OrganizationName = ""
+		}
+	}
+
+	return &ProjectList{Total: page.Total, Projects: summaries}, nil
 }
 
-func listAllProjects(organizationID, search string) ([]ProjectSummary, error) {
+func listProjectPage(organizationID string, limit, offset *int, search string) (*models.ProjectList, error) {
 	client, err := ClientForOrganization(organizationID)
 	if err != nil {
 		return nil, err
 	}
-	ctx, err := context()
+	service := organization.New(client)
+	options := []organization.ListProjectsOption{}
+	if queries := windowQueries(limit, offset); len(queries) > 0 {
+		options = append(options, service.WithListProjectsQueries(queries))
+	}
+	if search != "" {
+		options = append(options, service.WithListProjectsSearch(search))
+	}
+
+	return service.ListProjects(options...)
+}
+
+// listAllProjectsForSession restores the all-organization behavior needed by
+// cookie and self-hosted sessions. The previous Go fallback only resolved the
+// organization in local config, making this root command incomplete.
+func listAllProjectsForSession(limit, offset *int, search string) (*ProjectList, error) {
+	organizations, err := listAllOrganizations("")
 	if err != nil {
 		return nil, err
 	}
-	endpoint := ctx.Global.CurrentValue(config.PreferenceEndpoint)
 
+	all := []ProjectSummary{}
+	for _, item := range organizations {
+		projects, err := listAllProjects(item.ID, search)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, summarizeProjects(projects, item.ID, item.Name)...)
+	}
+
+	return &ProjectList{Total: len(all), Projects: applyWindow(all, limit, offset)}, nil
+}
+
+func listAllProjects(organizationID, search string) ([]models.Project, error) {
+	client, err := ClientForOrganization(organizationID)
+	if err != nil {
+		return nil, err
+	}
 	service := organization.New(client)
 
-	summaries := []ProjectSummary{}
+	projects := []models.Project{}
 	offset := 0
 	for {
 		options := []organization.ListProjectsOption{
@@ -277,19 +463,37 @@ func listAllProjects(organizationID, search string) ([]ProjectSummary, error) {
 		if err != nil {
 			return nil, err
 		}
-		for _, project := range page.Projects {
-			summaries = append(summaries, ProjectSummary{
-				ID:       project.Id,
-				Endpoint: endpointForRegion(endpoint, project.Region),
-			})
-		}
+		projects = append(projects, page.Projects...)
 		if len(page.Projects) < pageSize {
 			break
 		}
 		offset += pageSize
 	}
 
-	return summaries, nil
+	return projects, nil
+}
+
+func summarizeProjects(projects []models.Project, organizationID, organizationName string) []ProjectSummary {
+	ctx, _ := context()
+	endpoint := ""
+	if ctx != nil {
+		endpoint = ctx.Global.CurrentValue(config.PreferenceEndpoint)
+	}
+
+	summaries := make([]ProjectSummary, 0, len(projects))
+	for _, item := range projects {
+		teamID := item.TeamId
+		if teamID == "" {
+			teamID = organizationID
+		}
+		summaries = append(summaries, ProjectSummary{
+			ID: item.Id, Name: item.Name, OrganizationID: teamID,
+			OrganizationName: organizationName, Region: item.Region,
+			Endpoint: endpointForRegion(endpoint, item.Region),
+		})
+	}
+
+	return summaries
 }
 
 // GetOrganizationForSession returns the organization the session is acting on.
@@ -306,13 +510,120 @@ func GetOrganizationForSession(organizationID string) (any, error) {
 	if !isRouteMissing(err) {
 		return nil, err
 	}
-
-	// Self-hosted: the organization is a team.
 	if organizationID == "" {
 		return nil, errors.New("an organization ID is required on this endpoint")
 	}
 
 	return teams.New(client).Get(organizationID)
+}
+
+// RenderOrganizationList renders a normalized result and only emits contextual
+// hints in an interactive human-readable invocation.
+func RenderOrganizationList(result *OrganizationList, limit, offset *int, search string) error {
+	if err := RenderValue(result); err != nil {
+		return err
+	}
+	printListHints(listHints("organizations", result.Total, len(result.Organizations), limit, offset, search, ""))
+
+	return nil
+}
+
+// RenderProjectList renders a normalized result and contextual next actions.
+func RenderProjectList(result *ProjectList, limit, offset *int, search, organizationID string) error {
+	if err := RenderValue(result); err != nil {
+		return err
+	}
+	printListHints(listHints("projects", result.Total, len(result.Projects), limit, offset, search, organizationID))
+
+	return nil
+}
+
+func printListHints(hints []string) {
+	if Flags().JSON || Flags().Raw || !term.IsTerminal(int(os.Stdout.Fd())) {
+		return
+	}
+	for _, hint := range hints {
+		output.Hint(os.Stderr, "%s", hint)
+	}
+}
+
+// listHints is pure so pagination, filtering, and empty states can be tested
+// without pretending a test buffer is a terminal.
+func listHints(kind string, total, count int, limit, offset *int, search, organizationID string) []string {
+	hints := []string{}
+	start := defaultOffset
+	if offset != nil {
+		start = *offset
+	}
+	end := start + count
+
+	if count > 0 && end < total {
+		command := listCommand(kind, limit, end, search, organizationID)
+		hints = append(hints, fmt.Sprintf(
+			"Showing %d–%d of %d. Next page: %s", start+1, end, total, command))
+	}
+
+	filtered := search != "" || (kind == "projects" && organizationID != "")
+	if count > 0 && filtered {
+		if kind == "projects" {
+			hints = append(hints, "Project details: "+ExecutableName+" project get --project-id <PROJECT_ID>")
+		} else {
+			hints = append(hints, "Organization details: "+ExecutableName+" organization get --organization-id <ORGANIZATION_ID>")
+		}
+	}
+	if count == 0 && search != "" {
+		hints = append(hints, "Try a shorter search or remove --search.")
+	}
+
+	return hints
+}
+
+func listCommand(kind string, limit *int, offset int, search, organizationID string) string {
+	command := []string{ExecutableName, "list-" + kind}
+	if organizationID != "" {
+		command = append(command, "--organization-id", shellArgument(organizationID))
+	}
+	if search != "" {
+		command = append(command, "--search", shellArgument(search))
+	}
+	if limit != nil {
+		command = append(command, "--limit", strconv.Itoa(*limit))
+	}
+	command = append(command, "--offset", strconv.Itoa(offset))
+
+	return strings.Join(command, " ")
+}
+
+func shellArgument(value string) string {
+	if value != "" {
+		safe := true
+		for _, character := range value {
+			if !(character >= 'a' && character <= 'z') &&
+				!(character >= 'A' && character <= 'Z') &&
+				!(character >= '0' && character <= '9') &&
+				!strings.ContainsRune("-._", character) {
+				safe = false
+				break
+			}
+		}
+		if safe {
+			return value
+		}
+	}
+
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func windowQueries(limit, offset *int) []string {
+	queries := []string{}
+	if limit != nil {
+		queries = append(queries, `{"method":"limit","values":[`+strconv.Itoa(*limit)+`]}`)
+	}
+	if offset != nil {
+		queries = append(queries, `{"method":"offset","values":[`+strconv.Itoa(*offset)+`]}`)
+	}
+
+	return queries
 }
 
 // pageQueries builds the limit/offset pair the fallback pages with.

--- a/templates/cli/internal/app/fallback.go.twig
+++ b/templates/cli/internal/app/fallback.go.twig
@@ -323,10 +323,18 @@ func enrichOAuth2Projects(items []models.Oauth2Project) []ProjectSummary {
 	for index, item := range items {
 		index, item := index, item
 		group.Go(func() error {
-			summary := ProjectSummary{
-				ID: item.Id, Region: item.Region, Endpoint: item.Endpoint,
+			endpoint := item.Endpoint
+			if endpoint == "" {
+				ctx, contextErr := context()
+				if contextErr == nil {
+					endpoint = endpointForRegion(
+						ctx.Global.CurrentValue(config.PreferenceEndpoint), item.Region)
+				}
 			}
-			client, err := ClientForSessionProject(item.Id)
+			summary := ProjectSummary{
+				ID: item.Id, Region: item.Region, Endpoint: endpoint,
+			}
+			client, err := ClientForSessionProject(item.Id, endpoint)
 			if err == nil {
 				if details, getErr := project.New(client).Get(); getErr == nil {
 					summary.Name = details.Name
@@ -334,13 +342,6 @@ func enrichOAuth2Projects(items []models.Oauth2Project) []ProjectSummary {
 					if details.Region != "" {
 						summary.Region = details.Region
 					}
-				}
-			}
-			if summary.Endpoint == "" {
-				ctx, contextErr := context()
-				if contextErr == nil {
-					summary.Endpoint = endpointForRegion(
-						ctx.Global.CurrentValue(config.PreferenceEndpoint), summary.Region)
 				}
 			}
 			summaries[index] = summary

--- a/templates/cli/internal/app/fallback_test.go.twig
+++ b/templates/cli/internal/app/fallback_test.go.twig
@@ -1,0 +1,67 @@
+{% if sdk.test %}
+package app
+{% else %}
+package app
+
+import (
+	"reflect"
+	"testing"
+)
+
+func intPointer(value int) *int { return &value }
+
+func TestListHintsAreContextual(t *testing.T) {
+	tests := []struct {
+		name           string
+		kind           string
+		total          int
+		count          int
+		limit          *int
+		offset         *int
+		search         string
+		organizationID string
+		want           []string
+	}{
+		{
+			name: "complete unfiltered list is quiet", kind: "projects", total: 3, count: 3,
+			want: []string{},
+		},
+		{
+			name: "next page preserves filters", kind: "projects", total: 80, count: 10,
+			limit: intPointer(10), offset: intPointer(20), search: "billing api",
+			organizationID: "org-id",
+			want: []string{
+				"Showing 21–30 of 80. Next page: appwrite list-projects --organization-id org-id --search 'billing api' --limit 10 --offset 30",
+				"Project details: appwrite project get --project-id <PROJECT_ID>",
+			},
+		},
+		{
+			name: "organization search suggests details", kind: "organizations", total: 1, count: 1,
+			search: "Example",
+			want:   []string{"Organization details: appwrite organization get --organization-id <ORGANIZATION_ID>"},
+		},
+		{
+			name: "empty search suggests recovery", kind: "projects", total: 0, count: 0,
+			search: "missing",
+			want:   []string{"Try a shorter search or remove --search."},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := listHints(test.kind, test.total, test.count, test.limit, test.offset,
+				test.search, test.organizationID)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("listHints() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestShellArgumentQuotesApostrophes(t *testing.T) {
+	got := shellArgument("Chirag's Organization")
+	if got != `'Chirag'"'"'s Organization'` {
+		t.Fatalf("shellArgument() = %q", got)
+	}
+}
+{% endif %}

--- a/templates/cli/internal/app/globals.go
+++ b/templates/cli/internal/app/globals.go
@@ -99,6 +99,20 @@ func Render(value any) error {
 	return render(Renderer(), value)
 }
 
+// RenderValue renders a result assembled by the CLI rather than the body of the
+// last request it made. List commands use this after enriching or combining
+// several API responses; allowing the response recorder to win there would
+// print whichever enrichment request happened to finish last.
+func RenderValue(value any) error {
+	return renderValue(Renderer(), value)
+}
+
+func renderValue(renderer *output.Renderer, value any) error {
+	sdk.LastResponse.Take()
+
+	return render(renderer, value)
+}
+
 // render is Render against an explicit renderer, so it can be exercised without
 // the process-wide global flags.
 func render(renderer *output.Renderer, value any) error {

--- a/templates/cli/internal/app/render_test.go
+++ b/templates/cli/internal/app/render_test.go
@@ -101,6 +101,23 @@ func TestRenderFallsBackToTheValue(t *testing.T) {
 	}
 }
 
+// A locally assembled result must beat the last request body. Session list
+// commands make several requests to enrich one page, so that body belongs to
+// an implementation detail rather than to the command result.
+func TestRenderValueDiscardsTheCapturedResponse(t *testing.T) {
+	sdk.LastResponse.Take()
+	sdk.LastResponse.Record([]byte(`{"from":"enrichment request"}`))
+
+	buffer := &bytes.Buffer{}
+	if err := renderValue(&output.Renderer{Mode: output.ModeRaw, Writer: buffer},
+		map[string]any{"from": "assembled result"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buffer.String(), "assembled result") {
+		t.Errorf("did not render the assembled result:\n%s", buffer.String())
+	}
+}
+
 // Two renders, one response: the second must not reprint the first's body.
 func TestRenderDoesNotReuseAStaleResponse(t *testing.T) {
 	renderer := func(buffer *bytes.Buffer) *output.Renderer {

--- a/templates/cli/internal/cmd/services/service.go.twig
+++ b/templates/cli/internal/cmd/services/service.go.twig
@@ -143,6 +143,9 @@ func new{{ service.name | caseUcfirst }}{{ (method | methodName) | caseUcfirst }
 {% if scopedFlag %}
 	var {{ scope.idVar }} string
 {% endif %}
+{% if implementation == 'listProjectsForSession' and not scopedFlag %}
+	var organizationId string
+{% endif %}
 
 {# Same alignment rule as query.Options below: `Hidden` only renders for a
    promoted command, and its presence widens the run. RunE is excluded -- gofmt
@@ -154,7 +157,17 @@ func new{{ service.name | caseUcfirst }}{{ (method | methodName) | caseUcfirst }
 {% if isTopLevel %}
 		{{ commandKeyFormat|format('Hidden:') }}true,
 {% endif %}
+{% if implementation == 'listOrganizationsForSession' %}
+		Example: "  " + app.ExecutableName + " list-organizations --search <NAME>\n" +
+			"  " + app.ExecutableName + " organization get --organization-id <ORGANIZATION_ID>",
+		Args: cobra.NoArgs,
+{% elseif implementation == 'listProjectsForSession' %}
+		Example: "  " + app.ExecutableName + " list-projects --organization-id <ORGANIZATION_ID>\n" +
+			"  " + app.ExecutableName + " project get --project-id <PROJECT_ID>",
+		Args: cobra.NoArgs,
+{% else %}
 		{{ commandKeyFormat|format('Args:') }}cobra.NoArgs,
+{% endif %}
 		RunE: func(cmd *cobra.Command, args []string) error {
 {% set plan = getGoCallPlan(method, service) %}
 {% if sdk.test %}
@@ -252,11 +265,14 @@ func new{{ service.name | caseUcfirst }}{{ (method | methodName) | caseUcfirst }
 {% endif %}
 
 {% if implementation == 'listOrganizationsForSession' %}
-			result, err := app.ListOrganizationsForSession(
-				app.FlagInt(cmd, "limit", limit), app.FlagInt(cmd, "offset", offset), search)
+			limitFlag := app.FlagInt(cmd, "limit", limit)
+			offsetFlag := app.FlagInt(cmd, "offset", offset)
+			result, err := app.ListOrganizationsForSession(limitFlag, offsetFlag, search)
 {% elseif implementation == 'listProjectsForSession' %}
-			result, err := app.ListProjectsForSession({{ scopedFlag ? scope.idVar : '""' }},
-				app.FlagInt(cmd, "limit", limit), app.FlagInt(cmd, "offset", offset), search)
+			limitFlag := app.FlagInt(cmd, "limit", limit)
+			offsetFlag := app.FlagInt(cmd, "offset", offset)
+			result, err := app.ListProjectsForSession({{ scopedFlag ? scope.idVar : 'organizationId' }},
+				limitFlag, offsetFlag, search)
 {% elseif implementation == 'getOrganizationForSession' %}
 			result, err := app.GetOrganizationForSession({{ scopedFlag ? scope.idVar : '""' }})
 {% elseif sdk.test %}
@@ -280,6 +296,12 @@ func new{{ service.name | caseUcfirst }}{{ (method | methodName) | caseUcfirst }
 			// A location method returns the file bytes, not a URL -- the SDK
 			// has already fetched them.
 			return app.WriteFile(destination, result)
+{% elseif implementation == 'listOrganizationsForSession' %}
+
+			return app.RenderOrganizationList(result, limitFlag, offsetFlag, search)
+{% elseif implementation == 'listProjectsForSession' %}
+
+			return app.RenderProjectList(result, limitFlag, offsetFlag, search, organizationId)
 {% else %}
 
 			return app.Render(result)
@@ -322,6 +344,9 @@ func new{{ service.name | caseUcfirst }}{{ (method | methodName) | caseUcfirst }
 {% endif %}
 {% if scopedFlag %}
 	cmd.Flags().StringVar(&{{ scope.idVar }}, "{{ scope.flag }}", "", "{{ scope.label }} to act on. Defaults to the {{ scope.label | lower }} linked in {{ language.params.executableName }}.config.json.")
+{% endif %}
+{% if implementation == 'listProjectsForSession' and not scopedFlag %}
+	cmd.Flags().StringVar(&organizationId, "organization-id", "", "Only show projects in this organization.")
 {% endif %}
 	return cmd
 }

--- a/templates/cli/internal/output/collections.go
+++ b/templates/cli/internal/output/collections.go
@@ -391,7 +391,71 @@ type structuredRenderer struct {
 	columns []column
 }
 
+// compactDisplay keeps discovery tables inside an ordinary terminal while IDs
+// remain complete and copyable. Only descriptive labels are truncated.
+func compactDisplay(value string, maximum int) string {
+	if lipgloss.Width(value) <= maximum {
+		return value
+	}
+
+	result := ""
+	for _, character := range value {
+		if lipgloss.Width(result+string(character)+"…") > maximum {
+			break
+		}
+		result += string(character)
+	}
+
+	return result + "…"
+}
+
 var structuredRenderers = map[string]structuredRenderer{
+	"organizations": {
+		schema: summarySchema{
+			mustExist: []string{"$id"},
+			strings:   []string{"name"},
+			numeric:   []string{"members"},
+		},
+		columns: []column{
+			{"name", func(row structuredRow, _ int) string {
+				return compactDisplay(compactText(row, "name", emDash), 28)
+			}},
+			{"id", func(row structuredRow, _ int) string { return compactText(row, "$id", emDash) }},
+			{"members", func(row structuredRow, _ int) string {
+				if members, ok := stringAt(row, "members"); ok {
+					return members
+				}
+
+				return emDash
+			}},
+		},
+	},
+	"projects": {
+		schema: summarySchema{
+			mustExist: []string{"$id"},
+			strings: []string{
+				"name", "organization", "organizationId", "teamId", "region", "endpoint",
+			},
+		},
+		columns: []column{
+			{"name", func(row structuredRow, _ int) string {
+				return compactDisplay(compactText(row, "name", emDash), 24)
+			}},
+			{"id", func(row structuredRow, _ int) string { return compactText(row, "$id", emDash) }},
+			{"organization", func(row structuredRow, _ int) string {
+				name := compactText(row, "organization", "")
+				if name == "" {
+					name = compactText(row, "organizationId", "")
+				}
+				if name == "" {
+					name = compactText(row, "teamId", emDash)
+				}
+
+				return compactDisplay(name, 18)
+			}},
+			{"region", func(row structuredRow, _ int) string { return compactText(row, "region", emDash) }},
+		},
+	},
 	"deployments": {
 		schema: summarySchema{
 			mustExist: []string{"$id", "status"},

--- a/templates/cli/internal/output/render.go
+++ b/templates/cli/internal/output/render.go
@@ -75,13 +75,15 @@ func (r *Renderer) renderHuman(writer io.Writer, value any) error {
 		value any
 	}
 
+	listKey, listCount, listTotal, isDiscoveryList := discoveryListSummary(object)
+
 	var (
 		scalars  [][2]string
 		sections []section
 	)
 
 	for _, key := range object.Keys() {
-		if IsNormalViewHiddenKey(key) {
+		if IsNormalViewHiddenKey(key) || (isDiscoveryList && key == "total") {
 			continue
 		}
 		item, _ := object.Get(key)
@@ -128,7 +130,11 @@ func (r *Renderer) renderHuman(writer io.Writer, value any) error {
 		case []any:
 			rows := objectRows(typed)
 			if len(rows) > 0 {
-				fmt.Fprintln(writer, sectionStyle.Render(fmt.Sprintf("%s (%d)", item.key, len(typed))))
+				title := fmt.Sprintf("%s (%d)", item.key, len(typed))
+				if isDiscoveryList && item.key == listKey {
+					title = fmt.Sprintf("%s (%d of %s)", item.key, listCount, listTotal)
+				}
+				fmt.Fprintln(writer, sectionStyle.Render(title))
 				// A section with a renderer of its own, or one whose rows are
 				// plain on/off toggles, gets a shape built for it. Everything
 				// else falls back to the generic table -- unless that table
@@ -157,10 +163,44 @@ func (r *Renderer) renderHuman(writer io.Writer, value any) error {
 	}
 
 	if !printed {
-		fmt.Fprintln(writer, "Request completed successfully.")
+		if isDiscoveryList {
+			fmt.Fprintf(writer, "No %s found.\n", listKey)
+		} else {
+			fmt.Fprintln(writer, "Request completed successfully.")
+		}
 	}
 
 	return nil
+}
+
+// discoveryListSummary recognizes the two normalized session discovery lists.
+// Their total belongs in the collection heading, not in a detached key/value
+// line whose relationship to the returned page is unclear.
+func discoveryListSummary(object *jsonx.Object) (string, int, string, bool) {
+	// A project or organization model can itself contain a `total` and a
+	// `projects` field. Only the two-key list envelope is a discovery list.
+	if object.Len() != 2 {
+		return "", 0, "", false
+	}
+
+	for _, key := range []string{"organizations", "projects"} {
+		value, ok := object.Get(key)
+		if !ok {
+			continue
+		}
+		items, ok := value.([]any)
+		if !ok {
+			continue
+		}
+		total, ok := object.Get("total")
+		if !ok {
+			continue
+		}
+
+		return key, len(items), formatScalar(total), true
+	}
+
+	return "", 0, "", false
 }
 
 // objectRows returns the elements that are objects, flattened for display.

--- a/templates/cli/internal/output/sections_test.go
+++ b/templates/cli/internal/output/sections_test.go
@@ -98,6 +98,58 @@ func TestNarrowSectionsStayTables(t *testing.T) {
 	}
 }
 
+func TestDiscoveryListsShowUsefulColumnsAndPageCount(t *testing.T) {
+	input := decode(t, `{
+		"total": 224,
+		"projects": [{
+			"$id": "project-id", "name": "A project with a deliberately very long display name",
+			"organizationId": "organization-id", "organization": "Example Organization",
+			"region": "fra", "endpoint": "https://fra.cloud.appwrite.io/v1"
+		}]
+	}`)
+
+	buffer := &bytes.Buffer{}
+	renderer := &Renderer{Mode: ModeTable, Writer: buffer}
+	if err := renderer.Render(input); err != nil {
+		t.Fatal(err)
+	}
+	got := buffer.String()
+
+	for _, want := range []string{"projects (1 of 224)", "name", "project-id", "Example Organizat…", "fra"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q from:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "endpoint") || strings.Contains(got, "total :") {
+		t.Errorf("discovery table kept low-value default fields:\n%s", got)
+	}
+	if !strings.Contains(got, "…") {
+		t.Errorf("long project name was not compacted:\n%s", got)
+	}
+}
+
+func TestEmptyDiscoveryListHasAnEmptyState(t *testing.T) {
+	input := decode(t, `{"total":0,"organizations":[]}`)
+	buffer := &bytes.Buffer{}
+	if err := (&Renderer{Mode: ModeTable, Writer: buffer}).Render(input); err != nil {
+		t.Fatal(err)
+	}
+	if got := buffer.String(); !strings.Contains(got, "No organizations found.") {
+		t.Errorf("missing empty state:\n%s", got)
+	}
+}
+
+func TestOrganizationModelIsNotMistakenForAProjectList(t *testing.T) {
+	input := decode(t, `{"$id":"org","name":"Example","total":11,"projects":[]}`)
+	buffer := &bytes.Buffer{}
+	if err := (&Renderer{Mode: ModeTable, Writer: buffer}).Render(input); err != nil {
+		t.Fatal(err)
+	}
+	if got := buffer.String(); !strings.Contains(got, "total") || !strings.Contains(got, "11") {
+		t.Errorf("organization member total was hidden:\n%s", got)
+	}
+}
+
 // A section with no allowlist keeps every field; only the shape changes.
 func TestUnknownWideSectionKeepsItsFields(t *testing.T) {
 	input := decode(t, `{

--- a/templates/cli/internal/sdk/sdk.go.twig
+++ b/templates/cli/internal/sdk/sdk.go.twig
@@ -243,21 +243,31 @@ func (c *Context) ForConsoleWithOrganization(organizationID string) (sdkclient.C
 	return client, nil
 }
 
-// ForSessionProject builds a project client from the active login only.
+// ForSessionProject builds a project client from the active login and the
+// endpoint returned by project discovery.
 //
 // Resource discovery must not consult appwrite.config.json: a user can list
-// projects while standing in a repository for another endpoint, and enriching
-// those results must not turn that unrelated local config into a mismatch.
-func (c *Context) ForSessionProject(projectID string) (sdkclient.Client, error) {
-	endpoint, err := c.endpoint()
+// projects while standing in a repository for another endpoint. The discovered
+// endpoint is still checked against the session before credentials are sent;
+// regional Cloud endpoints normalize to the same login endpoint.
+func (c *Context) ForSessionProject(projectID, projectEndpoint string) (sdkclient.Client, error) {
+	sessionEndpoint, err := c.endpoint()
 	if err != nil {
 		return sdkclient.Client{}, err
 	}
 	if projectID == "" {
 		return sdkclient.Client{}, ErrProjectNotSet
 	}
+	if projectEndpoint == "" {
+		projectEndpoint = sessionEndpoint
+	}
+	if !config.EndpointsMatch(projectEndpoint, sessionEndpoint) {
+		return sdkclient.Client{}, fmt.Errorf(
+			"project endpoint %s does not belong to the current login endpoint %s",
+			projectEndpoint, sessionEndpoint)
+	}
 
-	client := c.base(endpoint)
+	client := c.base(projectEndpoint)
 	client.Config["project"] = projectID
 	client.AddHeader("X-Appwrite-Project", projectID)
 	if err := c.authenticate(&client, true); err != nil {

--- a/templates/cli/internal/sdk/sdk.go.twig
+++ b/templates/cli/internal/sdk/sdk.go.twig
@@ -243,6 +243,30 @@ func (c *Context) ForConsoleWithOrganization(organizationID string) (sdkclient.C
 	return client, nil
 }
 
+// ForSessionProject builds a project client from the active login only.
+//
+// Resource discovery must not consult appwrite.config.json: a user can list
+// projects while standing in a repository for another endpoint, and enriching
+// those results must not turn that unrelated local config into a mismatch.
+func (c *Context) ForSessionProject(projectID string) (sdkclient.Client, error) {
+	endpoint, err := c.endpoint()
+	if err != nil {
+		return sdkclient.Client{}, err
+	}
+	if projectID == "" {
+		return sdkclient.Client{}, ErrProjectNotSet
+	}
+
+	client := c.base(endpoint)
+	client.Config["project"] = projectID
+	client.AddHeader("X-Appwrite-Project", projectID)
+	if err := c.authenticate(&client, true); err != nil {
+		return sdkclient.Client{}, err
+	}
+
+	return client, nil
+}
+
 // ForProject builds a client against the project in the working directory's
 // config.
 func (c *Context) ForProject(projectID string) (sdkclient.Client, error) {

--- a/templates/cli/internal/sdk/sdk_test.go.twig
+++ b/templates/cli/internal/sdk/sdk_test.go.twig
@@ -167,6 +167,34 @@ func TestProjectEndpointAcceptsAMatchingOverride(t *testing.T) {
 	}
 }
 
+func TestSessionProjectUsesItsDiscoveredRegionalEndpoint(t *testing.T) {
+	context := withSession(t, map[string]any{
+		"endpoint": "https://cloud.appwrite.io/v1", "cookie": "session=1",
+	})
+	regionalEndpoint := "https://syd.cloud.appwrite.io/v1"
+
+	client, err := context.ForSessionProject("project-id", regionalEndpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.Endpoint != regionalEndpoint {
+		t.Errorf("endpoint = %q, want %q", client.Endpoint, regionalEndpoint)
+	}
+	if client.Headers["X-Appwrite-Project"] != "project-id" {
+		t.Errorf("project = %q, want project-id", client.Headers["X-Appwrite-Project"])
+	}
+}
+
+func TestSessionProjectRejectsAnUnrelatedEndpoint(t *testing.T) {
+	context := withSession(t, map[string]any{
+		"endpoint": "https://cloud.appwrite.io/v1", "cookie": "session=1",
+	})
+
+	if _, err := context.ForSessionProject("project-id", "https://example.test/v1"); err == nil {
+		t.Fatal("an unrelated discovery endpoint should be refused")
+	}
+}
+
 func TestOrganizationHeaderHonoursTheEnvironment(t *testing.T) {
 	context := withSession(t, map[string]any{
 		"endpoint": localEndpoint, "accessToken": "", "cookie": "session=1",


### PR DESCRIPTION
## Summary

- add names, member counts, and organization metadata to `list-organizations` and `list-projects`
- add `list-projects --organization-id` and restore all-organization discovery for self-hosted session logins
- normalize OAuth, cookie, and self-hosted results into the same response shape
- add compact tables, page counts, empty states, and contextual hints
- suppress hints for JSON, raw, and piped output

```text
before: projects (25) -> $id, region, repeated endpoint
after:  projects (25 of 224) -> name, id, organization, region
```

## Live verification

Built the generated CLI and ran it against an Appwrite Cloud account with 3 organizations and 224 projects.

### Organization metadata

```console
$ appwrite list-organizations
organizations (3 of 3)
  name                   id                    members
  Refetch                6394ab479bf0a354e412  11
  Chirag's Organization  67610b8ee51f147ca943  2
  Appwrite Official      appwriteOfficials     19
```

### Enriched projects across organizations

```console
$ appwrite list-projects --limit 5
projects (5 of 224)
  name                      id                    organization       region
  Newsletterf sdf ksdlf k…  6394ab53c97037196912  Refetch            fra
  Refetch                   63ef1792594ff4f50de2  Refetch            fra
  Website Thumbnail         651154975c6cabe565be  Appwrite Official  fra
  Threads                   656dd556812fe2e5f4ed  Appwrite Official  fra
  Init                      659868b10fff07726b85  Appwrite Official  fra
```

Verified that enrichment also works for projects outside FRA:

```console
$ appwrite list-projects --limit 5 --offset 29
projects (5 of 224)
  name                id                    organization       region
  Sydney Project      67fe9a9900181f824398  Appwrite Official  syd
  New York Project    67fe9ae60029483b7b7c  Appwrite Official  nyc
  Frankfurt Project   67fe9be3002093df458  Appwrite Official  fra
  Matej project       67fe9e9900300e0db652  Appwrite Official  syd
  New York Project 2  67fe9ef4001a5b80ce28  Appwrite Official  nyc
```

### Organization filtering and server-side pagination

```console
$ appwrite list-projects --organization-id appwriteOfficials --limit 2 --offset 2
projects (2 of 213)
  name                 id                 organization       region
  TechScrunch          techCrunchs        Appwrite Official  fra
  Built with Appwrite  builtWithAppwrite  Appwrite Official  fra
```

The three organization totals were 5, 6, and 213 projects, matching the global total of 224.

### Contextual hints

Ran the generated binary under a PTY to exercise the interactive-only path:

```console
$ appwrite list-projects --limit 2
projects (2 of 224)
  ...
♥ Hint: Showing 1–2 of 224. Next page: appwrite list-projects --limit 2 --offset 2
```

A filtered result suggests the matching detail command:

```console
$ appwrite list-projects --organization-id 6394ab479bf0a354e412 --search Refetch
projects (1 of 1)
  name     id                    organization  region
  Refetch  63ef1792594ff4f50de2  Refetch       fra
♥ Hint: Project details: appwrite project get --project-id <PROJECT_ID>
```

An empty search provides recovery guidance:

```console
$ appwrite list-projects --search zzqqvvxxnonesuch987654321
No projects found.
♥ Hint: Try a shorter search or remove --search.
```

Also verified that these hints are absent from `--json`, `--raw`, and piped output. JSON contains the normalized metadata:

```json
{
  "$id": "63ef1792594ff4f50de2",
  "name": "Refetch",
  "organizationId": "6394ab479bf0a354e412",
  "organization": "Refetch",
  "region": "fra",
  "endpoint": "https://fra.cloud.appwrite.io/v1"
}
```

## OSS self-hosted verification

Switched the generated CLI to an existing self-hosted session at `https://oss.appwrite.org/v1` and exercised the console fallback rather than the Cloud-only OAuth2 discovery routes.

### Organization and project metadata

```console
$ appwrite list-organizations
organizations (1 of 1)
  name           id                    members
  Appwrite Labs  6a6c75b80022febbdc5f  1

$ appwrite list-projects --limit 5
projects (1 of 1)
  name                  id                    organization   region
  Appwrite Self Hosted  appwrite-self-hosted  Appwrite Labs  default
```

The normalized self-hosted JSON includes the configured endpoint and the same fields as Cloud:

```json
{
  "$id": "appwrite-self-hosted",
  "name": "Appwrite Self Hosted",
  "organizationId": "6a6c75b80022febbdc5f",
  "organization": "Appwrite Labs",
  "region": "default",
  "endpoint": "https://oss.appwrite.org/v1"
}
```

### Filtering, hints, and detail commands

```console
$ appwrite list-projects --organization-id 6a6c75b80022febbdc5f --search "Self Hosted"
projects (1 of 1)
  name                  id                    organization   region
  Appwrite Self Hosted  appwrite-self-hosted  Appwrite Labs  default
♥ Hint: Project details: appwrite project get --project-id <PROJECT_ID>
```

Verified both commands suggested by the discovery output against the self-hosted session:

```console
$ appwrite organization get --organization-id 6a6c75b80022febbdc5f
$id   : 6a6c75b80022febbdc5f
name  : Appwrite Labs
total : 1

$ appwrite project get --project-id appwrite-self-hosted
$id      : appwrite-self-hosted
name     : Appwrite Self Hosted
teamId   : 6a6c75b80022febbdc5f
region   : default
status   : active
```

Also verified self-hosted `--json` and `--raw`, the empty-search recovery hint, and that piping the filtered command through `cat` suppresses hints. The active session was switched back to Appwrite Cloud after testing.

## Test plan

- [x] `php example.php cli`
- [x] `cd examples/cli && go mod tidy && go build ./... && go vet ./... && go test ./...`
- [x] `cd examples/cli && go test -race ./internal/app ./internal/output ./internal/sdk`
- [x] `test -z "$(gofmt -l examples/cli)"`
- [x] `composer lint`
- [x] `composer lint-twig`
- [x] `composer refactor:check`
- [x] Live Cloud checks above for metadata, filtering, pagination, regions, hints, JSON, raw, and piped output

