### PR TITLE
feat(cli): add guided function setup workflow

### DIFF
--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -1104,6 +1104,11 @@ class CLI extends Go
             ],
             [
                 'scope'         => 'default',
+                'destination'   => 'internal/cmd/initfunction_test.go',
+                'template'      => 'cli/internal/cmd/initfunction_test.go',
+            ],
+            [
+                'scope'         => 'default',
                 'destination'   => 'internal/cmd/initsite.go',
                 'template'      => 'cli/internal/cmd/initsite.go',
             ],

--- a/templates/cli/internal/cmd/errors.go
+++ b/templates/cli/internal/cmd/errors.go
@@ -8,10 +8,12 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/app"
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/config"
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/output"
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/prompt"
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/sdk"
@@ -42,6 +44,64 @@ type apiError interface {
 // Comfortably longer than any message the API sends and far shorter than a
 // rendered error page.
 const maximumMessageLength = 400
+
+// actionableError carries a known recovery path without baking terminal layout
+// into Error(). Logs and reports retain the ordinary message; Report can render
+// the title, facts and command as a readable block.
+type actionableError struct {
+	cause   error
+	title   string
+	details []output.FailureDetail
+	action  string
+	command string
+}
+
+func (e *actionableError) Error() string { return e.cause.Error() }
+func (e *actionableError) Unwrap() error { return e.cause }
+
+func endpointMismatchError(projectEndpoint, sessionEndpoint string) error {
+	switchEndpoint := config.NormalizeCloudConsoleEndpoint(projectEndpoint)
+	environment := "the project environment"
+	if base, cloud := config.CloudBaseHost(projectEndpoint); cloud {
+		environment = "Appwrite Cloud"
+		if strings.Contains(base, "staging") {
+			environment = "Appwrite Cloud Staging"
+		}
+	}
+
+	cause := fmt.Errorf("project endpoint %s does not match active session endpoint %s",
+		projectEndpoint, sessionEndpoint)
+	return &actionableError{
+		cause: cause,
+		title: "Active session doesn’t match this project",
+		details: []output.FailureDetail{
+			{Label: "Project endpoint", Value: projectEndpoint},
+			{Label: "Active session", Value: sessionEndpoint},
+		},
+		action: "Switch to " + environment + ":",
+		command: fmt.Sprintf("%s login --switch --endpoint %s",
+			app.ExecutableName, switchEndpoint),
+	}
+}
+
+func missingProjectConfigError(err error) *actionableError {
+	var pathError *os.PathError
+	if !errors.As(err, &pathError) || !errors.Is(err, os.ErrNotExist) ||
+		filepath.Base(pathError.Path) != config.LocalFileName {
+		return nil
+	}
+
+	return &actionableError{
+		cause: err,
+		title: "Appwrite project configuration not found",
+		details: []output.FailureDetail{
+			{Label: "Expected file", Value: pathError.Path},
+		},
+		action: "Run this command from a directory containing " + config.LocalFileName +
+			", or initialize a project:",
+		command: app.ExecutableName + " init project",
+	}
+}
 
 // FormatError renders a command failure for the terminal.
 func FormatError(err error) string {
@@ -196,7 +256,16 @@ func Report(writer io.Writer, executed *cobra.Command, err error) int {
 		output.Log(writer, "For detailed error pass the --verbose or --report flag")
 	}
 
-	output.Failure(writer, "%s", FormatError(err))
+	var actionable *actionableError
+	if errors.As(err, &actionable) {
+		output.ActionableFailure(writer, actionable.title, actionable.details,
+			actionable.action, actionable.command)
+	} else if missing := missingProjectConfigError(err); missing != nil {
+		output.ActionableFailure(writer, missing.title, missing.details,
+			missing.action, missing.command)
+	} else {
+		output.Failure(writer, "%s", FormatError(err))
+	}
 
 	// --verbose has to add the response body: on the failure it matters most for
 	// -- a response the SDK could not decode -- a message naming a field and a

--- a/templates/cli/internal/cmd/errors_test.go
+++ b/templates/cli/internal/cmd/errors_test.go
@@ -263,6 +263,59 @@ func TestReportDistinguishesCancellationFromFailure(t *testing.T) {
 	}
 }
 
+func TestEndpointMismatchRendersActionableBlock(t *testing.T) {
+	requestWasMade(t, false)
+	buffer := &bytes.Buffer{}
+	err := endpointMismatchError(
+		"https://sgp.cloud.appwrite.io/v1",
+		"https://cloud.staging.appwrite.io/v1",
+	)
+
+	if status := Report(buffer, nil, err); status != 1 {
+		t.Fatalf("status = %d", status)
+	}
+	printed := buffer.String()
+	for _, wanted := range []string{
+		"Active session doesn’t match this project",
+		"Project endpoint", "https://sgp.cloud.appwrite.io/v1",
+		"Active session", "https://cloud.staging.appwrite.io/v1",
+		"Switch to Appwrite Cloud:",
+		"appwrite login --switch --endpoint https://cloud.appwrite.io/v1",
+	} {
+		if !strings.Contains(printed, wanted) {
+			t.Errorf("output does not contain %q:\n%s", wanted, printed)
+		}
+	}
+	if strings.Contains(printed, "✗ Error:") {
+		t.Errorf("actionable block retained generic prefix:\n%s", printed)
+	}
+}
+
+func TestMissingProjectConfigRendersActionableBlock(t *testing.T) {
+	requestWasMade(t, false)
+	path := "/work/project/appwrite.config.json"
+	buffer := &bytes.Buffer{}
+	err := &os.PathError{Op: "open", Path: path, Err: os.ErrNotExist}
+
+	if status := Report(buffer, nil, err); status != 1 {
+		t.Fatalf("status = %d", status)
+	}
+	printed := buffer.String()
+	for _, wanted := range []string{
+		"Appwrite project configuration not found",
+		"Expected file", path,
+		"Run this command from a directory containing appwrite.config.json",
+		"appwrite init project",
+	} {
+		if !strings.Contains(printed, wanted) {
+			t.Errorf("output does not contain %q:\n%s", wanted, printed)
+		}
+	}
+	if strings.Contains(printed, "no such file or directory") {
+		t.Errorf("raw filesystem error leaked into primary output:\n%s", printed)
+	}
+}
+
 // A command that fails DURING parsing never reaches the later flags, so the
 // parsed globals cannot answer "did the user ask for detail". `users get
 // --bogus --verbose` stopped at --bogus and then advised passing --verbose.

--- a/templates/cli/internal/cmd/initfunction.go
+++ b/templates/cli/internal/cmd/initfunction.go
@@ -161,37 +161,40 @@ func ignoresFor(language string) []string {
 // that type is the READ model used by `run`, and the two are deliberately
 // separate rather than one type trying to be both.
 type FunctionEntry struct {
-	ID                    string   `json:"$id"`
-	Name                  string   `json:"name"`
-	Runtime               string   `json:"runtime"`
-	BuildSpecification    string   `json:"buildSpecification"`
-	RuntimeSpecification  string   `json:"runtimeSpecification"`
-	Execute               []string `json:"execute"`
-	Events                []string `json:"events"`
-	Scopes                []string `json:"scopes"`
-	Schedule              string   `json:"schedule"`
-	Timeout               int      `json:"timeout"`
-	Enabled               bool     `json:"enabled"`
-	Logging               bool     `json:"logging"`
-	Entrypoint            string   `json:"entrypoint"`
-	Commands              string   `json:"commands"`
-	Ignore                []string `json:"ignore"`
-	DeploymentRetention   int      `json:"deploymentRetention"`
-	Path                  string   `json:"path"`
-	PreviewDomainTarget   string   `json:"previewDomainTarget,omitempty"`
-	PreviewDomainLabel    string   `json:"previewDomainLabel,omitempty"`
-	InstallationID        string   `json:"installationId,omitempty"`
-	ProviderRepositoryID  string   `json:"providerRepositoryId,omitempty"`
-	ProviderBranch        string   `json:"providerBranch,omitempty"`
-	ProviderSilentMode    bool     `json:"providerSilentMode,omitempty"`
-	ProviderRootDirectory string   `json:"providerRootDirectory,omitempty"`
-	ProviderBranches      []string `json:"providerBranches,omitempty"`
-	ProviderPaths         []string `json:"providerPaths,omitempty"`
-	TemplateRepository    string   `json:"templateRepository,omitempty"`
-	TemplateOwner         string   `json:"templateOwner,omitempty"`
-	TemplateRootDirectory string   `json:"templateRootDirectory,omitempty"`
-	TemplateReference     string   `json:"templateReference,omitempty"`
-	TemplateReferenceType string   `json:"templateReferenceType,omitempty"`
+	ID                        string   `json:"$id"`
+	Name                      string   `json:"name"`
+	Runtime                   string   `json:"runtime"`
+	BuildSpecification        string   `json:"buildSpecification"`
+	RuntimeSpecification      string   `json:"runtimeSpecification"`
+	Execute                   []string `json:"execute"`
+	Events                    []string `json:"events"`
+	Scopes                    []string `json:"scopes"`
+	Schedule                  string   `json:"schedule"`
+	Timeout                   int      `json:"timeout"`
+	Enabled                   bool     `json:"enabled"`
+	Logging                   bool     `json:"logging"`
+	Entrypoint                string   `json:"entrypoint"`
+	Commands                  string   `json:"commands"`
+	Ignore                    []string `json:"ignore"`
+	DeploymentRetention       int      `json:"deploymentRetention"`
+	Path                      string   `json:"path"`
+	PreviewDomainTarget       string   `json:"previewDomainTarget,omitempty"`
+	PreviewDomainLabel        string   `json:"previewDomainLabel,omitempty"`
+	InstallationID            string   `json:"installationId,omitempty"`
+	ProviderRepositoryID      string   `json:"providerRepositoryId,omitempty"`
+	ProviderRepositoryName    string   `json:"providerRepositoryName,omitempty"`
+	ProviderRepositoryPrivate bool     `json:"providerRepositoryPrivate,omitempty"`
+	ProviderRepositoryPending bool     `json:"providerRepositoryPending,omitempty"`
+	ProviderBranch            string   `json:"providerBranch,omitempty"`
+	ProviderSilentMode        bool     `json:"providerSilentMode,omitempty"`
+	ProviderRootDirectory     string   `json:"providerRootDirectory,omitempty"`
+	ProviderBranches          []string `json:"providerBranches,omitempty"`
+	ProviderPaths             []string `json:"providerPaths,omitempty"`
+	TemplateRepository        string   `json:"templateRepository,omitempty"`
+	TemplateOwner             string   `json:"templateOwner,omitempty"`
+	TemplateRootDirectory     string   `json:"templateRootDirectory,omitempty"`
+	TemplateReference         string   `json:"templateReference,omitempty"`
+	TemplateReferenceType     string   `json:"templateReferenceType,omitempty"`
 }
 
 type initFunctionOptions struct {
@@ -606,13 +609,6 @@ func runInitFunction(command *cobra.Command, options initFunctionOptions) error 
 		}
 		output.Log(out, "Imported environment variables into functions/%s/.env", directoryName)
 	}
-	if vcs.CreateRepository {
-		vcs, err = createFunctionVCSRepository(api, vcs)
-		if err != nil {
-			return err
-		}
-	}
-
 	execute := []string{}
 	if public {
 		execute = []string{"any"}
@@ -626,9 +622,14 @@ func runInitFunction(command *cobra.Command, options initFunctionOptions) error 
 		Ignore: selected.Ignore, DeploymentRetention: 0,
 		Path:                "functions/" + directoryName,
 		PreviewDomainTarget: domainTarget, PreviewDomainLabel: domainLabel,
-		InstallationID: vcs.InstallationID, ProviderRepositoryID: vcs.RepositoryID,
-		ProviderBranch: vcs.Branch, ProviderSilentMode: vcs.SilentMode,
-		ProviderRootDirectory: vcs.RootDirectory,
+		InstallationID:            vcs.InstallationID,
+		ProviderRepositoryID:      vcs.RepositoryID,
+		ProviderRepositoryName:    vcs.RepositoryName,
+		ProviderRepositoryPrivate: vcs.RepositoryPrivate,
+		ProviderRepositoryPending: vcs.CreateRepository,
+		ProviderBranch:            vcs.Branch,
+		ProviderSilentMode:        vcs.SilentMode,
+		ProviderRootDirectory:     vcs.RootDirectory,
 	}
 	if source == "github" && seedRepository {
 		entry.TemplateRepository = template.Repository

--- a/templates/cli/internal/cmd/initfunction.go
+++ b/templates/cli/internal/cmd/initfunction.go
@@ -4,7 +4,9 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -14,15 +16,14 @@ import (
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/appwrite"
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/client"
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/config"
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/dotenv"
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/jsonx"
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/output"
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
 // Initializes a function and collects its scaffold settings.
-
-// templatesRepo holds the function starter templates.
-const templatesRepo = "https://github.com/appwrite/templates"
 
 // runtimeChoice is one entry of the runtime list. Directory and Language are not
 // the same string: Directory is the first dash-separated segment of the runtime
@@ -160,37 +161,100 @@ func ignoresFor(language string) []string {
 // that type is the READ model used by `run`, and the two are deliberately
 // separate rather than one type trying to be both.
 type FunctionEntry struct {
-	ID                   string   `json:"$id"`
-	Name                 string   `json:"name"`
-	Runtime              string   `json:"runtime"`
-	BuildSpecification   string   `json:"buildSpecification"`
-	RuntimeSpecification string   `json:"runtimeSpecification"`
-	Execute              []string `json:"execute"`
-	Events               []string `json:"events"`
-	Scopes               []string `json:"scopes"`
-	Schedule             string   `json:"schedule"`
-	Timeout              int      `json:"timeout"`
-	Enabled              bool     `json:"enabled"`
-	Logging              bool     `json:"logging"`
-	Entrypoint           string   `json:"entrypoint"`
-	Commands             string   `json:"commands"`
-	Ignore               []string `json:"ignore"`
-	DeploymentRetention  int      `json:"deploymentRetention"`
-	Path                 string   `json:"path"`
+	ID                    string   `json:"$id"`
+	Name                  string   `json:"name"`
+	Runtime               string   `json:"runtime"`
+	BuildSpecification    string   `json:"buildSpecification"`
+	RuntimeSpecification  string   `json:"runtimeSpecification"`
+	Execute               []string `json:"execute"`
+	Events                []string `json:"events"`
+	Scopes                []string `json:"scopes"`
+	Schedule              string   `json:"schedule"`
+	Timeout               int      `json:"timeout"`
+	Enabled               bool     `json:"enabled"`
+	Logging               bool     `json:"logging"`
+	Entrypoint            string   `json:"entrypoint"`
+	Commands              string   `json:"commands"`
+	Ignore                []string `json:"ignore"`
+	DeploymentRetention   int      `json:"deploymentRetention"`
+	Path                  string   `json:"path"`
+	PreviewDomainTarget   string   `json:"previewDomainTarget,omitempty"`
+	PreviewDomainLabel    string   `json:"previewDomainLabel,omitempty"`
+	InstallationID        string   `json:"installationId,omitempty"`
+	ProviderRepositoryID  string   `json:"providerRepositoryId,omitempty"`
+	ProviderBranch        string   `json:"providerBranch,omitempty"`
+	ProviderSilentMode    bool     `json:"providerSilentMode,omitempty"`
+	ProviderRootDirectory string   `json:"providerRootDirectory,omitempty"`
+	ProviderBranches      []string `json:"providerBranches,omitempty"`
+	ProviderPaths         []string `json:"providerPaths,omitempty"`
+	TemplateRepository    string   `json:"templateRepository,omitempty"`
+	TemplateOwner         string   `json:"templateOwner,omitempty"`
+	TemplateRootDirectory string   `json:"templateRootDirectory,omitempty"`
+	TemplateReference     string   `json:"templateReference,omitempty"`
+	TemplateReferenceType string   `json:"templateReferenceType,omitempty"`
+}
+
+type initFunctionOptions struct {
+	Name                  string
+	ID                    string
+	Runtime               string
+	BuildSpecification    string
+	RuntimeSpecification  string
+	Public                bool
+	Source                string
+	DomainTarget          string
+	DomainLabel           string
+	InstallationID        string
+	RepositoryMode        string
+	RepositoryID          string
+	RepositoryName        string
+	RepositoryPrivate     bool
+	ProviderBranch        string
+	ProviderRootDirectory string
+	ProviderSilentMode    bool
+	EnvFile               string
+	Deploy                bool
 }
 
 func newInitFunctionCommand() *cobra.Command {
-	return &cobra.Command{
+	options := initFunctionOptions{Public: true, RepositoryPrivate: true}
+	command := &cobra.Command{
 		Use:     "function",
 		Aliases: []string{"functions"},
 		Short:   "Init a new Appwrite function",
+		PreRunE: func(command *cobra.Command, args []string) error {
+			return applyNegatedFlags(command)
+		},
 		RunE: func(command *cobra.Command, args []string) error {
-			return runInitFunction(command)
+			return runInitFunction(command, options)
 		},
 	}
+
+	flags := command.Flags()
+	flags.StringVar(&options.Name, "name", "", "Function name")
+	flags.StringVar(&options.ID, "function-id", "", "Function ID or unique()")
+	flags.StringVar(&options.Runtime, "runtime", "", "Execution runtime")
+	flags.StringVar(&options.BuildSpecification, "build-specification", "", "Build CPU and memory specification")
+	flags.StringVar(&options.RuntimeSpecification, "runtime-specification", "", "Runtime CPU and memory specification")
+	negatableBool(flags, &options.Public, "public", "Allow anyone to execute the function")
+	flags.StringVar(&options.Source, "source", "", "Source workflow: local or github")
+	flags.StringVar(&options.DomainTarget, "domain-target", "", "Function endpoint: region or edge")
+	flags.StringVar(&options.DomainLabel, "domain", "", "Generated function domain label, without its suffix")
+	flags.StringVar(&options.InstallationID, "installation-id", "", "Appwrite GitHub installation ID")
+	flags.StringVar(&options.RepositoryMode, "repository-mode", "", "GitHub repository mode: existing or new")
+	flags.StringVar(&options.RepositoryID, "provider-repository-id", "", "GitHub provider repository ID")
+	flags.StringVar(&options.RepositoryName, "repository-name", "", "Name of a new GitHub repository")
+	negatableBool(flags, &options.RepositoryPrivate, "repository-private", "Create a private GitHub repository")
+	flags.StringVar(&options.ProviderBranch, "provider-branch", "", "Production branch for Git deployments")
+	flags.StringVar(&options.ProviderRootDirectory, "provider-root-directory", "", "Path to the function in the Git repository")
+	flags.BoolVar(&options.ProviderSilentMode, "provider-silent-mode", false, "Disable VCS commit and pull request comments")
+	flags.StringVar(&options.EnvFile, "env-file", "", "Import function variables from a .env file")
+	flags.BoolVar(&options.Deploy, "deploy", false, "Create and deploy the function after initialization")
+
+	return command
 }
 
-func runInitFunction(command *cobra.Command) error {
+func runInitFunction(command *cobra.Command, options initFunctionOptions) error {
 	context, err := newInitContext()
 	if err != nil {
 		return err
@@ -203,132 +267,989 @@ func runInitFunction(command *cobra.Command) error {
 
 	out := command.OutOrStdout()
 
-	name, err := context.prompter.Text(prompt.Text{
-		Message: "What would you like to name your function?",
-		Default: "My Awesome Function",
-	})
-	if err != nil {
-		return err
+	name := strings.TrimSpace(options.Name)
+	if name == "" {
+		name, err = context.prompter.Text(prompt.Text{
+			Message: "What would you like to name your function?",
+			Default: "My Awesome Function",
+			Flag:    "--name",
+		})
+		if err != nil {
+			return err
+		}
 	}
 
-	id, err := context.prompter.Text(prompt.Text{
-		Message: "What ID would you like to have for your function?",
-		Default: appwrite.UniqueSentinel,
-	})
-	if err != nil {
-		return err
+	id := strings.TrimSpace(options.ID)
+	if id == "" {
+		id, err = context.prompter.Text(prompt.Text{
+			Message: "What ID would you like to have for your function?",
+			Default: appwrite.UniqueSentinel,
+			Flag:    "--function-id",
+		})
+		if err != nil {
+			return err
+		}
 	}
 
-	runtimeID, err := chooseRuntime(api, context.prompter)
-	if err != nil {
+	runtimeID := strings.TrimSpace(options.Runtime)
+	if runtimeID == "" {
+		runtimeID, err = chooseRuntime(api, context.prompter)
+		if err != nil {
+			return err
+		}
+	} else if err := validateRuntimeChoice(api, runtimeID); err != nil {
 		return err
 	}
 	selected := newRuntimeChoice(runtimeID)
 
-	buildSpecification, err := chooseSpecification(api, context.prompter,
-		"/functions/specifications", buildSpecifications,
-		"What build specification would you like to use?")
-	if err != nil {
+	buildSpecification := strings.TrimSpace(options.BuildSpecification)
+	if buildSpecification == "" {
+		buildSpecification, err = chooseSpecification(api, context.prompter,
+			"/functions/specifications", buildSpecifications,
+			"What build specification would you like to use?")
+		if err != nil {
+			return err
+		}
+	} else if err := validateSpecificationChoice(
+		api, buildSpecifications, buildSpecification,
+	); err != nil {
 		return err
 	}
 
-	runtimeSpecification, err := chooseSpecification(api, context.prompter,
-		"/functions/specifications", runtimeSpecifications,
-		"What runtime specification would you like to use?")
-	if err != nil {
+	runtimeSpecification := strings.TrimSpace(options.RuntimeSpecification)
+	if runtimeSpecification == "" {
+		runtimeSpecification, err = chooseSpecification(api, context.prompter,
+			"/functions/specifications", runtimeSpecifications,
+			"What runtime specification would you like to use?")
+		if err != nil {
+			return err
+		}
+	} else if err := validateSpecificationChoice(
+		api, runtimeSpecifications, runtimeSpecification,
+	); err != nil {
 		return err
+	}
+
+	public := options.Public
+	if !command.Flags().Changed("public") {
+		public, err = context.prompter.Confirm(prompt.Question{
+			Message: "Allow anyone to execute this function?",
+			Default: true,
+			Flag:    "--public or --no-public",
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	domainTarget := strings.ToLower(strings.TrimSpace(options.DomainTarget))
+	if domainTarget == "" {
+		domainTarget, err = context.prompter.Choice(prompt.Choice{
+			Message: "Where should your function run?",
+			Options: functionEndpointOptions(api),
+			Default: "region",
+			Flag:    "--domain-target",
+		})
+		if err != nil {
+			return err
+		}
+	}
+	if domainTarget != "region" && domainTarget != "edge" {
+		return fmt.Errorf("domain target must be region or edge")
 	}
 
 	functionID := appwrite.ResolveID(id)
 	directoryName := SafeDirectoryName(name, functionID)
+	domainLabel := strings.ToLower(strings.TrimSpace(options.DomainLabel))
+	if domainLabel == "" {
+		suffix := appwrite.Unique()
+		if len(suffix) > 4 {
+			suffix = suffix[:4]
+		}
+		domainSuffix, _ := functionDomainSuffix(api, domainTarget)
+		if domainSuffix != "" {
+			domainSuffix = "." + domainSuffix
+		}
+		domainLabel, err = context.prompter.Text(prompt.Text{
+			Message:  "Choose the function domain",
+			Default:  directoryName + "-" + suffix,
+			Suffix:   domainSuffix,
+			Flag:     "--domain",
+			Validate: validatePreviewDomainLabel,
+		})
+		if err != nil {
+			return err
+		}
+	} else if err := validatePreviewDomainLabel(domainLabel); err != nil {
+		return err
+	}
+	functionDomain := ""
+	if domain, fatal, domainErr := preflightFunctionDomain(api, domainTarget, domainLabel); domainErr != nil {
+		if fatal {
+			return domainErr
+		}
+		output.Warn(out, "Could not check function domain availability: %s", domainErr)
+	} else {
+		functionDomain = domain
+	}
+	if functionDomain == "" {
+		if suffix, suffixErr := functionDomainSuffix(api, domainTarget); suffixErr == nil {
+			functionDomain = domainLabel + "." + suffix
+		}
+	}
+
+	source := strings.ToLower(strings.TrimSpace(options.Source))
+	if source == "" {
+		source, err = context.prompter.Choice(prompt.Choice{
+			Message: "How would you like to manage the function source?",
+			Options: []prompt.Option{
+				{Label: "Connect later — deploy local source with the CLI", Value: "local"},
+				{Label: "Connect a GitHub repository", Value: "github"},
+			},
+			Default: "local",
+			Flag:    "--source",
+		})
+		if err != nil {
+			return err
+		}
+	}
+	if source != "local" && source != "github" {
+		return fmt.Errorf("source must be local or github")
+	}
+
+	template := starterFunctionTemplate{
+		Repository: "templates", Owner: "appwrite", Reference: "main",
+		ReferenceType: "branch", RootDirectory: strings.ToLower(selected.Directory + "/starter"),
+	}
+	if discovered, lookupErr := getStarterFunctionTemplate(api, selected.ID); lookupErr == nil {
+		template = discovered
+	} else {
+		output.Warn(out, "Could not read starter template metadata; using the default template: %s", lookupErr)
+	}
+
+	vcs := functionVCS{}
+	for source == "github" {
+		vcs, err = configureFunctionVCS(command, api, context.prompter, name, options)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, errNoGitHubInstallation) {
+			return err
+		}
+
+		setupURL := githubInstallationSetupURL(api.Endpoint,
+			context.local.Data.GetString("projectId"))
+		if !prompt.Interactive() {
+			return fmt.Errorf(
+				"no GitHub installation is connected to this project. Set one up at %s, "+
+					"or rerun with --source local",
+				setupURL)
+		}
+
+		action, askErr := promptGitHubInstallationFallback(
+			context.prompter, setupURL)
+		if askErr != nil {
+			return askErr
+		}
+		switch action {
+		case "local":
+			source = "local"
+		case "retry":
+			continue
+		default:
+			return prompt.ErrAborted
+		}
+	}
 
 	base := context.local.ResourceDirname("functions")
 	functionFolder := filepath.Join(base, "functions")
+	availableName, renamed, err := availableFunctionDirectory(functionFolder, directoryName)
+	if err != nil {
+		return err
+	}
+	if renamed {
+		directoryName = availableName
+	}
 	functionDir := filepath.Join(functionFolder, directoryName)
 	templatesDir := filepath.Join(functionFolder, functionID+"-templates")
-
-	if _, err := os.Stat(functionDir); err == nil {
-		return fmt.Errorf(
-			"( %s ) already exists in the current directory. Please choose another name",
-			directoryName)
-	}
 
 	if selected.Entrypoint == "" {
 		output.Log(out, "Entrypoint for this runtime not found. You will be "+
 			"asked to configure entrypoint when you first push the function.")
 	}
-	// No companion line for a missing install command. The entrypoint one above
-	// earns its second sentence -- push really does prompt for that -- while the
-	// install-command message named an action nobody has to take: push never
-	// asks for the field, and a runtime with no command listed deploys as the
-	// starter template intends, whether because it has nothing to fetch
-	// (swift, java, kotlin, cpp) or because its build resolves dependencies
-	// itself (go).
 
-	if err := os.MkdirAll(functionDir, 0o777); err != nil {
-		return err
+	envFile := strings.TrimSpace(options.EnvFile)
+	if envFile == "" && prompt.Interactive() {
+		environment, askErr := context.prompter.Choice(prompt.Choice{
+			Message: "Configure environment variables?",
+			Options: []prompt.Option{
+				{Label: "No variables", Value: "none"},
+				{Label: "Import from a .env file", Value: "import"},
+			},
+			Default: "none", Flag: "--env-file",
+		})
+		if askErr != nil {
+			return askErr
+		}
+		if environment == "import" {
+			envFile, askErr = context.prompter.Text(prompt.Text{
+				Message: "Path to the .env file", Default: ".env",
+				Flag: "--env-file", Validate: prompt.Required("environment file"),
+			})
+			if askErr != nil {
+				return askErr
+			}
+		}
 	}
+	var envContents []byte
+	if envFile != "" {
+		envContents, err = os.ReadFile(envFile)
+		if err != nil {
+			return fmt.Errorf("read environment file %s: %w", envFile, err)
+		}
+		if names, _ := dotenv.ParseOrdered(string(envContents)); len(names) > 0 {
+			if err := validateVariableKeys(names); err != nil {
+				return err
+			}
+		}
+	}
+
+	deployNow := options.Deploy
+	if prompt.Interactive() {
+		printFunctionPreview(out, functionPreview{
+			Name:                 name,
+			ID:                   functionID,
+			Runtime:              selected.ID,
+			BuildSpecification:   buildSpecification,
+			RuntimeSpecification: runtimeSpecification,
+			Public:               public,
+			DomainTarget:         domainTarget,
+			Domain:               functionDomain,
+			Source:               source,
+			InstallationID:       vcs.InstallationID,
+			Repository:           vcs.RepositoryName,
+			Branch:               vcs.Branch,
+			RootDirectory:        vcs.RootDirectory,
+			SilentMode:           vcs.SilentMode,
+			CreateRepository:     vcs.CreateRepository,
+			RepositoryPrivate:    vcs.RepositoryPrivate,
+			Directory:            "functions/" + directoryName,
+			EnvironmentFile:      envFile,
+		})
+	}
+	if !command.Flags().Changed("deploy") && prompt.Interactive() {
+		action, askErr := context.prompter.Choice(prompt.Choice{
+			Message: "What would you like to do?",
+			Options: []prompt.Option{
+				{Label: "Save configuration and deploy later", Value: "save"},
+				{Label: "Create and deploy now", Value: "deploy"},
+				{Label: "Start over and change selections", Value: "redo"},
+				{Label: "Cancel", Value: "cancel"},
+			},
+			Default: "save", Flag: "--deploy",
+		})
+		if askErr != nil {
+			return askErr
+		}
+		switch action {
+		case "redo":
+			return runInitFunction(command, options)
+		case "cancel":
+			return prompt.ErrAborted
+		case "deploy":
+			deployNow = true
+		default:
+			deployNow = false
+		}
+	}
+
+	seedRepository := vcs.CreateRepository
 	if err := os.MkdirAll(templatesDir, 0o777); err != nil {
 		return err
 	}
 	defer os.RemoveAll(templatesDir)
 
-	// The template is always "starter": only the starter is ever fetched.
-	sparse := strings.ToLower(selected.Directory + "/starter")
-
-	if err := runGit(templatesDir, fmt.Sprintf(
-		"git clone --single-branch --depth 1 --sparse %s .", templatesRepo)); err != nil {
+	repositoryURL := fmt.Sprintf("https://github.com/%s/%s", template.Owner, template.Repository)
+	clone := fmt.Sprintf("git clone --single-branch --depth 1 --sparse %s .", repositoryURL)
+	if template.Reference != "" {
+		clone = fmt.Sprintf("git clone --single-branch --depth 1 --branch %s --sparse %s .",
+			template.Reference, repositoryURL)
+	}
+	if err := runGit(templatesDir, clone); err != nil {
 		return err
 	}
-	if err := runGit(templatesDir, "git sparse-checkout add "+sparse); err != nil {
+	if err := runGit(templatesDir, "git sparse-checkout add "+template.RootDirectory); err != nil {
 		return err
 	}
-
 	if err := os.RemoveAll(filepath.Join(templatesDir, ".git")); err != nil {
 		return err
 	}
-
-	if err := copyTree(filepath.Join(templatesDir, selected.Directory, "starter"),
+	if err := os.MkdirAll(functionDir, 0o777); err != nil {
+		return err
+	}
+	functionCommitted := false
+	defer func() {
+		if !functionCommitted {
+			_ = os.RemoveAll(functionDir)
+		}
+	}()
+	if err := copyTree(filepath.Join(templatesDir, filepath.FromSlash(template.RootDirectory)),
 		functionDir); err != nil {
 		return err
 	}
-
 	if err := retitleReadme(filepath.Join(functionDir, "README.md"), name); err != nil {
 		return err
 	}
-
-	if err := context.local.AddFunction(FunctionEntry{
-		ID:                   functionID,
-		Name:                 name,
-		Runtime:              selected.ID,
-		BuildSpecification:   buildSpecification,
-		RuntimeSpecification: runtimeSpecification,
-		Execute:              []string{"any"},
-		Events:               []string{},
-		Scopes:               []string{"users.read"},
-		Schedule:             "",
-		Timeout:              15,
-		Enabled:              true,
-		Logging:              true,
-		Entrypoint:           selected.Entrypoint,
-		Commands:             selected.Commands,
-		Ignore:               selected.Ignore,
-		DeploymentRetention:  0,
-		Path:                 "functions/" + directoryName,
-	}); err != nil {
-		return err
+	if envFile != "" {
+		if err := os.WriteFile(filepath.Join(functionDir, ".env"), envContents, 0o600); err != nil {
+			return fmt.Errorf("write function environment file: %w", err)
+		}
+		output.Log(out, "Imported environment variables into functions/%s/.env", directoryName)
+	}
+	if vcs.CreateRepository {
+		vcs, err = createFunctionVCSRepository(api, vcs)
+		if err != nil {
+			return err
+		}
 	}
 
+	execute := []string{}
+	if public {
+		execute = []string{"any"}
+	}
+	entry := FunctionEntry{
+		ID: functionID, Name: name, Runtime: selected.ID,
+		BuildSpecification: buildSpecification, RuntimeSpecification: runtimeSpecification,
+		Execute: execute, Events: []string{}, Scopes: []string{"users.read"},
+		Schedule: "", Timeout: 15, Enabled: true, Logging: true,
+		Entrypoint: selected.Entrypoint, Commands: selected.Commands,
+		Ignore: selected.Ignore, DeploymentRetention: 0,
+		Path:                "functions/" + directoryName,
+		PreviewDomainTarget: domainTarget, PreviewDomainLabel: domainLabel,
+		InstallationID: vcs.InstallationID, ProviderRepositoryID: vcs.RepositoryID,
+		ProviderBranch: vcs.Branch, ProviderSilentMode: vcs.SilentMode,
+		ProviderRootDirectory: vcs.RootDirectory,
+	}
+	if source == "github" && seedRepository {
+		entry.TemplateRepository = template.Repository
+		entry.TemplateOwner = template.Owner
+		entry.TemplateRootDirectory = template.RootDirectory
+		entry.TemplateReference = template.Reference
+		entry.TemplateReferenceType = template.ReferenceType
+	}
+	if err := context.local.AddFunction(entry); err != nil {
+		return err
+	}
 	if err := context.local.Write(); err != nil {
 		return err
 	}
+	functionCommitted = true
 
-	output.Success(out, "Initialing function")
-	output.Log(out, "Next you can use '%s run function' to develop a function "+
-		"locally. To deploy the function, use '%s push function'",
-		app.ExecutableName, app.ExecutableName)
+	output.Success(out, "Initialized function")
+	output.Log(out, "Endpoint target: %s", domainTarget)
+	if source == "github" {
+		output.Log(out, "Source: GitHub repository %s on branch %s", vcs.RepositoryName, vcs.Branch)
+	}
+
+	if !deployNow {
+		output.Log(out, "Use '%s run function' to develop locally, or '%s push function' to deploy.",
+			app.ExecutableName, app.ExecutableName)
+		return nil
+	}
+
+	previousForce := app.Flags().Force
+	app.Flags().Force = true
+	defer func() { app.Flags().Force = previousForce }()
+
+	return runPushDeployable(command, deployables[0], deployOptions{
+		ResourceID:    functionID,
+		Code:          true,
+		Activate:      true,
+		ActivateSet:   true,
+		Logs:          true,
+		WithVariables: envFile != "",
+		FailOnError:   true,
+	})
+}
+
+type functionPreview struct {
+	Name                 string
+	ID                   string
+	Runtime              string
+	BuildSpecification   string
+	RuntimeSpecification string
+	Public               bool
+	DomainTarget         string
+	Domain               string
+	Source               string
+	InstallationID       string
+	Repository           string
+	Branch               string
+	RootDirectory        string
+	SilentMode           bool
+	CreateRepository     bool
+	RepositoryPrivate    bool
+	Directory            string
+	EnvironmentFile      string
+}
+
+func printFunctionPreview(writer io.Writer, preview functionPreview) {
+	access := "Restricted"
+	if preview.Public {
+		access = "Public (any)"
+	}
+	target := "Region compute"
+	if preview.DomainTarget == "edge" {
+		target = "Edge network"
+	}
+	source := "Local CLI deployment"
+	if preview.Source == "github" {
+		source = "GitHub · " + preview.Repository
+		if preview.CreateRepository {
+			visibility := "public"
+			if preview.RepositoryPrivate {
+				visibility = "private"
+			}
+			source += " (new, " + visibility + ")"
+		}
+	}
+	environment := "None"
+	if preview.EnvironmentFile != "" {
+		environment = preview.EnvironmentFile
+	}
+
+	fields := []output.FailureDetail{
+		{Label: "Name", Value: preview.Name},
+		{Label: "Function ID", Value: preview.ID},
+		{Label: "Runtime", Value: preview.Runtime},
+		{Label: "Build compute", Value: preview.BuildSpecification},
+		{Label: "Runtime compute", Value: preview.RuntimeSpecification},
+		{Label: "Access", Value: access},
+		{Label: "Execution", Value: target},
+		{Label: "Endpoint", Value: "https://" + preview.Domain},
+		{Label: "Source", Value: source},
+		{Label: "Directory", Value: preview.Directory},
+		{Label: "Environment", Value: environment},
+	}
+	if preview.Source == "github" {
+		comments := "Enabled"
+		if preview.SilentMode {
+			comments = "Silent"
+		}
+		fields = append(fields,
+			output.FailureDetail{Label: "Installation", Value: preview.InstallationID},
+			output.FailureDetail{Label: "Branch", Value: preview.Branch},
+			output.FailureDetail{Label: "Repository path", Value: preview.RootDirectory},
+			output.FailureDetail{Label: "GitHub comments", Value: comments},
+		)
+	}
+
+	width := 0
+	for _, field := range fields {
+		width = max(width, len(field.Label))
+	}
+	fmt.Fprintf(writer, "\n%s\n\n", output.Heading("Function preview"))
+	for _, field := range fields {
+		fmt.Fprintf(writer, "  %-*s   %s\n", width, field.Label, field.Value)
+	}
+	fmt.Fprintln(writer)
+}
+
+func availableFunctionDirectory(parent, preferred string) (string, bool, error) {
+	for suffix := 1; ; suffix++ {
+		candidate := preferred
+		if suffix > 1 {
+			candidate = fmt.Sprintf("%s-%d", preferred, suffix)
+		}
+		_, err := os.Stat(filepath.Join(parent, candidate))
+		switch {
+		case errors.Is(err, os.ErrNotExist):
+			return candidate, suffix > 1, nil
+		case err != nil:
+			return "", false, err
+		}
+	}
+}
+
+func functionEndpointOptions(api *client.Client) []prompt.Option {
+	domains, _, _ := availableFunctionDomains(api)
+
+	return functionEndpointOptionsFromDomains(api.Endpoint, domains)
+}
+
+func functionEndpointOptionsFromDomains(endpoint string, domains []string) []prompt.Option {
+	regionLabel := "Region compute"
+	if regionSuffix, err := functionDomainForTarget(domains, "region"); err == nil {
+		regionLabel += " (*." + regionSuffix + ")"
+	} else if region := endpointRegion(endpoint); region != "" {
+		regionLabel += " (" + region + ")"
+	}
+
+	options := []prompt.Option{
+		{
+			Label: regionLabel,
+			Value: "region",
+		},
+	}
+
+	edgeSuffix, _ := functionDomainForTarget(domains, "edge")
+	if edgeSuffix != "" {
+		options = append(options, prompt.Option{
+			Label: "Edge network (*." + edgeSuffix + ")",
+			Value: "edge",
+		})
+	}
+
+	return options
+}
+
+func functionDomainSuffix(api *client.Client, target string) (string, error) {
+	domains, _, _ := availableFunctionDomains(api)
+
+	return functionDomainForTarget(domains, target)
+}
+
+func availableFunctionDomains(
+	api *client.Client,
+) ([]string, *client.Client, error) {
+	console, _, consoleErr := consoleClientAt(api.Endpoint)
+	domains := make([]string, 0)
+	if consoleErr == nil {
+		variables := jsonx.NewObject()
+		if err := console.Call("GET", "/console/variables", nil, variables); err == nil {
+			configured := strings.Join([]string{
+				// Prefer the Sites suffix for edge Functions. Regional Cloud responses
+				// can also include a region-prefixed appwrite.network Functions suffix.
+				variables.GetString("_APP_DOMAIN_SITES"),
+				variables.GetString("_APP_DOMAIN_FUNCTIONS"),
+			}, ",")
+			for _, domain := range strings.Split(configured, ",") {
+				domain = strings.TrimSpace(domain)
+				if domain == "" {
+					continue
+				}
+				if region := endpointRegion(api.Endpoint); region != "" &&
+					!strings.HasSuffix(strings.ToLower(domain), ".appwrite.network") {
+					parts := strings.Split(domain, ".")
+					if len(parts) >= 3 {
+						parts[0] = region
+						domain = strings.Join(parts, ".")
+					}
+				}
+				domains = append(domains, domain)
+			}
+		} else {
+			consoleErr = err
+		}
+	}
+	if len(domains) == 0 {
+		domains = cloudFunctionDomains(api.Endpoint)
+	}
+
+	return domains, console, consoleErr
+}
+
+func preflightFunctionDomain(
+	api *client.Client,
+	target, label string,
+) (string, bool, error) {
+	domains, console, consoleErr := availableFunctionDomains(api)
+	if len(domains) == 0 && consoleErr != nil {
+		return "", false, consoleErr
+	}
+
+	suffix, err := functionDomainForTarget(domains, target)
+	if err != nil {
+		return "", true, err
+	}
+	domain := label + "." + suffix
+
+	// An API-key workflow can derive Cloud's endpoint without a Console
+	// session, but only a session can query global rule availability.
+	if consoleErr != nil {
+		return domain, false, nil
+	}
+
+	query := url.Values{"value": []string{domain}, "type": []string{"rules"}}
+	if err := console.Call("GET", "/console/resources?"+query.Encode(), nil, nil); err != nil {
+		var apiErr *client.APIError
+		if errors.As(err, &apiErr) && apiErr.Status == 409 {
+			return "", true, fmt.Errorf("function domain %s is not available", domain)
+		}
+		return "", false, err
+	}
+
+	return domain, false, nil
+}
+
+func validatePreviewDomainLabel(value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fmt.Errorf("domain is required")
+	}
+	if len(value) > 63 {
+		return fmt.Errorf("domain must be at most 63 characters")
+	}
+	for index, character := range value {
+		valid := character >= 'a' && character <= 'z' ||
+			character >= '0' && character <= '9' || character == '-'
+		if !valid {
+			return fmt.Errorf("domain can contain only lowercase letters, numbers, and hyphens")
+		}
+		if character == '-' && (index == 0 || index == len(value)-1) {
+			return fmt.Errorf("domain cannot start or end with a hyphen")
+		}
+	}
 
 	return nil
+}
+
+type starterFunctionTemplate struct {
+	Repository    string
+	Owner         string
+	Reference     string
+	ReferenceType string
+	RootDirectory string
+}
+
+func getStarterFunctionTemplate(api *client.Client, runtime string) (starterFunctionTemplate, error) {
+	var response struct {
+		ID                   string `json:"id"`
+		ProviderRepositoryID string `json:"providerRepositoryId"`
+		ProviderOwner        string `json:"providerOwner"`
+		ProviderVersion      string `json:"providerVersion"`
+		Runtimes             []struct {
+			Name                  string `json:"name"`
+			ProviderRootDirectory string `json:"providerRootDirectory"`
+		} `json:"runtimes"`
+	}
+	if err := api.Call("GET", "/functions/templates/starter", nil, &response); err != nil {
+		return starterFunctionTemplate{}, err
+	}
+	for _, candidate := range response.Runtimes {
+		if candidate.Name != runtime {
+			continue
+		}
+		typeName := "tag"
+		if response.ProviderVersion == "main" || response.ProviderVersion == "master" {
+			typeName = "branch"
+		}
+		return starterFunctionTemplate{
+			Repository:    response.ProviderRepositoryID,
+			Owner:         response.ProviderOwner,
+			Reference:     response.ProviderVersion,
+			ReferenceType: typeName,
+			RootDirectory: strings.TrimPrefix(candidate.ProviderRootDirectory, "./"),
+		}, nil
+	}
+
+	return starterFunctionTemplate{}, fmt.Errorf("starter template does not support runtime %s", runtime)
+}
+
+var errNoGitHubInstallation = errors.New("no GitHub installation is connected to this project")
+
+func githubInstallationSetupURL(endpoint, projectID string) string {
+	base := consoleBaseURL(config.NormalizeCloudConsoleEndpoint(endpoint))
+	region := endpointRegion(endpoint)
+	if region != "" {
+		return fmt.Sprintf("%s/console/project-%s-%s/settings",
+			base, region, url.PathEscape(projectID))
+	}
+	if _, cloud := config.CloudBaseHost(endpoint); cloud {
+		return fmt.Sprintf("%s/console/project-%s/settings",
+			base, url.PathEscape(projectID))
+	}
+
+	return fmt.Sprintf("%s/console/project-default-%s/settings",
+		base, url.PathEscape(projectID))
+}
+
+func githubInstallationDescription(setupURL string) string {
+	return "No GitHub installation is connected to this project.\n\n" +
+		"Set one up in the Appwrite Console:\n" + setupURL
+}
+
+func promptGitHubInstallationFallback(
+	prompter prompt.Prompter,
+	setupURL string,
+) (string, error) {
+	return prompter.Choice(prompt.Choice{
+		Message:     "GitHub connection required",
+		Description: githubInstallationDescription(setupURL),
+		Options: []prompt.Option{
+			{Label: "Continue with local source", Value: "local"},
+			{Label: "I connected GitHub — retry", Value: "retry"},
+			{Label: "Cancel", Value: "cancel"},
+		},
+		Default: "local", Flag: "--source local",
+	})
+}
+
+type functionVCS struct {
+	InstallationID    string
+	RepositoryID      string
+	RepositoryName    string
+	Branch            string
+	RootDirectory     string
+	SilentMode        bool
+	CreateRepository  bool
+	RepositoryPrivate bool
+}
+
+type vcsInstallation struct {
+	ID           string `json:"$id"`
+	Organization string `json:"organization"`
+}
+
+type vcsRepository struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Organization  string `json:"organization"`
+	DefaultBranch string `json:"defaultBranch"`
+}
+
+func configureFunctionVCS(
+	command *cobra.Command,
+	api *client.Client,
+	prompter prompt.Prompter,
+	functionName string,
+	options initFunctionOptions,
+) (functionVCS, error) {
+	var installationList struct {
+		Installations []vcsInstallation `json:"installations"`
+	}
+	if err := api.Call("GET", "/vcs/installations", nil, &installationList); err != nil {
+		return functionVCS{}, fmt.Errorf("list GitHub installations: %w", err)
+	}
+	if len(installationList.Installations) == 0 {
+		return functionVCS{}, errNoGitHubInstallation
+	}
+
+	installationID := strings.TrimSpace(options.InstallationID)
+	if installationID == "" {
+		choices := make([]prompt.Option, 0, len(installationList.Installations))
+		for _, installation := range installationList.Installations {
+			choices = append(choices, prompt.Option{
+				Label: installation.Organization + " (" + installation.ID + ")",
+				Value: installation.ID,
+			})
+		}
+		var err error
+		installationID, err = prompter.Choice(prompt.Choice{
+			Message: "Select a GitHub installation", Options: choices,
+			Default: choices[0].Value, Flag: "--installation-id",
+		})
+		if err != nil {
+			return functionVCS{}, err
+		}
+	}
+
+	repositoryMode := strings.ToLower(strings.TrimSpace(options.RepositoryMode))
+	if repositoryMode == "" {
+		if options.RepositoryID != "" {
+			repositoryMode = "existing"
+		} else {
+			var err error
+			repositoryMode, err = prompter.Choice(prompt.Choice{
+				Message: "Which repository would you like to use?",
+				Options: []prompt.Option{
+					{Label: "Create a new repository", Value: "new"},
+					{Label: "Connect an existing repository", Value: "existing"},
+				},
+				Default: "new", Flag: "--repository-mode",
+			})
+			if err != nil {
+				return functionVCS{}, err
+			}
+		}
+	}
+	if repositoryMode != "new" && repositoryMode != "existing" {
+		return functionVCS{}, fmt.Errorf("repository mode must be new or existing")
+	}
+
+	installationOrganization := ""
+	for _, installation := range installationList.Installations {
+		if installation.ID == installationID {
+			installationOrganization = installation.Organization
+			break
+		}
+	}
+
+	var repository vcsRepository
+	createRepository := false
+	repositoryPrivate := false
+	if repositoryMode == "new" {
+		repositoryName := strings.TrimSpace(options.RepositoryName)
+		if repositoryName == "" {
+			var err error
+			repositoryName, err = prompter.Text(prompt.Text{
+				Message: "Name the new GitHub repository",
+				Default: SafeDirectoryName(functionName, "appwrite-function"),
+				Flag:    "--repository-name", Validate: prompt.Required("repository name"),
+			})
+			if err != nil {
+				return functionVCS{}, err
+			}
+		}
+		private := options.RepositoryPrivate
+		if !command.Flags().Changed("repository-private") {
+			var err error
+			private, err = prompter.Confirm(prompt.Question{
+				Message: "Keep the repository private?", Default: true,
+				Flag: "--repository-private",
+			})
+			if err != nil {
+				return functionVCS{}, err
+			}
+		}
+		// Repository creation is deferred until the review screen is accepted.
+		// Choosing “Start over” must not leave an unused GitHub repository behind.
+		repository = vcsRepository{
+			Name: repositoryName, Organization: installationOrganization,
+			DefaultBranch: "main",
+		}
+		createRepository = true
+		repositoryPrivate = private
+	} else {
+		repositoryID := strings.TrimSpace(options.RepositoryID)
+		basePath := "/vcs/github/installations/" + url.PathEscape(installationID) +
+			"/providerRepositories"
+		if repositoryID != "" {
+			path := basePath + "/" + url.PathEscape(repositoryID)
+			if err := api.Call("GET", path, nil, &repository); err != nil {
+				return functionVCS{}, fmt.Errorf("get GitHub repository %s: %w", repositoryID, err)
+			}
+		} else {
+			var listing struct {
+				Repositories []vcsRepository `json:"runtimeProviderRepositories"`
+			}
+			path := basePath + "?type=runtime&" + client.EncodeQueries(
+				[]string{`{"method":"limit","values":[100]}`})
+			if err := api.Call("GET", path, nil, &listing); err != nil {
+				return functionVCS{}, fmt.Errorf("list GitHub repositories: %w", err)
+			}
+			if len(listing.Repositories) == 0 {
+				return functionVCS{}, fmt.Errorf("the selected GitHub installation has no repositories")
+			}
+			choices := make([]prompt.Option, 0, len(listing.Repositories))
+			for _, candidate := range listing.Repositories {
+				choices = append(choices, prompt.Option{
+					Label: candidate.Organization + "/" + candidate.Name,
+					Value: candidate.ID,
+				})
+			}
+			var err error
+			repositoryID, err = prompter.Choice(prompt.Choice{
+				Message: "Select a GitHub repository", Options: choices,
+				Filter: true, Flag: "--provider-repository-id",
+			})
+			if err != nil {
+				return functionVCS{}, err
+			}
+			for _, candidate := range listing.Repositories {
+				if candidate.ID == repositoryID {
+					repository = candidate
+					break
+				}
+			}
+		}
+		if repository.ID == "" {
+			return functionVCS{}, fmt.Errorf("repository %s is not available to installation %s",
+				repositoryID, installationID)
+		}
+	}
+
+	branch := strings.TrimSpace(options.ProviderBranch)
+	if branch == "" {
+		branch = repository.DefaultBranch
+		if branch == "" {
+			branch = "main"
+		}
+		if repository.ID != "" {
+			var listing struct {
+				Branches []struct {
+					Name string `json:"name"`
+				} `json:"branches"`
+			}
+			path := "/vcs/github/installations/" + url.PathEscape(installationID) +
+				"/providerRepositories/" + url.PathEscape(repository.ID) + "/branches?" +
+				client.EncodeQueries([]string{`{"method":"limit","values":[100]}`})
+			if err := api.Call("GET", path, nil, &listing); err == nil && len(listing.Branches) > 0 {
+				choices := make([]prompt.Option, 0, len(listing.Branches))
+				for _, candidate := range listing.Branches {
+					choices = append(choices, prompt.Option{Label: candidate.Name, Value: candidate.Name})
+				}
+				var err error
+				branch, err = prompter.Choice(prompt.Choice{
+					Message: "Select the production branch", Options: choices,
+					Default: branch, Filter: true, Flag: "--provider-branch",
+				})
+				if err != nil {
+					return functionVCS{}, err
+				}
+			}
+		}
+	}
+
+	rootDirectory := strings.TrimSpace(options.ProviderRootDirectory)
+	if rootDirectory == "" {
+		var err error
+		rootDirectory, err = prompter.Text(prompt.Text{
+			Message: "Function root directory", Default: "./",
+			Flag: "--provider-root-directory", Validate: prompt.Required("root directory"),
+		})
+		if err != nil {
+			return functionVCS{}, err
+		}
+	}
+
+	silentMode := options.ProviderSilentMode
+	if !command.Flags().Changed("provider-silent-mode") {
+		var err error
+		silentMode, err = prompter.Confirm(prompt.Question{
+			Message: "Enable silent mode for Git comments?", Default: false,
+			Flag: "--provider-silent-mode",
+		})
+		if err != nil {
+			return functionVCS{}, err
+		}
+	}
+
+	return functionVCS{
+		InstallationID: installationID, RepositoryID: repository.ID,
+		RepositoryName: strings.TrimPrefix(repository.Organization+"/"+repository.Name, "/"),
+		Branch:         branch, RootDirectory: rootDirectory, SilentMode: silentMode,
+		CreateRepository: createRepository, RepositoryPrivate: repositoryPrivate,
+	}, nil
+}
+
+func createFunctionVCSRepository(
+	api *client.Client,
+	vcs functionVCS,
+) (functionVCS, error) {
+	parts := strings.SplitN(vcs.RepositoryName, "/", 2)
+	repositoryName := vcs.RepositoryName
+	if len(parts) == 2 {
+		repositoryName = parts[1]
+	}
+	body := jsonx.NewObject()
+	body.Set("name", repositoryName)
+	body.Set("private", vcs.RepositoryPrivate)
+	path := "/vcs/github/installations/" + url.PathEscape(vcs.InstallationID) +
+		"/providerRepositories"
+	var repository vcsRepository
+	if err := api.Call("POST", path, body, &repository); err != nil {
+		return functionVCS{}, fmt.Errorf("create GitHub repository: %w", err)
+	}
+
+	vcs.RepositoryID = repository.ID
+	vcs.RepositoryName = repository.Organization + "/" + repository.Name
+	if repository.DefaultBranch != "" {
+		vcs.Branch = repository.DefaultBranch
+	}
+	vcs.CreateRepository = false
+
+	return vcs, nil
 }
 
 // chooseRuntime asks which runtime to use.
@@ -355,7 +1276,29 @@ func chooseRuntime(api *client.Client, prompter prompt.Prompter) (string, error)
 	return prompter.Choice(prompt.Choice{
 		Message: "What runtime would you like to use?",
 		Options: options,
+		// Start in filtering mode so typing "go" immediately narrows the list;
+		// the user should not have to discover and press `/` first.
+		Filter: true,
+		Flag:   "--runtime",
 	})
+}
+
+func validateRuntimeChoice(api *client.Client, runtime string) error {
+	var response struct {
+		Runtimes []struct {
+			ID string `json:"$id"`
+		} `json:"runtimes"`
+	}
+	if err := api.Call("GET", "/functions/runtimes", nil, &response); err != nil {
+		return err
+	}
+	for _, entry := range response.Runtimes {
+		if entry.ID == runtime {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("runtime %s is not available for this project", runtime)
 }
 
 // Specification types the list endpoint distinguishes. A plan allows a different
@@ -367,6 +1310,30 @@ const (
 	buildSpecifications   = "builds"
 	runtimeSpecifications = "runtimes"
 )
+
+func validateSpecificationChoice(
+	api *client.Client,
+	specificationType, specification string,
+) error {
+	var response struct {
+		Specifications []struct {
+			Slug    string `json:"slug"`
+			Enabled *bool  `json:"enabled"`
+		} `json:"specifications"`
+	}
+	query := url.Values{"type": []string{specificationType}}
+	if err := api.Call("GET", "/functions/specifications?"+query.Encode(), nil, &response); err != nil {
+		return err
+	}
+	for _, entry := range response.Specifications {
+		if entry.Slug == specification && (entry.Enabled == nil || *entry.Enabled) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("%s specification %s is not available for this project",
+		strings.TrimSuffix(specificationType, "s"), specification)
+}
 
 // chooseSpecification asks for a CPU/memory pairing. The API omits the
 // specifications that are unavailable server-side, so `enabled: false` means one
@@ -409,7 +1376,14 @@ func chooseSpecification(
 		options = append(options, option)
 	}
 
-	return prompter.Choice(prompt.Choice{Message: message, Options: options})
+	flag := "--runtime-specification"
+	if specificationType == buildSpecifications {
+		flag = "--build-specification"
+	}
+
+	return prompter.Choice(prompt.Choice{
+		Message: message, Options: options, Flag: flag,
+	})
 }
 
 // scaffoldAPI builds a project-scoped client for the init scaffolds.

--- a/templates/cli/internal/cmd/initfunction_test.go
+++ b/templates/cli/internal/cmd/initfunction_test.go
@@ -131,12 +131,28 @@ func TestNewGitHubRepositoryIsCreatedOnlyAfterReview(t *testing.T) {
 		t.Fatalf("repository created before review: posts=%d vcs=%#v", posts, vcs)
 	}
 
-	vcs, err = createFunctionVCSRepository(client.New(server.URL, "test"), vcs)
+	path := filepath.Join(t.TempDir(), config.LocalFileName)
+	if err := os.WriteFile(path, []byte(`{"functions":[{"$id":"checkout","installationId":"installation","providerRepositoryName":"team/checkout","providerRepositoryPrivate":true,"providerRepositoryPending":true,"providerBranch":"main","providerRootDirectory":"./"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	local, err := config.LoadLocal(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if posts != 1 || vcs.RepositoryID != "repository" || vcs.CreateRepository {
-		t.Fatalf("repository was not materialized: posts=%d vcs=%#v", posts, vcs)
+	context := pushContext{api: client.New(server.URL, "test"), local: local}
+	if err := context.materializePendingFunctionRepositories(
+		local.ResourceEntries("functions"),
+	); err != nil {
+		t.Fatal(err)
+	}
+	reloaded, err := config.LoadLocal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := reloaded.ResourceEntries("functions")[0]
+	if posts != 1 || entry.GetString("providerRepositoryId") != "repository" ||
+		entry.GetBool("providerRepositoryPending") {
+		t.Fatalf("repository was not materialized: posts=%d entry=%#v", posts, entry)
 	}
 }
 
@@ -267,6 +283,31 @@ func TestFunctionDomainForTarget(t *testing.T) {
 	}
 }
 
+func TestPullPreservesPendingTemplateDeploymentState(t *testing.T) {
+	path := filepath.Join(t.TempDir(), config.LocalFileName)
+	if err := os.WriteFile(path, []byte(`{"functions":[{"$id":"checkout","providerRepositoryName":"team/checkout","providerRepositoryPending":true,"templateRepository":"templates","templateOwner":"appwrite","templateRootDirectory":"node/starter","templateReference":"main","templateReferenceType":"branch"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	local, err := config.LoadLocal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pulled := jsonx.NewObject()
+	pulled.Set("$id", "checkout")
+	pulled.Set("name", "Checkout")
+	preservePendingFunctionTemplate(local, pulled)
+
+	for _, key := range []string{
+		"providerRepositoryName", "providerRepositoryPending", "templateRepository",
+		"templateOwner", "templateRootDirectory", "templateReference",
+		"templateReferenceType",
+	} {
+		if !pulled.Has(key) {
+			t.Errorf("pending key %s was discarded", key)
+		}
+	}
+}
+
 func TestFunctionWriteBodyIncludesVCSButNotDomainIntent(t *testing.T) {
 	entry := jsonx.NewObject()
 	entry.Set("installationId", "installation")
@@ -275,6 +316,8 @@ func TestFunctionWriteBodyIncludesVCSButNotDomainIntent(t *testing.T) {
 	entry.Set("providerRootDirectory", "functions/api")
 	entry.Set("previewDomainTarget", "edge")
 	entry.Set("previewDomainLabel", "api")
+	entry.Set("providerRepositoryName", "team/api")
+	entry.Set("providerRepositoryPending", true)
 
 	body := writeBody(entry, deployables[0].WriteKeys, nil, "functionId", "api")
 	if body.GetString("installationId") != "installation" ||
@@ -282,8 +325,12 @@ func TestFunctionWriteBodyIncludesVCSButNotDomainIntent(t *testing.T) {
 		body.GetString("providerBranch") != "main" {
 		t.Fatalf("VCS fields missing from body: %#v", body)
 	}
-	if _, exists := body.Get("previewDomainTarget"); exists {
-		t.Fatal("local domain intent leaked into Function API body")
+	for _, key := range []string{
+		"previewDomainTarget", "providerRepositoryName", "providerRepositoryPending",
+	} {
+		if _, exists := body.Get(key); exists {
+			t.Fatalf("local intent %s leaked into Function API body", key)
+		}
 	}
 }
 

--- a/templates/cli/internal/cmd/initfunction_test.go
+++ b/templates/cli/internal/cmd/initfunction_test.go
@@ -1,0 +1,438 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/client"
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/config"
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/jsonx"
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/prompt"
+	"github.com/spf13/cobra"
+)
+
+func TestMissingGitHubInstallationOffersConsoleLinkAndLocalFallback(t *testing.T) {
+	setupURL := githubInstallationSetupURL(
+		"https://sgp.cloud.appwrite.io/v1", "project-id")
+	wantURL := "https://cloud.appwrite.io/console/project-sgp-project-id/settings"
+	if setupURL != wantURL {
+		t.Fatalf("setup URL = %q, want %q", setupURL, wantURL)
+	}
+	baseURL := githubInstallationSetupURL(
+		"https://cloud.appwrite.io/v1", "project-id")
+	if baseURL != "https://cloud.appwrite.io/console/project-project-id/settings" {
+		t.Fatalf("base Cloud setup URL = %q", baseURL)
+	}
+
+	description := githubInstallationDescription(setupURL)
+	for _, wanted := range []string{"No GitHub installation", wantURL} {
+		if !strings.Contains(description, wanted) {
+			t.Errorf("guide does not contain %q:\n%s", wanted, description)
+		}
+	}
+
+	prompter := &prompt.Scripted{Choices: map[string]string{
+		"GitHub connection required": "local",
+	}}
+	action, err := promptGitHubInstallationFallback(prompter, setupURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if action != "local" {
+		t.Fatalf("action = %q", action)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		response.Header().Set("content-type", "application/json")
+		_, _ = response.Write([]byte(`{"installations":[]}`))
+	}))
+	defer server.Close()
+	_, err = configureFunctionVCS(&cobra.Command{}, client.New(server.URL, "test"),
+		prompter, "Checkout", initFunctionOptions{})
+	if !errors.Is(err, errNoGitHubInstallation) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestExplicitGitHubRepositoryIsFetchedDirectly(t *testing.T) {
+	asked := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		asked = append(asked, request.URL.Path)
+		response.Header().Set("content-type", "application/json")
+		switch request.URL.Path {
+		case "/vcs/installations":
+			_, _ = response.Write([]byte(`{"installations":[{"$id":"installation","organization":"team"}]}`))
+		case "/vcs/github/installations/installation/providerRepositories/repository":
+			_, _ = response.Write([]byte(`{"id":"repository","name":"checkout","organization":"team","defaultBranch":"main"}`))
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+
+	prompter := &prompt.Scripted{Confirms: map[string]bool{
+		"Enable silent mode for Git comments?": false,
+	}}
+	vcs, err := configureFunctionVCS(&cobra.Command{}, client.New(server.URL, "test"),
+		prompter, "Checkout", initFunctionOptions{
+			InstallationID: "installation", RepositoryMode: "existing",
+			RepositoryID: "repository", ProviderBranch: "main",
+			ProviderRootDirectory: "./",
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vcs.RepositoryID != "repository" || len(asked) != 2 {
+		t.Fatalf("vcs=%#v requests=%#v", vcs, asked)
+	}
+}
+
+func TestNewGitHubRepositoryIsCreatedOnlyAfterReview(t *testing.T) {
+	posts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Header().Set("content-type", "application/json")
+		switch request.Method {
+		case http.MethodGet:
+			_, _ = response.Write([]byte(`{"installations":[{"$id":"installation","organization":"team"}]}`))
+		case http.MethodPost:
+			posts++
+			_, _ = response.Write([]byte(`{"id":"repository","name":"checkout","organization":"team","defaultBranch":"main"}`))
+		}
+	}))
+	defer server.Close()
+
+	prompter := &prompt.Scripted{
+		Choices: map[string]string{
+			"Select a GitHub installation":            "installation",
+			"Which repository would you like to use?": "new",
+		},
+		Texts: map[string]string{
+			"Name the new GitHub repository": "checkout",
+			"Function root directory":        "./",
+		},
+		Confirms: map[string]bool{
+			"Keep the repository private?":         true,
+			"Enable silent mode for Git comments?": false,
+		},
+	}
+	vcs, err := configureFunctionVCS(&cobra.Command{}, client.New(server.URL, "test"),
+		prompter, "Checkout", initFunctionOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if posts != 0 || !vcs.CreateRepository || vcs.RepositoryID != "" {
+		t.Fatalf("repository created before review: posts=%d vcs=%#v", posts, vcs)
+	}
+
+	vcs, err = createFunctionVCSRepository(client.New(server.URL, "test"), vcs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if posts != 1 || vcs.RepositoryID != "repository" || vcs.CreateRepository {
+		t.Fatalf("repository was not materialized: posts=%d vcs=%#v", posts, vcs)
+	}
+}
+
+func TestFunctionPreviewShowsSelectedConfiguration(t *testing.T) {
+	buffer := &bytes.Buffer{}
+	printFunctionPreview(buffer, functionPreview{
+		Name: "Checkout", ID: "checkout", Runtime: "node-22",
+		BuildSpecification: "s-2vcpu-2gb", RuntimeSpecification: "s-1vcpu-1gb",
+		Public: true, DomainTarget: "edge", Domain: "checkout.appwrite.network",
+		Source: "github", InstallationID: "installation", Repository: "team/checkout",
+		Branch: "main", RootDirectory: "functions/checkout", SilentMode: true,
+		CreateRepository: true, RepositoryPrivate: true,
+		Directory: "functions/checkout", EnvironmentFile: ".env",
+	})
+
+	for _, wanted := range []string{
+		"Function preview", "Checkout", "node-22", "s-2vcpu-2gb", "s-1vcpu-1gb",
+		"Public (any)", "Edge network", "https://checkout.appwrite.network",
+		"team/checkout (new, private)", "installation", "main", "functions/checkout",
+		"Silent", ".env",
+	} {
+		if !strings.Contains(buffer.String(), wanted) {
+			t.Errorf("preview does not contain %q:\n%s", wanted, buffer.String())
+		}
+	}
+}
+
+func TestAvailableFunctionDirectoryAddsNumericSuffix(t *testing.T) {
+	parent := t.TempDir()
+	for _, name := range []string{"my-function", "my-function-2"} {
+		if err := os.Mkdir(filepath.Join(parent, name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	name, renamed, err := availableFunctionDirectory(parent, "my-function")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "my-function-3" || !renamed {
+		t.Fatalf("name = %q, renamed = %v", name, renamed)
+	}
+}
+
+func TestValidateRuntimeAndSpecificationChoices(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Header().Set("content-type", "application/json")
+		switch request.URL.Path {
+		case "/functions/runtimes":
+			_, _ = response.Write([]byte(`{"runtimes":[{"$id":"node-22"}]}`))
+		case "/functions/specifications":
+			if request.URL.Query().Get("type") != "builds" {
+				t.Fatalf("type = %q", request.URL.Query().Get("type"))
+			}
+			_, _ = response.Write([]byte(`{"specifications":[{"slug":"s-2vcpu-2gb","enabled":true}]}`))
+		}
+	}))
+	defer server.Close()
+
+	api := client.New(server.URL, "test")
+	if err := validateRuntimeChoice(api, "node-22"); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateRuntimeChoice(api, "node-26"); err == nil {
+		t.Fatal("unavailable runtime accepted")
+	}
+	if err := validateSpecificationChoice(api, buildSpecifications, "s-2vcpu-2gb"); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateSpecificationChoice(api, buildSpecifications, "s-1vcpu-512mb"); err == nil {
+		t.Fatal("unavailable build specification accepted")
+	}
+}
+
+func TestValidatePreviewDomainLabel(t *testing.T) {
+	valid := []string{"checkout-api-hl3k", "a", "function-123"}
+	for _, value := range valid {
+		if err := validatePreviewDomainLabel(value); err != nil {
+			t.Errorf("validatePreviewDomainLabel(%q) = %v", value, err)
+		}
+	}
+
+	invalid := []string{"", "UPPER", "has.dot", "-starts", "ends-", strings.Repeat("a", 64)}
+	for _, value := range invalid {
+		if err := validatePreviewDomainLabel(value); err == nil {
+			t.Errorf("validatePreviewDomainLabel(%q) unexpectedly passed", value)
+		}
+	}
+}
+
+func TestFunctionEndpointOptionsShowFullAssignedSuffixes(t *testing.T) {
+	options := functionEndpointOptionsFromDomains(
+		"https://fra.cloud.appwrite.io/v1",
+		[]string{"fra.appwrite.run", "appwrite.network"},
+	)
+	if len(options) != 2 || options[0].Label != "Region compute (*.fra.appwrite.run)" ||
+		options[1].Label != "Edge network (*.appwrite.network)" {
+		t.Fatalf("options = %#v", options)
+	}
+}
+
+func TestRuleDomainsKeepsEdgeGlobalAndRegionalisesCompute(t *testing.T) {
+	variables := jsonx.NewObject()
+	variables.Set("_APP_DOMAIN_SITES", "stage.appwrite.network")
+	variables.Set("_APP_DOMAIN_FUNCTIONS", "ams.stage.appwrite.run")
+	context := pushContext{api: client.New("https://fra.cloud.staging.appwrite.io/v1", "test")}
+
+	domains := context.ruleDomains(deployables[0], variables)
+	if len(domains) != 2 || domains[0] != "stage.appwrite.network" ||
+		domains[1] != "fra.stage.appwrite.run" {
+		t.Fatalf("domains = %#v", domains)
+	}
+}
+
+func TestFunctionDomainForTarget(t *testing.T) {
+	domains := []string{"fra.appwrite.run", "appwrite.network"}
+
+	region, err := functionDomainForTarget(domains, "region")
+	if err != nil || region != "fra.appwrite.run" {
+		t.Fatalf("region = %q, %v", region, err)
+	}
+	edge, err := functionDomainForTarget(domains, "edge")
+	if err != nil || edge != "appwrite.network" {
+		t.Fatalf("edge = %q, %v", edge, err)
+	}
+	if _, err := functionDomainForTarget(domains[:1], "edge"); err == nil {
+		t.Fatal("missing edge endpoint unexpectedly passed")
+	}
+}
+
+func TestFunctionWriteBodyIncludesVCSButNotDomainIntent(t *testing.T) {
+	entry := jsonx.NewObject()
+	entry.Set("installationId", "installation")
+	entry.Set("providerRepositoryId", "repository")
+	entry.Set("providerBranch", "main")
+	entry.Set("providerRootDirectory", "functions/api")
+	entry.Set("previewDomainTarget", "edge")
+	entry.Set("previewDomainLabel", "api")
+
+	body := writeBody(entry, deployables[0].WriteKeys, nil, "functionId", "api")
+	if body.GetString("installationId") != "installation" ||
+		body.GetString("providerRepositoryId") != "repository" ||
+		body.GetString("providerBranch") != "main" {
+		t.Fatalf("VCS fields missing from body: %#v", body)
+	}
+	if _, exists := body.Get("previewDomainTarget"); exists {
+		t.Fatal("local domain intent leaked into Function API body")
+	}
+}
+
+func TestPullInfersEdgePreviewDomainAndIgnoresCustomDomain(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Header().Set("content-type", "application/json")
+		_, _ = response.Write([]byte(`{"total":2,"rules":[{"$id":"custom","domain":"api.example.com"},{"$id":"edge","domain":"checkout.appwrite.network"}]}`))
+	}))
+	defer server.Close()
+
+	function := jsonx.NewObject()
+	function.Set("$id", "checkout")
+	pull := projectPull{api: client.New(server.URL, "test")}
+	pull.addPreviewDomain(function)
+
+	if function.GetString("previewDomainTarget") != "edge" ||
+		function.GetString("previewDomainLabel") != "checkout" {
+		t.Fatalf("preview domain = %#v", function)
+	}
+}
+
+func TestPullDoesNotInferIntentFromMultipleManagedDomains(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		response.Header().Set("content-type", "application/json")
+		_, _ = response.Write([]byte(`{"total":2,"rules":[{"$id":"edge","domain":"checkout.appwrite.network"},{"$id":"region","domain":"checkout.fra.appwrite.run"}]}`))
+	}))
+	defer server.Close()
+
+	function := jsonx.NewObject()
+	function.Set("$id", "checkout")
+	pull := projectPull{api: client.New(server.URL, "test")}
+	pull.addPreviewDomain(function)
+	if function.GetString("previewDomainTarget") != "" ||
+		function.GetString("previewDomainLabel") != "" {
+		t.Fatalf("ambiguous domain intent was inferred: %#v", function)
+	}
+}
+
+func TestRemoveOtherPreviewRulesPreservesCustomDomain(t *testing.T) {
+	deleted := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.Method == http.MethodDelete {
+			deleted = append(deleted, request.URL.Path)
+		}
+		response.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	custom := jsonx.NewObject()
+	custom.Set("$id", "custom")
+	custom.Set("domain", "api.example.com")
+	old := jsonx.NewObject()
+	old.Set("$id", "old-edge")
+	old.Set("domain", "old.appwrite.network")
+	keep := jsonx.NewObject()
+	keep.Set("$id", "keep-region")
+	keep.Set("domain", "new.fra.appwrite.run")
+
+	context := pushContext{api: client.New(server.URL, "test")}
+	if err := context.removeOtherPreviewRules(
+		[]any{custom, old, keep}, "new.fra.appwrite.run",
+	); err != nil {
+		t.Fatal(err)
+	}
+	if len(deleted) != 1 || deleted[0] != "/proxy/rules/old-edge" {
+		t.Fatalf("deleted = %#v", deleted)
+	}
+}
+
+func TestCreateGitFunctionDeploymentSeedsTemplateOnce(t *testing.T) {
+	var body map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/functions/checkout/deployments/template" {
+			t.Errorf("path = %s", request.URL.Path)
+		}
+		if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		response.Header().Set("content-type", "application/json")
+		response.WriteHeader(http.StatusAccepted)
+		_, _ = response.Write([]byte(`{"$id":"deployment-1","status":"waiting"}`))
+	}))
+	defer server.Close()
+
+	path := filepath.Join(t.TempDir(), config.LocalFileName)
+	contents := `{"projectId":"project","functions":[{"$id":"checkout","templateRepository":"templates","templateOwner":"appwrite","templateRootDirectory":"node/starter","templateReference":"1.0.1","templateReferenceType":"tag"}]}`
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	local, err := config.LoadLocal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := local.ResourceEntries("functions")[0]
+	context := pushContext{api: client.New(server.URL, "test"), local: local}
+
+	deployment, err := context.createGitFunctionDeployment(entry, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deployment.GetString("$id") != "deployment-1" {
+		t.Fatalf("deployment = %#v", deployment)
+	}
+	if body["repository"] != "templates" || body["type"] != "tag" || body["activate"] != true {
+		t.Fatalf("body = %#v", body)
+	}
+
+	reloaded, err := config.LoadLocal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	persisted := reloaded.ResourceEntries("functions")[0]
+	if _, exists := persisted.Get("templateRepository"); exists {
+		t.Fatal("one-shot template metadata was not removed")
+	}
+}
+
+func TestCreateGitFunctionDeploymentUsesBranchAfterSeed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/functions/checkout/deployments/vcs" {
+			t.Errorf("path = %s", request.URL.Path)
+		}
+		body := jsonx.NewObject()
+		if err := json.NewDecoder(request.Body).Decode(body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		if body.GetString("type") != "branch" || body.GetString("reference") != "main" {
+			t.Errorf("body = %#v", body)
+		}
+		response.Header().Set("content-type", "application/json")
+		response.WriteHeader(http.StatusAccepted)
+		_, _ = response.Write([]byte(`{"$id":"deployment-2","status":"waiting"}`))
+	}))
+	defer server.Close()
+
+	path := filepath.Join(t.TempDir(), config.LocalFileName)
+	if err := os.WriteFile(path, []byte(`{"projectId":"project","functions":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	local, err := config.LoadLocal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := jsonx.NewObject()
+	entry.Set("$id", "checkout")
+	entry.Set("providerBranch", "main")
+	context := pushContext{api: client.New(server.URL, "test"), local: local}
+
+	if _, err := context.createGitFunctionDeployment(entry, true); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/templates/cli/internal/cmd/pull.go
+++ b/templates/cli/internal/cmd/pull.go
@@ -177,10 +177,7 @@ func projectAPI(global *config.Global, local *config.Local) (*client.Client, err
 		endpoint = value
 	}
 	if !config.EndpointsMatch(endpoint, sessionEndpoint) {
-		return nil, fmt.Errorf(
-			"endpoint %s does not match the current login session endpoint %s. "+
-				"Switch to an account for this environment with `%s login --switch --endpoint %s`",
-			endpoint, sessionEndpoint, app.ExecutableName, endpoint)
+		return nil, endpointMismatchError(endpoint, sessionEndpoint)
 	}
 
 	// WithoutResponseFormat is load bearing: with the header the API answers in

--- a/templates/cli/internal/cmd/pullfunction.go
+++ b/templates/cli/internal/cmd/pullfunction.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/app"
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/archive"
+	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/client"
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/config"
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/jsonx"
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/output"
@@ -44,9 +45,12 @@ var codeResources = []codeResource{
 		resourceIdentity: functionIdentity,
 		Directory:        "functions",
 		Keys: []string{
-			"$id", "name", "runtime", "path", "entrypoint", "execute",
-			"enabled", "logging", "events", "schedule", "timeout", "commands",
-			"scopes", "buildSpecification", "runtimeSpecification",
+			"$id", "name", "runtime", "path", "previewDomainTarget",
+			"previewDomainLabel", "entrypoint", "execute", "enabled", "logging",
+			"events", "schedule", "timeout", "commands", "scopes",
+			"installationId", "providerRepositoryId", "providerBranch",
+			"providerSilentMode", "providerRootDirectory", "providerBranches",
+			"providerPaths", "buildSpecification", "runtimeSpecification",
 			"deploymentRetention",
 		},
 	},
@@ -154,15 +158,26 @@ func runPullCode(command *cobra.Command, resource codeResource, code, withVariab
 		// API never returns it -- it is a local concept -- so filtering first
 		// and setting after would append it at the end.
 		row.Set("path", relative)
+		if resource.Name == "function" {
+			context.addPreviewDomain(row)
+		}
 
 		entry := config.FilterBySchema(row, resource.Keys)
 		context.local.UpsertByID(resource.ConfigKey, entry)
 
+		absolute := filepath.Join(directory, filepath.FromSlash(relative))
 		if !code {
+			if withVariables {
+				if err := os.MkdirAll(absolute, 0o755); err != nil {
+					return err
+				}
+				if err := writeVariables(row, absolute); err != nil {
+					return err
+				}
+			}
 			continue
 		}
 
-		absolute := filepath.Join(directory, filepath.FromSlash(relative))
 		if err := os.MkdirAll(absolute, 0o755); err != nil {
 			return err
 		}
@@ -221,6 +236,55 @@ func selectResources(rows []*jsonx.Object, resource codeResource) ([]*jsonx.Obje
 	}
 
 	return filtered, nil
+}
+
+// addPreviewDomain records the Appwrite-managed function endpoint. Custom
+// domains are deliberately ignored: previewDomain* owns only the generated
+// region/edge rule and push must never reconcile a user's custom hostname.
+func (p *projectPull) addPreviewDomain(function *jsonx.Object) {
+	queries := []string{
+		`{"method":"equal","attribute":"deploymentResourceType","values":["function"]}`,
+		`{"method":"equal","attribute":"deploymentResourceId","values":["` +
+			function.GetString("$id") + `"]}`,
+		`{"method":"equal","attribute":"trigger","values":["manual"]}`,
+		`{"method":"limit","values":[100]}`,
+	}
+	listing := jsonx.NewObject()
+	if err := p.api.Call("GET", "/proxy/rules?"+client.EncodeQueries(queries), nil, listing); err != nil {
+		return
+	}
+
+	value, _ := listing.Get("rules")
+	rules, _ := value.([]any)
+	type managedDomain struct{ target, label string }
+	managed := make([]managedDomain, 0, len(rules))
+	for _, item := range rules {
+		rule, ok := item.(*jsonx.Object)
+		if !ok {
+			continue
+		}
+		domain := strings.ToLower(rule.GetString("domain"))
+		target := ""
+		switch {
+		case strings.HasSuffix(domain, ".appwrite.network"):
+			target = "edge"
+		case strings.HasSuffix(domain, ".appwrite.run"):
+			target = "region"
+		default:
+			continue
+		}
+		label, _, found := strings.Cut(domain, ".")
+		if !found || label == "" {
+			continue
+		}
+		managed = append(managed, managedDomain{target: target, label: label})
+	}
+	// Multiple generated endpoints are valid. Without an explicit user choice,
+	// recording one arbitrarily would make the next push delete the others.
+	if len(managed) == 1 {
+		function.Set("previewDomainTarget", managed[0].target)
+		function.Set("previewDomainLabel", managed[0].label)
+	}
 }
 
 // downloadDeployment fetches the latest deployment and unpacks it.

--- a/templates/cli/internal/cmd/pullfunction.go
+++ b/templates/cli/internal/cmd/pullfunction.go
@@ -163,6 +163,9 @@ func runPullCode(command *cobra.Command, resource codeResource, code, withVariab
 		}
 
 		entry := config.FilterBySchema(row, resource.Keys)
+		if resource.Name == "function" {
+			preservePendingFunctionTemplate(context.local, entry)
+		}
 		context.local.UpsertByID(resource.ConfigKey, entry)
 
 		absolute := filepath.Join(directory, filepath.FromSlash(relative))
@@ -198,6 +201,30 @@ func runPullCode(command *cobra.Command, resource codeResource, code, withVariab
 	output.Success(out, "Successfully pulled %d %s.", len(rows), resource.Label)
 
 	return nil
+}
+
+// preservePendingFunctionTemplate keeps the one-shot deployment coordinates
+// for a newly requested GitHub repository. They have no remote representation
+// until the first push seeds that repository, so replacing the local entry with
+// the Function API response would silently turn the first deployment into a
+// branch deployment against an empty repository.
+func preservePendingFunctionTemplate(local *config.Local, pulled *jsonx.Object) {
+	for _, existing := range local.ResourceEntries("functions") {
+		if existing.GetString("$id") != pulled.GetString("$id") ||
+			!existing.GetBool("providerRepositoryPending") {
+			continue
+		}
+		for _, key := range []string{
+			"providerRepositoryName", "providerRepositoryPrivate",
+			"providerRepositoryPending", "templateRepository", "templateOwner",
+			"templateRootDirectory", "templateReference", "templateReferenceType",
+		} {
+			if value, ok := existing.Get(key); ok {
+				pulled.Set(key, value)
+			}
+		}
+		return
+	}
 }
 
 // selectResources asks which resources to pull.

--- a/templates/cli/internal/cmd/pushdeploy.go
+++ b/templates/cli/internal/cmd/pushdeploy.go
@@ -494,12 +494,18 @@ var deployables = []deployable{
 		WriteKeys: []string{
 			"name", "runtime", "execute", "events", "schedule", "timeout",
 			"enabled", "logging", "entrypoint", "commands", "scopes",
-			"buildSpecification", "runtimeSpecification", "deploymentRetention",
+			"installationId", "providerRepositoryId", "providerBranch",
+			"providerSilentMode", "providerRootDirectory", "providerBranches",
+			"providerPaths", "buildSpecification", "runtimeSpecification",
+			"deploymentRetention",
 		},
 		ApproveKeys: []string{
 			"path", "$id", "execute", "name", "enabled", "logging", "runtime",
 			"buildSpecification", "runtimeSpecification", "deploymentRetention",
 			"scopes", "events", "schedule", "timeout", "entrypoint", "commands",
+			"installationId", "providerRepositoryId", "providerBranch",
+			"providerSilentMode", "providerRootDirectory", "providerBranches",
+			"providerPaths", "previewDomainTarget", "previewDomainLabel",
 			"vars", "ignore",
 		},
 		DeploymentKeys: []string{"entrypoint", "commands"},
@@ -556,6 +562,10 @@ type deployOptions struct {
 	// Logs streams the deployment's build log while it builds; --no-logs
 	// reports status transitions only.
 	Logs bool
+	// FailOnError returns an error when any selected resource fails. Ordinary
+	// multi-resource push commands keep reporting a summary so other resources
+	// can finish; init --deploy needs a failing exit status for its one resource.
+	FailOnError bool
 }
 
 func newPushDeployableCommand(resource deployable) *cobra.Command {
@@ -737,6 +747,10 @@ func runPushDeployable(
 	}
 
 	summary.report(command, resource, options.Async, time.Since(started))
+	if options.FailOnError && len(summary.Failed) > 0 {
+		return fmt.Errorf("failed to deploy %s: %s",
+			resource.Singular, summary.Failed[0].Reason)
+	}
 
 	return nil
 }
@@ -817,7 +831,9 @@ func (s *pushSummary) report(
 	// The link and nothing else: the spinner row above has already named the
 	// resource and the reason.
 	for _, failure := range s.Failed {
-		output.Log(out, "Deployment page: %s", failure.ConsoleURL)
+		if failure.ConsoleURL != "" {
+			output.Log(out, "Deployment page: %s", failure.ConsoleURL)
+		}
 	}
 
 	if async {
@@ -1034,7 +1050,7 @@ func (c *pushContext) pushDeployable(
 	case err != nil && isNotFound(err):
 		exists = false
 	case err != nil:
-		output.Failure(out, "Failed to push %s %s: %s", resource.Singular, name, err)
+		recordPushFailure(command, resource, name, err.Error(), summary)
 
 		return
 	}
@@ -1042,10 +1058,11 @@ func (c *pushContext) pushDeployable(
 	if exists {
 		local := entry.GetString(resource.MismatchKey)
 		if remoteValue := remote.GetString(resource.MismatchKey); remoteValue != local {
-			output.Failure(out,
-				"%s mismatch! (local=%s,remote=%s) Please delete remote %s or update your %s",
+			reason := fmt.Sprintf(
+				"%s mismatch (local=%s, remote=%s); delete the remote %s or update %s",
 				strings.ToUpper(resource.MismatchKey[:1])+resource.MismatchKey[1:],
 				local, remoteValue, resource.Singular, config.LocalFileName)
+			recordPushFailure(command, resource, name, reason, summary)
 
 			return
 		}
@@ -1058,22 +1075,22 @@ func (c *pushContext) pushDeployable(
 				resource.IDField, id), nil)
 	}
 	if err != nil {
-		output.Failure(out, "Failed to push %s %s: %s", resource.Singular, name, err)
+		recordPushFailure(command, resource, name, err.Error(), summary)
 
 		return
 	}
 
 	// Ensured on every push, not only on create, so a function whose rule was
 	// deleted in the console gets it back.
-	if err := c.ensureDefaultRule(command, resource, id); err != nil {
-		output.Failure(out, "Failed to push %s %s: %s", resource.Singular, name, err)
+	if err := c.ensureDefaultRule(command, resource, entry); err != nil {
+		recordPushFailure(command, resource, name, err.Error(), summary)
 
 		return
 	}
 
 	if run.WithVariables {
 		if err := c.replaceVariables(resource, entry); err != nil {
-			output.Failure(out, "Failed to push %s %s: %s", resource.Singular, name, err)
+			recordPushFailure(command, resource, name, err.Error(), summary)
 
 			return
 		}
@@ -1088,7 +1105,7 @@ func (c *pushContext) pushDeployable(
 
 	deployment, err := c.createDeployment(command, resource, entry, run.Activate)
 	if err != nil {
-		output.Failure(out, "Failed to push %s %s: %s", resource.Singular, name, err)
+		recordPushFailure(command, resource, name, err.Error(), summary)
 
 		return
 	}
@@ -1099,6 +1116,17 @@ func (c *pushContext) pushDeployable(
 	}
 
 	c.awaitDeployment(command, resource, entry, deployment, run, summary)
+}
+
+func recordPushFailure(
+	command *cobra.Command,
+	resource deployable,
+	name, reason string,
+	summary *pushSummary,
+) {
+	output.Failure(command.OutOrStdout(), "Failed to push %s %s: %s",
+		resource.Singular, name, reason)
+	summary.Failed = append(summary.Failed, failedDeployment{Name: name, Reason: reason})
 }
 
 // writeBody builds a create or update body from the config entry.
@@ -1219,7 +1247,8 @@ func (c *pushContext) replaceVariables(resource deployable, entry *jsonx.Object)
 	return nil
 }
 
-// createDeployment packages the resource and uploads it.
+// createDeployment deploys from Git when a function is connected to VCS;
+// otherwise it packages and uploads the local resource directory.
 func (c *pushContext) createDeployment(
 	command *cobra.Command,
 	resource deployable,
@@ -1227,6 +1256,10 @@ func (c *pushContext) createDeployment(
 	activate bool,
 ) (*jsonx.Object, error) {
 	out := command.OutOrStdout()
+
+	if resource.Name == "function" && entry.GetString("providerRepositoryId") != "" {
+		return c.createGitFunctionDeployment(entry, activate)
+	}
 
 	configured := entry.GetString("path")
 	if configured == "" {
@@ -1279,6 +1312,50 @@ func (c *pushContext) createDeployment(
 	}
 
 	return result.Deployment, nil
+}
+
+func (c *pushContext) createGitFunctionDeployment(
+	entry *jsonx.Object,
+	activate bool,
+) (*jsonx.Object, error) {
+	functionID := url.PathEscape(entry.GetString("$id"))
+	body := jsonx.NewObject()
+	body.Set("activate", activate)
+
+	path := "/functions/" + functionID + "/deployments/vcs"
+	if entry.GetString("templateRepository") != "" {
+		path = "/functions/" + functionID + "/deployments/template"
+		body.Set("repository", entry.GetString("templateRepository"))
+		body.Set("owner", entry.GetString("templateOwner"))
+		body.Set("rootDirectory", entry.GetString("templateRootDirectory"))
+		body.Set("type", entry.GetString("templateReferenceType"))
+		body.Set("reference", entry.GetString("templateReference"))
+	} else {
+		body.Set("type", "branch")
+		body.Set("reference", entry.GetString("providerBranch"))
+	}
+
+	deployment := jsonx.NewObject()
+	if err := c.api.Call("POST", path, body, deployment); err != nil {
+		return nil, err
+	}
+
+	// Template coordinates are one-shot. Keeping them would merge the starter
+	// into the repository again on every explicit CLI deployment.
+	if entry.GetString("templateRepository") != "" {
+		for _, key := range []string{
+			"templateRepository", "templateOwner", "templateRootDirectory",
+			"templateReference", "templateReferenceType",
+		} {
+			entry.Delete(key)
+		}
+		c.local.UpsertByID("functions", entry)
+		if err := c.local.Write(); err != nil {
+			return nil, fmt.Errorf("deployment created but template state could not be saved: %w", err)
+		}
+	}
+
+	return deployment, nil
 }
 
 // normalizeIgnoreRules reads a resource's `ignore` field as a pattern list.
@@ -1571,7 +1648,7 @@ func progressSignature(deployment *jsonx.Object) string {
 // ruleQueries selects a resource's manual proxy rule.
 func ruleQueries(resourceType, id string) []string {
 	return []string{
-		`{"method":"limit","values":[1]}`,
+		`{"method":"limit","values":[100]}`,
 		`{"method":"equal","attribute":"deploymentResourceType","values":["` + resourceType + `"]}`,
 		`{"method":"equal","attribute":"deploymentResourceId","values":["` + id + `"]}`,
 		`{"method":"equal","attribute":"trigger","values":["manual"]}`,
@@ -1618,21 +1695,40 @@ func (c *pushContext) previewURL(resource deployable, id string) string {
 func (c *pushContext) ensureDefaultRule(
 	command *cobra.Command,
 	resource deployable,
-	id string,
+	entry *jsonx.Object,
 ) error {
 	out := command.OutOrStdout()
+	id := entry.GetString("$id")
 
 	rules, err := c.listRules(resource, id)
 	if err != nil {
 		return err
 	}
 	value, _ := rules.Get("rules")
-	if items, _ := value.([]any); len(items) > 0 {
+	items, _ := value.([]any)
+
+	label := entry.GetString("previewDomainLabel")
+	target := entry.GetString("previewDomainTarget")
+	// A resource without explicit endpoint intent retains the old behavior:
+	// any existing manual rule satisfies the default-domain requirement.
+	if label == "" && len(items) > 0 {
 		return nil
 	}
 
-	console, _, err := consoleClient()
-	if err != nil {
+	var domains []string
+	console, _, consoleErr := consoleClientAt(c.api.Endpoint)
+	if consoleErr == nil {
+		variables := jsonx.NewObject()
+		if err := console.Call("GET", "/console/variables", nil, variables); err == nil {
+			domains = c.ruleDomains(resource, variables)
+		} else {
+			consoleErr = err
+		}
+	}
+	if len(domains) == 0 && resource.Name == "function" && label != "" {
+		domains = cloudFunctionDomains(c.api.Endpoint)
+	}
+	if len(domains) == 0 && consoleErr != nil {
 		output.Warn(out,
 			"Skipping default domain rule for %s: console session required to read "+
 				"%s domains. Run `%s login` or create the domain in the Console.",
@@ -1640,33 +1736,116 @@ func (c *pushContext) ensureDefaultRule(
 
 		return nil
 	}
-
-	variables := jsonx.NewObject()
-	if err := console.Call("GET", "/console/variables", nil, variables); err != nil {
-		return fmt.Errorf("read console variables: %w", err)
-	}
-
-	domains := c.ruleDomains(resource, variables)
 	if len(domains) == 0 {
 		return fmt.Errorf("_APP_DOMAIN_%s is not configured",
 			strings.ToUpper(resource.Label))
 	}
 
+	suffix := domains[0]
+	if label != "" && resource.Name == "function" {
+		suffix, err = functionDomainForTarget(domains, target)
+		if err != nil {
+			return err
+		}
+	}
+	if label == "" {
+		label = appwrite.Unique()
+	}
+	domain := label + "." + suffix
+
+	exists, err := c.ruleExists(resource, id, domain)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return c.removeOtherPreviewRules(items, domain)
+	}
+
 	body := jsonx.NewObject()
-	body.Set("domain", appwrite.Unique()+"."+domains[0])
+	body.Set("domain", domain)
 	body.Set(resource.IDField, id)
 
 	output.Log(out, "Creating %s proxy rule for %s ...",
 		resource.Singular, body.GetString("domain"))
 
-	return c.api.Call("POST", "/proxy/rules/"+resource.Name, body, nil)
+	if err := c.api.Call("POST", "/proxy/rules/"+resource.Name, body, nil); err != nil {
+		return err
+	}
+
+	return c.removeOtherPreviewRules(items, domain)
 }
 
-// ruleDomains reads the configured domains for a resource type. A function's
-// domain is regionalised by replacing the first label, standing in until the
-// API reports a regional functions domain. Sites are not regionalised.
+func (c *pushContext) removeOtherPreviewRules(items []any, keep string) error {
+	for _, item := range items {
+		rule, ok := item.(*jsonx.Object)
+		if !ok {
+			continue
+		}
+		domain := strings.ToLower(rule.GetString("domain"))
+		managed := strings.HasSuffix(domain, ".appwrite.network") ||
+			strings.HasSuffix(domain, ".appwrite.run")
+		if !managed || strings.EqualFold(domain, keep) {
+			continue
+		}
+		if err := c.api.Call("DELETE", "/proxy/rules/"+
+			url.PathEscape(rule.GetString("$id")), nil, nil); err != nil {
+			return fmt.Errorf("remove previous function endpoint %s: %w", domain, err)
+		}
+	}
+
+	return nil
+}
+
+func (c *pushContext) ruleExists(resource deployable, id, domain string) (bool, error) {
+	queries := ruleQueries(resource.RuleResourceType, id)
+	queries = append(queries,
+		`{"method":"equal","attribute":"domain","values":["`+domain+`"]}`)
+
+	rules := jsonx.NewObject()
+	if err := c.api.Call("GET", "/proxy/rules?"+client.EncodeQueries(queries), nil, rules); err != nil {
+		return false, err
+	}
+
+	return rules.GetInt64("total") > 0, nil
+}
+
+func cloudFunctionDomains(endpoint string) []string {
+	region := endpointRegion(endpoint)
+	base, cloud := config.CloudBaseHost(endpoint)
+	if region == "" || !cloud {
+		return nil
+	}
+
+	stage := ""
+	if strings.Contains(base, "staging") {
+		stage = "stage."
+	}
+
+	return []string{region + "." + stage + "appwrite.run", stage + "appwrite.network"}
+}
+
+func functionDomainForTarget(domains []string, target string) (string, error) {
+	for _, domain := range domains {
+		isEdge := strings.HasSuffix(strings.ToLower(domain), ".appwrite.network") ||
+			strings.EqualFold(domain, "appwrite.network")
+		if target == "edge" && isEdge || target == "region" && !isEdge {
+			return domain, nil
+		}
+	}
+
+	return "", fmt.Errorf("function %s endpoint is not available for this project", target)
+}
+
+// ruleDomains reads the configured domains for a resource type. A regional
+// Function domain is adjusted to the project's endpoint region; the shared
+// Appwrite Network edge suffix is deliberately left unchanged.
 func (c *pushContext) ruleDomains(resource deployable, variables *jsonx.Object) []string {
 	configured := variables.GetString("_APP_DOMAIN_" + strings.ToUpper(resource.Label))
+	if resource.Name == "function" {
+		// Prefer the Sites suffix for edge Functions. A regional Cloud response
+		// may also expose a region-prefixed appwrite.network Functions suffix.
+		configured = variables.GetString("_APP_DOMAIN_SITES") + "," + configured
+	}
 
 	var domains []string
 	for _, domain := range strings.Split(configured, ",") {
@@ -1674,7 +1853,8 @@ func (c *pushContext) ruleDomains(resource deployable, variables *jsonx.Object) 
 		if domain == "" {
 			continue
 		}
-		if resource.Name == "function" {
+		if resource.Name == "function" &&
+			!strings.HasSuffix(strings.ToLower(domain), ".appwrite.network") {
 			domain = c.regionalRuleDomain(domain)
 		}
 		domains = append(domains, domain)

--- a/templates/cli/internal/cmd/pushdeploy.go
+++ b/templates/cli/internal/cmd/pushdeploy.go
@@ -680,6 +680,12 @@ func runPushDeployable(
 		return nil
 	}
 
+	if resource.Name == "function" {
+		if err := context.materializePendingFunctionRepositories(entries); err != nil {
+			return err
+		}
+	}
+
 	pushCode := options.Code
 	if pushCode {
 		confirmed, err := context.prompter.Confirm(prompt.Question{
@@ -1245,6 +1251,84 @@ func (c *pushContext) replaceVariables(resource deployable, entry *jsonx.Object)
 	}
 
 	return nil
+}
+
+// materializePendingFunctionRepositories creates repositories accepted on the
+// init review screen. The pending intent is already persisted before any
+// remote write. If saving the returned repository id fails, a retry sees the
+// same intent, receives GitHub's duplicate-name response, and resolves the
+// created repository by name instead of creating another one.
+func (c *pushContext) materializePendingFunctionRepositories(
+	entries []*jsonx.Object,
+) error {
+	for _, entry := range entries {
+		if !entry.GetBool("providerRepositoryPending") {
+			continue
+		}
+		vcs := functionVCS{
+			InstallationID:    entry.GetString("installationId"),
+			RepositoryName:    entry.GetString("providerRepositoryName"),
+			Branch:            entry.GetString("providerBranch"),
+			RootDirectory:     entry.GetString("providerRootDirectory"),
+			SilentMode:        entry.GetBool("providerSilentMode"),
+			CreateRepository:  true,
+			RepositoryPrivate: entry.GetBool("providerRepositoryPrivate"),
+		}
+		created, err := createFunctionVCSRepository(c.api, vcs)
+		if err != nil {
+			created, err = c.findPendingFunctionRepository(vcs)
+			if err != nil {
+				return fmt.Errorf("create GitHub repository %s: %w", vcs.RepositoryName, err)
+			}
+		}
+
+		entry.Set("providerRepositoryId", created.RepositoryID)
+		entry.Set("providerRepositoryName", created.RepositoryName)
+		entry.Delete("providerRepositoryPrivate")
+		entry.Delete("providerRepositoryPending")
+		c.local.UpsertByID("functions", entry)
+		if err := c.local.Write(); err != nil {
+			return fmt.Errorf(
+				"GitHub repository %s was created but its id could not be saved; retry this push to recover it: %w",
+				created.RepositoryName, err)
+		}
+	}
+
+	return nil
+}
+
+func (c *pushContext) findPendingFunctionRepository(
+	vcs functionVCS,
+) (functionVCS, error) {
+	parts := strings.SplitN(vcs.RepositoryName, "/", 2)
+	name := vcs.RepositoryName
+	if len(parts) == 2 {
+		name = parts[1]
+	}
+	query := url.Values{"type": []string{"runtime"}, "search": []string{name}}
+	query["queries[]"] = []string{`{"method":"limit","values":[100]}`}
+	path := "/vcs/github/installations/" + url.PathEscape(vcs.InstallationID) +
+		"/providerRepositories?" + query.Encode()
+	var listing struct {
+		Repositories []vcsRepository `json:"runtimeProviderRepositories"`
+	}
+	if err := c.api.Call("GET", path, nil, &listing); err != nil {
+		return functionVCS{}, err
+	}
+	for _, repository := range listing.Repositories {
+		fullName := strings.TrimPrefix(repository.Organization+"/"+repository.Name, "/")
+		if fullName == vcs.RepositoryName || repository.Name == vcs.RepositoryName {
+			vcs.RepositoryID = repository.ID
+			vcs.RepositoryName = fullName
+			if repository.DefaultBranch != "" {
+				vcs.Branch = repository.DefaultBranch
+			}
+			vcs.CreateRepository = false
+			return vcs, nil
+		}
+	}
+
+	return functionVCS{}, fmt.Errorf("repository was not found after creation failed")
 }
 
 // createDeployment deploys from Git when a function is connected to VCS;

--- a/templates/cli/internal/jsonx/object.go
+++ b/templates/cli/internal/jsonx/object.go
@@ -64,6 +64,17 @@ func (o *Object) GetString(key string) string {
 	return ""
 }
 
+// GetBool returns a boolean value, or false when absent or another type.
+func (o *Object) GetBool(key string) bool {
+	value, ok := o.Get(key)
+	if !ok {
+		return false
+	}
+	boolean, _ := value.(bool)
+
+	return boolean
+}
+
 // GetObject returns a nested object, or nil when absent or another type.
 func (o *Object) GetObject(key string) *Object {
 	value, ok := o.Get(key)

--- a/templates/cli/internal/output/message.go
+++ b/templates/cli/internal/output/message.go
@@ -105,6 +105,42 @@ func Failure(writer io.Writer, format string, arguments ...any) {
 	writeMessage(writer, failureStyle, "✗ Error:", format, arguments...)
 }
 
+// FailureDetail is one aligned fact in an actionable failure block.
+type FailureDetail struct {
+	Label string
+	Value string
+}
+
+// ActionableFailure renders a failure whose resolution is known. The title,
+// facts and command are split into separate visual groups so a long recovery
+// instruction does not become one dense red sentence.
+func ActionableFailure(
+	writer io.Writer,
+	title string,
+	details []FailureDetail,
+	action, command string,
+) {
+	fmt.Fprintf(writer, "%s\n", failureStyle.Bold(true).Render("✗ "+title))
+
+	if len(details) > 0 {
+		width := 0
+		for _, detail := range details {
+			width = max(width, len(detail.Label))
+		}
+		fmt.Fprintln(writer)
+		for _, detail := range details {
+			fmt.Fprintf(writer, "  %-*s   %s\n", width, detail.Label, detail.Value)
+		}
+	}
+
+	if action != "" {
+		fmt.Fprintf(writer, "\n  %s\n", action)
+	}
+	if command != "" {
+		fmt.Fprintf(writer, "\n    %s\n", infoStyle.Render(command))
+	}
+}
+
 func writeMessage(writer io.Writer, style lipgloss.Style, prefix, format string, arguments ...any) {
 	message := fmt.Sprintf(format, arguments...)
 	fmt.Fprintf(writer, "%s %s\n", style.Bold(true).Render(prefix), style.Render(message))

--- a/templates/cli/internal/prompt/prompt.go
+++ b/templates/cli/internal/prompt/prompt.go
@@ -65,6 +65,9 @@ func Options(values ...string) []Option {
 type Text struct {
 	Message string
 	Default string
+	// Suffix is rendered as a live preview after the typed/default value without
+	// becoming part of the value returned to the caller.
+	Suffix string
 	// Flag is named when there is no terminal.
 	Flag string
 	// Validate rejects a value with a message the user sees. Nil accepts
@@ -76,10 +79,11 @@ type Text struct {
 
 // Choice asks for one option.
 type Choice struct {
-	Message string
-	Options []Option
-	Default string
-	Flag    string
+	Message     string
+	Description string
+	Options     []Option
+	Default     string
+	Flag        string
 	// Filter shows a type-to-narrow field. A property rather than a separate
 	// question type, because the only difference is whether the filter is
 	// visible.

--- a/templates/cli/internal/prompt/prompt_test.go
+++ b/templates/cli/internal/prompt/prompt_test.go
@@ -178,6 +178,19 @@ func TestNonNegativeInteger(t *testing.T) {
 // TestScriptedTreatsDefaultAsAPlaceholder pins a contract a live run exposed: a
 // default is REPLACED when the user types, not prepended. huh's Value() seeds
 // the editable buffer instead, which produced "My Awesome TeamQA Team".
+func TestTextSuffixIsDisplayOnly(t *testing.T) {
+	scripted := &Scripted{Texts: map[string]string{"Domain?": "checkout"}}
+	value, err := scripted.Text(Text{
+		Message: "Domain?", Default: "api", Suffix: ".appwrite.network",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value != "checkout" {
+		t.Fatalf("Text = %q, want raw label without suffix", value)
+	}
+}
+
 func TestScriptedTreatsDefaultAsAPlaceholder(t *testing.T) {
 	scripted := &Scripted{Texts: map[string]string{"Name?": "QA Team"}}
 

--- a/templates/cli/internal/prompt/terminal.go
+++ b/templates/cli/internal/prompt/terminal.go
@@ -110,6 +110,17 @@ func (t *Terminal) Text(question Text) (string, error) {
 		Placeholder(question.Default).
 		Value(&value)
 
+	if question.Suffix != "" {
+		field = field.DescriptionFunc(func() string {
+			preview := value
+			if preview == "" {
+				preview = question.Default
+			}
+
+			return preview + question.Suffix
+		}, &value)
+	}
+
 	if question.Secret {
 		field = field.EchoMode(huh.EchoModePassword)
 	}
@@ -166,6 +177,7 @@ func (t *Terminal) Choice(question Choice) (string, error) {
 
 	field := huh.NewSelect[string]().
 		Title(question.Message).
+		Description(question.Description).
 		Options(options...).
 		Filtering(question.Filter).
 		Value(&value).


### PR DESCRIPTION
## Summary

Adds a Console-like, guided `appwrite init function` workflow while preserving the CLI's existing local-first and non-interactive behavior.

The flow now collects runtime and compute settings, execution access, regional or edge networking, generated domains, local or GitHub source, and environment variables. Before anything is written, it presents a complete review screen with options to save, deploy, start over, or exit without saving.

## What changed

### Guided function creation

- Searchable runtime selector that filters as the user types.
- Separate build and runtime compute selection, validated against the project plan.
- Public or restricted execution access.
- Regional compute and edge-network choices with the actual generated domain suffixes.
- Live full-domain preview while editing the domain label.
- Automatic collision-free local directories (`function`, `function-2`, etc.).
- Optional `.env` import with `0600` permissions.
- Final configuration preview before local files, configuration, Appwrite resources, or GitHub repositories are created.
- Save, create-and-deploy, start-over, and cancel actions.

### GitHub source workflow

- Select an Appwrite GitHub installation and an existing repository, or configure a new repository.
- Configure branch, root directory, repository visibility, and silent mode.
- Show a project-specific Console setup link when no installation exists.
- Continue with local source or retry after connecting GitHub without restarting the setup flow.
- Defer new GitHub repository creation until the review is accepted.
- Seed only newly created repositories from the starter template; existing repositories deploy their selected branch without being modified by template seeding.
- Resolve explicitly supplied repository IDs directly instead of requiring them to appear in the first list page.

### Deployment and synchronization

- `--deploy` creates, deploys, activates, streams build logs, imports variables, and returns a failing exit status if deployment fails.
- Local functions continue to use archive deployments.
- Git-connected functions use template deployment once for a new repository, then branch-based VCS deployments.
- Region/edge generated proxy rules are reconciled safely while custom domains are preserved.
- Pull records generated-domain intent only when it is unambiguous, preventing a later push from deleting one of multiple existing managed endpoints arbitrarily.
- Pull preserves VCS metadata and supports variables with or without source download.

### Error and prompt presentation

- Actionable session/environment mismatch blocks with aligned endpoint details and a normalized switch command.
- Actionable missing-project configuration blocks.
- Prompt descriptions clear after selection so the final review is the persistent configuration view.
- Non-interactive prompt failures identify the flag required to continue.

## Screenshots

### Search runtimes by typing

![Runtime selector filtered to Go](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/runtime-search-e21c1104.png)

### Review every selection before saving or deploying

![Function configuration preview](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/function-preview-7cc03ed5.png)

### Create, build, and deploy on Appwrite Cloud staging

![Successful function deployment and build logs](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/function-deploy-1ee6f40c.png)

### Invoke the generated endpoint and verify imported variables

![Endpoint and variable verification](https://github.com/ChiragAgg5k/gitshot-images/releases/download/_gitshot/endpoint-verification-71bb0e48.png)

## Live staging verification

Tested end to end against Appwrite Cloud staging with a temporary Node.js function:

- Initialized the function from the starter template.
- Imported a `.env` variable.
- Created and activated an archive deployment.
- Streamed the successful build logs.
- Created and reconciled the edge `stage.appwrite.network` proxy rule.
- Invoked the generated endpoint and received HTTP 200 with the starter response.
- Verified the imported variable through the Functions API.
- Previously exercised regional `appwrite.run` reconciliation and invocation as part of this implementation.
- Deleted the temporary function and confirmed that zero proxy rules remained.

No production resources were created or modified.

## Validation

- `php example.php cli`
- `test -z "$(gofmt -l examples/cli)"`
- `cd examples/cli && go test ./...`
- `cd examples/cli && go vet ./...`
- `cd examples/cli && go build ./...`
- `composer lint-twig`
- `composer refactor:check`
- `git diff --check`

## Notes

- The generated `examples/cli` tree was regenerated and inspected as required; it remains gitignored.
- The new generated test template is explicitly registered in `src/SDK/Language/CLI.php`.
- Runtime choices remain project/environment-driven through `/functions/runtimes`; unsupported production runtimes are not offered on older staging environments.
