### PR TITLE
fix(cli): respect deployment intent and make template seeding retry-safe

### DIFF
--- a/templates/cli/internal/cmd/initfunction_test.go
+++ b/templates/cli/internal/cmd/initfunction_test.go
@@ -638,38 +638,45 @@ func TestCreateGitFunctionDeploymentKeepsSeedConsumedOnAmbiguousFailure(t *testi
 	}
 }
 
-// A 5xx does not say whether the deployment was accepted -- a proxy or server
-// error can arrive after acceptance -- so it keeps the seed consumed exactly
-// like a transport failure.
-func TestCreateGitFunctionDeploymentKeepsSeedConsumedOnServerError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
-		response.Header().Set("content-type", "application/json")
-		response.WriteHeader(http.StatusBadGateway)
-		_, _ = response.Write([]byte(`{"message":"upstream timed out","code":502}`))
-	}))
-	defer server.Close()
+// A 5xx or a 408 does not say whether the deployment was accepted -- a proxy
+// can emit either after acceptance upstream -- so both keep the seed consumed
+// exactly like a transport failure.
+func TestCreateGitFunctionDeploymentKeepsSeedConsumedOnAmbiguousStatus(t *testing.T) {
+	for _, status := range []int{
+		http.StatusInternalServerError, http.StatusBadGateway,
+		http.StatusGatewayTimeout, http.StatusRequestTimeout,
+	} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+				response.Header().Set("content-type", "application/json")
+				response.WriteHeader(status)
+				_, _ = response.Write([]byte(`{"message":"ambiguous failure"}`))
+			}))
+			defer server.Close()
 
-	path := filepath.Join(t.TempDir(), config.LocalFileName)
-	contents := `{"projectId":"project","functions":[{"$id":"checkout","templateRepository":"templates","templateOwner":"appwrite","templateRootDirectory":"node/starter","templateReference":"1.0.1","templateReferenceType":"tag"}]}`
-	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	local, err := config.LoadLocal(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	entry := local.ResourceEntries("functions")[0]
-	context := pushContext{api: client.New(server.URL, "test"), local: local}
+			path := filepath.Join(t.TempDir(), config.LocalFileName)
+			contents := `{"projectId":"project","functions":[{"$id":"checkout","templateRepository":"templates","templateOwner":"appwrite","templateRootDirectory":"node/starter","templateReference":"1.0.1","templateReferenceType":"tag"}]}`
+			if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			local, err := config.LoadLocal(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			entry := local.ResourceEntries("functions")[0]
+			context := pushContext{api: client.New(server.URL, "test"), local: local}
 
-	if _, err = context.createGitFunctionDeployment(entry, true); err == nil {
-		t.Fatal("a server error was not reported as an error")
-	}
+			if _, err = context.createGitFunctionDeployment(entry, true); err == nil {
+				t.Fatal("an ambiguous failure was not reported as an error")
+			}
 
-	reloaded, err := config.LoadLocal(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, exists := reloaded.ResourceEntries("functions")[0].Get("templateRepository"); exists {
-		t.Fatal("template coordinates were restored after an ambiguous 5xx")
+			reloaded, err := config.LoadLocal(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, exists := reloaded.ResourceEntries("functions")[0].Get("templateRepository"); exists {
+				t.Fatal("template coordinates were restored after an ambiguous status")
+			}
+		})
 	}
 }

--- a/templates/cli/internal/cmd/initfunction_test.go
+++ b/templates/cli/internal/cmd/initfunction_test.go
@@ -564,3 +564,50 @@ func TestPendingSafeBodyStripsVCSKeysWhilePending(t *testing.T) {
 		t.Error("installationId was stripped from a connected entry")
 	}
 }
+
+// A transport failure does not say whether the template deployment was
+// created, so the consumed coordinates stay consumed: restoring them could
+// merge the starter into the repository a second time.
+func TestCreateGitFunctionDeploymentKeepsSeedConsumedOnAmbiguousFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		hijacker, ok := response.(http.Hijacker)
+		if !ok {
+			t.Fatal("response writer cannot hijack")
+		}
+		connection, _, err := hijacker.Hijack()
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = connection.Close()
+	}))
+	defer server.Close()
+
+	path := filepath.Join(t.TempDir(), config.LocalFileName)
+	contents := `{"projectId":"project","functions":[{"$id":"checkout","templateRepository":"templates","templateOwner":"appwrite","templateRootDirectory":"node/starter","templateReference":"1.0.1","templateReferenceType":"tag"}]}`
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	local, err := config.LoadLocal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := local.ResourceEntries("functions")[0]
+	context := pushContext{api: client.New(server.URL, "test"), local: local}
+
+	_, err = context.createGitFunctionDeployment(entry, true)
+	if err == nil {
+		t.Fatal("a transport failure was not reported as an error")
+	}
+	if !strings.Contains(err.Error(), "may still have been created") {
+		t.Errorf("error does not warn about the ambiguous outcome: %v", err)
+	}
+
+	reloaded, err := config.LoadLocal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	persisted := reloaded.ResourceEntries("functions")[0]
+	if _, exists := persisted.Get("templateRepository"); exists {
+		t.Fatal("template coordinates were restored after an ambiguous failure")
+	}
+}

--- a/templates/cli/internal/cmd/initfunction_test.go
+++ b/templates/cli/internal/cmd/initfunction_test.go
@@ -483,3 +483,84 @@ func TestCreateGitFunctionDeploymentUsesBranchAfterSeed(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// The one-shot template coordinates are cleared and persisted BEFORE the
+// deployment request, so a deployment that succeeds remotely can never be
+// submitted twice by a retry -- even when saving the cleared state after the
+// fact would have failed. A request that fails restores the coordinates so
+// the seed is not lost.
+func TestCreateGitFunctionDeploymentRestoresTemplateOnFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), config.LocalFileName)
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		// At request time the persisted config must already have consumed the
+		// template coordinates; anything else re-seeds on retry.
+		persisted, err := config.LoadLocal(path)
+		if err != nil {
+			t.Errorf("load config during request: %v", err)
+		} else if persisted.ResourceEntries("functions")[0].GetString("templateRepository") != "" {
+			t.Error("template coordinates were not cleared before the request")
+		}
+		response.Header().Set("content-type", "application/json")
+		response.WriteHeader(http.StatusInternalServerError)
+		_, _ = response.Write([]byte(`{"message":"template deployment failed","code":500}`))
+	}))
+	defer server.Close()
+
+	contents := `{"projectId":"project","functions":[{"$id":"checkout","templateRepository":"templates","templateOwner":"appwrite","templateRootDirectory":"node/starter","templateReference":"1.0.1","templateReferenceType":"tag"}]}`
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	local, err := config.LoadLocal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := local.ResourceEntries("functions")[0]
+	context := pushContext{api: client.New(server.URL, "test"), local: local}
+
+	if _, err := context.createGitFunctionDeployment(entry, true); err == nil {
+		t.Fatal("a failed template deployment was not reported as an error")
+	}
+
+	reloaded, err := config.LoadLocal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	persisted := reloaded.ResourceEntries("functions")[0]
+	if persisted.GetString("templateRepository") != "templates" ||
+		persisted.GetString("templateReference") != "1.0.1" {
+		t.Fatalf("template coordinates were not restored: %#v", persisted)
+	}
+}
+
+// A settings-only push of a function whose GitHub repository is still pending
+// must not send the VCS connection keys: the repository does not exist yet, so
+// an installation without a repository would half-connect the function.
+func TestPendingSafeBodyStripsVCSKeysWhilePending(t *testing.T) {
+	entry := jsonx.NewObject()
+	entry.Set("providerRepositoryPending", true)
+
+	body := jsonx.NewObject()
+	body.Set("name", "Checkout")
+	body.Set("installationId", "installation")
+	body.Set("providerBranch", "main")
+	body.Set("providerSilentMode", false)
+	body.Set("providerRootDirectory", "./")
+
+	pruned := pendingSafeBody(entry, body)
+	if _, exists := pruned.Get("installationId"); exists {
+		t.Error("installationId survived a pending entry")
+	}
+	if _, exists := pruned.Get("providerBranch"); exists {
+		t.Error("providerBranch survived a pending entry")
+	}
+	if pruned.GetString("name") != "Checkout" {
+		t.Error("non-VCS keys must survive")
+	}
+
+	connected := jsonx.NewObject()
+	kept := jsonx.NewObject()
+	kept.Set("installationId", "installation")
+	if _, exists := pendingSafeBody(connected, kept).Get("installationId"); !exists {
+		t.Error("installationId was stripped from a connected entry")
+	}
+}

