### PR TITLE
fix(go): stop HTML-escaping model doc comments

### DIFF
--- a/templates/go/models/model.go.twig
+++ b/templates/go/models/model.go.twig
@@ -8,7 +8,7 @@ import (
 {{ ((definition.description | caseUcfirst) ~ " Model") | godocComment }}
 type {{ definitionName | caseUcfirst }} struct {
 	{%~ for property in definition.properties %}
-	{{ property.description | godocComment | replace({"\n": "\n\t"}) }}
+	{{ (property.description | godocComment | replace({"\n": "\n\t"})) | raw }}
 	{{ (property | schemaName) | caseUcfirst | escapeKeyword }} {{ property | propertyType(spec) }} `json:"{{ (property | schemaName) }}"`
 	{%~ endfor %}
 

--- a/templates/go/models/request_model.go.twig
+++ b/templates/go/models/request_model.go.twig
@@ -7,7 +7,7 @@ import (
 {{ ((requestModel.description | caseUcfirst) ~ " Request Model") | godocComment }}
 type {{ requestModelName | caseUcfirst }} struct {
 	{%~ for property in requestModel.properties %}
-	{{ property.description | godocComment | replace({"\n": "\n\t"}) }}
+	{{ (property.description | godocComment | replace({"\n": "\n\t"})) | raw }}
 	{{ (property | schemaName) | caseUcfirst | escapeKeyword }} {{ property | propertyType(spec) }}{% if not (property | schemaRequired) %} `json:"{{ (property | schemaName) }},omitempty"`{% else %} `json:"{{ (property | schemaName) }}"`{% endif %}
 
 	{%~ endfor %}

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -503,6 +503,7 @@ abstract class Base extends TestCase
 
         $sdk->generate(__DIR__ . '/sdks/' . $this->language);
         $this->assertExcludedFixtureWasRemoved($dir);
+        $this->assertCommentsAreNotHtmlEscaped($dir);
 
         /**
          * Build SDK
@@ -607,6 +608,45 @@ abstract class Base extends TestCase
                     $token,
                     $contents,
                     "Excluded fixture leaked into generated file: {$file->getPathname()}"
+                );
+            }
+        }
+    }
+
+    /**
+     * Twig autoescapes to HTML, so a description that reaches the template through an
+     * unsafe filter arrives in the source as `&quot;` rather than `"`. Go doc comments
+     * are read as plain text, so the entity is what the reader sees.
+     *
+     * Scoped to the generated models: the CLI ships hand-written Go that escapes HTML
+     * as its job, and those entities are the payload rather than a leak.
+     */
+    private function assertCommentsAreNotHtmlEscaped(string $dir): void
+    {
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'go') {
+                continue;
+            }
+
+            if (!\str_contains((string) $file->getPath(), '/models')) {
+                continue;
+            }
+
+            $contents = \file_get_contents($file->getPathname());
+
+            if ($contents === false) {
+                continue;
+            }
+
+            foreach (['&quot;', '&#039;', '&amp;', '&lt;', '&gt;'] as $entity) {
+                $this->assertStringNotContainsString(
+                    $entity,
+                    $contents,
+                    "HTML entity {$entity} leaked into generated source: {$file->getPathname()}"
                 );
             }
         }

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -2626,7 +2626,7 @@
           },
           "status": {
             "type": "string",
-            "description": "Mock status. Possible values: `active`, `inactive`, `pending`, `completed`, or `cancelled`",
+            "description": "Mock status. Possible values are \"active\", \"inactive\", \"pending\", \"completed\", or \"cancelled\". Reflects the mock's state.",
             "x-example": "active",
             "enum": [
               "active",


### PR DESCRIPTION
The gofmt-clean pass piped `godocComment` through Twig's `replace` filter to indent continuation lines. `replace` is not marked safe, so autoescaping turned every quote and apostrophe in a property description into `&quot;` and `&#039;`. Go doc comments are plain text, so the entity is what the reader sees — generating the Go server SDK against the current cloud spec produces 22 model files carrying them, against zero in the published v7.1.0 (generated before that pass landed).

`| raw` restores the filter's declared safety after `replace`, in both `model.go.twig` and `request_model.go.twig`.

## Test

The fixture's `mock.status` description now contains both a double quote and an apostrophe — no fixture description had either, which is why nothing caught this. `tests/e2e/Base.php` asserts that no HTML entity survives into a generated Go model, scoped to `models/` because the CLI ships hand-written Go whose job is HTML escaping and whose comments legitimately name the entities.

Seen red: reverting both template hunks makes the generated `models/mock.go` carry `&quot;` and `&#039;` and the assertion fail.