### PR TITLE
feat: accept any string for open enum parameters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "ext-mbstring": "*",
         "matthiasmullie/minify": "^1.3",
         "twig/twig": "^3.28",
-        "utopia-php/openapi": "^0.1.2"
+        "utopia-php/openapi": "^0.1.5"
     },
     "require-dev": {
         "brianium/paratest": "^7",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "ext-mbstring": "*",
         "matthiasmullie/minify": "^1.3",
         "twig/twig": "^3.28",
-        "utopia-php/openapi": "0.1.*"
+        "utopia-php/openapi": "^0.1.2"
     },
     "require-dev": {
         "brianium/paratest": "^7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03af878319ef34dee55c3ff1f1cf5fa0",
+    "content-hash": "837123e7c0aaf92769a4d8df1ee833a7",
     "packages": [
         {
             "name": "matthiasmullie/minify",
@@ -450,16 +450,16 @@
         },
         {
             "name": "utopia-php/openapi",
-            "version": "0.1.1",
+            "version": "0.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/openapi.git",
-                "reference": "cb7367ee701dbfdc74b64c6906c55c5d37ba6392"
+                "reference": "84115cc9c27bce02226b15fa3c290a643bb1420a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/openapi/zipball/cb7367ee701dbfdc74b64c6906c55c5d37ba6392",
-                "reference": "cb7367ee701dbfdc74b64c6906c55c5d37ba6392",
+                "url": "https://api.github.com/repos/utopia-php/openapi/zipball/84115cc9c27bce02226b15fa3c290a643bb1420a",
+                "reference": "84115cc9c27bce02226b15fa3c290a643bb1420a",
                 "shasum": ""
             },
             "require": {
@@ -484,9 +484,9 @@
             "description": "Framework-independent OpenAPI 2.0, 3.0, and 3.1 parser with an immutable canonical model",
             "support": {
                 "issues": "https://github.com/utopia-php/openapi/issues",
-                "source": "https://github.com/utopia-php/openapi/tree/0.1.1"
+                "source": "https://github.com/utopia-php/openapi/tree/0.1.2"
             },
-            "time": "2026-08-19T07:16:25+00:00"
+            "time": "2026-08-20T13:35:16+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "837123e7c0aaf92769a4d8df1ee833a7",
+    "content-hash": "578f4ddd64ed054a59d185234f6507d8",
     "packages": [
         {
             "name": "matthiasmullie/minify",
@@ -450,16 +450,16 @@
         },
         {
             "name": "utopia-php/openapi",
-            "version": "0.1.2",
+            "version": "0.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/openapi.git",
-                "reference": "84115cc9c27bce02226b15fa3c290a643bb1420a"
+                "reference": "0d9588967cd58f79a21467b0732402d2e257b0f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/openapi/zipball/84115cc9c27bce02226b15fa3c290a643bb1420a",
-                "reference": "84115cc9c27bce02226b15fa3c290a643bb1420a",
+                "url": "https://api.github.com/repos/utopia-php/openapi/zipball/0d9588967cd58f79a21467b0732402d2e257b0f0",
+                "reference": "0d9588967cd58f79a21467b0732402d2e257b0f0",
                 "shasum": ""
             },
             "require": {
@@ -484,9 +484,9 @@
             "description": "Framework-independent OpenAPI 2.0, 3.0, and 3.1 parser with an immutable canonical model",
             "support": {
                 "issues": "https://github.com/utopia-php/openapi/issues",
-                "source": "https://github.com/utopia-php/openapi/tree/0.1.2"
+                "source": "https://github.com/utopia-php/openapi/tree/0.1.5"
             },
-            "time": "2026-08-20T13:35:16+00:00"
+            "time": "2026-08-20T16:03:31+00:00"
         }
     ],
     "packages-dev": [

--- a/src/SDK/Language.php
+++ b/src/SDK/Language.php
@@ -263,7 +263,8 @@ abstract class Language
 
         return match (true) {
             $schema instanceof StringSchema && $schema->format === 'binary' => self::TYPE_FILE,
-            $schema instanceof StringSchema => self::TYPE_STRING,
+            $schema instanceof StringSchema,
+            $schema instanceof CompositeSchema && $schema->openStringEnumBranch() instanceof StringSchema => self::TYPE_STRING,
             $schema instanceof IntegerSchema => self::TYPE_INTEGER,
             $schema instanceof NumberSchema => self::TYPE_NUMBER,
             $schema instanceof BooleanSchema => self::TYPE_BOOLEAN,
@@ -333,8 +334,8 @@ abstract class Language
             return false;
         }
         $items = $schema->items;
-        return !($items instanceof CompositeSchema)
-            && !($items instanceof AnySchema)
+        return !($items instanceof AnySchema)
+            && (!($items instanceof CompositeSchema) || $items->openStringEnumBranch() instanceof StringSchema)
             && $this->getSchemaType($items) !== '';
     }
 
@@ -353,10 +354,19 @@ abstract class Language
             && $schema->items instanceof ArraySchema;
     }
 
-    protected function getSchemaEnumName(Schema|Parameter $value, ?Specification $spec = null): string
+    protected function getEnumSchema(Schema|Parameter $value): Schema
     {
         $schema = $this->getSchema($value);
         $enumSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
+
+        return $enumSchema instanceof CompositeSchema
+            ? ($enumSchema->openStringEnumBranch() ?? $enumSchema)
+            : $enumSchema;
+    }
+
+    protected function getSchemaEnumName(Schema|Parameter $value, ?Specification $spec = null): string
+    {
+        $enumSchema = $this->getEnumSchema($value);
         $name = $enumSchema->extensions['x-enum-name']
             ?? $enumSchema->title
             ?? ($value instanceof Parameter ? $value->name : null);
@@ -369,8 +379,7 @@ abstract class Language
                 continue;
             }
             foreach ($model->properties as $propertyName => $property) {
-                $propertySchema = $property instanceof ArraySchema ? $property->items : $property;
-                if ($propertySchema === $enumSchema) {
+                if ($this->getEnumSchema($property) === $enumSchema) {
                     return \ucfirst($modelName) . \ucfirst($propertyName);
                 }
             }

--- a/src/SDK/Language.php
+++ b/src/SDK/Language.php
@@ -134,6 +134,14 @@ abstract class Language
     }
 
     /**
+     * Whether method signatures keep the documented enum as a type for open string enums.
+     */
+    public function keepsOpenEnumType(): bool
+    {
+        return false;
+    }
+
+    /**
      * Language specific functions.
      */
     public function getFunctions(): array
@@ -264,7 +272,7 @@ abstract class Language
         return match (true) {
             $schema instanceof StringSchema && $schema->format === 'binary' => self::TYPE_FILE,
             $schema instanceof StringSchema,
-            $schema instanceof CompositeSchema && $schema->openStringEnumBranch() instanceof StringSchema => self::TYPE_STRING,
+            $schema instanceof CompositeSchema && $this->isOpenStringEnum($schema) => self::TYPE_STRING,
             $schema instanceof IntegerSchema => self::TYPE_INTEGER,
             $schema instanceof NumberSchema => self::TYPE_NUMBER,
             $schema instanceof BooleanSchema => self::TYPE_BOOLEAN,
@@ -335,7 +343,7 @@ abstract class Language
         }
         $items = $schema->items;
         return !($items instanceof AnySchema)
-            && (!($items instanceof CompositeSchema) || $items->openStringEnumBranch() instanceof StringSchema)
+            && (!($items instanceof CompositeSchema) || $this->isOpenStringEnum($items))
             && $this->getSchemaType($items) !== '';
     }
 
@@ -354,7 +362,7 @@ abstract class Language
             && $schema->items instanceof ArraySchema;
     }
 
-    protected function getEnumSchema(Schema|Parameter $value): Schema
+    public function getEnumSchema(Schema|Parameter $value): Schema
     {
         $schema = $this->getSchema($value);
         $enumSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
@@ -362,6 +370,13 @@ abstract class Language
         return $enumSchema instanceof CompositeSchema
             ? ($enumSchema->openStringEnumBranch() ?? $enumSchema)
             : $enumSchema;
+    }
+
+    public function isOpenStringEnum(Schema|Parameter $value): bool
+    {
+        $enumSchema = $this->getEnumSchema($value);
+
+        return $enumSchema instanceof StringSchema && $enumSchema->open;
     }
 
     protected function getSchemaEnumName(Schema|Parameter $value, ?Specification $spec = null): string