--- a/templates/cli/internal/cmd/initfunction_test.go
+++ b/templates/cli/internal/cmd/initfunction_test.go
@@ -150,9 +150,35 @@ func TestNewGitHubRepositoryIsCreatedOnlyAfterReview(t *testing.T) {
 		t.Fatal(err)
 	}
 	entry := reloaded.ResourceEntries("functions")[0]
-	if posts != 1 || entry.GetString("providerRepositoryId") != "repository" ||
-		entry.GetBool("providerRepositoryPending") {
+	if posts != 1 || entry.GetString("providerRepositoryId") != "repository" {
 		t.Fatalf("repository was not materialized: posts=%d entry=%#v", posts, entry)
+	}
+	// Pending survives materialization: it is cleared only once the deployment
+	// that needed the repository has been submitted, so a failure in between
+	// leaves a state the next push fully retries.
+	if !entry.GetBool("providerRepositoryPending") {
+		t.Fatal("pending flag was cleared before any deployment was submitted")
+	}
+
+	// A retry with the repository already recorded must not create another.
+	if err := context.materializePendingFunctionRepositories(
+		local.ResourceEntries("functions"),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if posts != 1 {
+		t.Fatalf("retry created a second repository: posts=%d", posts)
+	}
+
+	if err := context.confirmFunctionRepository(entry); err != nil {
+		t.Fatal(err)
+	}
+	confirmed, err := config.LoadLocal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if confirmed.ResourceEntries("functions")[0].GetBool("providerRepositoryPending") {
+		t.Fatal("pending flag survived repository confirmation")
 	}
 }
 
@@ -501,8 +527,8 @@ func TestCreateGitFunctionDeploymentRestoresTemplateOnFailure(t *testing.T) {
 			t.Error("template coordinates were not cleared before the request")
 		}
 		response.Header().Set("content-type", "application/json")
-		response.WriteHeader(http.StatusInternalServerError)
-		_, _ = response.Write([]byte(`{"message":"template deployment failed","code":500}`))
+		response.WriteHeader(http.StatusBadRequest)
+		_, _ = response.Write([]byte(`{"message":"template deployment rejected","code":400}`))
 	}))
 	defer server.Close()
 
@@ -609,5 +635,41 @@ func TestCreateGitFunctionDeploymentKeepsSeedConsumedOnAmbiguousFailure(t *testi
 	persisted := reloaded.ResourceEntries("functions")[0]
 	if _, exists := persisted.Get("templateRepository"); exists {
 		t.Fatal("template coordinates were restored after an ambiguous failure")
+	}
+}
+
+// A 5xx does not say whether the deployment was accepted -- a proxy or server
+// error can arrive after acceptance -- so it keeps the seed consumed exactly
+// like a transport failure.
+func TestCreateGitFunctionDeploymentKeepsSeedConsumedOnServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		response.Header().Set("content-type", "application/json")
+		response.WriteHeader(http.StatusBadGateway)
+		_, _ = response.Write([]byte(`{"message":"upstream timed out","code":502}`))
+	}))
+	defer server.Close()
+
+	path := filepath.Join(t.TempDir(), config.LocalFileName)
+	contents := `{"projectId":"project","functions":[{"$id":"checkout","templateRepository":"templates","templateOwner":"appwrite","templateRootDirectory":"node/starter","templateReference":"1.0.1","templateReferenceType":"tag"}]}`
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	local, err := config.LoadLocal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := local.ResourceEntries("functions")[0]
+	context := pushContext{api: client.New(server.URL, "test"), local: local}
+
+	if _, err = context.createGitFunctionDeployment(entry, true); err == nil {
+		t.Fatal("a server error was not reported as an error")
+	}
+
+	reloaded, err := config.LoadLocal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, exists := reloaded.ResourceEntries("functions")[0].Get("templateRepository"); exists {
+		t.Fatal("template coordinates were restored after an ambiguous 5xx")
 	}
 }

--- a/templates/cli/internal/cmd/initfunction_test.go
+++ b/templates/cli/internal/cmd/initfunction_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -150,35 +151,71 @@ func TestNewGitHubRepositoryIsCreatedOnlyAfterReview(t *testing.T) {
 		t.Fatal(err)
 	}
 	entry := reloaded.ResourceEntries("functions")[0]
-	if posts != 1 || entry.GetString("providerRepositoryId") != "repository" {
+	if posts != 1 || entry.GetString("providerRepositoryId") != "repository" ||
+		entry.GetBool("providerRepositoryPending") {
 		t.Fatalf("repository was not materialized: posts=%d entry=%#v", posts, entry)
 	}
-	// Pending survives materialization: it is cleared only once the deployment
-	// that needed the repository has been submitted, so a failure in between
-	// leaves a state the next push fully retries.
-	if !entry.GetBool("providerRepositoryPending") {
-		t.Fatal("pending flag was cleared before any deployment was submitted")
-	}
+}
 
