### PR TITLE
feat: infer upload IDs from multipart schemas

### DIFF
--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -175,6 +175,7 @@ class SDK
         $this->twig->addFilter(new TwigFilter('enumKeys', fn(Schema|Parameter $value): array => $this->getEnumKeys($value)));
         $this->twig->addFilter(new TwigFilter('operations', fn(Tag $tag): array => $this->getFilteredMethods($this->getMethods($tag->name), $tag->name)));
         $this->twig->addFilter(new TwigFilter('consumes', fn(Operation $operation): array => \array_keys($operation->requestBody?->content ?? [])));
+        $this->twig->addFilter(new TwigFilter('uploadIdParameter', $this->uploadIdParameter(...)));
         $this->twig->addFilter(new TwigFilter('produces', fn(Operation $operation): array => $this->getProduces($operation)));
         $this->twig->addFilter(new TwigFilter('endpoint', fn(Specification $spec): string => $spec->servers[0]->url ?? 'https://example.com'));
         $this->twig->addFilter(new TwigFilter('appwrite', fn(Operation|SecurityScheme $value, string $key, mixed $default = null): mixed => $value->extensions['x-appwrite'][$key] ?? $default));
@@ -1499,6 +1500,38 @@ class SDK
         return $operation->extensions['x-appwrite']['type'] ?? false;
     }
 
+    protected function uploadIdParameter(Operation $operation): ?Parameter
+    {
+        $content = $operation->requestBody?->content ?? [];
+        $schema = ($content[self::MULTIPART_MEDIA_TYPE] ?? null)?->schema;
+        if (!$schema instanceof ObjectSchema) {
+            return null;
+        }
+
+        $uploadId = null;
+        $binaryProperties = 0;
+        foreach ($schema->properties as $name => $property) {
+            if (!$property instanceof StringSchema || $property->format !== 'binary') {
+                continue;
+            }
+
+            $binaryProperties++;
+            if ($binaryProperties > 1) {
+                return null;
+            }
+
+            $idName = $name . 'Id';
+            $idProperty = $schema->properties[$idName] ?? null;
+            if (!$idProperty instanceof StringSchema || $idProperty->format === 'binary') {
+                continue;
+            }
+
+            $uploadId = $this->requestBodyParameter($idName, $idProperty, $schema);
+        }
+
+        return $uploadId;
+    }
+
     /** @return list<Parameter> */
     protected function getOperationParameters(Operation $operation, string $location = 'all'): array
     {
@@ -1520,14 +1553,7 @@ class SDK
                     continue;
                 }
                 foreach ($mediaType->schema->properties as $name => $schema) {
-                    $parameters[] = new Parameter(
-                        name: $name,
-                        location: ParameterLocation::QUERY,
-                        description: $schema->description,
-                        required: \in_array($name, $mediaType->schema->required, true),
-                        schema: $schema,
-                        extensions: $schema->extensions,
-                    );
+                    $parameters[] = $this->requestBodyParameter($name, $schema, $mediaType->schema);
                 }
                 break;
             }
@@ -1540,6 +1566,18 @@ class SDK
             \usort($parameters, static fn(Parameter $left, Parameter $right): int => (int) $right->required - (int) $left->required);
         }
         return $parameters;
+    }
+
+    private function requestBodyParameter(string $name, Schema $schema, ObjectSchema $object): Parameter
+    {
+        return new Parameter(
+            name: $name,
+            location: ParameterLocation::QUERY,
+            description: $schema->description,
+            required: \in_array($name, $object->required, true),
+            schema: $schema,
+            extensions: $schema->extensions,
+        );
     }
 
     protected function getSchema(Schema|Parameter $value): Schema

