### PR TITLE
fix(flutter): widen plus plugin constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ php example.php zed-extension
 | Target | Argument | Supported Versions | Coding Standards | Package Manager | Output |
 |--------|----------|--------------------|------------------|-----------------|--------|
 | Web | `web` | ES5+; Node.js >=18 for builds | [NPM Coding Style] | NPM | `examples/web/` |
-| Flutter | `flutter` | Dart >=2.17 <4; Flutter stable | [Effective Dart] | pub | `examples/flutter/` |
+| Flutter | `flutter` | Dart >=3.7 <4; Flutter >=3.29 | [Effective Dart] | pub | `examples/flutter/` |
 | Apple | `apple` | iOS 15+, macOS 11+, watchOS 7+, tvOS 13+ | [Swift Style Guide] | Swift Package Manager | `examples/apple/` |
 | Android | `android` | Android 6.0+; Java 17 in CI | [Android style guide] | Gradle, Maven | `examples/android/` |
 | React Native | `react-native` | React Native >=0.76.7 <1.0.0; Node.js >=18 | [NPM Coding Style] | NPM | `examples/react-native/` |

--- a/templates/flutter/pubspec.yaml.twig
+++ b/templates/flutter/pubspec.yaml.twig
@@ -13,16 +13,17 @@ platforms:
   web:
   windows:
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: '>=3.7.0 <4.0.0'
+  flutter: '>=3.29.0'
 
 dependencies:
   flutter:
     sdk: flutter
   cookie_jar: ^4.0.8
-  device_info_plus: '>=11.5.0 <13.0.0'
+  device_info_plus: '>=11.5.0 <14.0.0'
   flutter_web_auth_2: ^5.0.0
   http: '>=0.13.6 <2.0.0'
-  package_info_plus: '>=8.0.2 <10.0.0'
+  package_info_plus: '>=8.0.2 <11.0.0'
   path_provider: ^2.1.4
   web_socket_channel: ^3.0.1
   web: ^1.0.0


### PR DESCRIPTION
## Summary

- allow `package_info_plus` 10.x and `device_info_plus` 13.x in generated Flutter SDKs
- align the declared Dart and Flutter minimums with the existing `device_info_plus` 11.5.0 requirement
- retain compatibility with older supported toolchains through Pub's SDK-aware version resolution

## Tests

- `php example.php flutter client`
- `flutter pub get` (Flutter 3.35.6; resolved compatible `package_info_plus` 9.0.1 and `device_info_plus` 12.4.0)
- `flutter test`
- `composer lint-twig`
- `composer refactor:check`