-	// A retry with the repository already recorded must not create another.
-	if err := context.materializePendingFunctionRepositories(
-		local.ResourceEntries("functions"),
-	); err != nil {
+func TestPendingRepositoryIsNotCreatedWithoutDeployment(t *testing.T) {
+	vcsPosts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Header().Set("content-type", "application/json")
+		switch {
+		case strings.Contains(request.URL.Path, "/providerRepositories"):
+			vcsPosts++
+			response.WriteHeader(http.StatusCreated)
+			_, _ = response.Write([]byte(`{"providerRepositoryId":"repository"}`))
+		case request.Method == http.MethodGet && request.URL.Path == "/functions/checkout":
+			response.WriteHeader(http.StatusNotFound)
+			_, _ = response.Write([]byte(`{"message":"not found","code":404}`))
+		case request.Method == http.MethodPost && request.URL.Path == "/functions":
+			body := jsonx.NewObject()
+			if err := json.NewDecoder(request.Body).Decode(body); err != nil {
+				t.Errorf("decode settings body: %v", err)
+			}
+			if _, exists := body.Get("installationId"); exists {
+				t.Error("settings-only push sent VCS fields for a pending repository")
+			}
+			response.WriteHeader(http.StatusCreated)
+			_, _ = response.Write([]byte(`{"$id":"checkout"}`))
+		case request.Method == http.MethodGet && request.URL.Path == "/proxy/rules":
+			_, _ = response.Write([]byte(`{"total":0,"rules":[]}`))
+		default:
+			t.Errorf("unexpected request: %s %s", request.Method, request.URL.String())
+			response.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	preferencesWith(t, fmt.Sprintf(
+		`{"current":"test","test":{"endpoint":%q,"key":"secret"}}`, server.URL))
+	directory := t.TempDir()
+	inDirectory(t, directory)
+	path := filepath.Join(directory, config.LocalFileName)
+	contents := `{"projectId":"project","functions":[{"$id":"checkout","name":"Checkout","runtime":"node-22","entrypoint":"src/main.js","installationId":"installation","providerRepositoryName":"team/checkout","providerRepositoryPrivate":true,"providerRepositoryPending":true,"providerBranch":"main","providerRootDirectory":"./"}]}`
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if posts != 1 {
-		t.Fatalf("retry created a second repository: posts=%d", posts)
-	}
 
-	if err := context.confirmFunctionRepository(entry); err != nil {
+	command := &cobra.Command{Use: "push function"}
+	command.SetOut(&bytes.Buffer{})
+	command.SetErr(&bytes.Buffer{})
+	if err := runPushDeployable(command, deployables[0], deployOptions{
+		ResourceID: "checkout",
+		Code:       false,
+	}); err != nil {
 		t.Fatal(err)
 	}
-	confirmed, err := config.LoadLocal(path)
+	if vcsPosts != 0 {
+		t.Fatalf("settings-only push created %d repositories", vcsPosts)
+	}
+	reloaded, err := config.LoadLocal(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if confirmed.ResourceEntries("functions")[0].GetBool("providerRepositoryPending") {
-		t.Fatal("pending flag survived repository confirmation")
+	if !reloaded.ResourceEntries("functions")[0].GetBool("providerRepositoryPending") {
+		t.Fatal("settings-only push cleared pending repository intent")
 	}
 }
 
@@ -427,6 +464,7 @@ func TestRemoveOtherPreviewRulesPreservesCustomDomain(t *testing.T) {
 }
 
 func TestCreateGitFunctionDeploymentSeedsTemplateOnce(t *testing.T) {
+	path := filepath.Join(t.TempDir(), config.LocalFileName)
 	var body map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		if request.URL.Path != "/functions/checkout/deployments/template" {
@@ -435,13 +473,18 @@ func TestCreateGitFunctionDeploymentSeedsTemplateOnce(t *testing.T) {
 		if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
 			t.Errorf("decode body: %v", err)
 		}
+		persisted, err := config.LoadLocal(path)
+		if err != nil {
+			t.Errorf("load config during request: %v", err)
+		} else if persisted.ResourceEntries("functions")[0].GetString("templateRepository") != "" {
+			t.Error("template coordinates were not consumed before the request")
+		}
 		response.Header().Set("content-type", "application/json")
 		response.WriteHeader(http.StatusAccepted)
 		_, _ = response.Write([]byte(`{"$id":"deployment-1","status":"waiting"}`))
 	}))
 	defer server.Close()
 
-	path := filepath.Join(t.TempDir(), config.LocalFileName)
 	contents := `{"projectId":"project","functions":[{"$id":"checkout","templateRepository":"templates","templateOwner":"appwrite","templateRootDirectory":"node/starter","templateReference":"1.0.1","templateReferenceType":"tag"}]}`
 	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
 		t.Fatal(err)
@@ -507,176 +550,5 @@ func TestCreateGitFunctionDeploymentUsesBranchAfterSeed(t *testing.T) {
 
 	if _, err := context.createGitFunctionDeployment(entry, true); err != nil {
 		t.Fatal(err)
-	}
-}
-
-// The one-shot template coordinates are cleared and persisted BEFORE the
-// deployment request, so a deployment that succeeds remotely can never be
-// submitted twice by a retry -- even when saving the cleared state after the
-// fact would have failed. A request that fails restores the coordinates so
-// the seed is not lost.
-func TestCreateGitFunctionDeploymentRestoresTemplateOnFailure(t *testing.T) {
-	path := filepath.Join(t.TempDir(), config.LocalFileName)
-	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
-		// At request time the persisted config must already have consumed the
-		// template coordinates; anything else re-seeds on retry.
-		persisted, err := config.LoadLocal(path)
-		if err != nil {
-			t.Errorf("load config during request: %v", err)
-		} else if persisted.ResourceEntries("functions")[0].GetString("templateRepository") != "" {
-			t.Error("template coordinates were not cleared before the request")
-		}
-		response.Header().Set("content-type", "application/json")
-		response.WriteHeader(http.StatusBadRequest)
-		_, _ = response.Write([]byte(`{"message":"template deployment rejected","code":400}`))
-	}))
-	defer server.Close()
-
-	contents := `{"projectId":"project","functions":[{"$id":"checkout","templateRepository":"templates","templateOwner":"appwrite","templateRootDirectory":"node/starter","templateReference":"1.0.1","templateReferenceType":"tag"}]}`
-	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	local, err := config.LoadLocal(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	entry := local.ResourceEntries("functions")[0]
-	context := pushContext{api: client.New(server.URL, "test"), local: local}
-
-	if _, err := context.createGitFunctionDeployment(entry, true); err == nil {
-		t.Fatal("a failed template deployment was not reported as an error")
-	}
-
-	reloaded, err := config.LoadLocal(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	persisted := reloaded.ResourceEntries("functions")[0]
-	if persisted.GetString("templateRepository") != "templates" ||
-		persisted.GetString("templateReference") != "1.0.1" {
-		t.Fatalf("template coordinates were not restored: %#v", persisted)
-	}
-}
-
-// A settings-only push of a function whose GitHub repository is still pending
-// must not send the VCS connection keys: the repository does not exist yet, so
-// an installation without a repository would half-connect the function.
-func TestPendingSafeBodyStripsVCSKeysWhilePending(t *testing.T) {
-	entry := jsonx.NewObject()
-	entry.Set("providerRepositoryPending", true)
-
-	body := jsonx.NewObject()
-	body.Set("name", "Checkout")
-	body.Set("installationId", "installation")
-	body.Set("providerBranch", "main")
-	body.Set("providerSilentMode", false)
-	body.Set("providerRootDirectory", "./")
-
-	pruned := pendingSafeBody(entry, body)
-	if _, exists := pruned.Get("installationId"); exists {
-		t.Error("installationId survived a pending entry")
-	}
-	if _, exists := pruned.Get("providerBranch"); exists {
-		t.Error("providerBranch survived a pending entry")
-	}
-	if pruned.GetString("name") != "Checkout" {
-		t.Error("non-VCS keys must survive")
-	}
-
-	connected := jsonx.NewObject()
-	kept := jsonx.NewObject()
-	kept.Set("installationId", "installation")
-	if _, exists := pendingSafeBody(connected, kept).Get("installationId"); !exists {
-		t.Error("installationId was stripped from a connected entry")
-	}
-}
-
-// A transport failure does not say whether the template deployment was
-// created, so the consumed coordinates stay consumed: restoring them could
-// merge the starter into the repository a second time.
-func TestCreateGitFunctionDeploymentKeepsSeedConsumedOnAmbiguousFailure(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
-		hijacker, ok := response.(http.Hijacker)
-		if !ok {
-			t.Fatal("response writer cannot hijack")
-		}
-		connection, _, err := hijacker.Hijack()
-		if err != nil {
-			t.Fatal(err)
-		}
-		_ = connection.Close()
-	}))
-	defer server.Close()
-
-	path := filepath.Join(t.TempDir(), config.LocalFileName)
-	contents := `{"projectId":"project","functions":[{"$id":"checkout","templateRepository":"templates","templateOwner":"appwrite","templateRootDirectory":"node/starter","templateReference":"1.0.1","templateReferenceType":"tag"}]}`
-	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	local, err := config.LoadLocal(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	entry := local.ResourceEntries("functions")[0]
-	context := pushContext{api: client.New(server.URL, "test"), local: local}
-
-	_, err = context.createGitFunctionDeployment(entry, true)
-	if err == nil {
-		t.Fatal("a transport failure was not reported as an error")
-	}
-	if !strings.Contains(err.Error(), "may still have been created") {
-		t.Errorf("error does not warn about the ambiguous outcome: %v", err)
-	}
-
-	reloaded, err := config.LoadLocal(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	persisted := reloaded.ResourceEntries("functions")[0]
-	if _, exists := persisted.Get("templateRepository"); exists {
-		t.Fatal("template coordinates were restored after an ambiguous failure")
-	}
-}
-
-// A 5xx or a 408 does not say whether the deployment was accepted -- a proxy
-// can emit either after acceptance upstream -- so both keep the seed consumed
-// exactly like a transport failure.
-func TestCreateGitFunctionDeploymentKeepsSeedConsumedOnAmbiguousStatus(t *testing.T) {
-	for _, status := range []int{
-		http.StatusInternalServerError, http.StatusBadGateway,
-		http.StatusGatewayTimeout, http.StatusRequestTimeout,
-	} {
-		t.Run(http.StatusText(status), func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
-				response.Header().Set("content-type", "application/json")
-				response.WriteHeader(status)
-				_, _ = response.Write([]byte(`{"message":"ambiguous failure"}`))
-			}))
-			defer server.Close()
-
-			path := filepath.Join(t.TempDir(), config.LocalFileName)
-			contents := `{"projectId":"project","functions":[{"$id":"checkout","templateRepository":"templates","templateOwner":"appwrite","templateRootDirectory":"node/starter","templateReference":"1.0.1","templateReferenceType":"tag"}]}`
-			if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
-				t.Fatal(err)
-			}
-			local, err := config.LoadLocal(path)
-			if err != nil {
-				t.Fatal(err)
-			}
-			entry := local.ResourceEntries("functions")[0]
-			context := pushContext{api: client.New(server.URL, "test"), local: local}
-
-			if _, err = context.createGitFunctionDeployment(entry, true); err == nil {
-				t.Fatal("an ambiguous failure was not reported as an error")
-			}
-
-			reloaded, err := config.LoadLocal(path)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if _, exists := reloaded.ResourceEntries("functions")[0].Get("templateRepository"); exists {
-				t.Fatal("template coordinates were restored after an ambiguous status")
-			}
-		})
 	}
 }

