### PR TITLE
Prompt CLI login after refresh token rejection

### DIFF
--- a/templates/cli/internal/auth/device.go
+++ b/templates/cli/internal/auth/device.go
@@ -201,15 +201,16 @@ func (f *DeviceFlow) now() time.Time {
 
 // matchesOAuthError reports whether an API error carries an OAuth error code.
 //
-// The code can arrive as the error type or the message depending on how the
-// endpoint failed, so both are checked -- ports matchesOAuthError().
+// The code can arrive in the standard OAuth error field or as the Appwrite API
+// error type or message, so all three are checked -- ports matchesOAuthError().
 func matchesOAuthError(err error, code string) bool {
 	var apiError *client.APIError
 	if !errors.As(err, &apiError) {
 		return false
 	}
 
-	return apiError.Type == code ||
+	return apiError.OAuthError == code ||
+		apiError.Type == code ||
 		apiError.Message == code ||
 		strings.Contains(apiError.Message, code)
 }
@@ -220,10 +221,10 @@ func isSlowDown(err error) bool {
 
 // isAuthorizationPending reports whether polling should continue.
 //
-// An empty error body -- a 400 with no type and no message -- is treated as
-// pending rather than fatal. Ports isEmptyDevicePollError(): aborting the whole
-// login because one poll came back blank would be a worse failure than one more
-// round trip.
+// An empty error body -- a 400 with no Appwrite or OAuth error fields -- is
+// treated as pending rather than fatal. Ports isEmptyDevicePollError(): aborting
+// the whole login because one poll came back blank would be a worse failure than
+// one more round trip.
 func isAuthorizationPending(err error) bool {
 	if matchesOAuthError(err, "authorization_pending") || matchesOAuthError(err, "slow_down") {
 		return true
@@ -234,7 +235,10 @@ func isAuthorizationPending(err error) bool {
 		return false
 	}
 
-	return strings.TrimSpace(apiError.Type) == "" && strings.TrimSpace(apiError.Message) == ""
+	return strings.TrimSpace(apiError.Type) == "" &&
+		strings.TrimSpace(apiError.Message) == "" &&
+		strings.TrimSpace(apiError.OAuthError) == "" &&
+		strings.TrimSpace(apiError.OAuthDescription) == ""
 }
 
 // DecodeIDToken pulls the profile claims out of an OIDC ID token.

--- a/templates/cli/internal/auth/device_test.go
+++ b/templates/cli/internal/auth/device_test.go
@@ -32,12 +32,22 @@ func deviceServer(t *testing.T, responses []func(w http.ResponseWriter)) (*httpt
 
 func pendingResponse(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusBadRequest)
-	_ = json.NewEncoder(w).Encode(map[string]any{"type": "authorization_pending"})
+	_ = json.NewEncoder(w).Encode(map[string]any{"error": "authorization_pending"})
 }
 
 func slowDownResponse(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusBadRequest)
-	_ = json.NewEncoder(w).Encode(map[string]any{"type": "slow_down"})
+	_ = json.NewEncoder(w).Encode(map[string]any{"error": "slow_down"})
+}
+
+func legacyPendingTypeResponse(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusBadRequest)
+	_ = json.NewEncoder(w).Encode(map[string]any{"type": "authorization_pending"})
+}
+
+func legacyPendingMessageResponse(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusBadRequest)
+	_ = json.NewEncoder(w).Encode(map[string]any{"message": "authorization_pending"})
 }
 
 func tokenGrantedResponse(w http.ResponseWriter) {
@@ -92,6 +102,30 @@ func TestPollSucceedsAfterPendingResponses(t *testing.T) {
 	}
 }
 