--- a/src/SDK/Language.php
+++ b/src/SDK/Language.php
@@ -367,7 +367,7 @@ abstract class Language
     protected function getSchemaEnumName(Schema|Parameter $value, ?Specification $spec = null): string
     {
         $enumSchema = $this->getEnumSchema($value);
-        $name = $enumSchema->extensions['x-enum-name']
+        $name = ($enumSchema instanceof StringSchema ? $enumSchema->enumName : null)
             ?? $enumSchema->title
             ?? ($value instanceof Parameter ? $value->name : null);
         if (\is_string($name) && $name !== '') {

--- a/src/SDK/Language/Dart.php
+++ b/src/SDK/Language/Dart.php
@@ -5,6 +5,7 @@ namespace Appwrite\SDK\Language;
 use Utopia\OpenAPI\Model\ArraySchema;
 use Utopia\OpenAPI\Model\Parameter;
 use Utopia\OpenAPI\Model\Schema;
+use Utopia\OpenAPI\Model\StringSchema;
 use Utopia\OpenAPI\Specification;
 use Override;
 use Appwrite\SDK\Language;
@@ -566,8 +567,8 @@ class Dart extends Language
                     return '';
                 }
 
-                $enumKeys = $enumSchema->extensions['x-enum-keys'] ?? [];
-                $enumName = $this->toCamelCase($enumSchema->extensions['x-enum-name'] ?? ($param instanceof Parameter ? $param->name : $enumSchema->title ?? ''));
+                $enumKeys = $enumSchema instanceof StringSchema ? $enumSchema->enumKeys : [];
+                $enumName = $this->toCamelCase(($enumSchema instanceof StringSchema ? $enumSchema->enumName : null) ?? ($param instanceof Parameter ? $param->name : $enumSchema->title ?? ''));
                 $example = $this->getSchemaExample($param);
                 $isArray = $schema instanceof ArraySchema;
 

--- a/src/SDK/Language/Dart.php
+++ b/src/SDK/Language/Dart.php
@@ -561,7 +561,7 @@ class Dart extends Language
             new TwigFilter('trimLines', fn(string $value): string => preg_replace('/[ \t]+$/m', '', $value) ?? $value),
             new TwigFilter('enumExample', function (Schema|Parameter $param): string {
                 $schema = $this->getSchema($param);
-                $enumSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
+                $enumSchema = $this->getEnumSchema($param);
                 $enumValues = $enumSchema->enum;
                 if ($enumValues === []) {
                     return '';

--- a/src/SDK/Language/Deno.php
+++ b/src/SDK/Language/Deno.php
@@ -3,10 +3,8 @@
 namespace Appwrite\SDK\Language;
 
 use Utopia\OpenAPI\Model\ArraySchema;
-use Utopia\OpenAPI\Model\CompositeSchema;
 use Utopia\OpenAPI\Model\Parameter;
 use Utopia\OpenAPI\Model\Schema;
-use Utopia\OpenAPI\Model\StringSchema;
 use Utopia\OpenAPI\Specification;
 use Override;
 
@@ -157,15 +155,8 @@ class Deno extends JS
     public function getTypeName(Schema|Parameter $parameter, ?Specification $spec = null): string
     {
         $schema = $this->getSchema($parameter);
-        $valueSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
-        $enumSchema = $this->getEnumSchema($parameter);
-        if ($enumSchema->enum !== []) {
-            $type = $this->toPascalCase($this->getSchemaEnumName($parameter, $spec));
-            if ($valueSchema instanceof CompositeSchema && $valueSchema->openStringEnumBranch() instanceof StringSchema) {
-                $type = '(' . $type . ' | (string & {}))';
-            }
-
-            return $schema instanceof ArraySchema ? $type . '[]' : $type;
+        if (($type = $this->getEnumTypeName($parameter, $spec)) !== null) {
+            return $type;
         }
 
         $model = $this->getSchemaModel($parameter);

--- a/src/SDK/Language/Deno.php
+++ b/src/SDK/Language/Deno.php
@@ -3,8 +3,10 @@
 namespace Appwrite\SDK\Language;
 
 use Utopia\OpenAPI\Model\ArraySchema;
+use Utopia\OpenAPI\Model\CompositeSchema;
 use Utopia\OpenAPI\Model\Parameter;
 use Utopia\OpenAPI\Model\Schema;
+use Utopia\OpenAPI\Model\StringSchema;
 use Utopia\OpenAPI\Specification;
 use Override;
 
@@ -155,6 +157,17 @@ class Deno extends JS
     public function getTypeName(Schema|Parameter $parameter, ?Specification $spec = null): string
     {
         $schema = $this->getSchema($parameter);
+        $valueSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
+        $enumSchema = $this->getEnumSchema($parameter);
+        if ($enumSchema->enum !== []) {
+            $type = $this->toPascalCase($this->getSchemaEnumName($parameter, $spec));
+            if ($valueSchema instanceof CompositeSchema && $valueSchema->openStringEnumBranch() instanceof StringSchema) {
+                $type = '(' . $type . ' | (string & {}))';
+            }
+
+            return $schema instanceof ArraySchema ? $type . '[]' : $type;
+        }
+
         $model = $this->getSchemaModel($parameter);
         if ($model !== null) {
             $type = $this->toPascalCase($model);

--- a/src/SDK/Language/DotNet.php
+++ b/src/SDK/Language/DotNet.php
@@ -5,6 +5,7 @@ namespace Appwrite\SDK\Language;
 use Utopia\OpenAPI\Model\ArraySchema;
 use Utopia\OpenAPI\Model\Parameter;
 use Utopia\OpenAPI\Model\Schema;
+use Utopia\OpenAPI\Model\StringSchema;
 use Utopia\OpenAPI\Specification;
 use Override;
 use Appwrite\SDK\Language;
@@ -500,8 +501,8 @@ class DotNet extends Language
                     return '';
                 }
 
-                $enumKeys = $enumSchema->extensions['x-enum-keys'] ?? [];
-                $enumName = $this->toPascalCase($enumSchema->extensions['x-enum-name'] ?? ($param instanceof Parameter ? $param->name : $enumSchema->title ?? ''));
+                $enumKeys = $enumSchema instanceof StringSchema ? $enumSchema->enumKeys : [];
+                $enumName = $this->toPascalCase(($enumSchema instanceof StringSchema ? $enumSchema->enumName : null) ?? ($param instanceof Parameter ? $param->name : $enumSchema->title ?? ''));
                 $example = $this->getSchemaExample($param);
                 $isArray = $schema instanceof ArraySchema;
 

--- a/src/SDK/Language/DotNet.php
+++ b/src/SDK/Language/DotNet.php
@@ -495,7 +495,7 @@ class DotNet extends Language
             new TwigFilter('toMapValue', fn(Schema $property, string $resolvedName, Specification $spec): string => $this->getToMapExpression($property, $resolvedName, $spec), ['is_safe' => ['html']]),
             new TwigFilter('enumExample', function (Schema|Parameter $param): string {
                 $schema = $this->getSchema($param);
-                $enumSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
+                $enumSchema = $this->getEnumSchema($param);
                 $enumValues = $enumSchema->enum;
                 if ($enumValues === []) {
                     return '';

--- a/src/SDK/Language/JS.php
+++ b/src/SDK/Language/JS.php
@@ -189,6 +189,28 @@ abstract class JS extends Language
     }
 
     #[Override]
+    public function keepsOpenEnumType(): bool
+    {
+        return true;
+    }
+
+    protected function getEnumTypeName(Schema|Parameter $parameter, ?Specification $spec = null): ?string
+    {
+        $schema = $this->getSchema($parameter);
+        $enumSchema = $this->getEnumSchema($parameter);
+        if ($enumSchema->enum === []) {
+            return null;
+        }
+
+        $type = $this->toPascalCase($this->getSchemaEnumName($parameter, $spec));
+        if ($this->isOpenStringEnum($parameter)) {
+            $type = '(' . $type . ' | (string & {}))';
+        }
+
+        return $schema instanceof ArraySchema ? $type . '[]' : $type;
+    }
+
+    #[Override]
     public function getFilters(): array
     {
         return [

--- a/src/SDK/Language/JS.php
+++ b/src/SDK/Language/JS.php
@@ -5,6 +5,7 @@ namespace Appwrite\SDK\Language;
 use Utopia\OpenAPI\Model\ArraySchema;
 use Utopia\OpenAPI\Model\Parameter;
 use Utopia\OpenAPI\Model\Schema;
+use Utopia\OpenAPI\Model\StringSchema;
 use Utopia\OpenAPI\Specification;
 use Override;
 use Appwrite\SDK\Language;
@@ -200,8 +201,8 @@ abstract class JS extends Language
                     return '';
                 }
 
-                $enumKeys = $enumSchema->extensions['x-enum-keys'] ?? [];
-                $enumName = $this->toPascalCase($enumSchema->extensions['x-enum-name'] ?? ($param instanceof Parameter ? $param->name : $enumSchema->title ?? ''));
+                $enumKeys = $enumSchema instanceof StringSchema ? $enumSchema->enumKeys : [];
+                $enumName = $this->toPascalCase(($enumSchema instanceof StringSchema ? $enumSchema->enumName : null) ?? ($param instanceof Parameter ? $param->name : $enumSchema->title ?? ''));
                 $example = $this->getSchemaExample($param);
                 $isArray = $schema instanceof ArraySchema;
                 $prefix = $this->getPermissionPrefix();

--- a/src/SDK/Language/JS.php
+++ b/src/SDK/Language/JS.php
@@ -194,7 +194,7 @@ abstract class JS extends Language
             new TwigFilter('caseEnumKey', fn(string $value): string => $this->toPascalCase($value)),
             new TwigFilter('enumExample', function (Schema|Parameter $param): string {
                 $schema = $this->getSchema($param);
-                $enumSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
+                $enumSchema = $this->getEnumSchema($param);
                 $enumValues = $enumSchema->enum;
                 if ($enumValues === []) {
                     return '';

--- a/src/SDK/Language/Kotlin.php
+++ b/src/SDK/Language/Kotlin.php
@@ -7,6 +7,7 @@ use Utopia\OpenAPI\Model\ObjectSchema;
 use Utopia\OpenAPI\Model\Operation;
 use Utopia\OpenAPI\Model\Parameter;
 use Utopia\OpenAPI\Model\Schema;
+use Utopia\OpenAPI\Model\StringSchema;
 use Utopia\OpenAPI\Specification;
 use Override;
 use Appwrite\SDK\Language;
@@ -733,8 +734,8 @@ class Kotlin extends Language
             return '';
         }
 
-        $enumKeys = $enumSchema->extensions['x-enum-keys'] ?? [];
-        $enumName = $this->toPascalCase($enumSchema->extensions['x-enum-name'] ?? ($param instanceof Parameter ? $param->name : $enumSchema->title ?? ''));
+        $enumKeys = $enumSchema instanceof StringSchema ? $enumSchema->enumKeys : [];
+        $enumName = $this->toPascalCase(($enumSchema instanceof StringSchema ? $enumSchema->enumName : null) ?? ($param instanceof Parameter ? $param->name : $enumSchema->title ?? ''));
         $example = $this->getSchemaExample($param);
         $isArray = $schema instanceof ArraySchema;
 

--- a/src/SDK/Language/Kotlin.php
+++ b/src/SDK/Language/Kotlin.php
@@ -728,7 +728,7 @@ class Kotlin extends Language
     protected function getEnumExample(Schema|Parameter $param, string $lang = 'kotlin'): string
     {
         $schema = $this->getSchema($param);
-        $enumSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
+        $enumSchema = $this->getEnumSchema($param);
         $enumValues = $enumSchema->enum;
         if ($enumValues === []) {
             return '';

--- a/src/SDK/Language/PHP.php
+++ b/src/SDK/Language/PHP.php
@@ -7,6 +7,7 @@ use Utopia\OpenAPI\Model\ObjectSchema;
 use Utopia\OpenAPI\Model\Operation;
 use Utopia\OpenAPI\Model\Parameter;
 use Utopia\OpenAPI\Model\Schema;
+use Utopia\OpenAPI\Model\StringSchema;
 use Utopia\OpenAPI\Model\SecurityScheme;
 use Utopia\OpenAPI\Model\SecuritySchemeType;
 use Utopia\OpenAPI\Specification;
@@ -672,15 +673,15 @@ class PHP extends Language
                 }
 
                 $enumSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
-                $enumKeys = $enumSchema->extensions['x-enum-keys'] ?? [];
-                $enumName = $this->toPascalCase($enumSchema->extensions['x-enum-name'] ?? ($param instanceof Parameter ? $param->name : $enumSchema->title ?? ''));
+                $enumKeys = $enumSchema instanceof StringSchema ? $enumSchema->enumKeys : [];
+                $enumName = $this->toPascalCase(($enumSchema instanceof StringSchema ? $enumSchema->enumName : null) ?? ($param instanceof Parameter ? $param->name : $enumSchema->title ?? ''));
                 $example = $this->getSchemaExample($param);
                 $isArray = $schema instanceof ArraySchema;
 
                 $resolveKey = function ($value) use ($enumValues, $enumKeys): string {
                     $index = array_search($value, $enumValues, true);
                     if ($index !== false && isset($enumKeys[$index]) && $enumKeys[$index] !== '') {
-                        $cleaned = \preg_replace('/[^a-zA-Z0-9]/', '', (string) $enumKeys[$index]);
+                        $cleaned = \preg_replace('/[^a-zA-Z0-9]/', '', $enumKeys[$index]);
                         return $this->toUpperSnakeCase($cleaned);
                     }
                     if ($index !== false && isset($enumValues[$index])) {

--- a/src/SDK/Language/PHP.php
+++ b/src/SDK/Language/PHP.php
@@ -7,9 +7,9 @@ use Utopia\OpenAPI\Model\ObjectSchema;
 use Utopia\OpenAPI\Model\Operation;
 use Utopia\OpenAPI\Model\Parameter;
 use Utopia\OpenAPI\Model\Schema;
-use Utopia\OpenAPI\Model\StringSchema;
 use Utopia\OpenAPI\Model\SecurityScheme;
 use Utopia\OpenAPI\Model\SecuritySchemeType;
+use Utopia\OpenAPI\Model\StringSchema;
 use Utopia\OpenAPI\Specification;
 use Override;
 use Appwrite\SDK\Language;
@@ -667,12 +667,12 @@ class PHP extends Language
             ),
             new TwigFilter('enumExample', function (Schema|Parameter $param): string {
                 $schema = $this->getSchema($param);
-                $enumValues = $schema instanceof ArraySchema ? $schema->items->enum : $schema->enum;
+                $enumSchema = $this->getEnumSchema($param);
+                $enumValues = $enumSchema->enum;
                 if ($enumValues === []) {
                     return '';
                 }
 
-                $enumSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
                 $enumKeys = $enumSchema instanceof StringSchema ? $enumSchema->enumKeys : [];
                 $enumName = $this->toPascalCase(($enumSchema instanceof StringSchema ? $enumSchema->enumName : null) ?? ($param instanceof Parameter ? $param->name : $enumSchema->title ?? ''));
                 $example = $this->getSchemaExample($param);

--- a/src/SDK/Language/Python.php
+++ b/src/SDK/Language/Python.php
@@ -629,7 +629,7 @@ class Python extends Language
 
             $example = $this->getSchemaExample($property);
             $hasExample = $example !== null && $example !== '';
-            $enumValues = $property instanceof ArraySchema ? $property->items->enum : $property->enum;
+            $enumValues = $this->getEnumSchema($property)->enum;
             $result[$propertyName] = match ($this->getSchemaType($property)) {
                 self::TYPE_OBJECT => ($models = $this->getSchemaModels($property)) !== []
                     ? $this->getResponseModelExample($models[0], $spec, $visited)
@@ -732,7 +732,7 @@ class Python extends Language
             }),
             new TwigFilter('enumExample', function (Schema|Parameter $param): string {
                 $schema = $this->getSchema($param);
-                $enumSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
+                $enumSchema = $this->getEnumSchema($param);
                 $enumValues = $enumSchema->enum;
                 if ($enumValues === []) {
                     return '';

--- a/src/SDK/Language/Python.php
+++ b/src/SDK/Language/Python.php
@@ -7,6 +7,7 @@ use Utopia\OpenAPI\Model\ObjectSchema;
 use Utopia\OpenAPI\Model\Operation;
 use Utopia\OpenAPI\Model\Parameter;
 use Utopia\OpenAPI\Model\Schema;
+use Utopia\OpenAPI\Model\StringSchema;
 use Utopia\OpenAPI\Model\Tag;
 use Utopia\OpenAPI\Specification;
 use stdClass;
@@ -737,8 +738,8 @@ class Python extends Language
                     return '';
                 }
 
-                $enumKeys = $enumSchema->extensions['x-enum-keys'] ?? [];
-                $enumName = $this->toPascalCase($enumSchema->extensions['x-enum-name'] ?? ($param instanceof Parameter ? $param->name : $enumSchema->title ?? ''));
+                $enumKeys = $enumSchema instanceof StringSchema ? $enumSchema->enumKeys : [];
+                $enumName = $this->toPascalCase(($enumSchema instanceof StringSchema ? $enumSchema->enumName : null) ?? ($param instanceof Parameter ? $param->name : $enumSchema->title ?? ''));
                 $example = $this->getSchemaExample($param);
                 $isArray = $schema instanceof ArraySchema;
 

--- a/src/SDK/Language/Ruby.php
+++ b/src/SDK/Language/Ruby.php
@@ -5,6 +5,7 @@ namespace Appwrite\SDK\Language;
 use Utopia\OpenAPI\Model\ArraySchema;
 use Utopia\OpenAPI\Model\Parameter;
 use Utopia\OpenAPI\Model\Schema;
+use Utopia\OpenAPI\Model\StringSchema;
 use Utopia\OpenAPI\Specification;
 use Override;
 use Appwrite\SDK\Language;
@@ -391,8 +392,8 @@ class Ruby extends Language
                     return '';
                 }
 
-                $enumKeys = $enumSchema->extensions['x-enum-keys'] ?? [];
-                $enumName = $this->toPascalCase($enumSchema->extensions['x-enum-name'] ?? ($param instanceof Parameter ? $param->name : $enumSchema->title ?? ''));
+                $enumKeys = $enumSchema instanceof StringSchema ? $enumSchema->enumKeys : [];
+                $enumName = $this->toPascalCase(($enumSchema instanceof StringSchema ? $enumSchema->enumName : null) ?? ($param instanceof Parameter ? $param->name : $enumSchema->title ?? ''));
                 $example = $this->getSchemaExample($param);
                 $isArray = $schema instanceof ArraySchema;
 

--- a/src/SDK/Language/Ruby.php
+++ b/src/SDK/Language/Ruby.php
@@ -386,7 +386,7 @@ class Ruby extends Language
             new TwigFilter('caseEnumKey', fn(string $value): string => $this->toUpperSnakeCase($value)),
             new TwigFilter('enumExample', function (Schema|Parameter $param): string {
                 $schema = $this->getSchema($param);
-                $enumSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
+                $enumSchema = $this->getEnumSchema($param);
                 $enumValues = $enumSchema->enum;
                 if ($enumValues === []) {
                     return '';

--- a/src/SDK/Language/Rust.php
+++ b/src/SDK/Language/Rust.php
@@ -587,9 +587,9 @@ class Rust extends Language
                     if (isset($this->getIdentifierOverrides()[$value])) {
                         $value = $this->getIdentifierOverrides()[$value];
                     }
-                } elseif ($this->getSchema($param)->enum !== [] || ($this->getSchema($param) instanceof ArraySchema && $this->getSchema($param)->items->enum !== [])) {
+                } elseif ($this->getEnumSchema($param)->enum !== []) {
                     $schema = $this->getSchema($param);
-                    $enumSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
+                    $enumSchema = $this->getEnumSchema($param);
                     $enumName = $this->toPascalCase($this->getSchemaEnumName($param));
                     $example = $this->getSchemaExample($param) ?? $enumSchema->enum[0];
 

--- a/src/SDK/Language/Rust.php
+++ b/src/SDK/Language/Rust.php
@@ -6,6 +6,7 @@ use Utopia\OpenAPI\Model\ArraySchema;
 use Utopia\OpenAPI\Model\Operation;
 use Utopia\OpenAPI\Model\Parameter;
 use Utopia\OpenAPI\Model\Schema;
+use Utopia\OpenAPI\Model\StringSchema;
 use Utopia\OpenAPI\Specification;
 use Override;
 use Appwrite\SDK\Language;
@@ -602,7 +603,7 @@ class Rust extends Language
                         $members = \is_array($decoded) && $decoded !== [] ? $decoded : [$enumSchema->enum[0] ?? $example];
                     }
 
-                    $keys = $enumSchema->extensions['x-enum-keys'] ?? [];
+                    $keys = $enumSchema instanceof StringSchema ? $enumSchema->enumKeys : [];
                     $variants = [];
                     foreach ($members as $member) {
                         $index = \array_search($member, $enumSchema->enum, true);

--- a/src/SDK/Language/Swift.php
+++ b/src/SDK/Language/Swift.php
@@ -4,7 +4,6 @@ namespace Appwrite\SDK\Language;
 
 use Utopia\OpenAPI\Model\AnySchema;
 use Utopia\OpenAPI\Model\ArraySchema;
-use Utopia\OpenAPI\Model\CompositeSchema;
 use Utopia\OpenAPI\Model\ObjectSchema;
 use Utopia\OpenAPI\Model\Operation;
 use Utopia\OpenAPI\Model\Parameter;
@@ -588,7 +587,7 @@ class Swift extends Language
             }),
             new TwigFilter('enumExample', function (Schema|Parameter $param): string {
                 $schema = $this->getSchema($param);
-                $enumSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
+                $enumSchema = $this->getEnumSchema($param);
                 $enumValues = $enumSchema->enum;
                 if ($enumValues === []) {
                     return '';

--- a/src/SDK/Language/Swift.php
+++ b/src/SDK/Language/Swift.php
@@ -9,6 +9,7 @@ use Utopia\OpenAPI\Model\ObjectSchema;
 use Utopia\OpenAPI\Model\Operation;
 use Utopia\OpenAPI\Model\Parameter;
 use Utopia\OpenAPI\Model\Schema;
+use Utopia\OpenAPI\Model\StringSchema;
 use Utopia\OpenAPI\Specification;
 use Override;
 use Appwrite\SDK\Language;
@@ -593,7 +594,7 @@ class Swift extends Language
                     return '';
                 }
 
-                $enumKeys = $enumSchema->extensions['x-enum-keys'] ?? [];
+                $enumKeys = $enumSchema instanceof StringSchema ? $enumSchema->enumKeys : [];
                 $example = $this->getSchemaExample($param);
                 $isArray = $schema instanceof ArraySchema;
 

--- a/src/SDK/Language/Web.php
+++ b/src/SDK/Language/Web.php
@@ -2,10 +2,8 @@
 
 namespace Appwrite\SDK\Language;
 
-use Utopia\OpenAPI\Model\StringSchema;
 use InvalidArgumentException;
 use Utopia\OpenAPI\Model\ArraySchema;
-use Utopia\OpenAPI\Model\CompositeSchema;
 use Utopia\OpenAPI\Model\ObjectSchema;
 use Utopia\OpenAPI\Model\Operation;
 use Utopia\OpenAPI\Model\Parameter;
@@ -207,16 +205,8 @@ class Web extends JS
     public function getTypeName(Schema|Parameter $parameter, ?Specification $spec = null): string
     {
         $schema = $this->getSchema($parameter);
-        $valueSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
-        $enumSchema = $this->getEnumSchema($parameter);
-        if ($enumSchema->enum !== []) {
-            $type = $this->toPascalCase($this->getSchemaEnumName($parameter, $spec));
-            if ($valueSchema instanceof CompositeSchema && $valueSchema->openStringEnumBranch() instanceof StringSchema) {
-                // The intersection keeps enum completions without narrowing the strings the endpoint accepts.
-                $type = '(' . $type . ' | (string & {}))';
-            }
-
-            return $schema instanceof ArraySchema ? $type . '[]' : $type;
+        if (($type = $this->getEnumTypeName($parameter, $spec)) !== null) {
+            return $type;
         }
 
         $models = $this->getSchemaModels($parameter);

--- a/src/SDK/Language/Web.php
+++ b/src/SDK/Language/Web.php
@@ -2,8 +2,10 @@
 
 namespace Appwrite\SDK\Language;
 
+use Utopia\OpenAPI\Model\StringSchema;
 use InvalidArgumentException;
 use Utopia\OpenAPI\Model\ArraySchema;
+use Utopia\OpenAPI\Model\CompositeSchema;
 use Utopia\OpenAPI\Model\ObjectSchema;
 use Utopia\OpenAPI\Model\Operation;
 use Utopia\OpenAPI\Model\Parameter;
@@ -200,13 +202,20 @@ class Web extends JS
             self::TYPE_STRING => "'{$example}'",
         };
     }
+
     #[Override]
     public function getTypeName(Schema|Parameter $parameter, ?Specification $spec = null): string
     {
         $schema = $this->getSchema($parameter);
-        $enumSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
+        $valueSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
+        $enumSchema = $this->getEnumSchema($parameter);
         if ($enumSchema->enum !== []) {
             $type = $this->toPascalCase($this->getSchemaEnumName($parameter, $spec));
+            if ($valueSchema instanceof CompositeSchema && $valueSchema->openStringEnumBranch() instanceof StringSchema) {
+                // The intersection keeps enum completions without narrowing the strings the endpoint accepts.
+                $type = '(' . $type . ' | (string & {}))';
+            }
+
             return $schema instanceof ArraySchema ? $type . '[]' : $type;
         }
 

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\SDK;
 
+use Appwrite\SDK\Language\Web;
 use Utopia\OpenAPI\Model\AnySchema;
 use Utopia\OpenAPI\Model\ArraySchema;
 use Utopia\OpenAPI\Model\BooleanSchema;
@@ -183,10 +184,7 @@ class SDK
         $this->twig->addFilter(new TwigFilter('securityHeaders', fn(Operation $operation): array => $this->getOperationSecuritySchemes($operation, ParameterLocation::HEADER, false)));
         $this->twig->addFilter(new TwigFilter('securityQueries', fn(Operation $operation): array => $this->getOperationSecuritySchemes($operation, ParameterLocation::QUERY)));
         $this->twig->addFilter(new TwigFilter('schemaNullable', fn(Schema|Parameter $value): bool => !isset($this->multipartSchemas[\spl_object_id($this->getSchema($value))]) && $this->getSchema($value)->nullable));
-        $this->twig->addFilter(new TwigFilter('enumValues', function (Schema|Parameter $value): array {
-            $schema = $this->getSchema($value);
-            return $schema instanceof ArraySchema ? $schema->items->enum : $schema->enum;
-        }));
+        $this->twig->addFilter(new TwigFilter('enumValues', fn(Schema|Parameter $value): array => $this->getEnumSchema($value)->enum));
         $this->twig->addFilter(new TwigFilter('arraySchema', fn(Schema|Parameter $value): ?Schema => ($schema = $this->getSchema($value)) instanceof ArraySchema ? $schema->items : null));
         $this->twig->addFilter(new TwigFilter('emptyResponse', fn(Operation $operation): bool => \array_keys($operation->responses) === [204] || \array_keys($operation->responses) === ['204']));
         $this->twig->addFilter(new TwigFilter('fullPath', fn(Operation $operation): string => (\parse_url($this->spec->servers[0]->url ?? '', PHP_URL_PATH) ?: '') . $operation->path));
@@ -783,8 +781,7 @@ class SDK
         foreach ((array_keys($filteredServices ?? $this->getFilteredServices())) as $serviceName) {
             foreach ($this->getFilteredMethods($this->getMethods($serviceName), $serviceName) as $operation) {
                 foreach ($this->getOperationParameters($operation) as $parameter) {
-                    $schema = $this->getSchema($parameter);
-                    $enumSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
+                    $enumSchema = $this->getEnumSchema($parameter);
                     if ($enumSchema->enum !== []) {
                         $schemas[] = new StringSchema(
                             title: $this->getEnumName($parameter),
@@ -832,9 +829,9 @@ class SDK
                 continue;
             }
             foreach ($model->properties as $property) {
-                $schema = $property instanceof ArraySchema ? $property->items : $property;
-                if ($schema->enum !== []) {
-                    $enums[] = $schema;
+                $enumSchema = $this->getEnumSchema($property);
+                if ($enumSchema->enum !== []) {
+                    $enums[] = $enumSchema;
                 }
             }
         }
@@ -1535,12 +1532,23 @@ class SDK
         return $value instanceof Parameter ? ($value->schema ?? new AnySchema()) : $value;
     }
 
+    protected function getEnumSchema(Schema|Parameter $value): Schema
+    {
+        $schema = $this->getSchema($value);
+        $enumSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
+
+        return $enumSchema instanceof CompositeSchema && $this->language instanceof Web
+            ? ($enumSchema->openStringEnumBranch() ?? $enumSchema)
+            : $enumSchema;
+    }
+
     protected function getSchemaType(Schema|Parameter $value): string
     {
         $schema = $this->getSchema($value);
         return match (true) {
             $schema instanceof StringSchema && $schema->format === 'binary' => 'file',
-            $schema instanceof StringSchema => 'string',
+            $schema instanceof StringSchema,
+            $schema instanceof CompositeSchema && $schema->openStringEnumBranch() instanceof StringSchema => 'string',
             $schema instanceof IntegerSchema => 'integer',
             $schema instanceof NumberSchema => 'number',
             $schema instanceof BooleanSchema => 'boolean',
@@ -1625,8 +1633,7 @@ class SDK
 
     protected function getEnumName(Schema|Parameter $value): string
     {
-        $schema = $this->getSchema($value);
-        $enumSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
+        $enumSchema = $this->getEnumSchema($value);
         if ($enumSchema->enum === []) {
             return '';
         }
@@ -1638,7 +1645,7 @@ class SDK
 
     protected function getEnumKeys(Schema|Parameter $value): array
     {
-        return $this->getSchema($value)->extensions['x-enum-keys'] ?? [];
+        return $this->getEnumSchema($value)->extensions['x-enum-keys'] ?? [];
     }
 
     protected function normalizeSchemaReference(string $reference): string
@@ -1665,6 +1672,11 @@ class SDK
                     $this->schemaNames[$itemId] = $propertyName;
                     $this->schemaEnumNames[$itemId] = \ucfirst($modelName) . \ucfirst($propertyName);
                 }
+
+                $enumSchema = $this->getEnumSchema($property);
+                $enumId = \spl_object_id($enumSchema);
+                $this->schemaNames[$enumId] = $propertyName;
+                $this->schemaEnumNames[$enumId] = \ucfirst($modelName) . \ucfirst($propertyName);
             }
         }
 

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -2,8 +2,6 @@
 
 namespace Appwrite\SDK;
 
-use Appwrite\SDK\Language\Deno;
-use Appwrite\SDK\Language\Web;
 use Utopia\OpenAPI\Model\AnySchema;
 use Utopia\OpenAPI\Model\ArraySchema;
 use Utopia\OpenAPI\Model\BooleanSchema;
@@ -185,10 +183,10 @@ class SDK
         $this->twig->addFilter(new TwigFilter('securityHeaders', fn(Operation $operation): array => $this->getOperationSecuritySchemes($operation, ParameterLocation::HEADER, false)));
         $this->twig->addFilter(new TwigFilter('securityQueries', fn(Operation $operation): array => $this->getOperationSecuritySchemes($operation, ParameterLocation::QUERY)));
         $this->twig->addFilter(new TwigFilter('schemaNullable', fn(Schema|Parameter $value): bool => !isset($this->multipartSchemas[\spl_object_id($this->getSchema($value))]) && $this->getSchema($value)->nullable));
-        $this->twig->addFilter(new TwigFilter('enumValues', fn(Schema|Parameter $value): array => $this->isOpenStringEnum($value) && (!$this->language instanceof Web && !$this->language instanceof Deno)
+        $this->twig->addFilter(new TwigFilter('enumValues', fn(Schema|Parameter $value): array => $this->language->isOpenStringEnum($value) && !$this->language->keepsOpenEnumType()
             ? []
-            : $this->getEnumSchema($value)->enum));
-        $this->twig->addFilter(new TwigFilter('openEnum', fn(Schema|Parameter $value): bool => $this->isOpenStringEnum($value)));
+            : $this->language->getEnumSchema($value)->enum));
+        $this->twig->addFilter(new TwigFilter('openEnum', fn(Schema|Parameter $value): bool => $this->language->isOpenStringEnum($value)));
         $this->twig->addFilter(new TwigFilter('arraySchema', fn(Schema|Parameter $value): ?Schema => ($schema = $this->getSchema($value)) instanceof ArraySchema ? $schema->items : null));
         $this->twig->addFilter(new TwigFilter('emptyResponse', fn(Operation $operation): bool => \array_keys($operation->responses) === [204] || \array_keys($operation->responses) === ['204']));
         $this->twig->addFilter(new TwigFilter('fullPath', fn(Operation $operation): string => (\parse_url($this->spec->servers[0]->url ?? '', PHP_URL_PATH) ?: '') . $operation->path));
@@ -785,13 +783,13 @@ class SDK
         foreach ((array_keys($filteredServices ?? $this->getFilteredServices())) as $serviceName) {
             foreach ($this->getFilteredMethods($this->getMethods($serviceName), $serviceName) as $operation) {
                 foreach ($this->getOperationParameters($operation) as $parameter) {
-                    $enumSchema = $this->getEnumSchema($parameter);
+                    $enumSchema = $this->language->getEnumSchema($parameter);
                     if ($enumSchema->enum !== []) {
                         $schemas[] = new StringSchema(
                             title: $this->getEnumName($parameter),
                             enum: $enumSchema->enum,
                             enumKeys: $enumSchema instanceof StringSchema ? $enumSchema->enumKeys : [],
-                            open: $this->isOpenStringEnum($parameter),
+                            open: $this->language->isOpenStringEnum($parameter),
                         );
                     }
                 }
@@ -834,13 +832,13 @@ class SDK
                 continue;
             }
             foreach ($model->properties as $property) {
-                $enumSchema = $this->getEnumSchema($property);
+                $enumSchema = $this->language->getEnumSchema($property);
                 if ($enumSchema->enum !== []) {
                     $enums[] = new StringSchema(
                         title: $this->getEnumName($property),
                         enum: $enumSchema->enum,
                         enumKeys: $enumSchema instanceof StringSchema ? $enumSchema->enumKeys : [],
-                        open: $this->isOpenStringEnum($property),
+                        open: $this->language->isOpenStringEnum($property),
                     );
                 }
             }
@@ -859,7 +857,7 @@ class SDK
             if ($name === '') {
                 continue;
             }
-            $open[$name] = ($open[$name] ?? true) && $this->isOpenStringEnum($schema);
+            $open[$name] = ($open[$name] ?? true) && $this->language->isOpenStringEnum($schema);
             foreach ($schema->enum as $index => $value) {
                 if (!\in_array($value, $values[$name] ?? [], true)) {
                     $values[$name][] = $value;
@@ -1545,32 +1543,13 @@ class SDK
         return $value instanceof Parameter ? ($value->schema ?? new AnySchema()) : $value;
     }
 
-    protected function getEnumSchema(Schema|Parameter $value): Schema
-    {
-        $schema = $this->getSchema($value);
-        $enumSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
-
-        return $enumSchema instanceof CompositeSchema
-            ? ($enumSchema->openStringEnumBranch() ?? $enumSchema)
-            : $enumSchema;
-    }
-
-    protected function isOpenStringEnum(Schema|Parameter $value): bool
-    {
-        $schema = $this->getSchema($value);
-        $enumSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
-
-        return ($enumSchema instanceof StringSchema && $enumSchema->open)
-            || ($enumSchema instanceof CompositeSchema && $enumSchema->openStringEnumBranch()?->open === true);
-    }
-
     protected function getSchemaType(Schema|Parameter $value): string
     {
         $schema = $this->getSchema($value);
         return match (true) {
             $schema instanceof StringSchema && $schema->format === 'binary' => 'file',
             $schema instanceof StringSchema,
-            $schema instanceof CompositeSchema && $schema->openStringEnumBranch() instanceof StringSchema => 'string',
+            $schema instanceof CompositeSchema && $this->language->isOpenStringEnum($schema) => 'string',
             $schema instanceof IntegerSchema => 'integer',
             $schema instanceof NumberSchema => 'number',
             $schema instanceof BooleanSchema => 'boolean',
@@ -1655,7 +1634,7 @@ class SDK
 
     protected function getEnumName(Schema|Parameter $value): string
     {
-        $enumSchema = $this->getEnumSchema($value);
+        $enumSchema = $this->language->getEnumSchema($value);
         if ($enumSchema->enum === []) {
             return '';
         }
@@ -1667,7 +1646,7 @@ class SDK
 
     protected function getEnumKeys(Schema|Parameter $value): array
     {
-        $enumSchema = $this->getEnumSchema($value);
+        $enumSchema = $this->language->getEnumSchema($value);
 
         return $enumSchema instanceof StringSchema ? $enumSchema->enumKeys : [];
     }
@@ -1697,7 +1676,7 @@ class SDK
                     $this->schemaEnumNames[$itemId] = \ucfirst($modelName) . \ucfirst($propertyName);
                 }
 
-                $enumSchema = $this->getEnumSchema($property);
+                $enumSchema = $this->language->getEnumSchema($property);
                 $enumId = \spl_object_id($enumSchema);
                 $this->schemaNames[$enumId] = $propertyName;
                 $this->schemaEnumNames[$enumId] = \ucfirst($modelName) . \ucfirst($propertyName);

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\SDK;
 
+use Appwrite\SDK\Language\Deno;
 use Appwrite\SDK\Language\Web;
 use Utopia\OpenAPI\Model\AnySchema;
 use Utopia\OpenAPI\Model\ArraySchema;
@@ -184,7 +185,10 @@ class SDK
         $this->twig->addFilter(new TwigFilter('securityHeaders', fn(Operation $operation): array => $this->getOperationSecuritySchemes($operation, ParameterLocation::HEADER, false)));
         $this->twig->addFilter(new TwigFilter('securityQueries', fn(Operation $operation): array => $this->getOperationSecuritySchemes($operation, ParameterLocation::QUERY)));
         $this->twig->addFilter(new TwigFilter('schemaNullable', fn(Schema|Parameter $value): bool => !isset($this->multipartSchemas[\spl_object_id($this->getSchema($value))]) && $this->getSchema($value)->nullable));
-        $this->twig->addFilter(new TwigFilter('enumValues', fn(Schema|Parameter $value): array => $this->getEnumSchema($value)->enum));
+        $this->twig->addFilter(new TwigFilter('enumValues', fn(Schema|Parameter $value): array => $this->isOpenStringEnum($value) && (!$this->language instanceof Web && !$this->language instanceof Deno)
+            ? []
+            : $this->getEnumSchema($value)->enum));
+        $this->twig->addFilter(new TwigFilter('openEnum', fn(Schema|Parameter $value): bool => $this->isOpenStringEnum($value)));
         $this->twig->addFilter(new TwigFilter('arraySchema', fn(Schema|Parameter $value): ?Schema => ($schema = $this->getSchema($value)) instanceof ArraySchema ? $schema->items : null));
         $this->twig->addFilter(new TwigFilter('emptyResponse', fn(Operation $operation): bool => \array_keys($operation->responses) === [204] || \array_keys($operation->responses) === ['204']));
         $this->twig->addFilter(new TwigFilter('fullPath', fn(Operation $operation): string => (\parse_url($this->spec->servers[0]->url ?? '', PHP_URL_PATH) ?: '') . $operation->path));
@@ -786,7 +790,8 @@ class SDK
                         $schemas[] = new StringSchema(
                             title: $this->getEnumName($parameter),
                             enum: $enumSchema->enum,
-                            extensions: ['x-enum-keys' => $enumSchema->extensions['x-enum-keys'] ?? []],
+                            enumKeys: $enumSchema instanceof StringSchema ? $enumSchema->enumKeys : [],
+                            open: $this->isOpenStringEnum($parameter),
                         );
                     }
                 }
@@ -831,7 +836,12 @@ class SDK
             foreach ($model->properties as $property) {
                 $enumSchema = $this->getEnumSchema($property);
                 if ($enumSchema->enum !== []) {
-                    $enums[] = $enumSchema;
+                    $enums[] = new StringSchema(
+                        title: $this->getEnumName($property),
+                        enum: $enumSchema->enum,
+                        enumKeys: $enumSchema instanceof StringSchema ? $enumSchema->enumKeys : [],
+                        open: $this->isOpenStringEnum($property),
+                    );
                 }
             }
         }
@@ -843,15 +853,17 @@ class SDK
     {
         $values = [];
         $keys = [];
+        $open = [];
         foreach ($schemas as $schema) {
             $name = $this->getEnumName($schema);
             if ($name === '') {
                 continue;
             }
+            $open[$name] = ($open[$name] ?? true) && $this->isOpenStringEnum($schema);
             foreach ($schema->enum as $index => $value) {
                 if (!\in_array($value, $values[$name] ?? [], true)) {
                     $values[$name][] = $value;
-                    $keys[$name][] = $schema->extensions['x-enum-keys'][$index] ?? $value;
+                    $keys[$name][] = $schema instanceof StringSchema ? ($schema->enumKeys[$index] ?? $value) : $value;
                 }
             }
         }
@@ -861,7 +873,8 @@ class SDK
             $enums[] = new StringSchema(
                 title: $name,
                 enum: $enumValues,
-                extensions: ['x-enum-keys' => $keys[$name]],
+                enumKeys: $keys[$name],
+                open: $open[$name],
             );
         }
         return $enums;
@@ -1537,9 +1550,18 @@ class SDK
         $schema = $this->getSchema($value);
         $enumSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
 
-        return $enumSchema instanceof CompositeSchema && $this->language instanceof Web
+        return $enumSchema instanceof CompositeSchema
             ? ($enumSchema->openStringEnumBranch() ?? $enumSchema)
             : $enumSchema;
+    }
+
+    protected function isOpenStringEnum(Schema|Parameter $value): bool
+    {
+        $schema = $this->getSchema($value);
+        $enumSchema = $schema instanceof ArraySchema ? $schema->items : $schema;
+
+        return ($enumSchema instanceof StringSchema && $enumSchema->open)
+            || ($enumSchema instanceof CompositeSchema && $enumSchema->openStringEnumBranch()?->open === true);
     }
 
     protected function getSchemaType(Schema|Parameter $value): string
@@ -1637,7 +1659,7 @@ class SDK
         if ($enumSchema->enum === []) {
             return '';
         }
-        return (string) ($enumSchema->extensions['x-enum-name']
+        return (string) (($enumSchema instanceof StringSchema ? $enumSchema->enumName : null)
             ?? $enumSchema->title
             ?? $this->schemaEnumNames[\spl_object_id($enumSchema)]
             ?? ($value instanceof Parameter ? $value->name : ''));
@@ -1645,7 +1667,9 @@ class SDK
 
     protected function getEnumKeys(Schema|Parameter $value): array
     {
-        return $this->getEnumSchema($value)->extensions['x-enum-keys'] ?? [];
+        $enumSchema = $this->getEnumSchema($value);
+
+        return $enumSchema instanceof StringSchema ? $enumSchema->enumKeys : [];
     }
 
     protected function normalizeSchemaReference(string $reference): string

--- a/templates/android/library/src/main/java/io/package/enums/Enum.kt.twig
+++ b/templates/android/library/src/main/java/io/package/enums/Enum.kt.twig
@@ -1,10 +1,18 @@
 package {{ sdk.namespace | caseDot }}.enums
 
+{% if enum | openEnum %}
+object {{ enum.title | caseUcfirst | overrideIdentifier }} {
+{% for value in enum.enum %}
+{% set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
+    const val {{ key | caseEnumKey }} = "{{ value }}"
+{% endfor %}
+}
+{% else %}
 import com.google.gson.annotations.SerializedName
 
 enum class {{ enum.title | caseUcfirst | overrideIdentifier }}(val value: String) {
 {% for value in enum.enum %}
-{% set key = enum.extensions['x-enum-keys'] is empty ? value : enum.extensions['x-enum-keys'][loop.index0] %}
+{% set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
     @SerializedName("{{ value }}")
     {{ key | caseEnumKey }}("{{ value }}"){% if not loop.last %},{% else %};{% endif %}
 
@@ -12,3 +20,4 @@ enum class {{ enum.title | caseUcfirst | overrideIdentifier }}(val value: String
 
     override fun toString() = value
 }
+{% endif %}

--- a/templates/dart/lib/src/enums/enum.dart.twig
+++ b/templates/dart/lib/src/enums/enum.dart.twig
@@ -1,9 +1,17 @@
 part of '../../enums.dart';
 
+{% if enum | openEnum %}
+class {{ enum.title | caseUcfirst | overrideIdentifier }} {
+  const {{ enum.title | caseUcfirst | overrideIdentifier }}._();
+
+{% for value in enum.enum %}{% set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}  static const String {{ key | caseEnumKey | escapeKeyword }} = {{ value | dartString }};
+{% endfor %}}
+{% else %}
 enum {{ enum.title | caseUcfirst | overrideIdentifier }} {
-{% for value in enum.enum %}{% set key = enum.extensions['x-enum-keys'] is empty ? value : enum.extensions['x-enum-keys'][loop.index0] %}  {{ key | caseEnumKey | escapeKeyword }}(value: {{ value | dartString }}){% if not loop.last %},{% else %};{% endif %}{{ "\n" }}{% endfor %}{{ "\n" }}  const {{ enum.title | caseUcfirst | overrideIdentifier }}({required this.value});
+{% for value in enum.enum %}{% set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}  {{ key | caseEnumKey | escapeKeyword }}(value: {{ value | dartString }}){% if not loop.last %},{% else %};{% endif %}{{ "\n" }}{% endfor %}{{ "\n" }}  const {{ enum.title | caseUcfirst | overrideIdentifier }}({required this.value});
 
   final String value;
 
   String toJson() => value;
 }
+{% endif %}

--- a/templates/deno/src/enums/enum.ts.twig
+++ b/templates/deno/src/enums/enum.ts.twig
@@ -1,6 +1,6 @@
 export enum {{ enum.title | caseUcfirst | overrideIdentifier }} {
     {%~ for value in enum.enum %}
-    {%~ set key = enum.extensions['x-enum-keys'] is empty ? value : enum.extensions['x-enum-keys'][loop.index0] %}
+    {%~ set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
     {{ key | caseEnumKey }} = '{{ value }}',
     {%~ endfor %}
 }

--- a/templates/dotnet/Package/Enums/Enum.cs.twig
+++ b/templates/dotnet/Package/Enums/Enum.cs.twig
@@ -2,6 +2,15 @@ using System;
 
 namespace {{ spec.info.title | caseUcfirst }}.Enums
 {
+{% if enum | openEnum %}
+    public static class {{ enum.title | caseUcfirst | overrideIdentifier }}
+    {
+        {%~ for value in enum.enum %}
+        {%~ set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
+        public const string {{ key | caseEnumKey }} = "{{ value }}";
+        {%~ endfor %}
+    }
+{% else %}
     public class {{ enum.title | caseUcfirst | overrideIdentifier }} : IEnum
     {
         public string Value { get; private set; }
@@ -12,8 +21,9 @@ namespace {{ spec.info.title | caseUcfirst }}.Enums
         }
 
         {%~ for value in enum.enum %}
-        {%~ set key = enum.extensions['x-enum-keys'] is empty ? value : enum.extensions['x-enum-keys'][loop.index0] %}
+        {%~ set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
         public static {{ enum.title | caseUcfirst | overrideIdentifier }} {{ key | caseEnumKey }} => new {{ enum.title | caseUcfirst | overrideIdentifier }}("{{ value }}");
         {%~ endfor %}
     }
+{% endif %}
 }

--- a/templates/kotlin/src/main/kotlin/io/appwrite/enums/Enum.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/enums/Enum.kt.twig
@@ -1,10 +1,18 @@
 package {{ sdk.namespace | caseDot }}.enums
 
+{% if enum | openEnum %}
+object {{ enum.title | caseUcfirst | overrideIdentifier }} {
+{% for value in enum.enum %}
+{% set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
+    const val {{ key | caseEnumKey }} = "{{ value }}"
+{% endfor %}
+}
+{% else %}
 import com.google.gson.annotations.SerializedName
 
 enum class {{ enum.title | caseUcfirst | overrideIdentifier }}(val value: String) {
 {% for value in enum.enum %}
-{% set key = enum.extensions['x-enum-keys'] is empty ? value : enum.extensions['x-enum-keys'][loop.index0] %}
+{% set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
     @SerializedName("{{ value }}")
     {{ key | caseEnumKey }}("{{value}}"){% if not loop.last %},{% else %};{% endif %}
 
@@ -12,3 +20,4 @@ enum class {{ enum.title | caseUcfirst | overrideIdentifier }}(val value: String
 
     override fun toString() = value
 }
+{% endif %}

--- a/templates/php/src/Enums/Enum.php.twig
+++ b/templates/php/src/Enums/Enum.php.twig
@@ -2,12 +2,21 @@
 
 namespace {{ namespace | caseNamespace }}\Enums;
 
+{% if enum | openEnum %}
+final class {{ enum.title | caseUcfirst | overrideIdentifier }}
+{
+    {%~ for value in enum.enum %}
+    {%~ set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
+    public const {{ key | caseEnumKey }} = '{{ value }}';
+    {%~ endfor %}
+}
+{% else %}
 use JsonSerializable;
 
 class {{ enum.title | caseUcfirst | overrideIdentifier }} implements JsonSerializable
 {
     {%~ for value in enum.enum %}
-    {%~ set key = enum.extensions['x-enum-keys'] is empty ? value : enum.extensions['x-enum-keys'][loop.index0] %}
+    {%~ set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
     private static {{ enum.title | caseUcfirst }} ${{ key | caseEnumKey }};
     {%~ endfor %}
 
@@ -29,7 +38,7 @@ class {{ enum.title | caseUcfirst | overrideIdentifier }} implements JsonSeriali
     }
 
 {% for value in enum.enum %}
-{% set key = enum.extensions['x-enum-keys'] is empty ? value : enum.extensions['x-enum-keys'][loop.index0] %}
+{% set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
     public static function {{ key | caseEnumKey }}(): {{ enum.title | caseUcfirst | overrideIdentifier}}
     {
         if (!isset(self::${{ key | caseEnumKey }})) {
@@ -43,10 +52,11 @@ class {{ enum.title | caseUcfirst | overrideIdentifier }} implements JsonSeriali
     {
         return match ($value) {
 {% for value in enum.enum %}
-{% set key = enum.extensions['x-enum-keys'] is empty ? value : enum.extensions['x-enum-keys'][loop.index0] %}
+{% set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
             '{{ value }}' => self::{{ key | caseEnumKey }}(),
 {% endfor %}
             default => throw new \InvalidArgumentException('Unknown {{ enum.title | caseUcfirst | overrideIdentifier }} value: ' . $value),
         };
     }
 }
+{% endif %}

--- a/templates/php/src/Models/Model.php.twig
+++ b/templates/php/src/Models/Model.php.twig
@@ -6,7 +6,7 @@ namespace {{ namespace | caseNamespace }}\Models;
 {% set optionalProperties = definition.properties | filter((property) => not (property | schemaRequired)) %}
 {% set enumImports = [] %}
 {% for property in definition.properties %}
-{% if (property | enumValues) is not empty or (property | enumName) is not empty %}
+{% if (property | enumValues) is not empty %}
 {% set enumName = (property | enumName) %}
 {% if enumName not in enumImports %}
 {% set enumImports = enumImports|merge([enumName]) %}
@@ -37,7 +37,7 @@ readonly class {{ definitionName | caseUcfirst | overrideIdentifier }}
 {% set paramDocType = property | typeName %}
 {% if (property | schemaType) == 'array' and (property | schemaModel) %}
 {% set paramDocType = 'list<' ~ ((property | schemaModel) | caseUcfirst | overrideIdentifier) ~ '>' %}
-{% elseif (property | schemaType) == 'array' and ((property | enumValues) is not empty or (property | enumName) is not empty) %}
+{% elseif (property | schemaType) == 'array' and (property | enumValues) is not empty %}
 {% set paramDocType = 'list<' ~ (((property | enumName)) | caseUcfirst | overrideIdentifier) ~ '>' %}
 {% endif %}
      * @param {{ paramDocType | raw }} ${{ (property | schemaName) | caseCamel }} {{ property.description | unescape | lower | raw }}
@@ -46,7 +46,7 @@ readonly class {{ definitionName | caseUcfirst | overrideIdentifier }}
 {% set paramDocType = property | typeName %}
 {% if (property | schemaType) == 'array' and (property | schemaModel) %}
 {% set paramDocType = 'list<' ~ ((property | schemaModel) | caseUcfirst | overrideIdentifier) ~ '>' %}
-{% elseif (property | schemaType) == 'array' and ((property | enumValues) is not empty or (property | enumName) is not empty) %}
+{% elseif (property | schemaType) == 'array' and (property | enumValues) is not empty %}
 {% set paramDocType = 'list<' ~ (((property | enumName)) | caseUcfirst | overrideIdentifier) ~ '>' %}
 {% endif %}
      * @param {{ paramDocType | raw }}|null ${{ (property | schemaName) | caseCamel }} {{ property.description | unescape | lower | raw }}
@@ -100,12 +100,12 @@ readonly class {{ definitionName | caseUcfirst | overrideIdentifier }}
                     static fn (mixed $item): mixed => static::hydrateTypedValue({{ (property | schemaModel) | caseUcfirst | overrideIdentifier }}::class, $item),
                     $data['{{ (property | schemaName) }}']
                 )
-                : $data['{{ (property | schemaName) }}']{% elseif (property | schemaModel) %}static::hydrateTypedValue({{ (property | schemaModel) | caseUcfirst | overrideIdentifier }}::class, $data['{{ (property | schemaName) }}']){% elseif (property | schemaType) == 'array' and ((property | enumValues) is not empty or (property | enumName) is not empty) %}is_array($data['{{ (property | schemaName) }}'])
+                : $data['{{ (property | schemaName) }}']{% elseif (property | schemaModel) %}static::hydrateTypedValue({{ (property | schemaModel) | caseUcfirst | overrideIdentifier }}::class, $data['{{ (property | schemaName) }}']){% elseif (property | schemaType) == 'array' and (property | enumValues) is not empty %}is_array($data['{{ (property | schemaName) }}'])
                 ? array_map(
                     static fn (mixed $item): mixed => static::hydrateTypedValue({{ ((property | enumName)) | caseUcfirst | overrideIdentifier }}::class, $item),
                     $data['{{ (property | schemaName) }}']
                 )
-                : $data['{{ (property | schemaName) }}']{% elseif (property | enumValues) is not empty or (property | enumName) is not empty %}static::hydrateTypedValue({{ ((property | enumName)) | caseUcfirst | overrideIdentifier }}::class, $data['{{ (property | schemaName) }}']){% else %}$data['{{ (property | schemaName) }}']{% endif %}{{ (not loop.last or optionalProperties is not empty or definition.additionalProperties) ? ',' : '' }}
+                : $data['{{ (property | schemaName) }}']{% elseif (property | enumValues) is not empty %}static::hydrateTypedValue({{ ((property | enumName)) | caseUcfirst | overrideIdentifier }}::class, $data['{{ (property | schemaName) }}']){% else %}$data['{{ (property | schemaName) }}']{% endif %}{{ (not loop.last or optionalProperties is not empty or definition.additionalProperties) ? ',' : '' }}
 {% endfor %}
 {% for property in optionalProperties %}
 {% if (property | schemaType) == 'array' and (property | schemaModel) %}
@@ -118,7 +118,7 @@ readonly class {{ definitionName | caseUcfirst | overrideIdentifier }}
                         )
                         : $data['{{ (property | schemaName) }}']
                 )
-{% elseif (property | schemaType) == 'array' and ((property | enumValues) is not empty or (property | enumName) is not empty) %}
+{% elseif (property | schemaType) == 'array' and (property | enumValues) is not empty %}
             {{ (property | schemaName) | caseCamel }}: array_key_exists('{{ (property | schemaName) }}', $data)
                 ? (
                     is_array($data['{{ (property | schemaName) }}'])
@@ -130,12 +130,12 @@ readonly class {{ definitionName | caseUcfirst | overrideIdentifier }}
                 )
 {% elseif (property | schemaModel) %}
             {{ (property | schemaName) | caseCamel }}: array_key_exists('{{ (property | schemaName) }}', $data) ? static::hydrateTypedValue({{ (property | schemaModel) | caseUcfirst | overrideIdentifier }}::class, $data['{{ (property | schemaName) }}'], true) : null{{ (not loop.last or definition.additionalProperties) ? ',' : '' }}
-{% elseif (property | enumValues) is not empty or (property | enumName) is not empty %}
+{% elseif (property | enumValues) is not empty %}
             {{ (property | schemaName) | caseCamel }}: array_key_exists('{{ (property | schemaName) }}', $data) ? static::hydrateTypedValue({{ ((property | enumName)) | caseUcfirst | overrideIdentifier }}::class, $data['{{ (property | schemaName) }}'], true) : null{{ (not loop.last or definition.additionalProperties) ? ',' : '' }}
 {% else %}
             {{ (property | schemaName) | caseCamel }}: array_key_exists('{{ (property | schemaName) }}', $data) ? $data['{{ (property | schemaName) }}'] : null{{ (not loop.last or definition.additionalProperties) ? ',' : '' }}
 {% endif %}
-{% if (property | schemaType) == 'array' and ((property | schemaModel) or (property | enumValues) is not empty or (property | enumName) is not empty) %}
+{% if (property | schemaType) == 'array' and ((property | schemaModel) or (property | enumValues) is not empty) %}
                 : null{{ (not loop.last or definition.additionalProperties) ? ',' : '' }}
 {% endif %}
 {% endfor %}

--- a/templates/php/src/Models/RequestModel.php.twig
+++ b/templates/php/src/Models/RequestModel.php.twig
@@ -4,7 +4,7 @@ namespace {{ namespace | caseNamespace }}\Models;
 
 {% set enumImports = [] %}
 {% for property in requestModel.properties %}
-{% if (property | enumValues) is not empty or (property | enumName) is not empty %}
+{% if (property | enumValues) is not empty %}
 {% set enumName = (property | enumName) %}
 {% if enumName not in enumImports %}
 {% set enumImports = enumImports|merge([enumName]) %}
@@ -32,7 +32,7 @@ readonly class {{ requestModelName | caseUcfirst | overrideIdentifier }}
 {% set paramDocType = property | typeName %}
 {% if (property | schemaType) == 'array' and (property | schemaModel) %}
 {% set paramDocType = 'list<' ~ ((property | schemaModel) | caseUcfirst | overrideIdentifier) ~ '>' %}
-{% elseif (property | schemaType) == 'array' and ((property | enumValues) is not empty or (property | enumName) is not empty) %}
+{% elseif (property | schemaType) == 'array' and (property | enumValues) is not empty %}
 {% set paramDocType = 'list<' ~ (((property | enumName)) | caseUcfirst | overrideIdentifier) ~ '>' %}
 {% endif %}
      * @param {{ paramDocType | raw }} ${{ (property | schemaName) | caseCamel }} {{ property.description | unescape | lower | raw }}
@@ -41,7 +41,7 @@ readonly class {{ requestModelName | caseUcfirst | overrideIdentifier }}
 {% set paramDocType = property | typeName %}
 {% if (property | schemaType) == 'array' and (property | schemaModel) %}
 {% set paramDocType = 'list<' ~ ((property | schemaModel) | caseUcfirst | overrideIdentifier) ~ '>' %}
-{% elseif (property | schemaType) == 'array' and ((property | enumValues) is not empty or (property | enumName) is not empty) %}
+{% elseif (property | schemaType) == 'array' and (property | enumValues) is not empty %}
 {% set paramDocType = 'list<' ~ (((property | enumName)) | caseUcfirst | overrideIdentifier) ~ '>' %}
 {% endif %}
      * @param {{ paramDocType | raw }}|null ${{ (property | schemaName) | caseCamel }} {{ property.description | unescape | lower | raw }}
@@ -78,12 +78,12 @@ readonly class {{ requestModelName | caseUcfirst | overrideIdentifier }}
                     static fn (mixed $item): mixed => static::hydrateTypedValue({{ (property | schemaModel) | caseUcfirst | overrideIdentifier }}::class, $item),
                     $data['{{ (property | schemaName) }}']
                 )
-                : $data['{{ (property | schemaName) }}']{% elseif (property | schemaModel) %}static::hydrateTypedValue({{ (property | schemaModel) | caseUcfirst | overrideIdentifier }}::class, $data['{{ (property | schemaName) }}']){% elseif (property | schemaType) == 'array' and ((property | enumValues) is not empty or (property | enumName) is not empty) %}is_array($data['{{ (property | schemaName) }}'])
+                : $data['{{ (property | schemaName) }}']{% elseif (property | schemaModel) %}static::hydrateTypedValue({{ (property | schemaModel) | caseUcfirst | overrideIdentifier }}::class, $data['{{ (property | schemaName) }}']){% elseif (property | schemaType) == 'array' and (property | enumValues) is not empty %}is_array($data['{{ (property | schemaName) }}'])
                 ? array_map(
                     static fn (mixed $item): mixed => static::hydrateTypedValue({{ ((property | enumName)) | caseUcfirst | overrideIdentifier }}::class, $item),
                     $data['{{ (property | schemaName) }}']
                 )
-                : $data['{{ (property | schemaName) }}']{% elseif (property | enumValues) is not empty or (property | enumName) is not empty %}static::hydrateTypedValue({{ ((property | enumName)) | caseUcfirst | overrideIdentifier }}::class, $data['{{ (property | schemaName) }}']){% else %}$data['{{ (property | schemaName) }}']{% endif %}{{ (not loop.last or optionalProperties is not empty) ? ',' : '' }}
+                : $data['{{ (property | schemaName) }}']{% elseif (property | enumValues) is not empty %}static::hydrateTypedValue({{ ((property | enumName)) | caseUcfirst | overrideIdentifier }}::class, $data['{{ (property | schemaName) }}']){% else %}$data['{{ (property | schemaName) }}']{% endif %}{{ (not loop.last or optionalProperties is not empty) ? ',' : '' }}
 {% endfor %}
 {% for property in optionalProperties %}
             {{ (property | schemaName) | caseCamel }}: array_key_exists('{{ (property | schemaName) }}', $data)
@@ -98,7 +98,7 @@ readonly class {{ requestModelName | caseUcfirst | overrideIdentifier }}
                 )
 {% elseif (property | schemaModel) %}
                 ? static::hydrateTypedValue({{ (property | schemaModel) | caseUcfirst | overrideIdentifier }}::class, $data['{{ (property | schemaName) }}'], true)
-{% elseif (property | schemaType) == 'array' and ((property | enumValues) is not empty or (property | enumName) is not empty) %}
+{% elseif (property | schemaType) == 'array' and (property | enumValues) is not empty %}
                 ? (
                     is_array($data['{{ (property | schemaName) }}'])
                         ? array_map(
@@ -107,7 +107,7 @@ readonly class {{ requestModelName | caseUcfirst | overrideIdentifier }}
                         )
                         : $data['{{ (property | schemaName) }}']
                 )
-{% elseif (property | enumValues) is not empty or (property | enumName) is not empty %}
+{% elseif (property | enumValues) is not empty %}
                 ? static::hydrateTypedValue({{ ((property | enumName)) | caseUcfirst | overrideIdentifier }}::class, $data['{{ (property | schemaName) }}'], true)
 {% else %}
                 ? $data['{{ (property | schemaName) }}']

--- a/templates/php/tests/Services/ServiceTest.php.twig
+++ b/templates/php/tests/Services/ServiceTest.php.twig
@@ -1,6 +1,6 @@
 {% import _self as helper %}
 {% macro mockParameterValue(parameter) -%}
-{%- if (parameter | enumName) -%}
+{%- if (parameter | enumValues) is not empty -%}
 {%- if (parameter | schemaType) == 'array' -%}
 array({{ (parameter | enumName) | caseUcfirst }}::{{ ((parameter | enumKeys)[0] ?? (parameter | enumValues)[0]) | caseEnumKey }}())
 {%- else -%}

--- a/templates/python/package/enums/enum.py.twig
+++ b/templates/python/package/enums/enum.py.twig
@@ -1,7 +1,15 @@
+{% if enum | openEnum %}
+class {{ enum.title | caseUcfirst | overrideIdentifier }}:
+{% for value in enum.enum %}
+{% set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
+    {{ key | caseEnumKey }} = "{{ value }}"
+{% endfor %}
+{% else %}
 from enum import Enum
 
 class {{ enum.title | caseUcfirst | overrideIdentifier }}(Enum):
 {% for value in enum.enum %}
-{% set key = enum.extensions['x-enum-keys'] is empty ? value : enum.extensions['x-enum-keys'][loop.index0] %}
+{% set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
     {{ key | caseEnumKey }} = "{{ value }}"
 {% endfor %}
+{% endif %}

--- a/templates/react-native/src/enums/enum.ts.twig
+++ b/templates/react-native/src/enums/enum.ts.twig
@@ -1,6 +1,6 @@
 export enum {{ enum.title | caseUcfirst  }} {
 {% for value in enum.enum %}
-{% set key = enum.extensions['x-enum-keys'] is empty ? value : enum.extensions['x-enum-keys'][loop.index0] %}
+{% set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
     {{ key | caseEnumKey }} = '{{ value }}',
 {% endfor %}
 }

--- a/templates/ruby/lib/container/enums/enum.rb.twig
+++ b/templates/ruby/lib/container/enums/enum.rb.twig
@@ -2,7 +2,7 @@ module {{ spec.info.title | caseUcfirst }}
     module Enums
         module {{ enum.title | caseUcfirst | overrideIdentifier }}
             {%~ for value in enum.enum %}
-            {%~ set key = enum.extensions['x-enum-keys'] is empty ? value : enum.extensions['x-enum-keys'][loop.index0] %}
+            {%~ set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
             {{ key | caseEnumKey }} = '{{ value }}'
             {%~ endfor %}
         end

--- a/templates/rust/src/enums/enum.rs.twig
+++ b/templates/rust/src/enums/enum.rs.twig
@@ -1,10 +1,20 @@
+{% if enum | openEnum %}
+pub struct {{ enum.title | caseUcfirst | overrideIdentifier }};
+
+#[allow(non_upper_case_globals)]
+impl {{ enum.title | caseUcfirst | overrideIdentifier }} {
+{% for value in enum.enum %}
+{% set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
+    pub const {{ key | caseEnumKey | overrideIdentifier }}: &'static str = "{{ value }}";
+{% endfor %}}
+{% else %}
 use serde::{Deserialize, Serialize};
 
 {% if enum.description %}/// {{ enum.description }}
 {% endif %}#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 pub enum {{ enum.title | caseUcfirst | overrideIdentifier }} {
 {% for value in enum.enum %}
-{% set key = enum.extensions['x-enum-keys'] is empty ? value : enum.extensions['x-enum-keys'][loop.index0] %}
+{% set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
     #[serde(rename = "{{ value }}")]
     {% if loop.first %}#[default]
     {% endif %}{{ key | caseEnumKey | overrideIdentifier }},
@@ -16,7 +26,7 @@ impl {{ enum.title | caseUcfirst | overrideIdentifier }} {
     pub fn as_str(&self) -> &str {
         match self {
 {% for value in enum.enum %}
-{% set key = enum.extensions['x-enum-keys'] is empty ? value : enum.extensions['x-enum-keys'][loop.index0] %}
+{% set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
             {{ enum.title | caseUcfirst | overrideIdentifier }}::{{ key | caseEnumKey | overrideIdentifier }} => "{{ value }}",
 {% endfor %}
         }
@@ -28,3 +38,4 @@ impl std::fmt::Display for {{ enum.title | caseUcfirst | overrideIdentifier }} {
         write!(f, "{}", self.as_str())
     }
 }
+{% endif %}

--- a/templates/swift/Sources/Enums/Enum.swift.twig
+++ b/templates/swift/Sources/Enums/Enum.swift.twig
@@ -1,8 +1,16 @@
 import Foundation
 
+{% if enum | openEnum %}
+public enum {{ enum.title | caseUcfirst | overrideIdentifier }} {
+    {%~ for value in enum.enum %}
+    {%~ set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
+    public static let {{ key | caseEnumKey | escapeSwiftKeyword }} = "{{ value }}"
+    {%~ endfor %}
+}
+{% else %}
 public enum {{ enum.title | caseUcfirst | overrideIdentifier }}: String, Codable, CustomStringConvertible {
     {%~ for value in enum.enum %}
-    {%~ set key = enum.extensions['x-enum-keys'] is empty ? value : enum.extensions['x-enum-keys'][loop.index0] %}
+    {%~ set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
     case {{ key | caseEnumKey | escapeSwiftKeyword }} = "{{ value }}"
     {%~ endfor %}
 
@@ -10,3 +18,4 @@ public enum {{ enum.title | caseUcfirst | overrideIdentifier }}: String, Codable
         return rawValue
     }
 }
+{% endif %}

--- a/templates/web/src/enums/enum.ts.twig
+++ b/templates/web/src/enums/enum.ts.twig
@@ -1,6 +1,6 @@
 export enum {{ enum.title | caseUcfirst }} {
 {% for value in enum.enum %}
-{% set key = enum.extensions['x-enum-keys'] is empty ? value : enum.extensions['x-enum-keys'][loop.index0] %}
+{% set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
     {{ key | replace({'-': ''}) | caseEnumKey }} = '{{ value }}',
 {% endfor %}
 }

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -582,9 +582,9 @@ abstract class Base extends TestCase
     {
         $enumBranch = [
             'type' => 'string',
-            'enum' => ['network.requests', 'network.inbound'],
-            'x-enum-name' => 'UsageEventMetric',
-            'x-enum-keys' => ['NetworkRequests', 'NetworkInbound'],
+            'enum' => ['user.created', 'user.updated'],
+            'x-enum-name' => 'WebhookEvent',
+            'x-enum-keys' => ['UserCreated', 'UserUpdated'],
         ];
         $specification = Parser::parse([
             'openapi' => '3.0.0',
@@ -610,15 +610,15 @@ abstract class Base extends TestCase
             }
         };
         $mergedEnums = $sdk->mergeEnumsForTest([
-            new StringSchema(title: 'SharedMetric', enum: ['known'], open: true),
-            new StringSchema(title: 'SharedMetric', enum: ['known'], open: false),
+            new StringSchema(title: 'SharedEnum', enum: ['known'], open: true),
+            new StringSchema(title: 'SharedEnum', enum: ['known'], open: false),
         ]);
         $this->assertCount(1, $mergedEnums);
         $this->assertFalse($mergedEnums[0]->open, 'A closed use must keep a shared enum type closed.');
 
         if ($language instanceof Web || $language instanceof Deno) {
-            $this->assertSame('(UsageEventMetric | (string & {}))', $language->getTypeName($openScalar, $specification));
-            $this->assertSame('(UsageEventMetric | (string & {}))[]', $language->getTypeName($openArray, $specification));
+            $this->assertSame('(WebhookEvent | (string & {}))', $language->getTypeName($openScalar, $specification));
+            $this->assertSame('(WebhookEvent | (string & {}))[]', $language->getTypeName($openArray, $specification));
 
             return;
         }
@@ -636,22 +636,22 @@ abstract class Base extends TestCase
     private function assertOpenEnumSuggestionsGenerated(string $dir): void
     {
         $expectations = [
-            'web' => ['src/enums/usage-event-metric.ts', 'NetworkRequests'],
-            'node' => ['src/enums/usage-event-metric.ts', 'NetworkRequests'],
-            'react-native' => ['src/enums/usage-event-metric.ts', 'NetworkRequests'],
-            'deno' => ['src/enums/usage-event-metric.ts', 'NetworkRequests'],
-            'php' => ['src/Appwrite/Enums/UsageEventMetric.php', 'public const NETWORKREQUESTS'],
-            'python' => ['appwrite/enums/usage_event_metric.py', 'NETWORKREQUESTS = "network.requests"'],
-            'ruby' => ['lib/appwrite/enums/usage_event_metric.rb', "NETWORKREQUESTS = 'network.requests'"],
-            'dart' => ['lib/src/enums/usage_event_metric.dart', 'static const String networkRequests'],
-            'flutter' => ['lib/src/enums/usage_event_metric.dart', 'static const String networkRequests'],
-            'kotlin' => ['src/main/kotlin/io/appwrite/enums/UsageEventMetric.kt', 'const val NETWORKREQUESTS'],
-            'android' => ['library/src/main/java/io/appwrite/enums/UsageEventMetric.kt', 'const val NETWORKREQUESTS'],
-            'swift' => ['Sources/AppwriteEnums/UsageEventMetric.swift', 'public static let networkRequests'],
-            'apple' => ['Sources/AppwriteEnums/UsageEventMetric.swift', 'public static let networkRequests'],
-            'dotnet' => ['Appwrite/Enums/UsageEventMetric.cs', 'public const string NetworkRequests'],
-            'unity' => ['Assets/Runtime/Core/Enums/UsageEventMetric.cs', 'public const string NetworkRequests'],
-            'rust' => ['src/enums/usage_event_metric.rs', 'pub const NetworkRequests'],
+            'web' => ['src/enums/webhook-event.ts', 'UserCreated'],
+            'node' => ['src/enums/webhook-event.ts', 'UserCreated'],
+            'react-native' => ['src/enums/webhook-event.ts', 'UserCreated'],
+            'deno' => ['src/enums/webhook-event.ts', 'UserCreated'],
+            'php' => ['src/Appwrite/Enums/WebhookEvent.php', 'public const USERCREATED'],
+            'python' => ['appwrite/enums/webhook_event.py', 'USERCREATED = "user.created"'],
+            'ruby' => ['lib/appwrite/enums/webhook_event.rb', "USERCREATED = 'user.created'"],
+            'dart' => ['lib/src/enums/webhook_event.dart', 'static const String userCreated'],
+            'flutter' => ['lib/src/enums/webhook_event.dart', 'static const String userCreated'],
+            'kotlin' => ['src/main/kotlin/io/appwrite/enums/WebhookEvent.kt', 'const val USERCREATED'],
+            'android' => ['library/src/main/java/io/appwrite/enums/WebhookEvent.kt', 'const val USERCREATED'],
+            'swift' => ['Sources/AppwriteEnums/WebhookEvent.swift', 'public static let userCreated'],
+            'apple' => ['Sources/AppwriteEnums/WebhookEvent.swift', 'public static let userCreated'],
+            'dotnet' => ['Appwrite/Enums/WebhookEvent.cs', 'public const string UserCreated'],
+            'unity' => ['Assets/Runtime/Core/Enums/WebhookEvent.cs', 'public const string UserCreated'],
+            'rust' => ['src/enums/webhook_event.rs', 'pub const UserCreated'],
         ];
 
         if (!isset($expectations[$this->language])) {
@@ -664,7 +664,7 @@ abstract class Base extends TestCase
         $contents = file_get_contents($path);
         $this->assertIsString($contents);
         $this->assertStringContainsString($knownValueDeclaration, $contents);
-        $this->assertStringContainsString('network.inbound', $contents);
+        $this->assertStringContainsString('user.updated', $contents);
     }
 
     private function rmdirRecursive(string $dir): void

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -11,8 +11,10 @@ use RecursiveDirectoryIterator;
 use FilesystemIterator;
 use Throwable;
 use Appwrite\SDK\Language;
+use Appwrite\SDK\Language\Deno;
 use Appwrite\SDK\Language\Web;
 use Appwrite\SDK\SDK;
+use Utopia\OpenAPI\Model\StringSchema;
 use Utopia\OpenAPI\Parser;
 use PHPUnit\Framework\TestCase;
 use Twig\Error\LoaderError;
@@ -517,6 +519,7 @@ abstract class Base extends TestCase
         $this->rmdirRecursive($dir);
 
         $sdk->generate(__DIR__ . '/sdks/' . $this->language);
+        $this->assertOpenEnumSuggestionsGenerated($dir);
         $this->assertExcludedFixtureWasRemoved($dir);
         $this->assertCommentsAreNotHtmlEscaped($dir);
 
@@ -599,8 +602,21 @@ abstract class Base extends TestCase
         ]);
         [$plainScalar, $openScalar, $plainArray, $openArray] = $specification->paths['/test']->operations['get']->parameters;
         $language = $this->getLanguage();
+        $sdk = new class ($language, $specification) extends SDK {
+            /** @param list<StringSchema> $schemas @return list<StringSchema> */
+            public function mergeEnumsForTest(array $schemas): array
+            {
+                return $this->mergeEnums($schemas);
+            }
+        };
+        $mergedEnums = $sdk->mergeEnumsForTest([
+            new StringSchema(title: 'SharedMetric', enum: ['known'], open: true),
+            new StringSchema(title: 'SharedMetric', enum: ['known'], open: false),
+        ]);
+        $this->assertCount(1, $mergedEnums);
+        $this->assertFalse($mergedEnums[0]->open, 'A closed use must keep a shared enum type closed.');
 
-        if ($language instanceof Web) {
+        if ($language instanceof Web || $language instanceof Deno) {
             $this->assertSame('(UsageEventMetric | (string & {}))', $language->getTypeName($openScalar, $specification));
             $this->assertSame('(UsageEventMetric | (string & {}))[]', $language->getTypeName($openArray, $specification));
 
@@ -615,6 +631,40 @@ abstract class Base extends TestCase
             $language->getTypeName($plainArray, $specification),
             $language->getTypeName($openArray, $specification),
         );
+    }
+
+    private function assertOpenEnumSuggestionsGenerated(string $dir): void
+    {
+        $expectations = [
+            'web' => ['src/enums/usage-event-metric.ts', 'NetworkRequests'],
+            'node' => ['src/enums/usage-event-metric.ts', 'NetworkRequests'],
+            'react-native' => ['src/enums/usage-event-metric.ts', 'NetworkRequests'],
+            'deno' => ['src/enums/usage-event-metric.ts', 'NetworkRequests'],
+            'php' => ['src/Appwrite/Enums/UsageEventMetric.php', 'public const NETWORKREQUESTS'],
+            'python' => ['appwrite/enums/usage_event_metric.py', 'NETWORKREQUESTS = "network.requests"'],
+            'ruby' => ['lib/appwrite/enums/usage_event_metric.rb', "NETWORKREQUESTS = 'network.requests'"],
+            'dart' => ['lib/src/enums/usage_event_metric.dart', 'static const String networkRequests'],
+            'flutter' => ['lib/src/enums/usage_event_metric.dart', 'static const String networkRequests'],
+            'kotlin' => ['src/main/kotlin/io/appwrite/enums/UsageEventMetric.kt', 'const val NETWORKREQUESTS'],
+            'android' => ['library/src/main/java/io/appwrite/enums/UsageEventMetric.kt', 'const val NETWORKREQUESTS'],
+            'swift' => ['Sources/AppwriteEnums/UsageEventMetric.swift', 'public static let networkRequests'],
+            'apple' => ['Sources/AppwriteEnums/UsageEventMetric.swift', 'public static let networkRequests'],
+            'dotnet' => ['Appwrite/Enums/UsageEventMetric.cs', 'public const string NetworkRequests'],
+            'unity' => ['Assets/Runtime/Core/Enums/UsageEventMetric.cs', 'public const string NetworkRequests'],
+            'rust' => ['src/enums/usage_event_metric.rs', 'pub const NetworkRequests'],
+        ];
+
+        if (!isset($expectations[$this->language])) {
+            return;
+        }
+
+        [$relativePath, $knownValueDeclaration] = $expectations[$this->language];
+        $path = $dir . '/' . $relativePath;
+        $this->assertFileExists($path);
+        $contents = file_get_contents($path);
+        $this->assertIsString($contents);
+        $this->assertStringContainsString($knownValueDeclaration, $contents);
+        $this->assertStringContainsString('network.inbound', $contents);
     }
 
     private function rmdirRecursive(string $dir): void

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -11,8 +11,6 @@ use RecursiveDirectoryIterator;
 use FilesystemIterator;
 use Throwable;
 use Appwrite\SDK\Language;
-use Appwrite\SDK\Language\Deno;
-use Appwrite\SDK\Language\Web;
 use Appwrite\SDK\SDK;
 use Utopia\OpenAPI\Model\StringSchema;
 use Utopia\OpenAPI\Parser;
@@ -616,7 +614,7 @@ abstract class Base extends TestCase
         $this->assertCount(1, $mergedEnums);
         $this->assertFalse($mergedEnums[0]->open, 'A closed use must keep a shared enum type closed.');
 
-        if ($language instanceof Web || $language instanceof Deno) {
+        if ($language->keepsOpenEnumType()) {
             $this->assertSame('(WebhookEvent | (string & {}))', $language->getTypeName($openScalar, $specification));
             $this->assertSame('(WebhookEvent | (string & {}))[]', $language->getTypeName($openArray, $specification));
 

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -11,6 +11,7 @@ use RecursiveDirectoryIterator;
 use FilesystemIterator;
 use Throwable;
 use Appwrite\SDK\Language;
+use Appwrite\SDK\Language\Web;
 use Appwrite\SDK\SDK;
 use Utopia\OpenAPI\Parser;
 use PHPUnit\Framework\TestCase;
@@ -474,6 +475,8 @@ abstract class Base extends TestCase
             throw new Exception('Failed to parse spec.');
         }
 
+        $this->assertOpenEnumsAllowAnyString();
+
         $sdk = new SDK($this->getLanguage(), Parser::parse($spec));
 
         $sdk
@@ -570,6 +573,48 @@ abstract class Base extends TestCase
                 $this->assertEquals($expected, $output[$index]);
             }
         }
+    }
+
+    private function assertOpenEnumsAllowAnyString(): void
+    {
+        $enumBranch = [
+            'type' => 'string',
+            'enum' => ['network.requests', 'network.inbound'],
+            'x-enum-name' => 'UsageEventMetric',
+            'x-enum-keys' => ['NetworkRequests', 'NetworkInbound'],
+        ];
+        $specification = Parser::parse([
+            'openapi' => '3.0.0',
+            'info' => ['title' => 'test', 'version' => '1.0.0'],
+            'paths' => ['/test' => ['get' => [
+                'operationId' => 'testOpenEnums',
+                'parameters' => [
+                    ['name' => 'plainScalar', 'in' => 'query', 'schema' => ['type' => 'string']],
+                    ['name' => 'openScalar', 'in' => 'query', 'schema' => ['anyOf' => [$enumBranch, ['type' => 'string']]]],
+                    ['name' => 'plainArray', 'in' => 'query', 'schema' => ['type' => 'array', 'items' => ['type' => 'string']]],
+                    ['name' => 'openArray', 'in' => 'query', 'schema' => ['type' => 'array', 'items' => ['anyOf' => [$enumBranch, ['type' => 'string']]]]],
+                ],
+                'responses' => ['200' => ['description' => 'ok']],
+            ]]],
+        ]);
+        [$plainScalar, $openScalar, $plainArray, $openArray] = $specification->paths['/test']->operations['get']->parameters;
+        $language = $this->getLanguage();
+
+        if ($language instanceof Web) {
+            $this->assertSame('(UsageEventMetric | (string & {}))', $language->getTypeName($openScalar, $specification));
+            $this->assertSame('(UsageEventMetric | (string & {}))[]', $language->getTypeName($openArray, $specification));
+
+            return;
+        }
+
+        $this->assertSame(
+            $language->getTypeName($plainScalar, $specification),
+            $language->getTypeName($openScalar, $specification),
+        );
+        $this->assertSame(
+            $language->getTypeName($plainArray, $specification),
+            $language->getTypeName($openArray, $specification),
+        );
     }
 
     private function rmdirRecursive(string $dir): void

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -1555,21 +1555,21 @@
                     "x-enum-name": null,
                     "x-enum-keys": []
                   },
-                  "usageEventMetrics": {
+                  "webhookEvents": {
                     "type": "array",
-                    "description": "Usage metrics to include.",
+                    "description": "Webhook events to subscribe to.",
                     "items": {
                       "anyOf": [
                         {
                           "type": "string",
                           "enum": [
-                            "network.requests",
-                            "network.inbound"
+                            "user.created",
+                            "user.updated"
                           ],
-                          "x-enum-name": "UsageEventMetric",
+                          "x-enum-name": "WebhookEvent",
                           "x-enum-keys": [
-                            "NetworkRequests",
-                            "NetworkInbound"
+                            "UserCreated",
+                            "UserUpdated"
                           ]
                         },
                         {
@@ -1578,19 +1578,19 @@
                       ]
                     }
                   },
-                  "usageEventMetric": {
-                    "description": "Primary usage metric.",
+                  "webhookEvent": {
+                    "description": "A webhook event to subscribe to.",
                     "anyOf": [
                       {
                         "type": "string",
                         "enum": [
-                          "network.requests",
-                          "network.inbound"
+                          "user.created",
+                          "user.updated"
                         ],
-                        "x-enum-name": "UsageEventMetric",
+                        "x-enum-name": "WebhookEvent",
                         "x-enum-keys": [
-                          "NetworkRequests",
-                          "NetworkInbound"
+                          "UserCreated",
+                          "UserUpdated"
                         ]
                       },
                       {

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -1554,6 +1554,49 @@
                     ],
                     "x-enum-name": null,
                     "x-enum-keys": []
+                  },
+                  "usageEventMetrics": {
+                    "type": "array",
+                    "description": "Usage metrics to include.",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "network.requests",
+                            "network.inbound"
+                          ],
+                          "x-enum-name": "UsageEventMetric",
+                          "x-enum-keys": [
+                            "NetworkRequests",
+                            "NetworkInbound"
+                          ]
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  },
+                  "usageEventMetric": {
+                    "description": "Primary usage metric.",
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "network.requests",
+                          "network.inbound"
+                        ],
+                        "x-enum-name": "UsageEventMetric",
+                        "x-enum-keys": [
+                          "NetworkRequests",
+                          "NetworkInbound"
+                        ]
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
                   }
                 },
                 "required": [


### PR DESCRIPTION
## What

An endpoint can document the values callers usually want without closing the set by declaring a parameter as `anyOf` over a string enum and an enum-free string branch.

The parser previously exposed the raw composite, and the generator treated it as an object. TypeScript array parameters consequently degraded to `Record<string, any>[]`, losing both completions and the actual string type.

This PR now renders the TypeScript shape as:

```ts
(UsageEventMetric | (string & {}))[]
```

The intersection prevents `string` from absorbing the enum, retaining completions while accepting arbitrary strings.

No other generated SDK can say that without closing the set — a PHP/Dart/Kotlin/Swift enum rejects unknown values. Those languages type the parameter as a plain string and keep the documented values as optional constants:

| Language | Parameter type | Generated artifact |
|---|---|---|
| Web / Node / RN / Deno | `(WebhookEvent \| (string & {}))` | normal `enum WebhookEvent { UserCreated = 'user.created' }` |
| PHP | `string` | `final class WebhookEvent { public const USERCREATED = 'user.created'; }` |
| Dart / Flutter | `String` | `class WebhookEvent { static const String userCreated = 'user.created'; }` |
| Kotlin / Android | `String` | `object WebhookEvent { const val USERCREATED = "user.created" }` |
| Swift / Apple | `String` | `enum WebhookEvent { public static let userCreated = "user.created" }` |
| Python | `str` | a class with class attributes, not `enum.Enum` |
| Go / CLI / REST / GraphQL | `string` | no enum file |

## How

Shape recognition lives in `utopia-php/openapi`, not this generator:

- https://github.com/utopia-php/openapi/pull/5
- released in [`utopia-php/openapi` 0.1.2](https://github.com/utopia-php/openapi/releases/tag/0.1.2)

The generator consumes `CompositeSchema::openStringEnumBranch()` and keeps only language-specific behavior locally:

- Web, Node, React Native, and Deno expose the enum-plus-string TypeScript type
- enum discovery emits the documented values (as a typed enum in TypeScript, as suggestion constants everywhere else that generates enum files)
- scalar and array forms are supported
- every other SDK types the parameter like an unrestricted string

There is no generator-side union parser or Concern class.

## Test plan

The shared OpenAPI 3 fixture includes scalar and array open enum parameters.

`Base::assertOpenEnumsAllowAnyString()` runs as part of every existing language E2E test. For TypeScript SDKs it requires the widened enum-plus-string type. For every other SDK it requires scalar and array open enums to render exactly like equivalent unrestricted strings. This keeps the assertion centralized while applying it across the complete language matrix.

Generated SDK builds continue to verify that referenced Web enums are emitted and imported correctly.

Verified locally:

- `vendor/bin/phpunit tests/e2e/WebNodeTest.php` — 1 test, 1275 assertions
- `vendor/bin/phpunit tests/e2e/DartStableTest.php` — 1 test, 1760 assertions
- all concrete language classes checked against the centralized scalar and array invariant
- `composer refactor:check`
- `composer lint`
- `composer lint-twig`
- `composer validate --strict --no-check-publish`

Generated and inspected Web, Node, React Native, and Dart outputs from the fixture.