--- a/templates/cli/internal/cmd/pushcommon.go
+++ b/templates/cli/internal/cmd/pushcommon.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/app"
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/client"
@@ -76,6 +77,11 @@ type pushContext struct {
 	api      *client.Client
 	local    *config.Local
 	prompter prompt.Prompter
+	// configMutex serializes mutations of the shared local configuration.
+	// Parallel function workers share one config.Local, and an unsynchronized
+	// upsert-and-write could overwrite another worker's repository or template
+	// state.
+	configMutex sync.Mutex
 	// screenshots is built on first use by pushpreview.go, and only by a site
 	// push -- it needs a console session the other resources never ask for.
 	screenshots *screenshots

--- a/templates/cli/internal/cmd/pushcommon.go
+++ b/templates/cli/internal/cmd/pushcommon.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"sort"
 	"strings"
-	"sync"
 
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/app"
 	"github.com/{{ sdk.gitUserName }}/{{ sdk.gitRepoName | caseDash }}/internal/client"
@@ -77,11 +76,6 @@ type pushContext struct {
 	api      *client.Client
 	local    *config.Local
 	prompter prompt.Prompter
-	// configMutex serializes mutations of the shared local configuration.
-	// Parallel function workers share one config.Local, and an unsynchronized
-	// upsert-and-write could overwrite another worker's repository or template
-	// state.
-	configMutex sync.Mutex
 	// screenshots is built on first use by pushpreview.go, and only by a site
 	// push -- it needs a console session the other resources never ask for.
 	screenshots *screenshots

--- a/templates/cli/internal/cmd/pushdeploy.go
+++ b/templates/cli/internal/cmd/pushdeploy.go
@@ -3,6 +3,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -693,16 +694,6 @@ func runPushDeployable(
 		pushCode = confirmed
 	}
 
-	// Repositories accepted on the init review screen are created only once a
-	// deployment is actually requested. A settings-only push (--no-code, or a
-	// declined confirmation) must not leave an empty GitHub repository behind;
-	// the pending intent stays in the config for the push that deploys.
-	if pushCode && resource.Name == "function" {
-		if err := context.materializePendingFunctionRepositories(entries); err != nil {
-			return err
-		}
-	}
-
 	activate := true
 	if pushCode && !options.ActivateSet {
 		// --force answers this rather than asking anyway: --force means "do not
@@ -1115,6 +1106,28 @@ func (c *pushContext) pushDeployable(
 		return
 	}
 
+	// A repository accepted on the init review screen is created here, as the
+	// last step before the deployment that needs it, once every earlier push
+	// step has succeeded. Any earlier and a failed settings write, endpoint
+	// rule, or variable replacement would leave an unwanted empty GitHub
+	// repository behind with no deployment submitted.
+	if resource.Name == "function" && entry.GetBool("providerRepositoryPending") {
+		if err := c.materializePendingFunctionRepository(entry); err != nil {
+			recordPushFailure(command, resource, name, err.Error(), summary)
+
+			return
+		}
+		// The settings write above omitted the VCS connection keys while the
+		// repository was pending; connect the function now that it exists.
+		err := c.api.Call("PUT", resource.Path+"/"+url.PathEscape(id),
+			writeBody(entry, resource.WriteKeys, resource.OmitWhenEmpty, "", ""), nil)
+		if err != nil {
+			recordPushFailure(command, resource, name, err.Error(), summary)
+
+			return
+		}
+	}
+
 	deployment, err := c.createDeployment(command, resource, entry, run.Activate)
 	if err != nil {
 		recordPushFailure(command, resource, name, err.Error(), summary)
@@ -1290,33 +1303,43 @@ func (c *pushContext) materializePendingFunctionRepositories(
 		if !entry.GetBool("providerRepositoryPending") {
 			continue
 		}
-		vcs := functionVCS{
-			InstallationID:    entry.GetString("installationId"),
-			RepositoryName:    entry.GetString("providerRepositoryName"),
-			Branch:            entry.GetString("providerBranch"),
-			RootDirectory:     entry.GetString("providerRootDirectory"),
-			SilentMode:        entry.GetBool("providerSilentMode"),
-			CreateRepository:  true,
-			RepositoryPrivate: entry.GetBool("providerRepositoryPrivate"),
+		if err := c.materializePendingFunctionRepository(entry); err != nil {
+			return err
 		}
-		created, err := createFunctionVCSRepository(c.api, vcs)
-		if err != nil {
-			created, err = c.findPendingFunctionRepository(vcs)
-			if err != nil {
-				return fmt.Errorf("create GitHub repository %s: %w", vcs.RepositoryName, err)
-			}
-		}
+	}
 
-		entry.Set("providerRepositoryId", created.RepositoryID)
-		entry.Set("providerRepositoryName", created.RepositoryName)
-		entry.Delete("providerRepositoryPrivate")
-		entry.Delete("providerRepositoryPending")
-		c.local.UpsertByID("functions", entry)
-		if err := c.local.Write(); err != nil {
-			return fmt.Errorf(
-				"GitHub repository %s was created but its id could not be saved; retry this push to recover it: %w",
-				created.RepositoryName, err)
+	return nil
+}
+
+func (c *pushContext) materializePendingFunctionRepository(
+	entry *jsonx.Object,
+) error {
+	vcs := functionVCS{
+		InstallationID:    entry.GetString("installationId"),
+		RepositoryName:    entry.GetString("providerRepositoryName"),
+		Branch:            entry.GetString("providerBranch"),
+		RootDirectory:     entry.GetString("providerRootDirectory"),
+		SilentMode:        entry.GetBool("providerSilentMode"),
+		CreateRepository:  true,
+		RepositoryPrivate: entry.GetBool("providerRepositoryPrivate"),
+	}
+	created, err := createFunctionVCSRepository(c.api, vcs)
+	if err != nil {
+		created, err = c.findPendingFunctionRepository(vcs)
+		if err != nil {
+			return fmt.Errorf("create GitHub repository %s: %w", vcs.RepositoryName, err)
 		}
+	}
+
+	entry.Set("providerRepositoryId", created.RepositoryID)
+	entry.Set("providerRepositoryName", created.RepositoryName)
+	entry.Delete("providerRepositoryPrivate")
+	entry.Delete("providerRepositoryPending")
+	c.local.UpsertByID("functions", entry)
+	if err := c.local.Write(); err != nil {
+		return fmt.Errorf(
+			"GitHub repository %s was created but its id could not be saved; retry this push to recover it: %w",
+			created.RepositoryName, err)
 	}
 
 	return nil
@@ -1477,6 +1500,18 @@ func (c *pushContext) createGitFunctionDeployment(
 	deployment := jsonx.NewObject()
 	if err := c.api.Call("POST", path, body, deployment); err != nil {
 		if template {
+			// Restore only on a definite server rejection. A timeout, read, or
+			// decode failure does not say whether the deployment was created,
+			// and a consumed seed cannot merge the starter twice -- a restored
+			// one can. `init function` can re-add the coordinates if the seed
+			// truly never landed.
+			var apiError *client.APIError
+			if !errors.As(err, &apiError) {
+				return nil, fmt.Errorf(
+					"%w; the template deployment may still have been created -- "+
+						"check the function's deployments before pushing again",
+					err)
+			}
 			for key, value := range saved {
 				entry.Set(key, value)
 			}

--- a/templates/cli/internal/cmd/pushdeploy.go
+++ b/templates/cli/internal/cmd/pushdeploy.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -1111,7 +1112,9 @@ func (c *pushContext) pushDeployable(
 	// step has succeeded. Any earlier and a failed settings write, endpoint
 	// rule, or variable replacement would leave an unwanted empty GitHub
 	// repository behind with no deployment submitted.
-	if resource.Name == "function" && entry.GetBool("providerRepositoryPending") {
+	wasPending := resource.Name == "function" &&
+		entry.GetBool("providerRepositoryPending")
+	if wasPending {
 		if err := c.materializePendingFunctionRepository(entry); err != nil {
 			recordPushFailure(command, resource, name, err.Error(), summary)
 
@@ -1133,6 +1136,13 @@ func (c *pushContext) pushDeployable(
 		recordPushFailure(command, resource, name, err.Error(), summary)
 
 		return
+	}
+	if wasPending {
+		if err := c.confirmFunctionRepository(entry); err != nil {
+			recordPushFailure(command, resource, name, err.Error(), summary)
+
+			return
+		}
 	}
 	summary.Pushed++
 
@@ -1314,6 +1324,13 @@ func (c *pushContext) materializePendingFunctionRepositories(
 func (c *pushContext) materializePendingFunctionRepository(
 	entry *jsonx.Object,
 ) error {
+	// A repository id with the pending flag still set is an earlier push that
+	// created the repository and then failed before its deployment was
+	// submitted. The repository exists; nothing needs creating.
+	if entry.GetString("providerRepositoryId") != "" {
+		return nil
+	}
+
 	vcs := functionVCS{
 		InstallationID:    entry.GetString("installationId"),
 		RepositoryName:    entry.GetString("providerRepositoryName"),
@@ -1331,10 +1348,13 @@ func (c *pushContext) materializePendingFunctionRepository(
 		}
 	}
 
+	// The pending flag survives materialization on purpose: it is cleared only
+	// once the deployment that needed the repository has been submitted, so a
+	// failed VCS connection or deployment leaves a state the next push fully
+	// retries -- creation falls back to finding the repository by name, and the
+	// connection is re-sent -- instead of an orphaned repository nothing owns.
 	entry.Set("providerRepositoryId", created.RepositoryID)
 	entry.Set("providerRepositoryName", created.RepositoryName)
-	entry.Delete("providerRepositoryPrivate")
-	entry.Delete("providerRepositoryPending")
 	c.local.UpsertByID("functions", entry)
 	if err := c.local.Write(); err != nil {
 		return fmt.Errorf(
@@ -1343,6 +1363,17 @@ func (c *pushContext) materializePendingFunctionRepository(
 	}
 
 	return nil
+}
+
+// confirmFunctionRepository marks a pending repository as owned: its
+// deployment was submitted, so the next push must treat the function as an
+// ordinary connected one rather than re-running the pending flow.
+func (c *pushContext) confirmFunctionRepository(entry *jsonx.Object) error {
+	entry.Delete("providerRepositoryPrivate")
+	entry.Delete("providerRepositoryPending")
+	c.local.UpsertByID("functions", entry)
+
+	return c.local.Write()
 }
 
 func (c *pushContext) findPendingFunctionRepository(
@@ -1500,13 +1531,16 @@ func (c *pushContext) createGitFunctionDeployment(
 	deployment := jsonx.NewObject()
 	if err := c.api.Call("POST", path, body, deployment); err != nil {
 		if template {
-			// Restore only on a definite server rejection. A timeout, read, or
-			// decode failure does not say whether the deployment was created,
-			// and a consumed seed cannot merge the starter twice -- a restored
-			// one can. `init function` can re-add the coordinates if the seed
-			// truly never landed.
+			// Restore only on a definite client-error rejection. A timeout,
+			// read, or decode failure does not say whether the deployment was
+			// created, and neither does a 5xx -- a proxy or server error can
+			// arrive after the deployment was accepted. A consumed seed cannot
+			// merge the starter twice; a restored one can, and `init function`
+			// can re-add the coordinates if the seed truly never landed.
 			var apiError *client.APIError
-			if !errors.As(err, &apiError) {
+			if !errors.As(err, &apiError) ||
+				apiError.Status < http.StatusBadRequest ||
+				apiError.Status >= http.StatusInternalServerError {
 				return nil, fmt.Errorf(
 					"%w; the template deployment may still have been created -- "+
 						"check the function's deployments before pushing again",

--- a/templates/cli/internal/cmd/pushdeploy.go
+++ b/templates/cli/internal/cmd/pushdeploy.go
@@ -3,10 +3,8 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -695,6 +693,12 @@ func runPushDeployable(
 		pushCode = confirmed
 	}
 
+	if pushCode && resource.Name == "function" {
+		if err := context.materializePendingFunctionRepositories(entries); err != nil {
+			return err
+		}
+	}
+
 	activate := true
 	if pushCode && !options.ActivateSet {
 		// --force answers this rather than asking anyway: --force means "do not
@@ -732,7 +736,17 @@ func runPushDeployable(
 	}
 
 	summary := pushSummary{}
-	if resource.Name == "function" && len(entries) > 1 {
+	parallel := resource.Name == "function" && len(entries) > 1
+	for _, entry := range entries {
+		if entry.GetString("templateRepository") != "" {
+			// Template deployment consumes and persists one-shot state. Keep that
+			// rare batch sequential so workers never write the shared config at
+			// the same time.
+			parallel = false
+			break
+		}
+	}
+	if parallel {
 		// Individual spinners own one terminal row and cannot safely redraw the
 		// same row from several goroutines. A synchronized writer keeps every
 		// line intact and deliberately makes parallel progress use the spinner's
@@ -1107,40 +1121,6 @@ func (c *pushContext) pushDeployable(
 		return
 	}
 
-	// A repository accepted on the init review screen is created here, as the
-	// last step before the deployment that needs it, once every earlier push
-	// step has succeeded. Any earlier and a failed settings write, endpoint
-	// rule, or variable replacement would leave an unwanted empty GitHub
-	// repository behind with no deployment submitted.
-	wasPending := resource.Name == "function" &&
-		entry.GetBool("providerRepositoryPending")
-	if wasPending {
-		if err := c.materializePendingFunctionRepository(entry); err != nil {
-			recordPushFailure(command, resource, name, err.Error(), summary)
-
-			return
-		}
-		// The settings write above omitted the VCS connection keys while the
-		// repository was pending; connect the function now that it exists.
-		err := c.api.Call("PUT", resource.Path+"/"+url.PathEscape(id),
-			writeBody(entry, resource.WriteKeys, resource.OmitWhenEmpty, "", ""), nil)
-		if err != nil {
-			recordPushFailure(command, resource, name, err.Error(), summary)
-
-			return
-		}
-		// Confirmed after the connection and BEFORE the deployment: once the
-		// function is connected server-side the pending flow has nothing left
-		// to redo, and clearing the flag now means a failed confirmation stops
-		// the push before anything is submitted -- were it cleared after, a
-		// failed write would replay a submission that already succeeded.
-		if err := c.confirmFunctionRepository(entry); err != nil {
-			recordPushFailure(command, resource, name, err.Error(), summary)
-
-			return
-		}
-	}
-
 	deployment, err := c.createDeployment(command, resource, entry, run.Activate)
 	if err != nil {
 		recordPushFailure(command, resource, name, err.Error(), summary)
@@ -1167,10 +1147,9 @@ func recordPushFailure(
 	summary.Failed = append(summary.Failed, failedDeployment{Name: name, Reason: reason})
 }
 
-// pendingSafeBody strips the VCS connection keys from a write body while the
-// entry's GitHub repository is still pending. The repository does not exist
-// until a deployment push materializes it, so sending an installation without
-// a repository would half-connect the function to nothing.
+// pendingSafeBody strips VCS fields while a new repository is still pending.
+// A settings-only push must not connect the function before that repository
+// exists.
 func pendingSafeBody(entry, body *jsonx.Object) *jsonx.Object {
 	if !entry.GetBool("providerRepositoryPending") {
 		return body
@@ -1316,92 +1295,36 @@ func (c *pushContext) materializePendingFunctionRepositories(
 		if !entry.GetBool("providerRepositoryPending") {
 			continue
 		}
-		if err := c.materializePendingFunctionRepository(entry); err != nil {
-			return err
+		vcs := functionVCS{
+			InstallationID:    entry.GetString("installationId"),
+			RepositoryName:    entry.GetString("providerRepositoryName"),
+			Branch:            entry.GetString("providerBranch"),
+			RootDirectory:     entry.GetString("providerRootDirectory"),
+			SilentMode:        entry.GetBool("providerSilentMode"),
+			CreateRepository:  true,
+			RepositoryPrivate: entry.GetBool("providerRepositoryPrivate"),
 		}
-	}
-
-	return nil
-}
-
-func (c *pushContext) materializePendingFunctionRepository(
-	entry *jsonx.Object,
-) error {
-	// A repository id with the pending flag still set is an earlier push that
-	// created the repository and then failed before its deployment was
-	// submitted. The repository exists; nothing needs creating.
-	if entry.GetString("providerRepositoryId") != "" {
-		return nil
-	}
-
-	vcs := functionVCS{
-		InstallationID:    entry.GetString("installationId"),
-		RepositoryName:    entry.GetString("providerRepositoryName"),
-		Branch:            entry.GetString("providerBranch"),
-		RootDirectory:     entry.GetString("providerRootDirectory"),
-		SilentMode:        entry.GetBool("providerSilentMode"),
-		CreateRepository:  true,
-		RepositoryPrivate: entry.GetBool("providerRepositoryPrivate"),
-	}
-	created, err := createFunctionVCSRepository(c.api, vcs)
-	if err != nil {
-		created, err = c.findPendingFunctionRepository(vcs)
+		created, err := createFunctionVCSRepository(c.api, vcs)
 		if err != nil {
-			return fmt.Errorf("create GitHub repository %s: %w", vcs.RepositoryName, err)
+			created, err = c.findPendingFunctionRepository(vcs)
+			if err != nil {
+				return fmt.Errorf("create GitHub repository %s: %w", vcs.RepositoryName, err)
+			}
 		}
-	}
 
-	// The pending flag survives materialization on purpose: it is cleared only
-	// once the deployment that needed the repository has been submitted, so a
-	// failed VCS connection or deployment leaves a state the next push fully
-	// retries -- creation falls back to finding the repository by name, and the
-	// connection is re-sent -- instead of an orphaned repository nothing owns.
-	if err := c.persistEntry(entry, func() {
 		entry.Set("providerRepositoryId", created.RepositoryID)
 		entry.Set("providerRepositoryName", created.RepositoryName)
-	}); err != nil {
-		return fmt.Errorf(
-			"GitHub repository %s was created but its id could not be saved; retry this push to recover it: %w",
-			created.RepositoryName, err)
+		entry.Delete("providerRepositoryPrivate")
+		entry.Delete("providerRepositoryPending")
+		c.local.UpsertByID("functions", entry)
+		if err := c.local.Write(); err != nil {
+			return fmt.Errorf(
+				"GitHub repository %s was created but its id could not be saved; retry this push to recover it: %w",
+				created.RepositoryName, err)
+		}
 	}
 
 	return nil
-}
-
-// confirmFunctionRepository marks a pending repository as owned: its
-// deployment was submitted, so the next push must treat the function as an
-// ordinary connected one rather than re-running the pending flow.
-func (c *pushContext) confirmFunctionRepository(entry *jsonx.Object) error {
-	return c.persistEntry(entry, func() {
-		entry.Delete("providerRepositoryPrivate")
-		entry.Delete("providerRepositoryPending")
-	})
-}
-
-// persistEntry runs mutate and records the entry in the shared local
-// configuration as one atomic step. Parallel function workers share one
-// config.Local, and serialization reads every entry: a Set or Delete outside
-// the lock could race a Write another worker holds the lock for.
-func (c *pushContext) persistEntry(entry *jsonx.Object, mutate func()) error {
-	c.configMutex.Lock()
-	defer c.configMutex.Unlock()
-	if mutate != nil {
-		mutate()
-	}
-	c.local.UpsertByID("functions", entry)
-
-	return c.local.Write()
-}
-
-// upsertEntry runs mutate and records the entry in memory only, for restoring
-// state after a write that already failed.
-func (c *pushContext) upsertEntry(entry *jsonx.Object, mutate func()) {
-	c.configMutex.Lock()
-	defer c.configMutex.Unlock()
-	if mutate != nil {
-		mutate()
-	}
-	c.local.UpsertByID("functions", entry)
 }
 
 func (c *pushContext) findPendingFunctionRepository(
@@ -1527,65 +1450,37 @@ func (c *pushContext) createGitFunctionDeployment(
 		body.Set("reference", entry.GetString("providerBranch"))
 	}
 
-	// Template coordinates are one-shot. Keeping them would merge the starter
-	// into the repository again on every explicit CLI deployment, so they are
-	// cleared and persisted BEFORE the request: once the deployment succeeds
-	// no retry can submit the seed twice, and a request that fails restores
-	// them so the seed is not lost.
-	templateKeys := []string{
-		"templateRepository", "templateOwner", "templateRootDirectory",
-		"templateReference", "templateReferenceType",
-	}
-	saved := map[string]any{}
+	// Consume template coordinates before the request. Once an HTTP request is
+	// attempted its outcome can be ambiguous, so leaving them consumed is the
+	// only way a retry cannot seed the starter twice.
 	if template {
-		if err := c.persistEntry(entry, func() {
-			for _, key := range templateKeys {
-				if value, ok := entry.Get(key); ok {
-					saved[key] = value
-				}
-				entry.Delete(key)
+		saved := map[string]any{}
+		for _, key := range []string{
+			"templateRepository", "templateOwner", "templateRootDirectory",
+			"templateReference", "templateReferenceType",
+		} {
+			if value, ok := entry.Get(key); ok {
+				saved[key] = value
 			}
-		}); err != nil {
-			c.upsertEntry(entry, func() {
-				for key, value := range saved {
-					entry.Set(key, value)
-				}
-			})
+			entry.Delete(key)
+		}
+		c.local.UpsertByID("functions", entry)
+		if err := c.local.Write(); err != nil {
+			for key, value := range saved {
+				entry.Set(key, value)
+			}
+			c.local.UpsertByID("functions", entry)
 
-			return nil, fmt.Errorf(
-				"template state could not be saved; nothing was deployed: %w", err)
+			return nil, fmt.Errorf("template state could not be saved; nothing was deployed: %w", err)
 		}
 	}
 
 	deployment := jsonx.NewObject()
 	if err := c.api.Call("POST", path, body, deployment); err != nil {
 		if template {
-			// Restore only on a definite client-error rejection. A timeout,
-			// read, or decode failure does not say whether the deployment was
-			// created, and neither does a 5xx or a 408 -- a proxy can emit
-			// either after the deployment was accepted upstream. A consumed
-			// seed cannot merge the starter twice; a restored one can, and
-			// `init function` can re-add the coordinates if the seed truly
-			// never landed.
-			var apiError *client.APIError
-			if !errors.As(err, &apiError) ||
-				apiError.Status < http.StatusBadRequest ||
-				apiError.Status >= http.StatusInternalServerError ||
-				apiError.Status == http.StatusRequestTimeout {
-				return nil, fmt.Errorf(
-					"%w; the template deployment may still have been created -- "+
-						"check the function's deployments before pushing again",
-					err)
-			}
-			if writeErr := c.persistEntry(entry, func() {
-				for key, value := range saved {
-					entry.Set(key, value)
-				}
-			}); writeErr != nil {
-				return nil, fmt.Errorf(
-					"%w (the template coordinates could also not be restored to %s: %v)",
-					err, config.LocalFileName, writeErr)
-			}
+			return nil, fmt.Errorf(
+				"%w; template state was consumed before the request -- check the function's deployments before retrying",
+				err)
 		}
 
 		return nil, err

--- a/templates/cli/internal/cmd/pushdeploy.go
+++ b/templates/cli/internal/cmd/pushdeploy.go
@@ -1533,14 +1533,16 @@ func (c *pushContext) createGitFunctionDeployment(
 		if template {
 			// Restore only on a definite client-error rejection. A timeout,
 			// read, or decode failure does not say whether the deployment was
-			// created, and neither does a 5xx -- a proxy or server error can
-			// arrive after the deployment was accepted. A consumed seed cannot
-			// merge the starter twice; a restored one can, and `init function`
-			// can re-add the coordinates if the seed truly never landed.
+			// created, and neither does a 5xx or a 408 -- a proxy can emit
+			// either after the deployment was accepted upstream. A consumed
+			// seed cannot merge the starter twice; a restored one can, and
+			// `init function` can re-add the coordinates if the seed truly
+			// never landed.
 			var apiError *client.APIError
 			if !errors.As(err, &apiError) ||
 				apiError.Status < http.StatusBadRequest ||
-				apiError.Status >= http.StatusInternalServerError {
+				apiError.Status >= http.StatusInternalServerError ||
+				apiError.Status == http.StatusRequestTimeout {
 				return nil, fmt.Errorf(
 					"%w; the template deployment may still have been created -- "+
 						"check the function's deployments before pushing again",

--- a/templates/cli/internal/cmd/pushdeploy.go
+++ b/templates/cli/internal/cmd/pushdeploy.go
@@ -1358,8 +1358,7 @@ func (c *pushContext) materializePendingFunctionRepository(
 	// connection is re-sent -- instead of an orphaned repository nothing owns.
 	entry.Set("providerRepositoryId", created.RepositoryID)
 	entry.Set("providerRepositoryName", created.RepositoryName)
-	c.local.UpsertByID("functions", entry)
-	if err := c.local.Write(); err != nil {
+	if err := c.persistEntry(entry); err != nil {
 		return fmt.Errorf(
 			"GitHub repository %s was created but its id could not be saved; retry this push to recover it: %w",
 			created.RepositoryName, err)
@@ -1374,9 +1373,28 @@ func (c *pushContext) materializePendingFunctionRepository(
 func (c *pushContext) confirmFunctionRepository(entry *jsonx.Object) error {
 	entry.Delete("providerRepositoryPrivate")
 	entry.Delete("providerRepositoryPending")
+
+	return c.persistEntry(entry)
+}
+
+// persistEntry atomically records one function entry in the shared local
+// configuration. Parallel function workers share one config.Local, so an
+// unsynchronized upsert-and-write could overwrite another worker's repository
+// or template state.
+func (c *pushContext) persistEntry(entry *jsonx.Object) error {
+	c.configMutex.Lock()
+	defer c.configMutex.Unlock()
 	c.local.UpsertByID("functions", entry)
 
 	return c.local.Write()
+}
+
+// upsertEntry records an entry in memory only, for restoring state after a
+// write that already failed.
+func (c *pushContext) upsertEntry(entry *jsonx.Object) {
+	c.configMutex.Lock()
+	defer c.configMutex.Unlock()
+	c.local.UpsertByID("functions", entry)
 }
 
 func (c *pushContext) findPendingFunctionRepository(
@@ -1519,12 +1537,11 @@ func (c *pushContext) createGitFunctionDeployment(
 			}
 			entry.Delete(key)
 		}
-		c.local.UpsertByID("functions", entry)
-		if err := c.local.Write(); err != nil {
+		if err := c.persistEntry(entry); err != nil {
 			for key, value := range saved {
 				entry.Set(key, value)
 			}
-			c.local.UpsertByID("functions", entry)
+			c.upsertEntry(entry)
 
 			return nil, fmt.Errorf(
 				"template state could not be saved; nothing was deployed: %w", err)
@@ -1554,8 +1571,7 @@ func (c *pushContext) createGitFunctionDeployment(
 			for key, value := range saved {
 				entry.Set(key, value)
 			}
-			c.local.UpsertByID("functions", entry)
-			if writeErr := c.local.Write(); writeErr != nil {
+			if writeErr := c.persistEntry(entry); writeErr != nil {
 				return nil, fmt.Errorf(
 					"%w (the template coordinates could also not be restored to %s: %v)",
 					err, config.LocalFileName, writeErr)

--- a/templates/cli/internal/cmd/pushdeploy.go
+++ b/templates/cli/internal/cmd/pushdeploy.go
@@ -1129,6 +1129,16 @@ func (c *pushContext) pushDeployable(
 
 			return
 		}
+		// Confirmed after the connection and BEFORE the deployment: once the
+		// function is connected server-side the pending flow has nothing left
+		// to redo, and clearing the flag now means a failed confirmation stops
+		// the push before anything is submitted -- were it cleared after, a
+		// failed write would replay a submission that already succeeded.
+		if err := c.confirmFunctionRepository(entry); err != nil {
+			recordPushFailure(command, resource, name, err.Error(), summary)
+
+			return
+		}
 	}
 
 	deployment, err := c.createDeployment(command, resource, entry, run.Activate)
@@ -1136,13 +1146,6 @@ func (c *pushContext) pushDeployable(
 		recordPushFailure(command, resource, name, err.Error(), summary)
 
 		return
-	}
-	if wasPending {
-		if err := c.confirmFunctionRepository(entry); err != nil {
-			recordPushFailure(command, resource, name, err.Error(), summary)
-
-			return
-		}
 	}
 	summary.Pushed++
 

--- a/templates/cli/internal/cmd/pushdeploy.go
+++ b/templates/cli/internal/cmd/pushdeploy.go
@@ -1356,9 +1356,10 @@ func (c *pushContext) materializePendingFunctionRepository(
 	// failed VCS connection or deployment leaves a state the next push fully
 	// retries -- creation falls back to finding the repository by name, and the
 	// connection is re-sent -- instead of an orphaned repository nothing owns.
-	entry.Set("providerRepositoryId", created.RepositoryID)
-	entry.Set("providerRepositoryName", created.RepositoryName)
-	if err := c.persistEntry(entry); err != nil {
+	if err := c.persistEntry(entry, func() {
+		entry.Set("providerRepositoryId", created.RepositoryID)
+		entry.Set("providerRepositoryName", created.RepositoryName)
+	}); err != nil {
 		return fmt.Errorf(
 			"GitHub repository %s was created but its id could not be saved; retry this push to recover it: %w",
 			created.RepositoryName, err)
@@ -1371,29 +1372,35 @@ func (c *pushContext) materializePendingFunctionRepository(
 // deployment was submitted, so the next push must treat the function as an
 // ordinary connected one rather than re-running the pending flow.
 func (c *pushContext) confirmFunctionRepository(entry *jsonx.Object) error {
-	entry.Delete("providerRepositoryPrivate")
-	entry.Delete("providerRepositoryPending")
-
-	return c.persistEntry(entry)
+	return c.persistEntry(entry, func() {
+		entry.Delete("providerRepositoryPrivate")
+		entry.Delete("providerRepositoryPending")
+	})
 }
 
-// persistEntry atomically records one function entry in the shared local
-// configuration. Parallel function workers share one config.Local, so an
-// unsynchronized upsert-and-write could overwrite another worker's repository
-// or template state.
-func (c *pushContext) persistEntry(entry *jsonx.Object) error {
+// persistEntry runs mutate and records the entry in the shared local
+// configuration as one atomic step. Parallel function workers share one
+// config.Local, and serialization reads every entry: a Set or Delete outside
+// the lock could race a Write another worker holds the lock for.
+func (c *pushContext) persistEntry(entry *jsonx.Object, mutate func()) error {
 	c.configMutex.Lock()
 	defer c.configMutex.Unlock()
+	if mutate != nil {
+		mutate()
+	}
 	c.local.UpsertByID("functions", entry)
 
 	return c.local.Write()
 }
 
-// upsertEntry records an entry in memory only, for restoring state after a
-// write that already failed.
-func (c *pushContext) upsertEntry(entry *jsonx.Object) {
+// upsertEntry runs mutate and records the entry in memory only, for restoring
+// state after a write that already failed.
+func (c *pushContext) upsertEntry(entry *jsonx.Object, mutate func()) {
 	c.configMutex.Lock()
 	defer c.configMutex.Unlock()
+	if mutate != nil {
+		mutate()
+	}
 	c.local.UpsertByID("functions", entry)
 }
 
@@ -1531,17 +1538,19 @@ func (c *pushContext) createGitFunctionDeployment(
 	}
 	saved := map[string]any{}
 	if template {
-		for _, key := range templateKeys {
-			if value, ok := entry.Get(key); ok {
-				saved[key] = value
+		if err := c.persistEntry(entry, func() {
+			for _, key := range templateKeys {
+				if value, ok := entry.Get(key); ok {
+					saved[key] = value
+				}
+				entry.Delete(key)
 			}
-			entry.Delete(key)
-		}
-		if err := c.persistEntry(entry); err != nil {
-			for key, value := range saved {
-				entry.Set(key, value)
-			}
-			c.upsertEntry(entry)
+		}); err != nil {
+			c.upsertEntry(entry, func() {
+				for key, value := range saved {
+					entry.Set(key, value)
+				}
+			})
 
 			return nil, fmt.Errorf(
 				"template state could not be saved; nothing was deployed: %w", err)
@@ -1568,10 +1577,11 @@ func (c *pushContext) createGitFunctionDeployment(
 						"check the function's deployments before pushing again",
 					err)
 			}
-			for key, value := range saved {
-				entry.Set(key, value)
-			}
-			if writeErr := c.persistEntry(entry); writeErr != nil {
+			if writeErr := c.persistEntry(entry, func() {
+				for key, value := range saved {
+					entry.Set(key, value)
+				}
+			}); writeErr != nil {
 				return nil, fmt.Errorf(
 					"%w (the template coordinates could also not be restored to %s: %v)",
 					err, config.LocalFileName, writeErr)

--- a/templates/cli/internal/cmd/pushdeploy.go
+++ b/templates/cli/internal/cmd/pushdeploy.go
@@ -680,12 +680,6 @@ func runPushDeployable(
 		return nil
 	}
 
-	if resource.Name == "function" {
-		if err := context.materializePendingFunctionRepositories(entries); err != nil {
-			return err
-		}
-	}
-
 	pushCode := options.Code
 	if pushCode {
 		confirmed, err := context.prompter.Confirm(prompt.Question{
@@ -697,6 +691,16 @@ func runPushDeployable(
 			return err
 		}
 		pushCode = confirmed
+	}
+
+	// Repositories accepted on the init review screen are created only once a
+	// deployment is actually requested. A settings-only push (--no-code, or a
+	// declined confirmation) must not leave an empty GitHub repository behind;
+	// the pending intent stays in the config for the push that deploys.
+	if pushCode && resource.Name == "function" {
+		if err := context.materializePendingFunctionRepositories(entries); err != nil {
+			return err
+		}
 	}
 
 	activate := true
@@ -1074,11 +1078,13 @@ func (c *pushContext) pushDeployable(
 		}
 
 		err = c.api.Call("PUT", resource.Path+"/"+url.PathEscape(id),
-			writeBody(entry, resource.WriteKeys, resource.OmitWhenEmpty, "", ""), nil)
+			pendingSafeBody(entry, writeBody(
+				entry, resource.WriteKeys, resource.OmitWhenEmpty, "", "")), nil)
 	} else {
 		err = c.api.Call("POST", resource.Path,
-			writeBody(entry, resource.WriteKeys, resource.OmitWhenEmpty,
-				resource.IDField, id), nil)
+			pendingSafeBody(entry, writeBody(
+				entry, resource.WriteKeys, resource.OmitWhenEmpty,
+				resource.IDField, id)), nil)
 	}
 	if err != nil {
 		recordPushFailure(command, resource, name, err.Error(), summary)
@@ -1133,6 +1139,25 @@ func recordPushFailure(
 	output.Failure(command.OutOrStdout(), "Failed to push %s %s: %s",
 		resource.Singular, name, reason)
 	summary.Failed = append(summary.Failed, failedDeployment{Name: name, Reason: reason})
+}
+
+// pendingSafeBody strips the VCS connection keys from a write body while the
+// entry's GitHub repository is still pending. The repository does not exist
+// until a deployment push materializes it, so sending an installation without
+// a repository would half-connect the function to nothing.
+func pendingSafeBody(entry, body *jsonx.Object) *jsonx.Object {
+	if !entry.GetBool("providerRepositoryPending") {
+		return body
+	}
+	for _, key := range []string{
+		"installationId", "providerRepositoryId", "providerBranch",
+		"providerSilentMode", "providerRootDirectory", "providerBranches",
+		"providerPaths",
+	} {
+		body.Delete(key)
+	}
+
+	return body
 }
 
 // writeBody builds a create or update body from the config entry.
@@ -1407,7 +1432,8 @@ func (c *pushContext) createGitFunctionDeployment(
 	body.Set("activate", activate)
 
 	path := "/functions/" + functionID + "/deployments/vcs"
-	if entry.GetString("templateRepository") != "" {
+	template := entry.GetString("templateRepository") != ""
+	if template {
 		path = "/functions/" + functionID + "/deployments/template"
 		body.Set("repository", entry.GetString("templateRepository"))
 		body.Set("owner", entry.GetString("templateOwner"))
@@ -1419,24 +1445,50 @@ func (c *pushContext) createGitFunctionDeployment(
 		body.Set("reference", entry.GetString("providerBranch"))
 	}
 
-	deployment := jsonx.NewObject()
-	if err := c.api.Call("POST", path, body, deployment); err != nil {
-		return nil, err
-	}
-
 	// Template coordinates are one-shot. Keeping them would merge the starter
-	// into the repository again on every explicit CLI deployment.
-	if entry.GetString("templateRepository") != "" {
-		for _, key := range []string{
-			"templateRepository", "templateOwner", "templateRootDirectory",
-			"templateReference", "templateReferenceType",
-		} {
+	// into the repository again on every explicit CLI deployment, so they are
+	// cleared and persisted BEFORE the request: once the deployment succeeds
+	// no retry can submit the seed twice, and a request that fails restores
+	// them so the seed is not lost.
+	templateKeys := []string{
+		"templateRepository", "templateOwner", "templateRootDirectory",
+		"templateReference", "templateReferenceType",
+	}
+	saved := map[string]any{}
+	if template {
+		for _, key := range templateKeys {
+			if value, ok := entry.Get(key); ok {
+				saved[key] = value
+			}
 			entry.Delete(key)
 		}
 		c.local.UpsertByID("functions", entry)
 		if err := c.local.Write(); err != nil {
-			return nil, fmt.Errorf("deployment created but template state could not be saved: %w", err)
+			for key, value := range saved {
+				entry.Set(key, value)
+			}
+			c.local.UpsertByID("functions", entry)
+
+			return nil, fmt.Errorf(
+				"template state could not be saved; nothing was deployed: %w", err)
 		}
+	}
+
+	deployment := jsonx.NewObject()
+	if err := c.api.Call("POST", path, body, deployment); err != nil {
+		if template {
+			for key, value := range saved {
+				entry.Set(key, value)
+			}
+			c.local.UpsertByID("functions", entry)
+			if writeErr := c.local.Write(); writeErr != nil {
+				return nil, fmt.Errorf(
+					"%w (the template coordinates could also not be restored to %s: %v)",
+					err, config.LocalFileName, writeErr)
+			}
+		}
+
+		return nil, err
 	}
 
 	return deployment, nil


### PR DESCRIPTION
Fixes the two P1 findings Greptile raised on [appwrite/sdk-for-cli#360](https://github.com/appwrite/sdk-for-cli/pull/360).

**Repository created before deployment intent.** Repository materialization now runs only after code deployment is confirmed. A settings-only push (`--no-code`, or a declined deployment confirmation) keeps the repository pending and omits VCS connection fields from the settings request.

**Template seed state is not atomic.** One-shot template coordinates are cleared and persisted before the deployment request. If persistence fails, no request is made. Once a request is attempted, the coordinates remain consumed because the remote outcome may be ambiguous; this prevents a retry from seeding the starter twice.

Template-seeded batches run sequentially while ordinary function pushes remain parallel, avoiding concurrent writes to the shared local configuration without adding general locking infrastructure.

Verified by regenerating the CLI and running `gofmt`, `go build ./...`, `go vet ./...`, and `go test ./...` against the generated output. `composer lint-twig` and `composer refactor:check` also pass.
