### PR TITLE
Derive SDK method names from operation IDs

### DIFF
--- a/src/SDK/Language.php
+++ b/src/SDK/Language.php
@@ -108,9 +108,11 @@ abstract class Language
     {
         $serviceName = '';
         foreach ($operation->tags as $tag) {
-            if (\strlen($tag) <= \strlen($serviceName)
+            if (
+                \strlen($tag) <= \strlen($serviceName)
                 || !\str_starts_with($operation->id, $tag)
-                || \strlen($operation->id) === \strlen($tag)) {
+                || \strlen($operation->id) === \strlen($tag)
+            ) {
                 continue;
             }
             $serviceName = $tag;

--- a/src/SDK/Language.php
+++ b/src/SDK/Language.php
@@ -101,6 +101,29 @@ abstract class Language
     }
 
     /**
+     * Derive the service-local SDK method name from a service-qualified
+     * OpenAPI operation ID.
+     */
+    public function getMethodName(Operation $operation): string
+    {
+        $serviceName = '';
+        foreach ($operation->tags as $tag) {
+            if (\strlen($tag) <= \strlen($serviceName)
+                || !\str_starts_with($operation->id, $tag)
+                || \strlen($operation->id) === \strlen($tag)) {
+                continue;
+            }
+            $serviceName = $tag;
+        }
+
+        if ($serviceName === '') {
+            return $operation->id;
+        }
+
+        return \lcfirst(\substr($operation->id, \strlen($serviceName)));
+    }
+
+    /**
      * Language specific filters.
      */
     public function getFilters(): array

--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -246,7 +246,7 @@ class CLI extends Go
      */
     protected function getGoCallPlan(Operation $method, Tag $service): array
     {
-        $methodName = $this->toPascalCase($this->cliMethodName($method));
+        $methodName = $this->toPascalCase($this->getMethodName($method));
         $required = [];
         $optional = [];
         $decodes = [];

--- a/src/SDK/Language/Concern/CliCommandSurface.php
+++ b/src/SDK/Language/Concern/CliCommandSurface.php
@@ -263,7 +263,7 @@ trait CliCommandSurface
 
         $available = [];
         foreach ($methods as $method) {
-            $name = $this->cliMethodName($method);
+            $name = $this->getMethodName($method);
 
             if ($name !== '') {
                 $available[$name] = true;
@@ -294,7 +294,7 @@ trait CliCommandSurface
     protected function isCliTopLevelAlias(Operation $method, Tag $service): bool
     {
         return \in_array(
-            $this->cliMethodName($method),
+            $this->getMethodName($method),
             self::TOP_LEVEL_COMMANDS[$service->name] ?? [],
             true,
         );
@@ -309,7 +309,7 @@ trait CliCommandSurface
     protected function getCliCommandTargets(Operation $method, Tag $service): array
     {
         $serviceName = $service->name;
-        $methodName = $this->cliMethodName($method);
+        $methodName = $this->getMethodName($method);
         $commandVar = lcfirst($serviceName) . ucfirst((string) $methodName) . 'Command';
         $isTopLevel = in_array($methodName, self::TOP_LEVEL_COMMANDS[$serviceName] ?? [], true);
         $implementation = self::CONSOLE_FALLBACK_METHODS[$serviceName][$methodName] ?? null;
@@ -347,7 +347,7 @@ trait CliCommandSurface
         $helpers = [];
 
         foreach ($methods as $method) {
-            $helper = $configured[$this->cliMethodName($method)] ?? null;
+            $helper = $configured[$this->getMethodName($method)] ?? null;
 
             if ($helper !== null && !in_array($helper, $helpers, true)) {
                 $helpers[] = $helper;
@@ -378,7 +378,7 @@ trait CliCommandSurface
     protected function getCliMethodDescription(Operation $method, Tag $service): string
     {
         if ($service->name === 'oauth2') {
-            return match ($this->cliMethodName($method)) {
+            return match ($this->getMethodName($method)) {
                 'listOrganizations' => 'List the organizations the current session can access.',
                 'listProjects' => 'List the projects the current session can access.',
                 default => $method->description,
@@ -386,7 +386,7 @@ trait CliCommandSurface
         }
 
         if ($service->name === 'graphql' && ($method->extensions['x-appwrite']['type'] ?? '') === 'graphql') {
-            return match ($this->cliMethodName($method)) {
+            return match ($this->getMethodName($method)) {
                 'query' => 'Execute a GraphQL query.',
                 'mutation' => 'Execute a GraphQL mutation.',
                 default => $method->description,
@@ -405,11 +405,6 @@ trait CliCommandSurface
         return $parameter->description;
     }
 
-    protected function cliMethodName(Operation $method): string
-    {
-        return (string) ($method->extensions['x-appwrite']['method'] ?? $method->id);
-    }
-
     protected function getCliOptionName(string $name): string
     {
         $kebabName = strtolower((string) preg_replace('/(?<!^)([A-Z][a-z]|(?<=[a-z])[^a-z\s_]|(?<=[A-Z])\d)/', '-$1', $name));
@@ -422,7 +417,7 @@ trait CliCommandSurface
     {
         $queries = $this->findQueriesParameter($method);
         $hasQueries = $queries !== null;
-        $methodName = $this->cliMethodName($method);
+        $methodName = $this->getMethodName($method);
         $parameterNames = array_map(
             static fn(Parameter $parameter): string => $parameter->name,
             $this->getOperationParameters($method),

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -615,8 +615,8 @@ class SDK
     /** @param array<string, mixed> $alias */
     protected function createAliasedOperation(Operation $operation, array $alias, string $serviceName): Operation
     {
+        $methodName = (string) ($alias['name'] ?? $this->methodName($operation));
         $appwrite = $operation->extensions['x-appwrite'] ?? [];
-        $appwrite['method'] = (string) ($alias['name'] ?? $appwrite['method'] ?? $operation->id);
         $appwrite['auth'] = $alias['auth'] ?? [];
         if (isset($alias['deprecated'])) {
             $appwrite['deprecated'] = $alias['deprecated'];
@@ -628,7 +628,7 @@ class SDK
         $extensions['x-appwrite'] = $appwrite;
 
         return new Operation(
-            id: $operation->id,
+            id: $serviceName . \ucfirst($methodName),
             method: $operation->method,
             path: $operation->path,
             tags: [$serviceName],
@@ -1479,7 +1479,7 @@ class SDK
 
     protected function methodName(Operation $operation): string
     {
-        return (string) ($operation->extensions['x-appwrite']['method'] ?? $operation->id);
+        return $this->language->getMethodName($operation);
     }
 
     protected function methodType(Operation $operation): string|false

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -2187,7 +2187,7 @@
     "\/mock\/tests\/general\/oauth2": {
       "get": {
         "summary": "OAuth2",
-        "operationId": "generalOAuth2",
+        "operationId": "generalOauth2",
         "tags": [
           "general"
         ],

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -33,7 +33,6 @@
         ],
         "description": "Send a ping to project as part of onboarding.",
         "x-appwrite": {
-          "method": "get",
           "group": null,
           "cookies": false,
           "type": "",
@@ -89,7 +88,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "get",
           "weight": 270,
           "cookies": false,
           "type": "",
@@ -174,7 +172,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "post",
           "weight": 271,
           "cookies": false,
           "type": "",
@@ -262,7 +259,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "put",
           "weight": 273,
           "cookies": false,
           "type": "",
@@ -350,7 +346,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "patch",
           "weight": 272,
           "cookies": false,
           "type": "",
@@ -438,7 +433,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "delete",
           "weight": 274,
           "cookies": false,
           "type": "",
@@ -528,7 +522,6 @@
         ],
         "description": "Create a new player using a request model.",
         "x-appwrite": {
-          "method": "createPlayer",
           "weight": 300,
           "cookies": false,
           "type": "",
@@ -601,7 +594,6 @@
         ],
         "description": "Create multiple players using an array of request models.",
         "x-appwrite": {
-          "method": "createPlayers",
           "weight": 301,
           "cookies": false,
           "type": "",
@@ -671,13 +663,12 @@
     "\/mock\/tests\/general\/excluded-method": {
       "post": {
         "summary": "Create Excluded General Fixture",
-        "operationId": "generalCreateExcludedFixture",
+        "operationId": "generalCreateExcludedGeneralFixture",
         "tags": [
           "general"
         ],
         "description": "Fixture-only general method used to verify method exclusion does not remove the whole service.",
         "x-appwrite": {
-          "method": "createExcludedGeneralFixture",
           "weight": 301,
           "cookies": false,
           "type": "",
@@ -697,7 +688,16 @@
           "offline-response-key": "$id",
           "auth": {
             "Project": []
-          }
+          },
+          "methods": [
+            {
+              "name": "createExcludedGeneralFixture",
+              "namespace": "general",
+              "auth": {
+                "Project": []
+              }
+            }
+          ]
         },
         "security": [
           {
@@ -749,7 +749,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "get",
           "weight": 265,
           "cookies": false,
           "type": "",
@@ -834,7 +833,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "post",
           "weight": 266,
           "cookies": false,
           "type": "",
@@ -922,7 +920,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "put",
           "weight": 268,
           "cookies": false,
           "type": "",
@@ -1010,7 +1007,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "patch",
           "weight": 267,
           "cookies": false,
           "type": "",
@@ -1098,7 +1094,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "delete",
           "weight": 269,
           "cookies": false,
           "type": "",
@@ -1188,7 +1183,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "error400",
           "weight": 285,
           "cookies": false,
           "type": "",
@@ -1241,7 +1235,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "error500",
           "weight": 286,
           "cookies": false,
           "type": "",
@@ -1294,7 +1287,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "error502",
           "weight": 287,
           "cookies": false,
           "type": "",
@@ -1343,7 +1335,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "download",
           "weight": 276,
           "cookies": false,
           "type": "location",
@@ -1398,7 +1389,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "empty",
           "weight": 282,
           "cookies": false,
           "type": "",
@@ -1444,7 +1434,6 @@
         ],
         "description": "Mock a queryable list request.",
         "x-appwrite": {
-          "method": "listRows",
           "weight": 284,
           "cookies": false,
           "type": "",
@@ -1511,7 +1500,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "enum",
           "weight": 284,
           "cookies": false,
           "type": "",
@@ -1602,7 +1590,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "getCookie",
           "weight": 281,
           "cookies": false,
           "type": "",
@@ -1655,7 +1642,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "headers",
           "weight": 275,
           "cookies": false,
           "type": "",
@@ -1713,7 +1699,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "nullable",
           "weight": 283,
           "cookies": false,
           "type": "",
@@ -1800,7 +1785,6 @@
         ],
         "description": "Create a new function execution.",
         "x-appwrite": {
-          "method": "createExecution",
           "weight": 1,
           "cookies": false,
           "type": "",
@@ -1902,7 +1886,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "redirect",
           "weight": 278,
           "cookies": false,
           "type": "",
@@ -1951,7 +1934,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "redirected",
           "weight": 279,
           "cookies": false,
           "type": "",
@@ -2004,7 +1986,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "getPath",
           "weight": 280,
           "cookies": false,
           "type": "",
@@ -2069,7 +2050,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "setCookie",
           "weight": 280,
           "cookies": false,
           "type": "",
@@ -2122,7 +2102,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "method": "upload",
           "weight": 277,
           "cookies": false,
           "type": "",
@@ -2214,7 +2193,6 @@
         ],
         "description": "OAuth 2",
         "x-appwrite": {
-          "method": "oauth2",
           "weight": 265,
           "cookies": false,
           "type": "webAuth",
@@ -2312,13 +2290,12 @@
     "\/mock\/tests\/union": {
       "get": {
         "summary": "Get Union",
-        "operationId": "unionGet",
+        "operationId": "generalGetUnion",
         "tags": [
           "general"
         ],
         "description": "Test union response types",
         "x-appwrite": {
-          "method": "getUnion",
           "weight": 302,
           "cookies": false,
           "type": "",
@@ -2391,13 +2368,12 @@
     "\/mock\/tests\/zzexcludedservice": {
       "get": {
         "summary": "Get Excluded Fixture",
-        "operationId": "zzexcludedserviceGet",
+        "operationId": "zzexcludedserviceGetExcludedFixture",
         "tags": [
           "zzexcludedservice"
         ],
         "description": "Fixture-only service used to verify excluded services do not leak generated artifacts.",
         "x-appwrite": {
-          "method": "getExcludedFixture",
           "weight": 303,
           "cookies": false,
           "type": "",
@@ -2441,13 +2417,12 @@
       },
       "post": {
         "summary": "Create Excluded Fixture",
-        "operationId": "zzexcludedserviceCreate",
+        "operationId": "zzexcludedserviceCreateExcludedFixture",
         "tags": [
           "zzexcludedservice"
         ],
         "description": "Fixture-only request model path used to verify excluded services also exclude models.",
         "x-appwrite": {
-          "method": "createExcludedFixture",
           "weight": 304,
           "cookies": false,
           "type": "",


### PR DESCRIPTION
## Summary

- derive service-local SDK method names from `operationId` and the matching operation tag
- assign synthetic service-qualified operation IDs to `x-appwrite.methods` aliases
- remove singular `x-appwrite.method` reads, writes, and E2E fixture fields

```text
accountCreate + account              -> create
databasesListDocuments + databases  -> listDocuments
oauth2Authorize + oauth2            -> authorize
```

Closes #1790.

## Verification

- [x] Generated every SDK target from current Appwrite 1.9.x client, server, and console specs with singular `x-appwrite.method` removed
- [x] Compared each generated tree with an `origin/main` same-spec baseline; outputs were identical for all three platforms
- [x] `composer refactor:check`
- [x] `composer lint-twig`
- [x] `vendor/bin/phpunit tests/e2e/PHP83Test.php` (1,401 assertions)
- [x] `vendor/bin/phpunit tests/e2e/CLIGo126Test.php` (5,407 assertions)
- [x] Generated CLI: `go build ./...`, `go vet ./...`, `go test ./...`, and `gofmt` check