+// Older endpoints used Appwrite's type/message error envelope. Keep accepting
+// both shapes while preferring the standard OAuth error field.
+func TestPollAcceptsLegacyPendingErrorShapes(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		response func(http.ResponseWriter)
+	}{
+		{name: "type", response: legacyPendingTypeResponse},
+		{name: "message", response: legacyPendingMessageResponse},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server, calls := deviceServer(t, []func(http.ResponseWriter){test.response, tokenGrantedResponse})
+			flow, _ := newTestFlow(t, server.URL)
+
+			if _, err := flow.Poll(testAuthorization()); err != nil {
+				t.Fatal(err)
+			}
+			if *calls != 2 {
+				t.Errorf("polls = %d, want 2", *calls)
+			}
+		})
+	}
+}
+
 // RFC 8628 section 3.5: `slow_down` widens the interval by five seconds, and
 // the widened interval persists for subsequent polls.
 func TestPollWidensIntervalOnSlowDown(t *testing.T) {
@@ -140,7 +174,7 @@ func TestPollTreatsEmptyErrorBodyAsPending(t *testing.T) {
 func TestPollAbortsOnRealError(t *testing.T) {
 	denied := func(w http.ResponseWriter) {
 		w.WriteHeader(http.StatusBadRequest)
-		_ = json.NewEncoder(w).Encode(map[string]any{"type": "access_denied"})
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": "access_denied"})
 	}
 
 	server, calls := deviceServer(t, []func(http.ResponseWriter){denied})

--- a/templates/cli/internal/auth/refresh.go
+++ b/templates/cli/internal/auth/refresh.go
@@ -21,7 +21,19 @@ const DefaultClientID = "appwrite-cli"
 const refreshSkew = 60 * time.Second
 
 // ErrSessionExpired is returned when no usable credential remains.
-var ErrSessionExpired = errors.New("session expired. Run `appwrite login` to create a new session")
+var ErrSessionExpired = errors.New("session expired. Run `appwrite login` to sign in again")
+
+// expiredSessionError keeps the server's cause available to --verbose and
+// errors.As while presenting the short recovery instruction in normal output.
+type expiredSessionError struct {
+	cause error
+}
+
+func (e *expiredSessionError) Error() string { return ErrSessionExpired.Error() }
+func (e *expiredSessionError) Unwrap() error { return e.cause }
+func (e *expiredSessionError) Is(target error) bool {
+	return target == ErrSessionExpired
+}
 
 // tokenResponse is the subset of the OAuth2 token payload the CLI uses.
 type tokenResponse struct {
@@ -160,6 +172,11 @@ func (a *Authenticator) refresh(session *config.Object, sessionID, refreshToken 
 		"client_id":     clientID,
 	}, &token)
 	if err != nil {
+		var apiError *client.APIError
+		if errors.As(err, &apiError) && apiError.OAuthError == "invalid_grant" {
+			return "", &expiredSessionError{cause: err}
+		}
+
 		return "", err
 	}
 	if token.AccessToken == "" {

--- a/templates/cli/internal/auth/refresh.go
+++ b/templates/cli/internal/auth/refresh.go
@@ -20,18 +20,40 @@ const DefaultClientID = "appwrite-cli"
 // failure, so renew a minute early.
 const refreshSkew = 60 * time.Second
 
-// ErrSessionExpired is returned when no usable credential remains.
-var ErrSessionExpired = errors.New("session expired. Run `appwrite login` to sign in again")
+// sessionExpired is the type behind ErrSessionExpired. The message names a
+// command, and the executable's name is not known until root.go sets it, so it
+// is formatted when read rather than at package init.
+type sessionExpired struct{}
 
-// expiredSessionError keeps the server's cause available to --verbose and
-// errors.As while presenting the short recovery instruction in normal output.
-type expiredSessionError struct {
-	cause error
+func (sessionExpired) Error() string {
+	return fmt.Sprintf("session expired. Run `%s login` to sign in again", client.ExecutableName)
 }
 
-func (e *expiredSessionError) Error() string { return ErrSessionExpired.Error() }
-func (e *expiredSessionError) Unwrap() error { return e.cause }
-func (e *expiredSessionError) Is(target error) bool {
+// ErrSessionExpired is returned when no usable credential remains.
+var ErrSessionExpired error = sessionExpired{}
+
+// SessionRejectedError reports a refresh token the server refused.
+//
+// It says rejected rather than expired because invalid_grant covers a session
+// revoked elsewhere and a rotation the CLI lost a race on as well as a genuine
+// expiry, and expiry is the one of the three the CLI cannot confirm. It names
+// the session for the reason cannotRefresh does: preferences hold one per
+// environment, and "the session" identifies none of them.
+//
+// The server's own description stays in the unwrap chain rather than the
+// sentence. On this endpoint it is a fixed string -- "Invalid refresh token
+// provided." -- that only restates the rejection, and --verbose prints it.
+type SessionRejectedError struct {
+	Session string
+	cause   error
+}
+
+func (e *SessionRejectedError) Error() string {
+	return fmt.Sprintf("session for %s was rejected. Run `%s login` to sign in again",
+		e.Session, client.ExecutableName)
+}
+func (e *SessionRejectedError) Unwrap() error { return e.cause }
+func (e *SessionRejectedError) Is(target error) bool {
 	return target == ErrSessionExpired
 }
 
@@ -136,13 +158,22 @@ func describeSession(session *config.Object) string {
 	email := session.GetString(config.PreferenceEmail)
 	endpoint := session.GetString(config.PreferenceEndpoint)
 
-	switch {
-	case email != "" && endpoint != "":
+	if email != "" && endpoint != "" {
 		return email + " at " + endpoint
-	case endpoint != "":
-		return endpoint
-	case email != "":
-		return email
+	}
+
+	return nameSession(session)
+}
+
+// nameSession identifies a session in one term, for a sentence with no room for
+// both. Email first: two stored sessions rarely share one, and the endpoint
+// tells them apart only when they do.
+func nameSession(session *config.Object) string {
+	switch {
+	case session.GetString(config.PreferenceEmail) != "":
+		return session.GetString(config.PreferenceEmail)
+	case session.GetString(config.PreferenceEndpoint) != "":
+		return session.GetString(config.PreferenceEndpoint)
 	default:
 		return "the current account"
 	}
@@ -174,7 +205,7 @@ func (a *Authenticator) refresh(session *config.Object, sessionID, refreshToken 
 	if err != nil {
 		var apiError *client.APIError
 		if errors.As(err, &apiError) && apiError.OAuthError == "invalid_grant" {
-			return "", &expiredSessionError{cause: err}
+			return "", &SessionRejectedError{Session: nameSession(session), cause: err}
 		}
 
 		return "", err

--- a/templates/cli/internal/auth/refresh_test.go
+++ b/templates/cli/internal/auth/refresh_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/client"
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/config"
 )
 
@@ -121,6 +122,40 @@ func TestAccessTokenRefreshesInsideSkewWindow(t *testing.T) {
 	wantExpiry := fixedNow.Add(3600 * time.Second).UnixMilli()
 	if got := session.GetInt64(config.PreferenceTokenExpiry); got != wantExpiry {
 		t.Errorf("persisted expiry = %d, want %d", got, wantExpiry)
+	}
+}
+
+// An invalid refresh grant means the stored session cannot be renewed. Normal
+// output gives the recovery action, while the wrapped API error keeps the
+// server's description available to diagnostics.
+func TestAccessTokenTurnsInvalidGrantIntoExpiredSession(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error":             "invalid_grant",
+			"error_description": "Invalid refresh token provided.",
+		})
+	}))
+	defer server.Close()
+
+	global := newTestGlobal(t, server.URL, 0, "expired")
+	seedPrefsRefreshToken(t, global, "session-1", "invalid-refresh")
+
+	_, err := NewAuthenticator(global, "0.0.1").AccessToken(true)
+	if err == nil {
+		t.Fatal("expected refresh to fail")
+	}
+	if got := err.Error(); got != ErrSessionExpired.Error() {
+		t.Errorf("refresh error = %q, want %q", got, ErrSessionExpired)
+	}
+	if !errors.Is(err, ErrSessionExpired) {
+		t.Errorf("errors.Is(err, ErrSessionExpired) = false: %v", err)
+	}
+
+	var apiError *client.APIError
+	if !errors.As(err, &apiError) {
+		t.Errorf("refresh error does not retain *client.APIError: %v", err)
 	}
 }
 

--- a/templates/cli/internal/auth/refresh_test.go
+++ b/templates/cli/internal/auth/refresh_test.go
@@ -125,10 +125,10 @@ func TestAccessTokenRefreshesInsideSkewWindow(t *testing.T) {
 	}
 }
 
-// An invalid refresh grant means the stored session cannot be renewed. Normal
-// output gives the recovery action, while the wrapped API error keeps the
-// server's description available to diagnostics.
-func TestAccessTokenTurnsInvalidGrantIntoExpiredSession(t *testing.T) {
+// An invalid refresh grant means the server refused the stored session. The
+// sentence names that session and the recovery action; the server's description
+// stays in the unwrap chain, where --verbose reads it.
+func TestAccessTokenReportsRejectedSession(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("content-type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
@@ -146,16 +146,30 @@ func TestAccessTokenTurnsInvalidGrantIntoExpiredSession(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected refresh to fail")
 	}
-	if got := err.Error(); got != ErrSessionExpired.Error() {
-		t.Errorf("refresh error = %q, want %q", got, ErrSessionExpired)
+
+	message := err.Error()
+	if !strings.Contains(message, "someone@example.com") {
+		t.Errorf("rejection = %q, does not name the session", message)
 	}
+	if !strings.Contains(message, "`"+client.ExecutableName+" login`") {
+		t.Errorf("rejection = %q, does not name the recovery command", message)
+	}
+	// The description restates the rejection, so it belongs to --verbose rather
+	// than to a sentence that has to fit on one line.
+	if strings.Contains(message, "Invalid refresh token provided.") {
+		t.Errorf("rejection = %q, repeats the server description", message)
+	}
+
 	if !errors.Is(err, ErrSessionExpired) {
 		t.Errorf("errors.Is(err, ErrSessionExpired) = false: %v", err)
 	}
 
 	var apiError *client.APIError
 	if !errors.As(err, &apiError) {
-		t.Errorf("refresh error does not retain *client.APIError: %v", err)
+		t.Fatalf("refresh error does not retain *client.APIError: %v", err)
+	}
+	if apiError.OAuthDescription != "Invalid refresh token provided." {
+		t.Errorf("retained description = %q", apiError.OAuthDescription)
 	}
 }
 

--- a/templates/cli/internal/client/apierror_test.go
+++ b/templates/cli/internal/client/apierror_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -74,6 +75,50 @@ func TestGuestRoleMatching(t *testing.T) {
 		if apiError.Error() == message {
 			t.Errorf("did not recognise %q as unauthenticated", message)
 		}
+	}
+}
+
+// OAuth2 token endpoints use error/error_description rather than the Appwrite
+// API's code/message/type envelope. The description is the useful part for a
+// person trying to repair an expired session.
+func TestOAuthFailureUsesDescription(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{
+			"error":"invalid_grant",
+			"error_description":"Invalid refresh token provided."
+		}`))
+	}))
+	defer server.Close()
+
+	err := New(server.URL, "0.0.1").Call("POST", "/oauth2/console/token", nil, nil)
+	if err == nil {
+		t.Fatal("an OAuth2 failure was not reported as an error")
+	}
+	if got := err.Error(); got != "Invalid refresh token provided." {
+		t.Errorf("OAuth2 failure = %q", got)
+	}
+
+	var apiError *APIError
+	if !errors.As(err, &apiError) {
+		t.Fatalf("error is %T, want *APIError", err)
+	}
+	if apiError.OAuthError != "invalid_grant" {
+		t.Errorf("OAuthError = %q", apiError.OAuthError)
+	}
+	if apiError.Status != http.StatusBadRequest {
+		t.Errorf("Status = %d", apiError.Status)
+	}
+}
+
+// error_description is optional in RFC 6749. The required error identifier is
+// still more useful than a bare HTTP status when the server omits it.
+func TestOAuthFailureWithoutDescriptionUsesIdentifier(t *testing.T) {
+	apiError := &APIError{Status: http.StatusBadRequest, OAuthError: "invalid_grant"}
+
+	if got := apiError.Error(); got != "invalid_grant" {
+		t.Errorf("OAuth2 failure = %q", got)
 	}
 }
 

--- a/templates/cli/internal/client/client.go
+++ b/templates/cli/internal/client/client.go
@@ -340,16 +340,20 @@ const unauthorizedScopeType = "general_unauthorized_scope"
 // credentials it recognised.
 var guestRole = regexp.MustCompile(`(?i)role:\s*guests`)
 
-// APIError is a non-2xx response from the API.
+// APIError is a non-2xx response from the API. OAuthError and
+// OAuthDescription cover RFC 6749 token endpoint failures, whose shape differs
+// from the Appwrite API's code/message/type envelope.
 type APIError struct {
-	Status  int
-	Code    int    `json:"code"`
-	Message string `json:"message"`
-	Type    string `json:"type"`
+	Status           int
+	Code             int    `json:"code"`
+	Message          string `json:"message"`
+	Type             string `json:"type"`
+	OAuthError       string `json:"error"`
+	OAuthDescription string `json:"error_description"`
 }
 
-// Error is what the user reads. Message keeps the API's own wording, so
-// --verbose and a bug report still carry it.
+// Error is what the user reads. The API's human-readable wording wins over its
+// machine-readable error identifier.
 func (e *APIError) Error() string {
 	if e.unauthenticated() {
 		return "you are not authenticated. Run `" + ExecutableName +
@@ -358,6 +362,12 @@ func (e *APIError) Error() string {
 
 	if e.Message != "" {
 		return e.Message
+	}
+	if e.OAuthDescription != "" {
+		return e.OAuthDescription
+	}
+	if e.OAuthError != "" {
+		return e.OAuthError
 	}
 
 	return fmt.Sprintf("request failed with status %d", e.Status)


### PR DESCRIPTION
## Problem

OAuth token endpoints return RFC 6749 errors:

```json
{
  "error": "invalid_grant",
  "error_description": "Invalid refresh token provided."
}
```

The CLI only decoded Appwrite's `code` / `message` / `type` envelope, so refresh failures became:

```text
request failed with status 400
```

This PR makes the normal message short and actionable while retaining the server response for verbose diagnostics:

```text
session expired. Run `appwrite login` to sign in again
```

## Changes

### Decode OAuth errors

Before:

```go
type APIError struct {
	Status  int
	Code    int    `json:"code"`
	Message string `json:"message"`
	Type    string `json:"type"`
}
```

After:

```go
type APIError struct {
	Status           int
	Code             int    `json:"code"`
	Message          string `json:"message"`
	Type             string `json:"type"`
	OAuthError       string `json:"error"`
	OAuthDescription string `json:"error_description"`
}
```

`APIError.Error()` now prefers `error_description`, then falls back to `error` before using the HTTP status.

### Convert rejected refresh tokens into an actionable session error

```go
if errors.As(err, &apiError) && apiError.OAuthError == "invalid_grant" {
	return "", &expiredSessionError{cause: err}
}
```

The wrapper keeps normal output compact:

```go
func (e *expiredSessionError) Error() string { return ErrSessionExpired.Error() }
```

It still exposes the original OAuth error to `--verbose`, `errors.Is`, and `errors.As`:

```go
func (e *expiredSessionError) Unwrap() error { return e.cause }
func (e *expiredSessionError) Is(target error) bool {
	return target == ErrSessionExpired
}
```

The login instruction is added only for stored-session refreshes. Other OAuth commands can also return `invalid_grant`, but reauthentication is not always the correct recovery for those commands.

### Preserve device-flow behavior

Before:

```go
return apiError.Type == code ||
	apiError.Message == code ||
	strings.Contains(apiError.Message, code)
```

After:

```go
return apiError.OAuthError == code ||
	apiError.Type == code ||
	apiError.Message == code ||
	strings.Contains(apiError.Message, code)
```

This supports standard `authorization_pending`, `slow_down`, and `access_denied` responses while retaining legacy `type` and `message` handling.

## Tests

Added coverage for OAuth descriptions, code-only errors, invalid session refreshes, wrapped diagnostics, standard device-flow errors, and legacy device-flow envelopes.

```text
php example.php cli
composer refactor:check
composer lint-twig
cd examples/cli
go mod tidy
test -z "$(gofmt -l .)"
go build ./...
go vet ./...
go test -race ./...
go build -o appwrite .
```
