### PR TITLE
refactor: use standard OpenAPI schema fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           Rust183,
           AppleSwift61,
           Swift61,
-          Unity2021,
+          # TODO: Re-enable Unity2021 after the CI Unity license is restored.
           WebChromium,
           WebNode,
           ReactNative
@@ -87,8 +87,6 @@ jobs:
           composer install
 
       - name: Run Tests
-        env:
-          UNITY_LICENSE: ${{ matrix.sdk == 'Unity2021' && secrets.UNITY_LICENSE || '' }}
         run: composer test tests/e2e/${{ matrix.sdk }}Test.php
 
   lint:

--- a/src/SDK/Language.php
+++ b/src/SDK/Language.php
@@ -244,7 +244,7 @@ abstract class Language
     public function hasPermissionParam(array $parameters): bool
     {
         foreach ($parameters as $parameter) {
-            $example = $this->getSchema($parameter)->extensions['x-example'] ?? $this->getSchema($parameter)->example;
+            $example = $this->getSchemaExample($parameter);
             if (!empty($example) && is_string($example) && $this->isPermissionString($example)) {
                 return true;
             }
@@ -302,7 +302,17 @@ abstract class Language
     protected function getSchemaExample(Schema|Parameter $value): mixed
     {
         $schema = $this->getSchema($value);
-        return $schema->extensions['x-example'] ?? $schema->example;
+        $example = $schema->example;
+
+        if (!\is_array($example) && !\is_object($example)) {
+            return $example;
+        }
+
+        if ($this->getSchemaType($schema) === self::TYPE_OBJECT && empty((array) $example)) {
+            return '{}';
+        }
+
+        return \json_encode($example, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 
     protected function getSchemaDefault(Schema|Parameter $value): mixed

--- a/src/SDK/Language/Swift.php
+++ b/src/SDK/Language/Swift.php
@@ -321,6 +321,7 @@ class Swift extends Language
     public function getTypeName(Schema|Parameter $parameter, ?Specification $spec = null, bool $isProperty = false): string
     {
         $schema = $this->getSchema($parameter);
+        $items = $this->getArraySchema($parameter);
         $prefix = $spec?->info->title ?? '';
         $enumSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
         if ($enumSchema->enum !== []) {
@@ -339,12 +340,14 @@ class Swift extends Language
             self::TYPE_STRING => 'String',
             self::TYPE_FILE => 'InputFile',
             self::TYPE_BOOLEAN => 'Bool',
-            // A union or untyped element has no Swift spelling, so the whole
-            // array degrades to AnyCodable rather than each element being
-            // rendered as a dictionary.
+            // A union, untyped element, or generic object has no concrete
+            // Codable type, so the array uses AnyCodable.
             self::TYPE_ARRAY => match (true) {
                 $this->isUntypedNestedArray($parameter, $schema) => '[[AnyCodable]]',
-                $this->hasConcreteItemsType($schema) => '[' . $this->getTypeName($this->getArraySchema($parameter) ?? $schema, $spec) . ']',
+                $items instanceof Schema
+                    && $this->getSchemaType($items) === self::TYPE_OBJECT
+                    && $this->getSchemaModel($items) === null => '[AnyCodable]',
+                $this->hasConcreteItemsType($schema) => '[' . $this->getTypeName($items ?? $schema, $spec) . ']',
                 default => '[AnyCodable]',
             },
             self::TYPE_OBJECT => $isProperty ? '[String: AnyCodable]' : 'Any',

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -167,7 +167,7 @@ class SDK
         $this->twig->addFilter(new TwigFilter('schemaModel', fn(Schema|Parameter $value): string => $this->getSchemaModel($value)));
         $this->twig->addFilter(new TwigFilter('schemaModels', fn(Schema|Parameter $value): array => $this->getSchemaModels($value)));
         $this->twig->addFilter(new TwigFilter('schemaRequired', fn(Schema|Parameter $value): bool => $value instanceof Parameter ? $value->required : isset($this->requiredSchemas[\spl_object_id($value)])));
-        $this->twig->addFilter(new TwigFilter('schemaExample', fn(Schema|Parameter $value): mixed => $this->getSchema($value)->extensions['x-example'] ?? $this->getSchema($value)->example));
+        $this->twig->addFilter(new TwigFilter('schemaExample', fn(Schema|Parameter $value): mixed => $this->getSchema($value)->example));
         $this->twig->addFilter(new TwigFilter('schemaDefault', fn(Schema|Parameter $value): mixed => $this->getSchema($value)->default));
         $this->twig->addFilter(new TwigFilter('enumName', fn(Schema|Parameter $value): string => $this->getEnumName($value)));
         $this->twig->addFilter(new TwigFilter('enumKeys', fn(Schema|Parameter $value): array => $this->getEnumKeys($value)));

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -137,7 +137,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "x-example": "[REQUIRED]"
+              "example": "[REQUIRED]"
             }
           },
           {
@@ -223,19 +223,17 @@
                     "type": "string",
                     "description": "Sample string param",
                     "default": null,
-                    "x-example": "[REQUIRED]"
+                    "example": "[REQUIRED]"
                   },
                   "default": {
                     "type": "integer",
                     "description": "Sample numeric param",
-                    "default": null,
-                    "x-example": null
+                    "default": null
                   },
                   "z": {
                     "type": "array",
                     "description": "Sample array param",
                     "default": null,
-                    "x-example": null,
                     "items": {
                       "type": "string"
                     }
@@ -310,19 +308,17 @@
                     "type": "string",
                     "description": "Sample string param",
                     "default": null,
-                    "x-example": "[REQUIRED]"
+                    "example": "[REQUIRED]"
                   },
                   "default": {
                     "type": "integer",
                     "description": "Sample numeric param",
-                    "default": null,
-                    "x-example": null
+                    "default": null
                   },
                   "z": {
                     "type": "array",
                     "description": "Sample array param",
                     "default": null,
-                    "x-example": null,
                     "items": {
                       "type": "string"
                     }
@@ -397,19 +393,17 @@
                     "type": "string",
                     "description": "Sample string param",
                     "default": null,
-                    "x-example": "[REQUIRED]"
+                    "example": "[REQUIRED]"
                   },
                   "default": {
                     "type": "integer",
                     "description": "Sample numeric param",
-                    "default": null,
-                    "x-example": null
+                    "default": null
                   },
                   "z": {
                     "type": "array",
                     "description": "Sample array param",
                     "default": null,
-                    "x-example": null,
                     "items": {
                       "type": "string"
                     }
@@ -484,19 +478,17 @@
                     "type": "string",
                     "description": "Sample string param",
                     "default": null,
-                    "x-example": "[REQUIRED]"
+                    "example": "[REQUIRED]"
                   },
                   "default": {
                     "type": "integer",
                     "description": "Sample numeric param",
-                    "default": null,
-                    "x-example": null
+                    "default": null
                   },
                   "z": {
                     "type": "array",
                     "description": "Sample array param",
                     "default": null,
-                    "x-example": null,
                     "items": {
                       "type": "string"
                     }
@@ -798,7 +790,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "x-example": "[]"
+              "example": "[]"
             }
           },
           {
@@ -884,19 +876,17 @@
                     "type": "string",
                     "description": "Sample string param",
                     "default": null,
-                    "x-example": "[]"
+                    "example": "[]"
                   },
                   "y": {
                     "type": "integer",
                     "description": "Sample numeric param",
-                    "default": null,
-                    "x-example": null
+                    "default": null
                   },
                   "z": {
                     "type": "array",
                     "description": "Sample array param",
                     "default": null,
-                    "x-example": null,
                     "items": {
                       "type": "string"
                     }
@@ -971,19 +961,17 @@
                     "type": "string",
                     "description": "Sample string param",
                     "default": null,
-                    "x-example": "[]"
+                    "example": "[]"
                   },
                   "y": {
                     "type": "integer",
                     "description": "Sample numeric param",
-                    "default": null,
-                    "x-example": null
+                    "default": null
                   },
                   "z": {
                     "type": "array",
                     "description": "Sample array param",
                     "default": null,
-                    "x-example": null,
                     "items": {
                       "type": "string"
                     }
@@ -1058,19 +1046,17 @@
                     "type": "string",
                     "description": "Sample string param",
                     "default": null,
-                    "x-example": "[]"
+                    "example": "[]"
                   },
                   "y": {
                     "type": "integer",
                     "description": "Sample numeric param",
-                    "default": null,
-                    "x-example": null
+                    "default": null
                   },
                   "z": {
                     "type": "array",
                     "description": "Sample array param",
                     "default": null,
-                    "x-example": null,
                     "items": {
                       "type": "string"
                     }
@@ -1145,19 +1131,17 @@
                     "type": "string",
                     "description": "Sample string param",
                     "default": null,
-                    "x-example": "[]"
+                    "example": "[]"
                   },
                   "y": {
                     "type": "integer",
                     "description": "Sample numeric param",
-                    "default": null,
-                    "x-example": null
+                    "default": null
                   },
                   "z": {
                     "type": "array",
                     "description": "Sample array param",
                     "default": null,
-                    "x-example": null,
                     "items": {
                       "type": "string"
                     }
@@ -1562,7 +1546,7 @@
                     "type": "string",
                     "description": "Sample string param",
                     "default": null,
-                    "x-example": "first",
+                    "example": "first",
                     "enum": [
                       "first",
                       "second",
@@ -1743,27 +1727,27 @@
                     "type": "string",
                     "description": "Sample string param",
                     "default": null,
-                    "x-example": "[REQUIRED]"
+                    "example": "[REQUIRED]"
                   },
                   "nullable": {
                     "type": "string",
                     "description": "Sample string param",
                     "default": null,
-                    "x-example": "[NULLABLE]",
-                    "x-nullable": true
+                    "example": "[NULLABLE]",
+                    "nullable": true
                   },
                   "optionalNullable": {
                     "type": "string",
                     "description": "Optional nullable string param",
                     "default": null,
-                    "x-example": "[OPTIONAL_NULLABLE]",
-                    "x-nullable": true
+                    "example": "[OPTIONAL_NULLABLE]",
+                    "nullable": true
                   },
                   "optional": {
                     "type": "string",
                     "description": "Sample string param",
                     "default": "",
-                    "x-example": "[OPTIONAL]"
+                    "example": "[OPTIONAL]"
                   }
                 },
                 "required": [
@@ -1863,7 +1847,10 @@
                   "headers": {
                     "type": "object",
                     "description": "HTTP headers of execution. Defaults to empty.",
-                    "default": null
+                    "default": null,
+                    "example": {
+                      "Content-Type": "application\/json"
+                    }
                   },
                   "scheduledAt": {
                     "type": "string",
@@ -2035,7 +2022,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "x-example": "grant\/special&id"
+              "example": "grant\/special&id"
             }
           }
         ]
@@ -2152,7 +2139,7 @@
                   "x": {
                     "description": "Sample string param",
                     "type": "string",
-                    "x-example": "[]"
+                    "example": "[]"
                   },
                   "y": {
                     "description": "Sample numeric param",
@@ -2238,7 +2225,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "x-example": "12345"
+              "example": "12345"
             }
           },
           {
@@ -2251,7 +2238,7 @@
               "items": {
                 "type": "string"
               },
-              "x-example": "[]"
+              "example": []
             }
           },
           {
@@ -2261,7 +2248,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "x-example": "state"
+              "example": "state"
             }
           },
           {
@@ -2271,7 +2258,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "x-example": "http:\/\/localhost:8000\/auth\/callback"
+              "example": "http:\/\/localhost:8000\/auth\/callback"
             }
           },
           {
@@ -2281,7 +2268,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "x-example": "http:\/\/localhost:8000\/auth\/callback"
+              "example": "http:\/\/localhost:8000\/auth\/callback"
             }
           }
         ]