--- a/templates/android/library/src/main/java/io/package/Client.kt.twig
+++ b/templates/android/library/src/main/java/io/package/Client.kt.twig
@@ -430,18 +430,19 @@ class Client @JvmOverloads constructor(
         var result: Map<*, *>? = null
         var uploadId: String? = null
 
-        if (idParamName?.isNotEmpty() == true) {
+        val providedUploadId = idParamName?.let { params[it]?.toString() }
+        if (!providedUploadId.isNullOrEmpty()) {
             // Make a request to check if a file already exists
             val current = call(
                 method = "GET",
-                path = "$path/${params[idParamName]}",
+                path = "$path/$providedUploadId",
                 headers = headers,
                 params = emptyMap(),
                 responseType = Map::class.java,
             )
             val chunksUploaded = current["chunksUploaded"] as Long
             offset = chunksUploaded * CHUNK_SIZE
-            uploadId = params[idParamName]?.toString()
+            uploadId = providedUploadId
             result = current
         }
 

--- a/templates/android/library/src/main/java/io/package/services/Service.kt.twig
+++ b/templates/android/library/src/main/java/io/package/services/Service.kt.twig
@@ -184,7 +184,8 @@ class {{ service.name | caseUcfirst }}(client: Client) : Service(client) {
         }
         {%~ endif %}
         {%~ if 'multipart/form-data' in (method | consumes) %}
-        val idParamName: String? = {% if (method | parameters('all')) | filter(p => (p | extension('x-upload-id', false))) | length > 0 %}{% for parameter in (method | parameters('all')) | filter(parameter => (parameter | extension('x-upload-id', false))) %}"{{ parameter.name }}"{% endfor %}{% else %}null{% endif %}
+{% set uploadIdParameter = method | uploadIdParameter %}
+        val idParamName: String? = {% if uploadIdParameter %}"{{ uploadIdParameter.name }}"{% else %}null{% endif %}
     
         {%~ for parameter in (method | parameters('all')) %}
         {%~ if (parameter | schemaType) == 'file' %}

--- a/templates/apple/Sources/Client.swift.twig
+++ b/templates/apple/Sources/Client.swift.twig
@@ -455,12 +455,12 @@ open class Client {
         var result = [String:Any]()
         var uploadId = idParamName != nil ? params[idParamName!] as? String : nil
 
-        if idParamName != nil {
+        if let uploadId {
             // Make a request to check if a file already exists
             do {
                 let map = try await call(
                     method: "GET",
-                    path: path + "/" + (params[idParamName!] as! String),
+                    path: path + "/" + uploadId,
                     headers: headers,
                     params: [:],
                     converter: { return $0 as! [String: Any] }

--- a/templates/dart/base/requests/file.twig
+++ b/templates/dart/base/requests/file.twig
@@ -18,10 +18,11 @@
 {% if (parameter | schemaType) == 'file' %}
     final paramName = '{{ parameter.name }}';
 {% endif %}
-{% if (parameter | extension('x-upload-id', false)) %}
-    idParamName = '{{ parameter.name }}';
-{% endif %}
 {% endfor %}
+{% set uploadIdParameter = method | uploadIdParameter %}
+{% if uploadIdParameter %}
+    idParamName = '{{ uploadIdParameter.name }}';
+{% endif %}
     final res = await client.chunkedUpload(
       path: apiPath,
       params: apiParams,

--- a/templates/dart/lib/src/client_browser.dart.twig
+++ b/templates/dart/lib/src/client_browser.dart.twig
@@ -126,7 +126,7 @@ class ClientBrowser extends ClientBase with ClientMixin {
 
     var offset = 0;
     String? uploadId;
-    if (idParamName.isNotEmpty) {
+    if (idParamName.isNotEmpty && params[idParamName] != null) {
       //make a request to check if a file already exists
       try {
         res = await call(

--- a/templates/dart/lib/src/client_io.dart.twig
+++ b/templates/dart/lib/src/client_io.dart.twig
@@ -144,7 +144,7 @@ class ClientIO extends ClientBase with ClientMixin {
 
     var offset = 0;
     String? uploadId;
-    if (idParamName.isNotEmpty) {
+    if (idParamName.isNotEmpty && params[idParamName] != null) {
       //make a request to check if a file already exists
       try {
         res = await call(

--- a/templates/deno/src/services/service.ts.twig
+++ b/templates/deno/src/services/service.ts.twig
@@ -129,20 +129,21 @@ export class {{ service.name | caseUcfirst }} extends Service {
 
         let chunksUploaded = 0;
 
-{% for parameter in (method | parameters('all')) %}
-{% if (parameter | extension('x-upload-id', false)) %}
-        id = {{ parameter.name }};
-        try {
-            response = await this.client.call(
-                'get',
-                apiPath + '/' + {{ parameter.name }},
-                apiHeaders
-            );
-            chunksUploaded = response.chunksUploaded;
-        } catch(e) {
+{% set uploadIdParameter = method | uploadIdParameter %}
+{% if uploadIdParameter %}
+        id = {{ uploadIdParameter.name | caseCamel | escapeKeyword }};
+        if (id) {
+            try {
+                response = await this.client.call(
+                    'get',
+                    apiPath + '/' + id,
+                    apiHeaders
+                );
+                chunksUploaded = response.chunksUploaded;
+            } catch(e) {
+            }
         }
 {% endif %}
-{% endfor %}
 
         const totalChunks = Math.ceil(size / Client.CHUNK_SIZE);
         const chunks: { index: number; start: number; end: number; data: Uint8Array }[] = [];

--- a/templates/dotnet/Package/Client.cs.twig
+++ b/templates/dotnet/Package/Client.cs.twig
@@ -449,14 +449,18 @@ namespace {{ spec.info.title | caseUcfirst }}
 
             var uploadId = string.Empty;
 
-            if (!string.IsNullOrEmpty(idParamName))
+            if (idParamName is not null
+                && idParamName.Length > 0
+                && parameters.TryGetValue(idParamName, out var uploadIdValue)
+                && uploadIdValue != null)
             {
+                uploadId = uploadIdValue.ToString() ?? string.Empty;
                 try
                 {
                     // Make a request to check if a file already exists
                     var current = await Call<Dictionary<string, object?>>(
                         method: "GET",
-                        path: $"{path}/{parameters[idParamName!]}",
+                        path: $"{path}/{uploadId}",
                         new Dictionary<string, string> { { "content-type", "application/json" } },
                         parameters: new Dictionary<string, object?>()
                     );
@@ -465,7 +469,6 @@ namespace {{ spec.info.title | caseUcfirst }}
                         offset = Convert.ToInt64(chunksUploadedValue) * ChunkSize;
                     }
                     result = current;
-                    uploadId = parameters[idParamName!]?.ToString() ?? string.Empty;
                 }
                 catch
                 {

--- a/templates/dotnet/base/requests/file.twig
+++ b/templates/dotnet/base/requests/file.twig
@@ -1,4 +1,5 @@
-            string? idParamName = {% if (method | parameters('all')) | filter(p => (p | extension('x-upload-id', false))) | length > 0 %}{% for parameter in (method | parameters('all')) | filter(parameter => (parameter | extension('x-upload-id', false))) %}"{{ parameter.name }}"{% endfor %}{% else %}null{% endif %};
+{% set uploadIdParameter = method | uploadIdParameter %}
+            string? idParamName = {% if uploadIdParameter %}"{{ uploadIdParameter.name }}"{% else %}null{% endif %};
 
             {%~ for parameter in (method | parameters('all')) %}
             {%~ if (parameter | schemaType) == 'file' %}

--- a/templates/flutter/base/requests/file.twig
+++ b/templates/flutter/base/requests/file.twig
@@ -18,10 +18,11 @@
 {% if (parameter | schemaType) == 'file' %}
     final paramName = '{{ parameter.name }}';
 {% endif %}
-{% if (parameter | extension('x-upload-id', false)) %}
-    idParamName = '{{ parameter.name }}';
-{% endif %}
 {% endfor %}
+{% set uploadIdParameter = method | uploadIdParameter %}
+{% if uploadIdParameter %}
+    idParamName = '{{ uploadIdParameter.name }}';
+{% endif %}
     final res = await client.chunkedUpload(
       path: apiPath,
       params: apiParams,

--- a/templates/flutter/lib/src/client_browser.dart.twig
+++ b/templates/flutter/lib/src/client_browser.dart.twig
@@ -150,7 +150,7 @@ class ClientBrowser extends ClientBase with ClientMixin {
 
     var offset = 0;
     String? uploadId;
-    if (idParamName.isNotEmpty) {
+    if (idParamName.isNotEmpty && params[idParamName] != null) {
       //make a request to check if a file already exists
       try {
         res = await call(

--- a/templates/flutter/lib/src/client_io.dart.twig
+++ b/templates/flutter/lib/src/client_io.dart.twig
@@ -271,7 +271,7 @@ class ClientIO extends ClientBase with ClientMixin {
 
     var offset = 0;
     String? uploadId;
-    if (idParamName.isNotEmpty) {
+    if (idParamName.isNotEmpty && params[idParamName] != null) {
       //make a request to check if a file already exists
       try {
         res = await call(

--- a/templates/go/base/requests/file.twig
+++ b/templates/go/base/requests/file.twig
@@ -2,11 +2,12 @@
 	paramName := "{{ fileParameter.name }}"
 
 	uploadId := ""
-{% for parameter in (method | parameters('all')) %}
-{% if (parameter | extension('x-upload-id', false)) %}
-	uploadId = {{ parameter.name | escapeKeyword | caseUcfirst }}
+{% set uploadIdParameter = method | uploadIdParameter %}
+{% if uploadIdParameter %}
+	if value, ok := params["{{ uploadIdParameter.name }}"].(string); ok {
+		uploadId = value
+	}
 {% endif %}
-{% endfor %}
 
 	resp, err := srv.client.FileUpload(path, headers, params, paramName, uploadId)
 	if err != nil {

--- a/templates/kotlin/base/requests/file.twig
+++ b/templates/kotlin/base/requests/file.twig
@@ -1,4 +1,5 @@
-        val idParamName: String? = {% if (method | parameters('all')) | filter(p => (p | extension('x-upload-id', false))) | length > 0 %}{% for parameter in (method | parameters('all')) | filter(parameter => (parameter | extension('x-upload-id', false))) %}"{{ parameter.name }}"{% endfor %}{% else %}null{% endif %}
+{% set uploadIdParameter = method | uploadIdParameter %}
+        val idParamName: String? = {% if uploadIdParameter %}"{{ uploadIdParameter.name }}"{% else %}null{% endif %}
 
         {%~ for parameter in (method | parameters('all')) %}
         {%~ if (parameter | schemaType) == 'file' %}

--- a/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
@@ -411,18 +411,19 @@ class Client @JvmOverloads constructor(
         var result: Map<*, *>? = null
         var uploadId: String? = null
 
-        if (idParamName?.isNotEmpty() == true) {
+        val providedUploadId = idParamName?.let { params[it]?.toString() }
+        if (!providedUploadId.isNullOrEmpty()) {
             // Make a request to check if a file already exists
             val current = call(
                 method = "GET",
-                path = "$path/${params[idParamName]}",
+                path = "$path/$providedUploadId",
                 headers = headers,
                 params = emptyMap(),
                 responseType = Map::class.java,
             )
             val chunksUploaded = current["chunksUploaded"] as Long
             offset = chunksUploaded * CHUNK_SIZE
-            uploadId = params[idParamName]?.toString()
+            uploadId = providedUploadId
             result = current
         }
 

--- a/templates/php/base/requests/file.twig
+++ b/templates/php/base/requests/file.twig
@@ -84,15 +84,16 @@
         $id = '';
         $counter = 0;
 
-{% for parameter in (method | parameters('all')) %}
-{% if (parameter | extension('x-upload-id', false)) %}
-        try {
-            $response = $this->client->call(Client::METHOD_GET, $apiPath . '/' . ${{ parameter.name }});
-            $counter = $response['chunksUploaded'] ?? 0;
-        } catch(\Exception $e) {
+{% set uploadIdParameter = method | uploadIdParameter %}
+{% if uploadIdParameter %}
+        if (!empty(${{ uploadIdParameter.name }})) {
+            try {
+                $response = $this->client->call(Client::METHOD_GET, $apiPath . '/' . ${{ uploadIdParameter.name }});
+                $counter = $response['chunksUploaded'] ?? 0;
+            } catch(\Exception $e) {
+            }
         }
 {% endif %}
-{% endfor %}
 
         $apiHeaders = [
         {%~ for key, security in (method | securityHeaders) %}
@@ -112,9 +113,9 @@
         }
 
         $uploadId = '';
-        {% for parameter in (method | parameters('all')) %}{% if (parameter | extension('x-upload-id', false)) %}
-        $uploadId = ${{ parameter.name }} ?? '';
-        {% endif %}{% endfor %}
+{% if uploadIdParameter %}
+        $uploadId = ${{ uploadIdParameter.name }} ?? '';
+{% endif %}
         $totalChunks = (int) ceil($size / Client::CHUNK_SIZE);
         $chunks = [];
         $start = $counter * Client::CHUNK_SIZE;

--- a/templates/python/base/requests/file.twig
+++ b/templates/python/base/requests/file.twig
@@ -6,11 +6,10 @@
 {% endfor %}
 
         upload_id = ''
-{% for parameter in (method | parameters('all')) %}
-{% if (parameter | extension('x-upload-id', false)) %}
-        upload_id = {{ parameter.name | escapeKeyword | caseSnake }}
+{% set uploadIdParameter = method | uploadIdParameter %}
+{% if uploadIdParameter %}
+        upload_id = {{ uploadIdParameter.name | escapeKeyword | caseSnake }}
 {% endif %}
-{% endfor %}
 
         response = self.client.chunked_upload(api_path, {
 {%~ for key, security in (method | securityHeaders) %}

--- a/templates/python/package/client.py.twig
+++ b/templates/python/package/client.py.twig
@@ -164,11 +164,12 @@ class Client:
         offset = 0
         counter = 0
 
-        try:
-            result = self.call('get', path + '/' + upload_id, headers)
-            counter = result['chunksUploaded']
-        except:
-            pass
+        if upload_id:
+            try:
+                result = self.call('get', path + '/' + upload_id, headers)
+                counter = result['chunksUploaded']
+            except:
+                pass
 
         if counter > 0:
             offset = counter * self._chunk_size

--- a/templates/react-native/src/services/template.ts.twig
+++ b/templates/react-native/src/services/template.ts.twig
@@ -180,15 +180,17 @@ export class {{ service.name | caseUcfirst }} extends Service {
 
         let offset = 0;
         let response = undefined;
-{% for parameter in (method | parameters('all')) %}
-{% if (parameter | extension('x-upload-id', false)) %}
-        try {
-            response = await this.client.call('GET', new URL(this.client.config.endpoint + apiPath + '/' + {{ parameter.name }}), apiHeaders);
-            offset = response.chunksUploaded * Service.CHUNK_SIZE;
-        } catch(e) {
+{% set uploadIdParameter = method | uploadIdParameter %}
+{% if uploadIdParameter %}
+        const providedUploadId = {{ uploadIdParameter.name | caseCamel | escapeKeyword }};
+        if (providedUploadId) {
+            try {
+                response = await this.client.call('GET', new URL(this.client.config.endpoint + apiPath + '/' + providedUploadId), apiHeaders);
+                offset = response.chunksUploaded * Service.CHUNK_SIZE;
+            } catch(e) {
+            }
         }
 {% endif %}
-{% endfor %}
 
         const totalChunks = Math.ceil(size / Service.CHUNK_SIZE);
 

--- a/templates/ruby/base/requests/file.twig
+++ b/templates/ruby/base/requests/file.twig
@@ -1,4 +1,5 @@
-            id_param_name = {% if (method | parameters('all')) | filter(p => (p | extension('x-upload-id', false))) | length > 0 %}{% for parameter in (method | parameters('all')) | filter(parameter => (parameter | extension('x-upload-id', false))) %}"{{ parameter.name }}"{% endfor %}{% else %}nil{% endif %}
+{% set uploadIdParameter = method | uploadIdParameter %}
+            id_param_name = {% if uploadIdParameter %}"{{ uploadIdParameter.name }}"{% else %}nil{% endif %}
 
 {% for parameter in (method | parameters('all')) %}
 {% if (parameter | schemaType) == 'file' %}

--- a/templates/ruby/lib/container/client.rb.twig
+++ b/templates/ruby/lib/container/client.rb.twig
@@ -155,6 +155,8 @@ module {{ spec.info.title | caseUcfirst }}
             chunks_uploaded = 0
             if id_param_name&.empty? == false
                 upload_id = params[id_param_name]
+            end
+            if upload_id && !upload_id.empty?
                 # Make a request to check if a file already exists
                 begin
                     current = call(

--- a/templates/rust/src/services/service.rs.twig
+++ b/templates/rust/src/services/service.rs.twig
@@ -67,23 +67,22 @@ impl {{ service.name | caseUcfirst }} {
 {% endif %}
 {% endfor %}
     ) -> {{ method | returnType(spec, 'crate') | rustType }} {
-{% set hasUploadID = false %}
+{% set uploadIdParameter = method | uploadIdParameter %}
 {% set uploadIDRequired = false %}
-{% for parameter in (method | parameters('all')) %}
-{% if (parameter | extension('x-upload-id', false)) %}
-{% set hasUploadID = true %}
-{% if parameter.required and not (parameter | schemaNullable) %}
-{% set uploadIDRequired = true %}
-        let {{ parameter.name | caseSnake | overrideIdentifier }}_str = {{ parameter.name | caseSnake | overrideIdentifier }}.into();
+{% if uploadIdParameter %}
+{% set uploadIDRequired = uploadIdParameter.required and not (uploadIdParameter | schemaNullable) %}
+{% endif %}
+{% if uploadIdParameter %}
+{% if uploadIDRequired %}
+        let {{ uploadIdParameter.name | caseSnake | overrideIdentifier }}_str = {{ uploadIdParameter.name | caseSnake | overrideIdentifier }}.into();
 {% else %}
-        let {{ parameter.name | caseSnake | overrideIdentifier }}_str = {{ parameter.name | caseSnake | overrideIdentifier }}.map(|v| v.into());
+        let {{ uploadIdParameter.name | caseSnake | overrideIdentifier }}_str = {{ uploadIdParameter.name | caseSnake | overrideIdentifier }}.map(|v| v.into());
 {% endif %}
 {% endif %}
-{% endfor %}
         let {% if (method | parameters('query')) is not empty or (method | parameters('body')) is not empty %}mut {% endif %}params = HashMap::new();
 {% for parameter in (method | parameters('query')) %}
 {% if parameter.required and not (parameter | schemaNullable) %}
-{% if (parameter | extension('x-upload-id', false)) %}
+{% if uploadIdParameter and parameter.name == uploadIdParameter.name %}
         params.insert("{{ parameter.name }}".to_string(), json!({{ parameter.name | caseSnake | overrideIdentifier }}_str));
 {% else %}
         params.insert("{{ parameter.name }}".to_string(), json!({{ parameter | paramValue(parameter.name | caseSnake | overrideIdentifier) }}));
@@ -102,7 +101,7 @@ impl {{ service.name | caseUcfirst }} {
 {% for parameter in (method | parameters('body')) %}
 {% if (parameter | schemaType) != 'file' %}
 {% if parameter.required and not (parameter | schemaNullable) %}
-{% if (parameter | extension('x-upload-id', false)) %}
+{% if uploadIdParameter and parameter.name == uploadIdParameter.name %}
         params.insert("{{ parameter.name }}".to_string(), json!({{ parameter.name | caseSnake | overrideIdentifier }}_str));
 {% else %}
         params.insert("{{ parameter.name }}".to_string(), json!({{ parameter | paramValue(parameter.name | caseSnake | overrideIdentifier) }}));
@@ -142,14 +141,14 @@ impl {{ service.name | caseUcfirst }} {
 {% set fileParamName = '' %}
 {% set fileParamKey = '' %}
 {% set uploadIdParam = '' %}
+{% if uploadIdParameter %}
+{% set uploadIdParam = uploadIdParameter.name | caseSnake | overrideIdentifier %}
+{% endif %}
 {% for parameter in (method | parameters('all')) %}
 {% if (parameter | schemaType) == 'file' %}
 {% set hasFileParam = true %}
 {% set fileParamName = parameter.name | caseSnake | overrideIdentifier %}
 {% set fileParamKey = parameter.name %}
-{% endif %}
-{% if (parameter | extension('x-upload-id', false)) %}
-{% set uploadIdParam = parameter.name | caseSnake | overrideIdentifier %}
 {% endif %}
 {% endfor %}
 {% if hasFileParam %}

--- a/templates/swift/Sources/Client.swift.twig
+++ b/templates/swift/Sources/Client.swift.twig
@@ -457,12 +457,12 @@ open class Client {
         var result = [String:Any]()
         var uploadId = idParamName != nil ? params[idParamName!] as? String : nil
 
-        if idParamName != nil {
+        if let uploadId {
             // Make a request to check if a file already exists
             do {
                 let map = try await call(
                     method: "GET",
-                    path: path + "/" + (params[idParamName!] as! String),
+                    path: path + "/" + uploadId,
                     headers: headers,
                     params: [:],
                     converter: { return $0 as! [String: Any] }

--- a/templates/swift/base/requests/file.twig
+++ b/templates/swift/base/requests/file.twig
@@ -1,4 +1,5 @@
-        let idParamName: String? = {% if (method | parameters('all')) | filter(p => (p | extension('x-upload-id', false))) | length > 0 %}{% for parameter in (method | parameters('all')) | filter(parameter => (parameter | extension('x-upload-id', false))) %}"{{ parameter.name }}"{% endfor %}{% else %}nil{% endif %}
+{% set uploadIdParameter = method | uploadIdParameter %}
+        let idParamName: String? = {% if uploadIdParameter %}"{{ uploadIdParameter.name }}"{% else %}nil{% endif %}
 
 {% for parameter in (method | parameters('all')) %}
 {% if (parameter | schemaType) == 'file' %}

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -12,6 +12,8 @@ use FilesystemIterator;
 use Throwable;
 use Appwrite\SDK\Language;
 use Appwrite\SDK\SDK;
+use Utopia\OpenAPI\Model\Operation;
+use Utopia\OpenAPI\Model\Parameter;
 use Utopia\OpenAPI\Model\StringSchema;
 use Utopia\OpenAPI\Parser;
 use PHPUnit\Framework\TestCase;
@@ -476,6 +478,7 @@ abstract class Base extends TestCase
         }
 
         $this->assertOpenEnumsAllowAnyString();
+        $this->assertUploadIdParameterInference();
 
         $sdk = new SDK($this->getLanguage(), Parser::parse($spec));
 
@@ -657,6 +660,66 @@ abstract class Base extends TestCase
             $language->getTypeName($plainArray, $specification),
             $language->getTypeName($openArray, $specification),
         );
+    }
+
+    private function assertUploadIdParameterInference(): void
+    {
+        $multipart = static fn(array $properties, array $required = []): array => [
+            'requestBody' => ['content' => ['multipart/form-data' => ['schema' => [
+                'type' => 'object',
+                'properties' => $properties,
+                'required' => $required,
+            ]]]],
+            'responses' => ['200' => ['description' => 'ok']],
+        ];
+        $file = ['type' => 'string', 'format' => 'binary'];
+        $string = ['type' => 'string'];
+        $specification = Parser::parse([
+            'openapi' => '3.0.0',
+            'info' => ['title' => 'test', 'version' => '1.0.0'],
+            'paths' => [
+                '/file' => ['post' => $multipart(
+                    ['fileId' => $string, 'file' => $file],
+                    ['fileId', 'file'],
+                )],
+                '/code' => ['post' => $multipart(['code' => $file], ['code'])],
+                '/optional' => ['post' => $multipart(['fileId' => $string, 'file' => $file], ['file'])],
+                '/malformed' => ['post' => $multipart([
+                    'fileId' => ['type' => 'integer'],
+                    'file' => $file,
+                ])],
+                '/multiple' => ['post' => $multipart([
+                    'archive' => $file,
+                    'archiveId' => $string,
+                    'file' => $file,
+                ])],
+                '/json' => ['post' => [
+                    'requestBody' => ['content' => ['application/json' => ['schema' => [
+                        'type' => 'object',
+                        'properties' => ['fileId' => $string, 'file' => $file],
+                    ]]]],
+                    'responses' => ['200' => ['description' => 'ok']],
+                ]],
+            ],
+        ]);
+        $sdk = new class ($this->getLanguage(), $specification) extends SDK {
+            public function uploadIdParameterForTest(Operation $operation): ?Parameter
+            {
+                return $this->uploadIdParameter($operation);
+            }
+        };
+
+        $fileId = $sdk->uploadIdParameterForTest($specification->paths['/file']->operations['post']);
+        $this->assertInstanceOf(Parameter::class, $fileId);
+        $this->assertSame('fileId', $fileId->name);
+        $this->assertTrue($fileId->required);
+        $this->assertNotInstanceOf(Parameter::class, $sdk->uploadIdParameterForTest($specification->paths['/code']->operations['post']));
+        $optional = $sdk->uploadIdParameterForTest($specification->paths['/optional']->operations['post']);
+        $this->assertInstanceOf(Parameter::class, $optional);
+        $this->assertFalse($optional->required);
+        $this->assertNotInstanceOf(Parameter::class, $sdk->uploadIdParameterForTest($specification->paths['/malformed']->operations['post']));
+        $this->assertNotInstanceOf(Parameter::class, $sdk->uploadIdParameterForTest($specification->paths['/multiple']->operations['post']));
+        $this->assertNotInstanceOf(Parameter::class, $sdk->uploadIdParameterForTest($specification->paths['/json']->operations['post']));
     }
 
     private function assertOpenEnumSuggestionsGenerated(string $dir): void

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -2216,6 +2216,10 @@
                       "type": "string"
                     }
                   },
+                  "fileId": {
+                    "description": "Optional upload ID",
+                    "type": "string"
+                  },
                   "file": {
                     "description": "Sample file param",
                     "type": "string",

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -2271,6 +2271,7 @@
                   }
                 },
                 "required": [
+                  "fileId",
                   "file"
                 ]
               }

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -2216,6 +2216,50 @@
                       "type": "string"
                     }
                   },
+                  "file": {
+                    "description": "Sample file param",
+                    "type": "string",
+                    "format": "binary"
+                  }
+                },
+                "required": [
+                  "x",
+                  "y",
+                  "z",
+                  "file"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "\/mock\/tests\/general\/upload-with-id": {
+      "post": {
+        "summary": "Upload File With ID",
+        "operationId": "generalUploadWithId",
+        "tags": [
+          "general"
+        ],
+        "description": "Upload fixture with a structurally inferred ID.",
+        "responses": {
+          "200": {
+            "description": "Mock",
+            "content": {
+              "application\/json": {
+                "schema": {
+                  "$ref": "#\/components\/schemas\/mock"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "multipart\/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
                   "fileId": {
                     "description": "Optional upload ID",
                     "type": "string"
@@ -2227,9 +2271,6 @@
                   }
                 },
                 "required": [
-                  "x",
-                  "y",
-                  "z",
                   "file"
                 ]
               }


### PR DESCRIPTION
## Summary

This removes sdk-generator's dependency on the custom `x-upload-id` OpenAPI extension.

Upload IDs are now inferred from standard `multipart/form-data` schema structure:

- find the operation's single binary string property
- derive the expected sibling name as `<binaryPropertyName>Id`
- accept that sibling only when it is a non-binary string property
- preserve whether the inferred ID is required or optional
- return no inferred ID for ambiguous schemas containing multiple binary properties

## Before

Appwrite marked the upload ID explicitly in the generated specification:

```json
{
  "fileId": {
    "type": "string",
    "x-upload-id": true
  },
  "file": {
    "type": "string",
    "format": "binary"
  }
}
```

Every affected SDK template then searched the operation parameters for that extension. For example:

```twig
{% for parameter in (method | parameters('all')) %}
{% if parameter | extension('x-upload-id', false) %}
    uploadId = {{ parameter.name }}
{% endif %}
{% endfor %}
```

This coupled chunked-upload generation to Appwrite-specific metadata even though the relationship was already represented by the multipart property names.

## Now

The specification only needs standard OpenAPI fields:

```json
{
  "type": "object",
  "properties": {
    "fileId": {
      "type": "string"
    },
    "file": {
      "type": "string",
      "format": "binary"
    }
  }
}
```

The generator centrally infers the pair:

```php
foreach ($schema->properties as $name => $property) {
    if (!$property instanceof StringSchema || $property->format !== 'binary') {
        continue;
    }

    $idName = $name . 'Id';
    $idProperty = $schema->properties[$idName] ?? null;

    if ($idProperty instanceof StringSchema && $idProperty->format !== 'binary') {
        // `file` pairs with `fileId`
    }
}
```

Templates consume the centralized result instead of reading an extension:

```twig
{% set uploadIdParameter = method | uploadIdParameter %}
{% if uploadIdParameter %}
    idParamName = '{{ uploadIdParameter.name }}'
{% endif %}
```

### Examples

A storage upload has `file` and `fileId`, so `fileId` is inferred as the resumable upload ID:

```text
file (binary) + fileId (string) -> fileId
```

A deployment upload has `code` but no `codeId`, so no caller-provided upload ID is inferred. The SDK continues obtaining the ID from the first chunk response:

```text
code (binary) + no codeId -> no inferred upload ID
```

Schemas with multiple binary properties are intentionally treated as ambiguous:

```text
archive (binary) + archiveId + file (binary) -> no inferred upload ID
```

## Optional upload IDs

The inferred parameter retains its required/optional status. Chunked-upload clients were hardened so an omitted optional ID does not produce `/null`, `/undefined`, or a force-cast failure. When absent, upload proceeds normally and adopts the ID returned by the first chunk.

## SDK coverage

Updated upload generation for:

- Android and Kotlin
- Apple and Swift
- Dart and Flutter
- .NET
- Deno and React Native
- Go and CLI
- PHP
- Python
- Ruby
- Rust

There are no remaining `x-upload-id` references under `src/`, `templates/`, or `tests/`.

## Validation

- regenerated PHP, Python, Ruby, Dart, Flutter, React Native, Go, CLI, Swift, Apple, .NET, Android, Kotlin, and Rust
- upload-ID inference tests for required, optional, absent, malformed, non-multipart, and ambiguous schemas
- generated integration fixture containing `file` + `fileId` without `x-upload-id`
- Go, Kotlin, Swift, .NET, PHP, Python, Ruby, Dart, Deno, React Native, and Rust e2e suites
- generated Go tests and `gofmt`
- Dart/Flutter formatting and Dart analysis
- .NET, Kotlin, Android, Swift, Apple, Rust, and PHP generated builds/tests
- `composer lint-twig`
- `composer refactor:check`
- PHP lint
- `git diff --check`

## Follow-up

After this is released, Appwrite can stop emitting `x-upload-id` and regenerate the latest and 1.9.x specifications without changing generated chunked-upload behavior.