@@ -2358,7 +2345,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "x-example": "mock",
+              "example": "mock",
               "default": "mock"
             }
           }
@@ -2584,22 +2571,22 @@
           "message": {
             "type": "string",
             "description": "Error message.",
-            "x-example": "Not found"
+            "example": "Not found"
           },
           "code": {
             "type": "string",
             "description": "Error code.",
-            "x-example": "404"
+            "example": "404"
           },
           "type": {
             "type": "string",
             "description": "Error type. You can learn more about all the error types at https:\/\/appwrite.io\/docs\/error-codes#errorTypes",
-            "x-example": "not_found"
+            "example": "not_found"
           },
           "version": {
             "type": "string",
             "description": "Server version number.",
-            "x-example": "1.0"
+            "example": "1.0"
           }
         },
         "required": [
@@ -2616,18 +2603,17 @@
           "result": {
             "type": "string",
             "description": "Result message.",
-            "x-example": "Success"
+            "example": "Success"
           },
           "optionalResult": {
             "type": "string",
             "description": "Optional result message.",
-            "default": null,
-            "x-example": null
+            "default": null
           },
           "status": {
             "type": "string",
             "description": "Mock status. Possible values are \"active\", \"inactive\", \"pending\", \"completed\", or \"cancelled\". Reflects the mock's state.",
-            "x-example": "active",
+            "example": "active",
             "enum": [
               "active",
               "inactive",
@@ -2640,7 +2626,6 @@
           "relatedMock": {
             "type": "object",
             "description": "Optional nested mock.",
-            "x-example": null,
             "$ref": "#\/components\/schemas\/unionMock"
           }
         },
@@ -2655,12 +2640,12 @@
           "type": {
             "type": "string",
             "description": "Mock type.",
-            "x-example": "mock"
+            "example": "mock"
           },
           "result": {
             "type": "string",
             "description": "Result message.",
-            "x-example": "Success"
+            "example": "Success"
           }
         },
         "required": [
@@ -2676,17 +2661,17 @@
           "id": {
             "type": "string",
             "description": "Player ID.",
-            "x-example": "player123"
+            "example": "player123"
           },
           "name": {
             "type": "string",
             "description": "Player name.",
-            "x-example": "John Doe"
+            "example": "John Doe"
           },
           "score": {
             "type": "integer",
             "description": "Player score.",
-            "x-example": 100
+            "example": 100
           }
         },
         "required": [
@@ -2703,7 +2688,7 @@
           "message": {
             "type": "string",
             "description": "Excluded payload message.",
-            "x-example": "should-not-be-generated"
+            "example": "should-not-be-generated"
           },
           "children": {
             "type": "array",
@@ -2725,7 +2710,7 @@
           "state": {
             "type": "string",
             "description": "Excluded child status.",
-            "x-example": "sleeping",
+            "example": "sleeping",
             "enum": [
               "sleeping",
               "active"
@@ -2744,12 +2729,12 @@
           "result": {
             "type": "string",
             "description": "Excluded result message.",
-            "x-example": "excluded"
+            "example": "excluded"
           },
           "status": {
             "type": "string",
             "description": "Excluded result status.",
-            "x-example": "queued",
+            "example": "queued",
             "enum": [
               "queued",
               "done"
@@ -2770,7 +2755,7 @@
           "message": {
             "type": "string",
             "description": "Excluded method payload message.",
-            "x-example": "should-not-be-generated"
+            "example": "should-not-be-generated"
           }
         },
         "required": [
@@ -2784,12 +2769,12 @@
           "result": {
             "type": "string",
             "description": "Excluded method result message.",
-            "x-example": "excluded-method"
+            "example": "excluded-method"
           },
           "status": {
             "type": "string",
             "description": "Excluded method result status.",
-            "x-example": "pending",
+            "example": "pending",
             "enum": [
               "pending",
               "finished"
@@ -2810,12 +2795,12 @@
           "data": {
             "type": "string",
             "description": "Stub data.",
-            "x-example": "test-data"
+            "example": "test-data"
           },
           "type": {
             "type": "string",
             "description": "Stub type.",
-            "x-example": "testing"
+            "example": "testing"
           }
         },
         "required": [
@@ -2830,7 +2815,6 @@
           "mock": {
             "type": "object",
             "description": "Nested mock resolved through allOf.",
-            "x-example": null,
             "allOf": [
               {
                 "$ref": "#\/components\/schemas\/mock"
@@ -2840,7 +2824,6 @@
           "options": {
             "type": "object",
             "description": "Union of mock or stub.",
-            "x-example": null,
             "allOf": [
               {
                 "oneOf": [
@@ -2864,7 +2847,6 @@
           "entries": {
             "type": "array",
             "description": "List of mock or stub entries.",
-            "x-example": null,
             "items": {
               "anyOf": [
                 {
@@ -2879,7 +2861,6 @@
           "legacyOptions": {
             "type": "object",
             "description": "Union of mock or stub resolved through legacy items.",
-            "x-example": null,
             "items": {
               "oneOf": [
                 {
@@ -2894,7 +2875,6 @@
           "legacyMock": {
             "type": "object",
             "description": "Nested mock resolved through legacy items.",
-            "x-example": null,
             "items": {
               "$ref": "#\/components\/schemas\/mock"
             }
@@ -2902,7 +2882,6 @@
           "mocks": {
             "type": "array",
             "description": "List of mocks.",
-            "x-example": null,
             "items": {
               "$ref": "#\/components\/schemas\/mock"
             }

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -2627,6 +2627,19 @@
             "type": "object",
             "description": "Optional nested mock.",
             "$ref": "#\/components\/schemas\/unionMock"
+          },
+          "metadataList": {
+            "type": "array",
+            "description": "Optional generic object collection.",
+            "example": [
+              {
+                "enabled": true
+              }
+            ],
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
           }
         },
         "required": [


### PR DESCRIPTION
## What does this PR do?

Updates SDK Generator to consume official OpenAPI schema fields:

- `example` instead of the Appwrite-specific `x-example` extension
- `nullable` instead of `x-nullable` in the OpenAPI 3 test fixture

The `x-example` fallback has been intentionally removed from both parameter/example formatting and the `schemaExample` Twig filter. Structured OpenAPI examples are serialized at the common language boundary so native arrays and objects continue to render correctly across existing language formatters.

The fixture now uses typed examples, omits empty `example: null` fields, and contains no `x-example` or `x-nullable` occurrences.

The standard-field specs are published in appwrite/specs#96 and appwrite/specs#97. Producer work: appwrite/appwrite#13274, appwrite/appwrite#13276, and appwrite/appwrite#13279; Cloud integration: appwrite-labs/cloud#5374.

## Validation

- `composer refactor:check`
- `composer lint-twig`
- `vendor/bin/phpcs src/SDK/Language.php src/SDK/SDK.php`
- `vendor/bin/phpunit tests/e2e/PHP83Test.php` — 1,401 assertions
- `vendor/bin/phpunit tests/e2e/Node20Test.php` — 1,342 assertions
- Confirmed no `x-example` or `x-nullable` occurrences remain in `src/` or the OpenAPI 3 fixture
