### PR TITLE
Generate rustfmt-clean Rust SDK files

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -185,6 +185,8 @@ jobs:
       - name: Setup Rust
         if: matrix.sdk == 'rust'
         uses: dtolnay/rust-toolchain@bd41891a8e7f4b8649f6d684415e1a6155fe4e22 # 1.83.0
+        with:
+          components: rustfmt
 
       - name: Setup Rust for Zed extension
         if: matrix.sdk == 'zed-extension'
@@ -307,6 +309,7 @@ jobs:
                 cargo +1.85.0 install cargo-audit --version 0.22.1 --locked
               fi
               cargo audit
+              cargo +1.83.0 fmt --check --all
               cargo +1.83.0 build --release
               cargo +1.83.0 test --lib
               ;;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ The script strips Twig expressions before running `npm install`, then restores t
 
 ### Rule 7: Generated source must already be formatter-clean
 
-Keep Go templates accurate enough that their generated `.go` files are already `gofmt`-clean, Dart/Flutter templates accurate enough that their generated `.dart` files are already `dart format`-clean, Python templates accurate enough that their generated `.py` files are already Black-clean, and PHP templates accurate enough that their generated `.php` files pass Pint, PHPStan, and Rector checks. Do not add a post-generation formatting step or run a formatter to fix generated output in place—the fix belongs in the Twig template.
+Keep Go templates accurate enough that their generated `.go` files are already `gofmt`-clean, Dart/Flutter templates accurate enough that their generated `.dart` files are already `dart format`-clean, Python templates accurate enough that their generated `.py` files are already Black-clean, PHP templates accurate enough that their generated `.php` files pass Pint, PHPStan, and Rector checks, and Rust templates accurate enough that their generated `.rs` files are already rustfmt-clean. Do not add a post-generation formatting step or run a formatter to fix generated output in place—the fix belongs in the Twig template.
 
 After changing Go templates, regenerate the affected platform and verify formatting:
 
@@ -104,6 +104,14 @@ rm -rf examples/php
 php example.php php server
 (cd examples/php && composer install)
 (cd examples/php && composer lint && composer analyse && composer refactor)
+```
+
+After changing Rust templates, regenerate the SDK and verify rustfmt. Use the 1.83.0 toolchain so the check matches CI:
+
+```bash
+rm -rf examples/rust
+php example.php rust server
+(cd examples/rust && cargo +1.83.0 fmt --check --all)
 ```
 
 ## Repository at a Glance

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,59 +60,66 @@ The script strips Twig expressions before running `npm install`, then restores t
 
 ### Rule 7: Generated source must already be formatter-clean
 
-Keep Go templates accurate enough that their generated `.go` files are already `gofmt`-clean, Dart/Flutter templates accurate enough that their generated `.dart` files are already `dart format`-clean, Python templates accurate enough that their generated `.py` files are already Black-clean, PHP templates accurate enough that their generated `.php` files pass Pint, PHPStan, and Rector checks, and Rust templates accurate enough that their generated `.rs` files are already rustfmt-clean. Do not add a post-generation formatting step or run a formatter to fix generated output in place—the fix belongs in the Twig template.
+A clean generation must already match the target formatter. Do not add a post-generation formatting step or run a formatter to fix generated output in place—the fix belongs in the Twig template.
 
-After changing Go templates, regenerate the affected platform and verify formatting:
+When you change templates for a language below, regenerate and run that language's check. Child SDKs inherit parent templates — regenerate those too.
 
-```bash
-php example.php go <platform>
-test -z "$(gofmt -l examples/go)"
-```
+- **Go / CLI** — `gofmt`
 
-Because `CLI` inherits from `Go`, regenerate it after shared Go template changes and verify its generated Go files too.
+  ```bash
+  php example.php go <platform>
+  test -z "$(gofmt -l examples/go)"
+  ```
 
-After changing Dart templates, regenerate the affected platform and verify formatting:
+  `CLI` inherits from `Go`. After shared Go template changes:
 
-```bash
-rm -rf examples/dart examples/flutter
-php example.php dart <platform>
-(cd examples/dart && dart pub get)
-dart format --output=none --set-exit-if-changed examples/dart
-```
+  ```bash
+  php example.php cli
+  test -z "$(gofmt -l examples/cli)"
+  ```
 
-Because `Flutter` inherits from `Dart`, regenerate it after shared Dart template changes and verify its generated Dart files too:
+- **Dart / Flutter** — `dart format`
 
-```bash
-php example.php flutter client
-(cd examples/flutter && flutter pub get)
-dart format --output=none --set-exit-if-changed examples/flutter
-```
+  ```bash
+  rm -rf examples/dart examples/flutter
+  php example.php dart <platform>
+  (cd examples/dart && dart pub get)
+  dart format --output=none --set-exit-if-changed examples/dart
+  ```
 
-After changing Python templates, regenerate the SDK and check every generated source and test file explicitly because `examples/` is gitignored:
+  `Flutter` inherits from `Dart`. After shared Dart template changes:
 
-```bash
-rm -rf examples/python
-php example.php python <platform>
-(cd examples/python && find appwrite test -name '*.py' -print0 | xargs -0 python -m black --check)
-(cd examples/python && python -m black --check setup.py)
-```
+  ```bash
+  php example.php flutter client
+  (cd examples/flutter && flutter pub get)
+  dart format --output=none --set-exit-if-changed examples/flutter
+  ```
 
-After changing PHP templates, regenerate from a clean output directory and verify the generated source and tests:
+- **Python** — Black
 
-```bash
-rm -rf examples/php
-php example.php php server
-(cd examples/php && composer install)
-(cd examples/php && composer lint && composer analyse && composer refactor)
-```
+  ```bash
+  rm -rf examples/python
+  php example.php python <platform>
+  (cd examples/python && find appwrite test -name '*.py' -print0 | xargs -0 python -m black --check)
+  (cd examples/python && python -m black --check setup.py)
+  ```
 
-After changing Rust templates, regenerate the SDK and verify rustfmt. Use the 1.83.0 toolchain so the check matches CI:
+- **PHP** — Pint, PHPStan, and Rector
 
-```bash
-rm -rf examples/rust
-php example.php rust server
-(cd examples/rust && cargo +1.83.0 fmt --check --all)
-```
+  ```bash
+  rm -rf examples/php
+  php example.php php server
+  (cd examples/php && composer install)
+  (cd examples/php && composer lint && composer analyse && composer refactor)
+  ```
+
+- **Rust** — rustfmt 1.83.0
+
+  ```bash
+  rm -rf examples/rust
+  php example.php rust server
+  (cd examples/rust && cargo +1.83.0 fmt --check --all)
+  ```
 
 ## Repository at a Glance
 

--- a/src/SDK/Language/Rust.php
+++ b/src/SDK/Language/Rust.php
@@ -14,6 +14,10 @@ use Twig\TwigFilter;
 
 class Rust extends Language
 {
+    protected const RUSTFMT_MAX_WIDTH = 100;
+    protected const RUSTFMT_FN_CALL_WIDTH = 60;
+    protected const RUSTFMT_CHAIN_WIDTH = 60;
+
     #[Override]
     protected $params = [
         "cratePackage" => "packageName",
@@ -567,16 +571,27 @@ class Rust extends Language
             new TwigFilter(
                 "rustdocComment",
                 function ($value, $indent = 0): string {
-                    $value = trim($value);
+                    $value = trim((string) $value);
                     $value = explode("\n", $value);
                     $indent = \str_repeat(" ", $indent);
                     foreach ($value as $key => $line) {
-                        $value[$key] = "/// " . wordwrap(trim($line), 75, "\n" . $indent . "/// ");
+                        $trimmed = trim($line);
+                        $value[$key] = $trimmed === ''
+                            ? "///"
+                            : "/// " . wordwrap($trimmed, 75, "\n" . $indent . "/// ");
                     }
                     return implode("\n" . $indent, $value);
                 },
                 ["is_safe" => ["html"]],
             ),
+            new TwigFilter("rustfmtFn", fn(array $params, int $indent, string $prefix, string $returnType): string => $this->rustfmtFn($indent, $prefix, $params, $returnType), ["is_safe" => ["html"]]),
+            new TwigFilter("rustfmtCall", fn(array $args, int $indent, string $callee, string $terminator = ';'): string => $this->rustfmtCall($indent, $callee, $args, $terminator), ["is_safe" => ["html"]]),
+            new TwigFilter("rustfmtClientAwait", fn(array $args, int $indent, string $method): string => $this->rustfmtClientAwait($indent, $method, $args), ["is_safe" => ["html"]]),
+            new TwigFilter("rustfmtPath", fn(array $replaces, int $indent, string $path): string => $this->rustfmtPath($indent, $path, $replaces), ["is_safe" => ["html"]]),
+            new TwigFilter("rustfmtMatchArm", fn(string $value, int $indent, string $pattern): string => $this->rustfmtMatchArm($indent, $pattern, $value), ["is_safe" => ["html"]]),
+            new TwigFilter("rustfmtAssign", fn(string $rhs, int $indent, string $lhs, string $terminator = ';'): string => $this->rustfmtAssign($indent, $lhs, $rhs, $terminator), ["is_safe" => ["html"]]),
+            new TwigFilter("rustfmtChain", fn(string $suffix, int $indent, string $receiver): string => $this->rustfmtChain($indent, $receiver, $suffix), ["is_safe" => ["html"]]),
+            new TwigFilter("rustfmtHeaderInsert", fn(string $valueExpr, int $indent, string $key): string => $this->rustfmtHeaderInsert($indent, $key, $valueExpr), ["is_safe" => ["html"]]),
             new TwigFilter("propertyType", fn(Schema $property, ?Specification $spec = null, string $generic = "serde_json::Value"): string => $this->getTypeName($property, $spec)),
             new TwigFilter("returnType", fn(Operation $method, Specification $spec, string $namespace, string $generic = "serde_json::Value"): string => $this->getReturnType($method)),
             new TwigFilter("caseEnumKey", fn(string $value): string => $this->toPascalCase($value)),
@@ -637,6 +652,274 @@ class Rust extends Language
             new TwigFilter("stripProtocol", fn($value): string|array => str_replace(['https://', 'http://'], '', $value)),
         ];
     }
+
+    /**
+     * Layout a function signature the way rustfmt 1.83 does at max_width 100.
+     *
+     * @param list<string> $params
+     */
+    protected function rustfmtFn(int $indent, string $prefix, array $params, string $returnType): string
+    {
+        $pad = str_repeat(' ', $indent);
+        $joined = implode(', ', $params);
+        $suffix = $returnType === '' ? ' {' : ' -> ' . $returnType . ' {';
+        $one = $pad . $prefix . '(' . $joined . ')' . $suffix;
+        if (strlen($one) <= self::RUSTFMT_MAX_WIDTH) {
+            return $one;
+        }
+
+        $lines = [$pad . $prefix . '('];
+        foreach ($params as $param) {
+            $lines[] = $pad . '    ' . $param . ',';
+        }
+        $lines[] = $pad . ')' . $suffix;
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * Layout a function call the way rustfmt 1.83 does (fn_call_width 60, max_width 100).
+     *
+     * @param list<string> $args
+     */
+    protected function rustfmtCall(int $indent, string $callee, array $args, string $terminator = ';'): string
+    {
+        $pad = str_repeat(' ', $indent);
+        $joined = implode(', ', $args);
+        $one = $pad . $callee . '(' . $joined . ')' . $terminator;
+        if (strlen($joined) <= self::RUSTFMT_FN_CALL_WIDTH && strlen($one) <= self::RUSTFMT_MAX_WIDTH) {
+            return $one;
+        }
+
+        $inner = str_repeat(' ', $indent + 4);
+        $lines = [$pad . $callee . '('];
+        foreach ($args as $arg) {
+            $lines[] = $inner . $this->rustfmtJsonArg($indent + 4, $arg) . ',';
+        }
+        $lines[] = $pad . ')' . $terminator;
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * rustfmt wraps method chains inside `json!(...)` when they exceed chain_width.
+     */
+    protected function rustfmtJsonArg(int $argIndent, string $arg): string
+    {
+        $prefix = 'json!(';
+        $marker = '.into_iter().map(|s| s.into()).collect::<Vec<String>>()';
+        if (!str_starts_with($arg, $prefix) || !str_ends_with($arg, ')')) {
+            return $arg;
+        }
+
+        $inner = substr($arg, strlen($prefix), -1);
+        if (!str_ends_with($inner, $marker) || strlen($inner) <= self::RUSTFMT_CHAIN_WIDTH) {
+            return $arg;
+        }
+
+        $receiver = substr($inner, 0, -strlen($marker));
+        $innerPad = str_repeat(' ', $argIndent + 4);
+
+        return $prefix . $receiver . "\n"
+            . $innerPad . ".into_iter()\n"
+            . $innerPad . ".map(|s| s.into())\n"
+            . $innerPad . '.collect::<Vec<String>>())';
+    }
+
+    /**
+     * Layout `self.client.<method>(...).await` as a rustfmt method chain.
+     *
+     * @param list<string> $args
+     */
+    protected function rustfmtClientAwait(int $indent, string $method, array $args): string
+    {
+        $pad = str_repeat(' ', $indent);
+        $inner = str_repeat(' ', $indent + 4);
+        $joined = implode(', ', $args);
+        $call = '.' . $method . '(' . $joined . ')';
+        if (strlen($joined) <= self::RUSTFMT_FN_CALL_WIDTH && strlen($inner . $call) <= self::RUSTFMT_MAX_WIDTH) {
+            $callLine = $inner . $call;
+        } else {
+            $argPad = str_repeat(' ', $indent + 8);
+            $lines = [$inner . '.' . $method . '('];
+            foreach ($args as $arg) {
+                $lines[] = $argPad . $arg . ',';
+            }
+            $lines[] = $inner . ')';
+            $callLine = implode("\n", $lines);
+        }
+
+        return $pad . "self.client\n" . $callLine . "\n" . $inner . '.await';
+    }
+
+    /**
+     * Layout `let path = "...".to_string().replace(...)` the way rustfmt 1.83 does.
+     *
+     * @param list<string> $replaces Each entry starts with `.replace(...)`
+     */
+    protected function rustfmtPath(int $indent, string $path, array $replaces): string
+    {
+        $pad = str_repeat(' ', $indent);
+        $pathLit = '"' . $path . '"';
+        if ($replaces === []) {
+            return $pad . 'let path = ' . $pathLit . '.to_string();';
+        }
+
+        $parts = [];
+        foreach ($replaces as $replace) {
+            if (preg_match('/^\.replace\("([^"]+)", (.+)\)$/', $replace, $match) !== 1) {
+                $parts[] = ['kind' => 'raw', 'raw' => $replace];
+                continue;
+            }
+            $parts[] = ['kind' => 'replace', 'key' => $match[1], 'expr' => $match[2]];
+        }
+
+        $oneLineReplaces = '';
+        $allOneLine = true;
+        foreach ($parts as $part) {
+            if ($part['kind'] !== 'replace' || strlen('"' . $part['key'] . '", ' . $part['expr']) > self::RUSTFMT_FN_CALL_WIDTH) {
+                $allOneLine = false;
+                break;
+            }
+            $oneLineReplaces .= '.replace("' . $part['key'] . '", ' . $part['expr'] . ')';
+        }
+
+        $rhsOne = $pathLit . '.to_string()' . $oneLineReplaces;
+        $fullOne = $pad . 'let path = ' . $rhsOne . ';';
+        if ($allOneLine && strlen($rhsOne) <= self::RUSTFMT_CHAIN_WIDTH && strlen($fullOne) <= self::RUSTFMT_MAX_WIDTH) {
+            return $fullOne;
+        }
+
+        if (count($parts) === 1 && $parts[0]['kind'] === 'replace') {
+            $joined = '"' . $parts[0]['key'] . '", ' . $parts[0]['expr'];
+            $collapsedChain = $pathLit . '.to_string().replace(';
+            $prefix = $pad . 'let path = ' . $collapsedChain;
+            if (
+                strlen($joined) > self::RUSTFMT_FN_CALL_WIDTH
+                && strlen($collapsedChain) <= self::RUSTFMT_CHAIN_WIDTH
+                && strlen($prefix) <= self::RUSTFMT_MAX_WIDTH
+            ) {
+                return $prefix . "\n"
+                    . $this->rustfmtReplaceArgLines($indent + 4, $parts[0]['key'], $parts[0]['expr'])
+                    . $pad . ');';
+            }
+        }
+
+        $letLine = $pad . 'let path = ' . $pathLit;
+        if (strlen($letLine) > self::RUSTFMT_MAX_WIDTH) {
+            $chainIndent = $indent + 8;
+            $lines = [$pad . 'let path =', $pad . '    ' . $pathLit];
+        } else {
+            $chainIndent = $indent + 4;
+            $lines = [$letLine];
+        }
+
+        $chainPad = str_repeat(' ', $chainIndent);
+        $lines[] = $chainPad . '.to_string()';
+        foreach ($parts as $i => $part) {
+            $terminator = $i === array_key_last($parts) ? ';' : '';
+            if ($part['kind'] === 'raw') {
+                $lines[] = $chainPad . $part['raw'] . $terminator;
+                continue;
+            }
+            $lines[] = $this->rustfmtReplaceSegment($chainIndent, $part['key'], $part['expr'], $terminator);
+        }
+
+        return implode("\n", $lines);
+    }
+
+    protected function rustfmtReplaceSegment(int $dotIndent, string $key, string $expr, string $terminator): string
+    {
+        $pad = str_repeat(' ', $dotIndent);
+        $joined = '"' . $key . '", ' . $expr;
+        $one = $pad . '.replace(' . $joined . ')' . $terminator;
+        if (strlen($joined) <= self::RUSTFMT_FN_CALL_WIDTH && strlen($one) <= self::RUSTFMT_MAX_WIDTH) {
+            return $one;
+        }
+
+        return $pad . ".replace(\n"
+            . $this->rustfmtReplaceArgLines($dotIndent + 4, $key, $expr)
+            . $pad . ')' . $terminator;
+    }
+
+    protected function rustfmtReplaceArgLines(int $argIndent, string $key, string $expr): string
+    {
+        $argPad = str_repeat(' ', $argIndent);
+
+        return $argPad . '"' . $key . "\",\n"
+            . $argPad . $this->rustfmtChainExpr($argIndent, $expr) . ",\n";
+    }
+
+    /**
+     * rustfmt splits long method chains onto one call per line (chain_width 60).
+     */
+    protected function rustfmtChainExpr(int $indent, string $expr): string
+    {
+        if (strlen($expr) <= self::RUSTFMT_CHAIN_WIDTH) {
+            return $expr;
+        }
+
+        $segments = preg_split('/(?=\.[A-Za-z_])/', $expr, -1, PREG_SPLIT_NO_EMPTY);
+        if ($segments === false || count($segments) < 2) {
+            return $expr;
+        }
+
+        $inner = str_repeat(' ', $indent + 4);
+
+        return $segments[0] . "\n" . $inner . implode("\n" . $inner, array_slice($segments, 1));
+    }
+
+    protected function rustfmtMatchArm(int $indent, string $pattern, string $value): string
+    {
+        $pad = str_repeat(' ', $indent);
+        $one = $pad . $pattern . ' => "' . $value . '",';
+        if (strlen($one) <= self::RUSTFMT_MAX_WIDTH) {
+            return $one;
+        }
+
+        return $pad . $pattern . " => {\n"
+            . $pad . '    "' . $value . "\"\n"
+            . $pad . '}';
+    }
+
+    protected function rustfmtAssign(int $indent, string $lhs, string $rhs, string $terminator = ';'): string
+    {
+        $pad = str_repeat(' ', $indent);
+        $one = $pad . $lhs . ' = ' . $rhs . $terminator;
+        if (strlen($one) <= self::RUSTFMT_MAX_WIDTH) {
+            return $one;
+        }
+
+        return $pad . $lhs . " =\n" . $pad . '    ' . $rhs . $terminator;
+    }
+
+    protected function rustfmtChain(int $indent, string $receiver, string $suffix): string
+    {
+        $pad = str_repeat(' ', $indent);
+        $one = $pad . $receiver . $suffix;
+        if (strlen($receiver . $suffix) <= self::RUSTFMT_CHAIN_WIDTH && strlen($one) <= self::RUSTFMT_MAX_WIDTH) {
+            return $one;
+        }
+
+        return $pad . $receiver . "\n" . $pad . '    ' . $suffix;
+    }
+
+    protected function rustfmtHeaderInsert(int $indent, string $key, string $valueExpr): string
+    {
+        $args = ['"' . $key . '"', $valueExpr];
+        $joined = implode(', ', $args);
+        $chainInsert = str_repeat(' ', $indent + 4) . '.insert(' . $joined . ');';
+        if (strlen($joined) <= self::RUSTFMT_FN_CALL_WIDTH && strlen($chainInsert) <= self::RUSTFMT_MAX_WIDTH) {
+            $pad = str_repeat(' ', $indent);
+
+            return $pad . "next.config\n"
+                . $pad . "    .headers\n"
+                . $chainInsert;
+        }
+
+        return $this->rustfmtCall($indent, 'next.config.headers.insert', $args);
+    }
+
     /**
      * Snake-case using the same algorithm as the caseSnake Twig filter (SDK.php),
      * so PHP-generated variable references match template-generated declarations.

--- a/templates/rust/src/client.rs.twig
+++ b/templates/rust/src/client.rs.twig
@@ -94,7 +94,16 @@ impl Client {
 {% for key, header in defaultHeaders %}
         headers.insert("{{ key }}", "{{ header }}".parse().unwrap());
 {% endfor %}
-        headers.insert("user-agent", format!("{{ spec.info.title }}RustSDK/{{ sdk.version }} ({}; {})", std::env::consts::OS, std::env::consts::ARCH).parse().unwrap());
+        headers.insert(
+            "user-agent",
+            format!(
+                "{{ spec.info.title }}RustSDK/{{ sdk.version }} ({}; {})",
+                std::env::consts::OS,
+                std::env::consts::ARCH
+            )
+            .parse()
+            .unwrap(),
+        );
         headers.insert("x-sdk-name", "{{ sdk.name }}".parse().unwrap());
         headers.insert("x-sdk-platform", "{{ sdk.platform }}".parse().unwrap());
         headers.insert("x-sdk-language", "{{ language.name | caseLower }}".parse().unwrap());
@@ -111,7 +120,11 @@ impl Client {
         let http = Self::build_http_client(&config);
         let http_no_redirect = Self::build_http_client_no_redirect(&config);
 
-        let state = ClientState { config, http, http_no_redirect };
+        let state = ClientState {
+            config,
+            http,
+            http_no_redirect,
+        };
 
         Self {
             state: Arc::new(ArcSwap::from_pointee(state)),
@@ -137,14 +150,19 @@ impl Client {
             builder = builder.danger_accept_invalid_certs(true);
         }
 
-        builder.build().expect("Failed to create no-redirect HTTP client")
+        builder
+            .build()
+            .expect("Failed to create no-redirect HTTP client")
     }
 
     /// Set the API endpoint
     pub fn set_endpoint<S: Into<String>>(&self, endpoint: S) -> Self {
         let endpoint = endpoint.into();
         if !endpoint.starts_with("http://") && !endpoint.starts_with("https://") {
-            panic!("Invalid endpoint URL: {}. Endpoint must start with http:// or https://", endpoint);
+            panic!(
+                "Invalid endpoint URL: {}. Endpoint must start with http:// or https://",
+                endpoint
+            );
         }
         self.state.rcu(|state| {
             let mut next = (**state).clone();
@@ -155,7 +173,6 @@ impl Client {
     }
 
 {% for headerKey, header in globalHeaders %}
-
     /// Set {{headerKey | caseUcfirst}}
 {% if header.description %}
     ///
@@ -165,11 +182,18 @@ impl Client {
         let value = value.into();
         self.state.rcu(|state| {
             let mut next = (**state).clone();
-            next.config.headers.insert("{{header.name | caseLower}}", {% if header.scheme == 'bearer' %}format!("Bearer {}", value){% else %}value.clone(){% endif %}.parse().unwrap());
+{% if header.scheme == 'bearer' %}
+{{ ('format!("Bearer {}", value).parse().unwrap()') | rustfmtHeaderInsert(12, header.name | caseLower) }}
+{% else %}
+{{ ('value.clone().parse().unwrap()') | rustfmtHeaderInsert(12, header.name | caseLower) }}
+{% endif %}
             Arc::new(next)
         });
         self.clone()
     }
+{% if not loop.last %}
+
+{% endif %}
 {% endfor %}
 
     /// Enable or disable self-signed certificates
@@ -219,10 +243,9 @@ impl Client {
 
         self.state.rcu(|state| {
             let mut next = (**state).clone();
-            if let (Ok(header_name), Ok(header_value)) = (
-                key.parse::<HeaderName>(),
-                value.parse::<HeaderValue>(),
-            ) {
+            if let (Ok(header_name), Ok(header_value)) =
+                (key.parse::<HeaderName>(), value.parse::<HeaderValue>())
+            {
                 next.config.headers.insert(header_name, header_value);
             }
             Arc::new(next)
@@ -284,13 +307,19 @@ impl Client {
                             Value::Bool(b) => result.push((format!("{}[]", key), b.to_string())),
                             Value::Null => result.push((format!("{}[]", key), String::new())),
                             _ => {
-                                result.push((format!("{}[]", key), serde_json::to_string(item).unwrap_or_default()));
+                                result.push((
+                                    format!("{}[]", key),
+                                    serde_json::to_string(item).unwrap_or_default(),
+                                ));
                             }
                         }
                     }
                 }
                 Value::Object(_) => {
-                    result.push((key.clone(), serde_json::to_string(value).unwrap_or_default()));
+                    result.push((
+                        key.clone(),
+                        serde_json::to_string(value).unwrap_or_default(),
+                    ));
                 }
                 _ => {
                     result.push((key.clone(), Self::serialize_param_value(value)));
@@ -303,7 +332,10 @@ impl Client {
 
     /// Flatten nested parameters for multipart form data
     /// Converts nested arrays/objects to bracket notation: key[0], key[subkey], etc.
-    fn flatten_multipart_params(params: &HashMap<String, Value>, prefix: &str) -> Vec<(String, String)> {
+    fn flatten_multipart_params(
+        params: &HashMap<String, Value>,
+        prefix: &str,
+    ) -> Vec<(String, String)> {
         let mut result = Vec::new();
 
         for (key, value) in params {
@@ -357,7 +389,9 @@ impl Client {
 
         if let Some(params) = params {
             if method == Method::GET {
-                let mut url_with_params = Url::parse(&url).map_err(|e| {{ spec.info.title | caseUcfirst }}Error::new(0, format!("Invalid URL: {}", e), None, String::new()))?;
+                let mut url_with_params = Url::parse(&url).map_err(|e| {
+                    {{ spec.info.title | caseUcfirst }}Error::new(0, format!("Invalid URL: {}", e), None, String::new())
+                })?;
                 {
                     let mut query_pairs = url_with_params.query_pairs_mut();
                     for (key, value) in Self::flatten_query_params(&params) {
@@ -408,7 +442,9 @@ impl Client {
 
         if let Some(params) = params {
             if method == Method::GET {
-                let mut url_with_params = Url::parse(&url).map_err(|e| {{ spec.info.title | caseUcfirst }}Error::new(0, format!("Invalid URL: {}", e), None, String::new()))?;
+                let mut url_with_params = Url::parse(&url).map_err(|e| {
+                    {{ spec.info.title | caseUcfirst }}Error::new(0, format!("Invalid URL: {}", e), None, String::new())
+                })?;
                 {
                     let mut query_pairs = url_with_params.query_pairs_mut();
                     for (key, value) in Self::flatten_query_params(&params) {
@@ -437,12 +473,14 @@ impl Client {
                 .get("location")
                 .and_then(|v| v.to_str().ok())
                 .map(|s| s.to_string())
-                .ok_or_else(|| {{ spec.info.title | caseUcfirst }}Error::new(
-                    status.as_u16(),
-                    "Location header not found in redirect response",
-                    None,
-                    String::new(),
-                ))
+                .ok_or_else(|| {
+                    {{ spec.info.title | caseUcfirst }}Error::new(
+                        status.as_u16(),
+                        "Location header not found in redirect response",
+                        None,
+                        String::new(),
+                    )
+                })
         } else {
             let content_type = response
                 .headers()
@@ -495,7 +533,9 @@ impl Client {
 
         if let Some(params) = params {
             if method == Method::GET {
-                let mut url_with_params = Url::parse(&url).map_err(|e| {{ spec.info.title | caseUcfirst }}Error::new(0, format!("Invalid URL: {}", e), None, String::new()))?;
+                let mut url_with_params = Url::parse(&url).map_err(|e| {
+                    {{ spec.info.title | caseUcfirst }}Error::new(0, format!("Invalid URL: {}", e), None, String::new())
+                })?;
                 {
                     let mut query_pairs = url_with_params.query_pairs_mut();
                     for (key, value) in Self::flatten_query_params(&params) {
@@ -611,7 +651,9 @@ impl Client {
             let state = self.state.load_full();
             let url = format!("{}{}", state.config.endpoint, path);
 
-            let result = self.single_file_upload(&url, headers, params, param_name, &input_file).await?;
+            let result = self
+                .single_file_upload(&url, headers, params, param_name, &input_file)
+                .await?;
 
             if let Some(callback) = &options.on_progress {
                 callback(UploadProgress {
@@ -625,7 +667,15 @@ impl Client {
             return Ok(result);
         }
 
-        self.chunked_file_upload_with_progress(path, headers, params, param_name, &input_file, options).await
+        self.chunked_file_upload_with_progress(
+            path,
+            headers,
+            params,
+            param_name,
+            &input_file,
+            options,
+        )
+        .await
     }
 
     async fn single_file_upload<T: DeserializeOwned>(
@@ -645,8 +695,9 @@ impl Client {
             .file_name(input_file.filename().to_string());
 
         if let Some(mime_type) = input_file.mime_type() {
-            file_part = file_part.mime_str(mime_type)
-                .map_err(|e| {{ spec.info.title | caseUcfirst }}Error::new(0, format!("Invalid MIME type: {}", e), None, String::new()))?;
+            file_part = file_part.mime_str(mime_type).map_err(|e| {
+                {{ spec.info.title | caseUcfirst }}Error::new(0, format!("Invalid MIME type: {}", e), None, String::new())
+            })?;
         }
 
         form = form.part(param_name.to_string(), file_part);
@@ -673,11 +724,7 @@ impl Client {
             }
         }
 
-        let response = request_builder
-            .multipart(form)
-            .send()
-            .await
-            ?;
+        let response = request_builder.multipart(form).send().await?;
 
         self.handle_response(response).await
     }
@@ -704,13 +751,13 @@ impl Client {
         let mut start_chunk = 0u64;
         let mut last_response = None;
         if let Some(ref id) = current_upload_id {
-            if let Ok(response) = self.call::<Value>(
-                Method::GET,
-                &format!("{}/{}", path, id),
-                None,
-                None,
-            ).await {
-                if let Some(chunks_uploaded) = response.get("chunksUploaded").and_then(|v| v.as_u64()) {
+            if let Ok(response) = self
+                .call::<Value>(Method::GET, &format!("{}/{}", path, id), None, None)
+                .await
+            {
+                if let Some(chunks_uploaded) =
+                    response.get("chunksUploaded").and_then(|v| v.as_u64())
+                {
                     start_chunk = chunks_uploaded;
                 }
                 last_response = Some(response.clone());
@@ -723,7 +770,8 @@ impl Client {
         let mut completed_response = None;
 
         let is_upload_complete = |response: &Value| -> bool {
-            let Some(chunks_uploaded) = response.get("chunksUploaded").and_then(|v| v.as_u64()) else {
+            let Some(chunks_uploaded) = response.get("chunksUploaded").and_then(|v| v.as_u64())
+            else {
                 return false;
             };
             let chunks_total = response
@@ -735,17 +783,19 @@ impl Client {
         };
 
         if next_chunk == 0 {
-            let result = self.upload_file_chunk(
-                path,
-                headers.clone(),
-                params.clone(),
-                param_name,
-                input_file,
-                current_upload_id.clone(),
-                0,
-                file_size,
-                chunk_size,
-            ).await?;
+            let result = self
+                .upload_file_chunk(
+                    path,
+                    headers.clone(),
+                    params.clone(),
+                    param_name,
+                    input_file,
+                    current_upload_id.clone(),
+                    0,
+                    file_size,
+                    chunk_size,
+                )
+                .await?;
 
             if let Some(id) = result.get("$id").and_then(|v| v.as_str()) {
                 current_upload_id = Some(id.to_string());
@@ -784,17 +834,19 @@ impl Client {
             let chunk_index = next_chunk;
 
             tasks.spawn(async move {
-                let result = client.upload_file_chunk(
-                    &path,
-                    headers,
-                    params,
-                    &param_name,
-                    &input_file,
-                    upload_id,
-                    chunk_index,
-                    file_size,
-                    chunk_size,
-                ).await?;
+                let result = client
+                    .upload_file_chunk(
+                        &path,
+                        headers,
+                        params,
+                        &param_name,
+                        &input_file,
+                        upload_id,
+                        chunk_index,
+                        file_size,
+                        chunk_size,
+                    )
+                    .await?;
 
                 Ok::<_, {{ spec.info.title | caseUcfirst }}Error>((chunk_index, result))
             });
@@ -802,8 +854,14 @@ impl Client {
         }
 
         while let Some(joined) = tasks.join_next().await {
-            let (chunk_index, result) = joined
-                .map_err(|e| {{ spec.info.title | caseUcfirst }}Error::new(0, format!("Chunk upload task failed: {}", e), None, String::new()))??;
+            let (chunk_index, result) = joined.map_err(|e| {
+                {{ spec.info.title | caseUcfirst }}Error::new(
+                    0,
+                    format!("Chunk upload task failed: {}", e),
+                    None,
+                    String::new(),
+                )
+            })??;
 
             last_response = Some(result.clone());
             if is_upload_complete(&result) {
@@ -835,17 +893,19 @@ impl Client {
                 let chunk_index = next_chunk;
 
                 tasks.spawn(async move {
-                    let result = client.upload_file_chunk(
-                        &path,
-                        headers,
-                        params,
-                        &param_name,
-                        &input_file,
-                        upload_id,
-                        chunk_index,
-                        file_size,
-                        chunk_size,
-                    ).await?;
+                    let result = client
+                        .upload_file_chunk(
+                            &path,
+                            headers,
+                            params,
+                            &param_name,
+                            &input_file,
+                            upload_id,
+                            chunk_index,
+                            file_size,
+                            chunk_size,
+                        )
+                        .await?;
 
                     Ok::<_, {{ spec.info.title | caseUcfirst }}Error>((chunk_index, result))
                 });
@@ -882,17 +942,24 @@ impl Client {
         let actual_chunk_size = chunk_data.len();
 
         if actual_chunk_size == 0 {
-            return Err({{ spec.info.title | caseUcfirst }}Error::new(0, "Chunk data is empty", None, String::new()));
+            return Err({{ spec.info.title | caseUcfirst }}Error::new(
+                0,
+                "Chunk data is empty",
+                None,
+                String::new(),
+            ));
         }
 
         let state = self.state.load_full();
         let mut form = multipart::Form::new();
-        let mut file_part = multipart::Part::stream_with_length(chunk_data, actual_chunk_size as u64)
-            .file_name(input_file.filename().to_string());
+        let mut file_part =
+            multipart::Part::stream_with_length(chunk_data, actual_chunk_size as u64)
+                .file_name(input_file.filename().to_string());
 
         if let Some(mime_type) = input_file.mime_type() {
-            file_part = file_part.mime_str(mime_type)
-                .map_err(|e| {{ spec.info.title | caseUcfirst }}Error::new(0, format!("Invalid MIME type: {}", e), None, String::new()))?;
+            file_part = file_part.mime_str(mime_type).map_err(|e| {
+                {{ spec.info.title | caseUcfirst }}Error::new(0, format!("Invalid MIME type: {}", e), None, String::new())
+            })?;
         }
 
         form = form.part(param_name.to_string(), file_part);
@@ -928,10 +995,7 @@ impl Client {
         let content_range = format!("bytes {}-{}/{}", start, chunk_end, file_size);
         request_builder = request_builder.header("content-range", content_range);
 
-        let response = request_builder
-            .multipart(form)
-            .send()
-            .await?;
+        let response = request_builder.multipart(form).send().await?;
 
         self.handle_response(response).await
     }
@@ -949,10 +1013,16 @@ impl Client {
         if status.is_success() {
             let bytes = response.bytes().await?;
 
-            if !content_type.is_empty() && !content_type.starts_with("application/json") && !bytes.is_empty() {
+            if !content_type.is_empty()
+                && !content_type.starts_with("application/json")
+                && !bytes.is_empty()
+            {
                 return Err({{ spec.info.title | caseUcfirst }}Error::new(
                     status.as_u16(),
-                    format!("Expected JSON response but received content-type: {}", content_type),
+                    format!(
+                        "Expected JSON response but received content-type: {}",
+                        content_type
+                    ),
                     None,
                     String::from_utf8_lossy(&bytes).to_string(),
                 ));

--- a/templates/rust/src/enums/enum.rs.twig
+++ b/templates/rust/src/enums/enum.rs.twig
@@ -6,7 +6,8 @@ impl {{ enum.title | caseUcfirst | overrideIdentifier }} {
 {% for value in enum.enum %}
 {% set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
     pub const {{ key | caseEnumKey | overrideIdentifier }}: &'static str = "{{ value }}";
-{% endfor %}}
+{% endfor %}
+}
 {% else %}
 use serde::{Deserialize, Serialize};
 
@@ -16,8 +17,10 @@ pub enum {{ enum.title | caseUcfirst | overrideIdentifier }} {
 {% for value in enum.enum %}
 {% set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
     #[serde(rename = "{{ value }}")]
-    {% if loop.first %}#[default]
-    {% endif %}{{ key | caseEnumKey | overrideIdentifier }},
+{% if loop.first %}
+    #[default]
+{% endif %}
+    {{ key | caseEnumKey | overrideIdentifier }},
 {% endfor %}
 }
 
@@ -27,7 +30,7 @@ impl {{ enum.title | caseUcfirst | overrideIdentifier }} {
         match self {
 {% for value in enum.enum %}
 {% set key = enum.enumKeys is empty ? value : enum.enumKeys[loop.index0] %}
-            {{ enum.title | caseUcfirst | overrideIdentifier }}::{{ key | caseEnumKey | overrideIdentifier }} => "{{ value }}",
+{{ value | rustfmtMatchArm(12, (enum.title | caseUcfirst | overrideIdentifier) ~ '::' ~ (key | caseEnumKey | overrideIdentifier)) }}
 {% endfor %}
         }
     }

--- a/templates/rust/src/error.rs.twig
+++ b/templates/rust/src/error.rs.twig
@@ -16,7 +16,12 @@ pub struct {{ spec.info.title | caseUcfirst }}Error {
 }
 
 impl {{ spec.info.title | caseUcfirst }}Error {
-    pub fn new(code: u16, message: impl Into<String>, error_type: Option<String>, response: impl Into<String>) -> Self {
+    pub fn new(
+        code: u16,
+        message: impl Into<String>,
+        error_type: Option<String>,
+        response: impl Into<String>,
+    ) -> Self {
         Self {
             code,
             message: message.into(),
@@ -59,7 +64,12 @@ impl From<reqwest::Error> for {{ spec.info.title | caseUcfirst }}Error {
 
 impl From<serde_json::Error> for {{ spec.info.title | caseUcfirst }}Error {
     fn from(err: serde_json::Error) -> Self {
-        Self::new(0, format!("Serialization error: {}", err), None, String::new())
+        Self::new(
+            0,
+            format!("Serialization error: {}", err),
+            None,
+            String::new(),
+        )
     }
 }
 
@@ -84,12 +94,7 @@ mod tests {
 
     #[test]
     fn test_client_error() {
-        let error = {{ spec.info.title | caseUcfirst }}Error::new(
-            404,
-            "Not found",
-            None,
-            "{}",
-        );
+        let error = {{ spec.info.title | caseUcfirst }}Error::new(404, "Not found", None, "{}");
 
         assert_eq!(error.status_code(), 404);
         assert_eq!(error.get_message(), "Not found");
@@ -99,12 +104,7 @@ mod tests {
 
     #[test]
     fn test_server_error() {
-        let error = {{ spec.info.title | caseUcfirst }}Error::new(
-            500,
-            "Internal server error",
-            None,
-            "{}",
-        );
+        let error = {{ spec.info.title | caseUcfirst }}Error::new(500, "Internal server error", None, "{}");
 
         assert!(error.is_server_error());
         assert!(!error.is_client_error());

--- a/templates/rust/src/input_file.rs.twig
+++ b/templates/rust/src/input_file.rs.twig
@@ -63,7 +63,9 @@ impl InputFile {
             .to_string();
 
         Ok(Self {
-            source: InputFileSource::Path { path: path.to_path_buf() },
+            source: InputFileSource::Path {
+                path: path.to_path_buf(),
+            },
             filename,
             mime_type: mime_type.map(|s| s.to_string()),
         })
@@ -80,7 +82,9 @@ impl InputFile {
             .to_string();
 
         Ok(Self {
-            source: InputFileSource::Path { path: path.to_path_buf() },
+            source: InputFileSource::Path {
+                path: path.to_path_buf(),
+            },
             filename,
             mime_type: mime_type.map(|s| s.to_string()),
         })
@@ -101,27 +105,21 @@ impl InputFile {
     pub async fn size(&self) -> Result<u64> {
         match &self.source {
             InputFileSource::Bytes { data } => Ok(data.len() as u64),
-            InputFileSource::Path { path } => {
-                Ok(fs::metadata(path).await?.len())
-            }
+            InputFileSource::Path { path } => Ok(fs::metadata(path).await?.len()),
         }
     }
 
     pub fn size_sync(&self) -> Result<u64> {
         match &self.source {
             InputFileSource::Bytes { data } => Ok(data.len() as u64),
-            InputFileSource::Path { path } => {
-                Ok(std::fs::metadata(path)?.len())
-            }
+            InputFileSource::Path { path } => Ok(std::fs::metadata(path)?.len()),
         }
     }
 
     pub async fn read_all(&self) -> Result<Bytes> {
         match &self.source {
             InputFileSource::Bytes { data } => Ok(data.clone()),
-            InputFileSource::Path { path } => {
-                Ok(Bytes::from(fs::read(path).await?))
-            }
+            InputFileSource::Path { path } => Ok(Bytes::from(fs::read(path).await?)),
         }
     }
 
@@ -137,14 +135,12 @@ impl InputFile {
                     total_size,
                 })
             }
-            InputFileSource::Bytes { data } => {
-                Ok(ChunkedReader {
-                    file: None,
-                    data: Some(data.clone()),
-                    position: 0,
-                    total_size: data.len() as u64,
-                })
-            }
+            InputFileSource::Bytes { data } => Ok(ChunkedReader {
+                file: None,
+                data: Some(data.clone()),
+                position: 0,
+                total_size: data.len() as u64,
+            }),
         }
     }
 
@@ -163,11 +159,9 @@ impl InputFile {
     pub fn is_empty(&self) -> bool {
         match &self.source {
             InputFileSource::Bytes { data } => data.is_empty(),
-            InputFileSource::Path { path } => {
-                std::fs::metadata(path)
-                    .map(|m| m.len() == 0)
-                    .unwrap_or(true)
-            }
+            InputFileSource::Path { path } => std::fs::metadata(path)
+                .map(|m| m.len() == 0)
+                .unwrap_or(true),
         }
     }
 }
@@ -232,7 +226,10 @@ impl ChunkedReader {
         if position > self.total_size {
             return Err(crate::error::{{ spec.info.title | caseUcfirst }}Error::new(
                 0,
-                format!("Seek position {} exceeds file size {}", position, self.total_size),
+                format!(
+                    "Seek position {} exceeds file size {}",
+                    position, self.total_size
+                ),
                 None,
                 String::new(),
             ));

--- a/templates/rust/src/models/model.rs.twig
+++ b/templates/rust/src/models/model.rs.twig
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 {% if definition.additionalProperties %}
 use std::collections::HashMap;
 {% endif %}
-{% set fieldNames = {} %}
 {% set additionalFieldName = definition.properties.data is defined ? 'additional_data' : 'data' %}
 
 {{ definition.description | rustdocComment }}
@@ -25,7 +24,9 @@ pub struct {{ definitionName | caseUcfirst | overrideIdentifier }} {
 {% endif %}
 {% endfor %}
 {% if definition.additionalProperties %}
+{% if definition.properties %}
 
+{% endif %}
     #[serde(flatten)]
     pub {{ additionalFieldName }}: HashMap<String, serde_json::Value>,
 {% endif %}
@@ -36,29 +37,34 @@ impl {{ definitionName | caseUcfirst | overrideIdentifier }} {
 {% set propertyName = (property | schemaName) %}
 {% set fieldName = propertyName matches '/^_?[A-Z_]+$/' ? propertyName | lower | trim('_') : propertyName | caseSnake %}
 {% set fieldName = fieldName | overrideIdentifier %}
+{% if not loop.first %}
+
+{% endif %}
 {% if not (property | schemaRequired) %}
     /// Set {{ fieldName }}
-    pub fn set_{{ fieldName }}(mut self, {{ fieldName }}: {{ property | propertyType(spec) | rustType }}) -> Self {
-        self.{{ fieldName }} = Some({{ fieldName }});
+{{ [ 'mut self', fieldName ~ ': ' ~ (property | propertyType(spec) | rustType) ] | rustfmtFn(4, 'pub fn set_' ~ fieldName, 'Self') }}
+{{ ('Some(' ~ fieldName ~ ')') | rustfmtAssign(8, 'self.' ~ fieldName) }}
         self
     }
 
     /// Get {{ fieldName }}
-    pub fn {{ fieldName }}(&self) -> Option<&{{ property | propertyType(spec) | rustType }}> {
-        self.{{ fieldName }}.as_ref()
+{{ [ '&self' ] | rustfmtFn(4, 'pub fn ' ~ fieldName, 'Option<&' ~ (property | propertyType(spec) | rustType) ~ '>') }}
+{{ ('.as_ref()') | rustfmtChain(8, 'self.' ~ fieldName) }}
     }
 {% else %}
     /// Get {{ fieldName }}
-    pub fn {{ fieldName }}(&self) -> &{{ property | propertyType(spec) | rustType }} {
+{{ [ '&self' ] | rustfmtFn(4, 'pub fn ' ~ fieldName, '&' ~ (property | propertyType(spec) | rustType)) }}
         &self.{{ fieldName }}
     }
 {% endif %}
-
 {% endfor %}
 {% if definition.additionalProperties %}
+{% if definition.properties %}
 
+{% endif %}
     pub fn get<T: serde::de::DeserializeOwned>(&self, key: &str) -> Option<T> {
-        self.{{ additionalFieldName }}.get(key)
+        self.{{ additionalFieldName }}
+            .get(key)
             .and_then(|v| serde_json::from_value(v.clone()).ok())
     }
 
@@ -91,7 +97,7 @@ mod tests {
         let json = serde_json::to_string(&model);
         assert!(json.is_ok());
 
-        let deserialized: Result<{{ definitionName | caseUcfirst | overrideIdentifier }}, _> = serde_json::from_str(&json.unwrap());
+{{ ('serde_json::from_str(&json.unwrap())') | rustfmtAssign(8, 'let deserialized: Result<' ~ (definitionName | caseUcfirst | overrideIdentifier) ~ ', _>') }}
         assert!(deserialized.is_ok());
     }
 }

--- a/templates/rust/src/models/request_model.rs.twig
+++ b/templates/rust/src/models/request_model.rs.twig
@@ -1,7 +1,6 @@
 //! {{ requestModelName | caseUcfirst }} request model for {{ spec.info.title }} SDK
 
 use serde::{Deserialize, Serialize};
-{% set fieldNames = {} %}
 
 {{ requestModel.description | rustdocComment }}
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -27,24 +26,26 @@ impl {{ requestModelName | caseUcfirst | overrideIdentifier }} {
 {% set propertyName = (property | schemaName) %}
 {% set fieldName = propertyName matches '/^_?[A-Z_]+$/' ? propertyName | lower | trim('_') : propertyName | caseSnake %}
 {% set fieldName = fieldName | overrideIdentifier %}
+{% if not loop.first %}
+
+{% endif %}
 {% if not (property | schemaRequired) %}
     /// Set {{ fieldName }}
-    pub fn set_{{ fieldName }}(mut self, {{ fieldName }}: {{ property | propertyType(spec) | rustType }}) -> Self {
-        self.{{ fieldName }} = Some({{ fieldName }});
+{{ [ 'mut self', fieldName ~ ': ' ~ (property | propertyType(spec) | rustType) ] | rustfmtFn(4, 'pub fn set_' ~ fieldName, 'Self') }}
+{{ ('Some(' ~ fieldName ~ ')') | rustfmtAssign(8, 'self.' ~ fieldName) }}
         self
     }
 
     /// Get {{ fieldName }}
-    pub fn {{ fieldName }}(&self) -> Option<&{{ property | propertyType(spec) | rustType }}> {
-        self.{{ fieldName }}.as_ref()
+{{ [ '&self' ] | rustfmtFn(4, 'pub fn ' ~ fieldName, 'Option<&' ~ (property | propertyType(spec) | rustType) ~ '>') }}
+{{ ('.as_ref()') | rustfmtChain(8, 'self.' ~ fieldName) }}
     }
 {% else %}
     /// Get {{ fieldName }}
-    pub fn {{ fieldName }}(&self) -> &{{ property | propertyType(spec) | rustType }} {
+{{ [ '&self' ] | rustfmtFn(4, 'pub fn ' ~ fieldName, '&' ~ (property | propertyType(spec) | rustType)) }}
         &self.{{ fieldName }}
     }
 {% endif %}
-
 {% endfor %}
 }
 
@@ -71,7 +72,7 @@ mod tests {
         let json = serde_json::to_string(&model);
         assert!(json.is_ok());
 
-        let deserialized: Result<{{ requestModelName | caseUcfirst | overrideIdentifier }}, _> = serde_json::from_str(&json.unwrap());
+{{ ('serde_json::from_str(&json.unwrap())') | rustfmtAssign(8, 'let deserialized: Result<' ~ (requestModelName | caseUcfirst | overrideIdentifier) ~ ', _>') }}
         assert!(deserialized.is_ok());
     }
 }

--- a/templates/rust/src/operator.rs.twig
+++ b/templates/rust/src/operator.rs.twig
@@ -45,7 +45,7 @@ fn parse_operator(method: &str, values: Vec<Value>) -> String {
 }
 
 fn validate_numeric(value: &Value, param_name: &str) {
-     if !value.is_number() {
+    if !value.is_number() {
         panic!("{} must be a number", param_name);
     }
     if let Some(num) = value.as_f64() {
@@ -254,7 +254,10 @@ mod tests {
 
     #[test]
     fn test_increment_with_max() {
-        assert_eq!(increment_with_max(5, 100), r#"{"method":"increment","values":[5,100]}"#);
+        assert_eq!(
+            increment_with_max(5, 100),
+            r#"{"method":"increment","values":[5,100]}"#
+        );
     }
 
     #[test]
@@ -269,7 +272,10 @@ mod tests {
 
     #[test]
     fn test_decrement_with_min() {
-        assert_eq!(decrement_with_min(3, 0), r#"{"method":"decrement","values":[3,0]}"#);
+        assert_eq!(
+            decrement_with_min(3, 0),
+            r#"{"method":"decrement","values":[3,0]}"#
+        );
     }
 
     #[test]
@@ -279,7 +285,10 @@ mod tests {
 
     #[test]
     fn test_multiply_with_max() {
-        assert_eq!(multiply_with_max(3, 1000), r#"{"method":"multiply","values":[3,1000]}"#);
+        assert_eq!(
+            multiply_with_max(3, 1000),
+            r#"{"method":"multiply","values":[3,1000]}"#
+        );
     }
 
     #[test]
@@ -289,7 +298,10 @@ mod tests {
 
     #[test]
     fn test_divide_with_min() {
-        assert_eq!(divide_with_min(4, 1), r#"{"method":"divide","values":[4,1]}"#);
+        assert_eq!(
+            divide_with_min(4, 1),
+            r#"{"method":"divide","values":[4,1]}"#
+        );
     }
 
     #[test]
@@ -304,27 +316,42 @@ mod tests {
 
     #[test]
     fn test_power_with_max() {
-        assert_eq!(power_with_max(3, 100), r#"{"method":"power","values":[3,100]}"#);
+        assert_eq!(
+            power_with_max(3, 100),
+            r#"{"method":"power","values":[3,100]}"#
+        );
     }
 
     #[test]
     fn test_array_append() {
-        assert_eq!(array_append(&["item1", "item2"]), r#"{"method":"arrayAppend","values":["item1","item2"]}"#);
+        assert_eq!(
+            array_append(&["item1", "item2"]),
+            r#"{"method":"arrayAppend","values":["item1","item2"]}"#
+        );
     }
 
     #[test]
     fn test_array_prepend() {
-        assert_eq!(array_prepend(&["first", "second"]), r#"{"method":"arrayPrepend","values":["first","second"]}"#);
+        assert_eq!(
+            array_prepend(&["first", "second"]),
+            r#"{"method":"arrayPrepend","values":["first","second"]}"#
+        );
     }
 
     #[test]
     fn test_array_insert() {
-        assert_eq!(array_insert(0, "newItem"), r#"{"method":"arrayInsert","values":[0,"newItem"]}"#);
+        assert_eq!(
+            array_insert(0, "newItem"),
+            r#"{"method":"arrayInsert","values":[0,"newItem"]}"#
+        );
     }
 
     #[test]
     fn test_array_remove() {
-        assert_eq!(array_remove("oldItem"), r#"{"method":"arrayRemove","values":["oldItem"]}"#);
+        assert_eq!(
+            array_remove("oldItem"),
+            r#"{"method":"arrayRemove","values":["oldItem"]}"#
+        );
     }
 
     #[test]
@@ -334,32 +361,50 @@ mod tests {
 
     #[test]
     fn test_array_intersect() {
-        assert_eq!(array_intersect(&["a", "b", "c"]), r#"{"method":"arrayIntersect","values":["a","b","c"]}"#);
+        assert_eq!(
+            array_intersect(&["a", "b", "c"]),
+            r#"{"method":"arrayIntersect","values":["a","b","c"]}"#
+        );
     }
 
     #[test]
     fn test_array_diff() {
-        assert_eq!(array_diff(&["x", "y"]), r#"{"method":"arrayDiff","values":["x","y"]}"#);
+        assert_eq!(
+            array_diff(&["x", "y"]),
+            r#"{"method":"arrayDiff","values":["x","y"]}"#
+        );
     }
 
     #[test]
     fn test_array_filter() {
-        assert_eq!(array_filter(Condition::Equal), r#"{"method":"arrayFilter","values":["equal",null]}"#);
+        assert_eq!(
+            array_filter(Condition::Equal),
+            r#"{"method":"arrayFilter","values":["equal",null]}"#
+        );
     }
 
     #[test]
     fn test_array_filter_with_value() {
-        assert_eq!(array_filter_with_value(Condition::Equal, "test"), r#"{"method":"arrayFilter","values":["equal","test"]}"#);
+        assert_eq!(
+            array_filter_with_value(Condition::Equal, "test"),
+            r#"{"method":"arrayFilter","values":["equal","test"]}"#
+        );
     }
 
     #[test]
     fn test_string_concat() {
-        assert_eq!(string_concat("suffix"), r#"{"method":"stringConcat","values":["suffix"]}"#);
+        assert_eq!(
+            string_concat("suffix"),
+            r#"{"method":"stringConcat","values":["suffix"]}"#
+        );
     }
 
     #[test]
     fn test_string_replace() {
-        assert_eq!(string_replace("old", "new"), r#"{"method":"stringReplace","values":["old","new"]}"#);
+        assert_eq!(
+            string_replace("old", "new"),
+            r#"{"method":"stringReplace","values":["old","new"]}"#
+        );
     }
 
     #[test]

--- a/templates/rust/src/query.rs.twig
+++ b/templates/rust/src/query.rs.twig
@@ -30,27 +30,51 @@ impl Query {
     }
 
     pub fn equal<S: Into<String>, V: Into<Value>>(attribute: S, value: V) -> Self {
-        Self::new("equal".to_string(), Some(attribute.into()), Self::to_array(value.into()))
+        Self::new(
+            "equal".to_string(),
+            Some(attribute.into()),
+            Self::to_array(value.into()),
+        )
     }
 
     pub fn not_equal<S: Into<String>, V: Into<Value>>(attribute: S, value: V) -> Self {
-        Self::new("notEqual".to_string(), Some(attribute.into()), Self::to_array(value.into()))
+        Self::new(
+            "notEqual".to_string(),
+            Some(attribute.into()),
+            Self::to_array(value.into()),
+        )
     }
 
     pub fn less_than<S: Into<String>, V: Into<Value>>(attribute: S, value: V) -> Self {
-        Self::new("lessThan".to_string(), Some(attribute.into()), Self::to_array(value.into()))
+        Self::new(
+            "lessThan".to_string(),
+            Some(attribute.into()),
+            Self::to_array(value.into()),
+        )
     }
 
     pub fn less_than_equal<S: Into<String>, V: Into<Value>>(attribute: S, value: V) -> Self {
-        Self::new("lessThanEqual".to_string(), Some(attribute.into()), Self::to_array(value.into()))
+        Self::new(
+            "lessThanEqual".to_string(),
+            Some(attribute.into()),
+            Self::to_array(value.into()),
+        )
     }
 
     pub fn greater_than<S: Into<String>, V: Into<Value>>(attribute: S, value: V) -> Self {
-        Self::new("greaterThan".to_string(), Some(attribute.into()), Self::to_array(value.into()))
+        Self::new(
+            "greaterThan".to_string(),
+            Some(attribute.into()),
+            Self::to_array(value.into()),
+        )
     }
 
     pub fn greater_than_equal<S: Into<String>, V: Into<Value>>(attribute: S, value: V) -> Self {
-        Self::new("greaterThanEqual".to_string(), Some(attribute.into()), Self::to_array(value.into()))
+        Self::new(
+            "greaterThanEqual".to_string(),
+            Some(attribute.into()),
+            Self::to_array(value.into()),
+        )
     }
 
     pub fn is_null<S: Into<String>>(attribute: S) -> Self {
@@ -62,28 +86,51 @@ impl Query {
     }
 
     pub fn between<S: Into<String>, V: Into<Value>>(attribute: S, start: V, end: V) -> Self {
-        Self::new("between".to_string(), Some(attribute.into()), vec![start.into(), end.into()])
+        Self::new(
+            "between".to_string(),
+            Some(attribute.into()),
+            vec![start.into(), end.into()],
+        )
     }
 
     pub fn starts_with<S: Into<String>, V: Into<Value>>(attribute: S, value: V) -> Self {
-        Self::new("startsWith".to_string(), Some(attribute.into()), Self::to_array(value.into()))
+        Self::new(
+            "startsWith".to_string(),
+            Some(attribute.into()),
+            Self::to_array(value.into()),
+        )
     }
 
     pub fn ends_with<S: Into<String>, V: Into<Value>>(attribute: S, value: V) -> Self {
-        Self::new("endsWith".to_string(), Some(attribute.into()), Self::to_array(value.into()))
+        Self::new(
+            "endsWith".to_string(),
+            Some(attribute.into()),
+            Self::to_array(value.into()),
+        )
     }
 
     pub fn select<I: IntoIterator<Item = S>, S: Into<String>>(attributes: I) -> Self {
-        let values: Vec<Value> = attributes.into_iter().map(|s| Value::String(s.into())).collect();
+        let values: Vec<Value> = attributes
+            .into_iter()
+            .map(|s| Value::String(s.into()))
+            .collect();
         Self::new("select".to_string(), None, values)
     }
 
     pub fn search<S: Into<String>, V: Into<Value>>(attribute: S, value: V) -> Self {
-        Self::new("search".to_string(), Some(attribute.into()), Self::to_array(value.into()))
+        Self::new(
+            "search".to_string(),
+            Some(attribute.into()),
+            Self::to_array(value.into()),
+        )
     }
 
     pub fn not_search<S: Into<String>, V: Into<Value>>(attribute: S, value: V) -> Self {
-        Self::new("notSearch".to_string(), Some(attribute.into()), Self::to_array(value.into()))
+        Self::new(
+            "notSearch".to_string(),
+            Some(attribute.into()),
+            Self::to_array(value.into()),
+        )
     }
 
     pub fn order_asc<S: Into<String>>(attribute: S) -> Self {
@@ -99,11 +146,19 @@ impl Query {
     }
 
     pub fn cursor_after<S: Into<String>>(document_id: S) -> Self {
-        Self::new("cursorAfter".to_string(), None, vec![Value::String(document_id.into())])
+        Self::new(
+            "cursorAfter".to_string(),
+            None,
+            vec![Value::String(document_id.into())],
+        )
     }
 
     pub fn cursor_before<S: Into<String>>(document_id: S) -> Self {
-        Self::new("cursorBefore".to_string(), None, vec![Value::String(document_id.into())])
+        Self::new(
+            "cursorBefore".to_string(),
+            None,
+            vec![Value::String(document_id.into())],
+        )
     }
 
     pub fn limit(value: u32) -> Self {
@@ -111,35 +166,67 @@ impl Query {
     }
 
     pub fn offset(value: u32) -> Self {
-        Self::new("offset".to_string(), None, vec![Value::Number(value.into())])
+        Self::new(
+            "offset".to_string(),
+            None,
+            vec![Value::Number(value.into())],
+        )
     }
 
     pub fn contains<S: Into<String>, V: Into<Value>>(attribute: S, value: V) -> Self {
-        Self::new("contains".to_string(), Some(attribute.into()), Self::to_array(value.into()))
+        Self::new(
+            "contains".to_string(),
+            Some(attribute.into()),
+            Self::to_array(value.into()),
+        )
     }
 
     pub fn contains_any<S: Into<String>, V: Into<Value>>(attribute: S, values: Vec<V>) -> Self {
-        Self::new("containsAny".to_string(), Some(attribute.into()), values.into_iter().map(|v| v.into()).collect())
+        Self::new(
+            "containsAny".to_string(),
+            Some(attribute.into()),
+            values.into_iter().map(|v| v.into()).collect(),
+        )
     }
 
     pub fn contains_all<S: Into<String>, V: Into<Value>>(attribute: S, values: Vec<V>) -> Self {
-        Self::new("containsAll".to_string(), Some(attribute.into()), values.into_iter().map(|v| v.into()).collect())
+        Self::new(
+            "containsAll".to_string(),
+            Some(attribute.into()),
+            values.into_iter().map(|v| v.into()).collect(),
+        )
     }
 
     pub fn not_contains<S: Into<String>, V: Into<Value>>(attribute: S, value: V) -> Self {
-        Self::new("notContains".to_string(), Some(attribute.into()), Self::to_array(value.into()))
+        Self::new(
+            "notContains".to_string(),
+            Some(attribute.into()),
+            Self::to_array(value.into()),
+        )
     }
 
     pub fn not_between<S: Into<String>, V: Into<Value>>(attribute: S, start: V, end: V) -> Self {
-        Self::new("notBetween".to_string(), Some(attribute.into()), vec![start.into(), end.into()])
+        Self::new(
+            "notBetween".to_string(),
+            Some(attribute.into()),
+            vec![start.into(), end.into()],
+        )
     }
 
     pub fn not_starts_with<S: Into<String>, V: Into<Value>>(attribute: S, value: V) -> Self {
-        Self::new("notStartsWith".to_string(), Some(attribute.into()), Self::to_array(value.into()))
+        Self::new(
+            "notStartsWith".to_string(),
+            Some(attribute.into()),
+            Self::to_array(value.into()),
+        )
     }
 
     pub fn not_ends_with<S: Into<String>, V: Into<Value>>(attribute: S, value: V) -> Self {
-        Self::new("notEndsWith".to_string(), Some(attribute.into()), Self::to_array(value.into()))
+        Self::new(
+            "notEndsWith".to_string(),
+            Some(attribute.into()),
+            Self::to_array(value.into()),
+        )
     }
 
     pub fn created_before<V: Into<Value>>(value: V) -> Self {
@@ -166,68 +253,148 @@ impl Query {
         Self::between("$updatedAt", start, end)
     }
 
-    pub fn distance_equal<S: Into<String>, V: Into<Value>>(attribute: S, values: V, distance: impl Into<Value>, meters: bool) -> Self {
+    pub fn distance_equal<S: Into<String>, V: Into<Value>>(
+        attribute: S,
+        values: V,
+        distance: impl Into<Value>,
+        meters: bool,
+    ) -> Self {
         let params = Value::Array(vec![values.into(), distance.into(), Value::Bool(meters)]);
-        Self::new("distanceEqual".to_string(), Some(attribute.into()), vec![params])
+        Self::new(
+            "distanceEqual".to_string(),
+            Some(attribute.into()),
+            vec![params],
+        )
     }
 
-    pub fn distance_not_equal<S: Into<String>, V: Into<Value>>(attribute: S, values: V, distance: impl Into<Value>, meters: bool) -> Self {
+    pub fn distance_not_equal<S: Into<String>, V: Into<Value>>(
+        attribute: S,
+        values: V,
+        distance: impl Into<Value>,
+        meters: bool,
+    ) -> Self {
         let params = Value::Array(vec![values.into(), distance.into(), Value::Bool(meters)]);
-        Self::new("distanceNotEqual".to_string(), Some(attribute.into()), vec![params])
+        Self::new(
+            "distanceNotEqual".to_string(),
+            Some(attribute.into()),
+            vec![params],
+        )
     }
 
-    pub fn distance_greater_than<S: Into<String>, V: Into<Value>>(attribute: S, values: V, distance: impl Into<Value>, meters: bool) -> Self {
+    pub fn distance_greater_than<S: Into<String>, V: Into<Value>>(
+        attribute: S,
+        values: V,
+        distance: impl Into<Value>,
+        meters: bool,
+    ) -> Self {
         let params = Value::Array(vec![values.into(), distance.into(), Value::Bool(meters)]);
-        Self::new("distanceGreaterThan".to_string(), Some(attribute.into()), vec![params])
+        Self::new(
+            "distanceGreaterThan".to_string(),
+            Some(attribute.into()),
+            vec![params],
+        )
     }
 
-    pub fn distance_less_than<S: Into<String>, V: Into<Value>>(attribute: S, values: V, distance: impl Into<Value>, meters: bool) -> Self {
+    pub fn distance_less_than<S: Into<String>, V: Into<Value>>(
+        attribute: S,
+        values: V,
+        distance: impl Into<Value>,
+        meters: bool,
+    ) -> Self {
         let params = Value::Array(vec![values.into(), distance.into(), Value::Bool(meters)]);
-        Self::new("distanceLessThan".to_string(), Some(attribute.into()), vec![params])
+        Self::new(
+            "distanceLessThan".to_string(),
+            Some(attribute.into()),
+            vec![params],
+        )
     }
 
     pub fn vector_dot<S: Into<String>, V: Into<Value>>(attribute: S, vector: V) -> Self {
-        Self::new("vectorDot".to_string(), Some(attribute.into()), vec![vector.into()])
+        Self::new(
+            "vectorDot".to_string(),
+            Some(attribute.into()),
+            vec![vector.into()],
+        )
     }
 
     pub fn vector_cosine<S: Into<String>, V: Into<Value>>(attribute: S, vector: V) -> Self {
-        Self::new("vectorCosine".to_string(), Some(attribute.into()), vec![vector.into()])
+        Self::new(
+            "vectorCosine".to_string(),
+            Some(attribute.into()),
+            vec![vector.into()],
+        )
     }
 
     pub fn vector_euclidean<S: Into<String>, V: Into<Value>>(attribute: S, vector: V) -> Self {
-        Self::new("vectorEuclidean".to_string(), Some(attribute.into()), vec![vector.into()])
+        Self::new(
+            "vectorEuclidean".to_string(),
+            Some(attribute.into()),
+            vec![vector.into()],
+        )
     }
 
     pub fn intersects<S: Into<String>, V: Into<Value>>(attribute: S, values: V) -> Self {
-        Self::new("intersects".to_string(), Some(attribute.into()), vec![values.into()])
+        Self::new(
+            "intersects".to_string(),
+            Some(attribute.into()),
+            vec![values.into()],
+        )
     }
 
     pub fn not_intersects<S: Into<String>, V: Into<Value>>(attribute: S, values: V) -> Self {
-        Self::new("notIntersects".to_string(), Some(attribute.into()), vec![values.into()])
+        Self::new(
+            "notIntersects".to_string(),
+            Some(attribute.into()),
+            vec![values.into()],
+        )
     }
 
     pub fn crosses<S: Into<String>, V: Into<Value>>(attribute: S, values: V) -> Self {
-        Self::new("crosses".to_string(), Some(attribute.into()), vec![values.into()])
+        Self::new(
+            "crosses".to_string(),
+            Some(attribute.into()),
+            vec![values.into()],
+        )
     }
 
     pub fn not_crosses<S: Into<String>, V: Into<Value>>(attribute: S, values: V) -> Self {
-        Self::new("notCrosses".to_string(), Some(attribute.into()), vec![values.into()])
+        Self::new(
+            "notCrosses".to_string(),
+            Some(attribute.into()),
+            vec![values.into()],
+        )
     }
 
     pub fn overlaps<S: Into<String>, V: Into<Value>>(attribute: S, values: V) -> Self {
-        Self::new("overlaps".to_string(), Some(attribute.into()), vec![values.into()])
+        Self::new(
+            "overlaps".to_string(),
+            Some(attribute.into()),
+            vec![values.into()],
+        )
     }
 
     pub fn not_overlaps<S: Into<String>, V: Into<Value>>(attribute: S, values: V) -> Self {
-        Self::new("notOverlaps".to_string(), Some(attribute.into()), vec![values.into()])
+        Self::new(
+            "notOverlaps".to_string(),
+            Some(attribute.into()),
+            vec![values.into()],
+        )
     }
 
     pub fn touches<S: Into<String>, V: Into<Value>>(attribute: S, values: V) -> Self {
-        Self::new("touches".to_string(), Some(attribute.into()), vec![values.into()])
+        Self::new(
+            "touches".to_string(),
+            Some(attribute.into()),
+            vec![values.into()],
+        )
     }
 
     pub fn not_touches<S: Into<String>, V: Into<Value>>(attribute: S, values: V) -> Self {
-        Self::new("notTouches".to_string(), Some(attribute.into()), vec![values.into()])
+        Self::new(
+            "notTouches".to_string(),
+            Some(attribute.into()),
+            vec![values.into()],
+        )
     }
 
     pub fn or<I, S>(queries: I) -> Self
@@ -255,15 +422,27 @@ impl Query {
     }
 
     pub fn regex<S: Into<String>, V: Into<Value>>(attribute: S, value: V) -> Self {
-        Self::new("regex".to_string(), Some(attribute.into()), Self::to_array(value.into()))
+        Self::new(
+            "regex".to_string(),
+            Some(attribute.into()),
+            Self::to_array(value.into()),
+        )
     }
 
     pub fn exists<V: Into<Value>>(attributes: Vec<V>) -> Self {
-        Self::new("exists".to_string(), None, attributes.into_iter().map(|v| v.into()).collect())
+        Self::new(
+            "exists".to_string(),
+            None,
+            attributes.into_iter().map(|v| v.into()).collect(),
+        )
     }
 
     pub fn not_exists<V: Into<Value>>(attributes: Vec<V>) -> Self {
-        Self::new("notExists".to_string(), None, attributes.into_iter().map(|v| v.into()).collect())
+        Self::new(
+            "notExists".to_string(),
+            None,
+            attributes.into_iter().map(|v| v.into()).collect(),
+        )
     }
 
     pub fn elem_match<S, I, Q>(attribute: S, queries: I) -> Self
@@ -298,8 +477,7 @@ impl Query {
 
 impl std::fmt::Display for Query {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let json_str = serde_json::to_string(self)
-            .unwrap_or_else(|_| String::new());
+        let json_str = serde_json::to_string(self).unwrap_or_else(|_| String::new());
         write!(f, "{}", json_str)
     }
 }
@@ -425,7 +603,10 @@ mod tests {
     #[test]
     fn test_equal_with_array() {
         let arr = vec!["Movie1", "Movie2"];
-        let query = Query::equal("title", Value::Array(arr.iter().map(|s| Value::String(s.to_string())).collect()));
+        let query = Query::equal(
+            "title",
+            Value::Array(arr.iter().map(|s| Value::String(s.to_string())).collect()),
+        );
         let value = query.to_value();
         assert_eq!(value["method"], "equal");
         assert_eq!(value["attribute"], "title");
@@ -641,7 +822,12 @@ mod tests {
 
     #[test]
     fn test_distance_equal() {
-        let query = Query::distance_equal("location", Value::Array(vec![Value::from(40.7128), Value::from(-74.0060)]), 5000, true);
+        let query = Query::distance_equal(
+            "location",
+            Value::Array(vec![Value::from(40.7128), Value::from(-74.0060)]),
+            5000,
+            true,
+        );
         let value = query.to_value();
         assert_eq!(value["method"], "distanceEqual");
         assert_eq!(value["attribute"], "location");
@@ -652,7 +838,12 @@ mod tests {
 
     #[test]
     fn test_distance_not_equal() {
-        let query = Query::distance_not_equal("location", Value::Array(vec![Value::from(40.7128), Value::from(-74.0060)]), 5000, false);
+        let query = Query::distance_not_equal(
+            "location",
+            Value::Array(vec![Value::from(40.7128), Value::from(-74.0060)]),
+            5000,
+            false,
+        );
         let value = query.to_value();
         assert_eq!(value["method"], "distanceNotEqual");
         assert_eq!(value["attribute"], "location");
@@ -663,7 +854,12 @@ mod tests {
 
     #[test]
     fn test_distance_greater_than() {
-        let query = Query::distance_greater_than("location", Value::Array(vec![Value::from(1.0), Value::from(2.0)]), 123, true);
+        let query = Query::distance_greater_than(
+            "location",
+            Value::Array(vec![Value::from(1.0), Value::from(2.0)]),
+            123,
+            true,
+        );
         let value = query.to_value();
         assert_eq!(value["method"], "distanceGreaterThan");
         assert_eq!(value["attribute"], "location");
@@ -674,7 +870,12 @@ mod tests {
 
     #[test]
     fn test_distance_less_than() {
-        let query = Query::distance_less_than("location", Value::Array(vec![Value::from(1.0), Value::from(2.0)]), 321, false);
+        let query = Query::distance_less_than(
+            "location",
+            Value::Array(vec![Value::from(1.0), Value::from(2.0)]),
+            321,
+            false,
+        );
         let value = query.to_value();
         assert_eq!(value["method"], "distanceLessThan");
         assert_eq!(value["attribute"], "location");
@@ -685,7 +886,10 @@ mod tests {
 
     #[test]
     fn test_vector_dot() {
-        let query = Query::vector_dot("embedding", Value::Array(vec![Value::from(0.1), Value::from(0.2), Value::from(0.3)]));
+        let query = Query::vector_dot(
+            "embedding",
+            Value::Array(vec![Value::from(0.1), Value::from(0.2), Value::from(0.3)]),
+        );
         let value = query.to_value();
         assert_eq!(value["method"], "vectorDot");
         assert_eq!(value["attribute"], "embedding");
@@ -694,7 +898,10 @@ mod tests {
 
     #[test]
     fn test_vector_cosine() {
-        let query = Query::vector_cosine("embedding", Value::Array(vec![Value::from(0.1), Value::from(0.2), Value::from(0.3)]));
+        let query = Query::vector_cosine(
+            "embedding",
+            Value::Array(vec![Value::from(0.1), Value::from(0.2), Value::from(0.3)]),
+        );
         let value = query.to_value();
         assert_eq!(value["method"], "vectorCosine");
         assert_eq!(value["attribute"], "embedding");
@@ -703,7 +910,10 @@ mod tests {
 
     #[test]
     fn test_vector_euclidean() {
-        let query = Query::vector_euclidean("embedding", Value::Array(vec![Value::from(0.1), Value::from(0.2), Value::from(0.3)]));
+        let query = Query::vector_euclidean(
+            "embedding",
+            Value::Array(vec![Value::from(0.1), Value::from(0.2), Value::from(0.3)]),
+        );
         let value = query.to_value();
         assert_eq!(value["method"], "vectorEuclidean");
         assert_eq!(value["attribute"], "embedding");
@@ -722,7 +932,8 @@ mod tests {
 
     #[test]
     fn test_not_intersects() {
-        let query = Query::not_intersects("geo", Value::Array(vec![Value::from(1), Value::from(2)]));
+        let query =
+            Query::not_intersects("geo", Value::Array(vec![Value::from(1), Value::from(2)]));
         let value = query.to_value();
         assert_eq!(value["method"], "notIntersects");
         assert_eq!(value["attribute"], "geo");

--- a/templates/rust/src/services/service.rs.twig
+++ b/templates/rust/src/services/service.rs.twig
@@ -25,13 +25,14 @@ pub struct {{ service.name | caseUcfirst }} {
 
 impl {{ service.name | caseUcfirst }} {
     pub fn new(client: &Client) -> Self {
-        Self { client: client.clone() }
+        Self {
+            client: client.clone(),
+        }
     }
 
     pub fn client(&self) -> &Client {
         &self.client
     }
-
 {% for method in (service | operations) %}
 {% set methodNameSnake = (method | methodName) | caseSnake %}
 {% set shouldSkip = false %}
@@ -43,30 +44,30 @@ impl {{ service.name | caseUcfirst }} {
 {% endfor %}
 {% endif %}
 {% if not shouldSkip %}
-    {{ method.description | rustdocComment(4) }}
-{% if (method | parameters('all')) | length > 6 %}
-    #[allow(clippy::too_many_arguments)]
-{% endif %}
-    pub async fn {{ (method | methodName) | caseSnake | overrideIdentifier }}(
-        &self,
+{% set fnParams = ['&self'] %}
 {% for parameter in (method | parameters('all')) %}
 {% if parameter.required and not (parameter | schemaNullable) %}
-        {{ parameter.name | caseSnake | overrideIdentifier }}: {{ parameter | inputType | rustType }},
+{% set fnParams = fnParams | merge([ (parameter.name | caseSnake | overrideIdentifier) ~ ': ' ~ (parameter | inputType | rustType) ]) %}
 {% endif %}
 {% endfor %}
 {% for parameter in (method | parameters('all')) %}
 {% if not parameter.required or (parameter | schemaNullable) %}
 {% set inputTypeRaw = parameter | inputType %}
 {% if inputTypeRaw == 'impl Into<String>' %}
-        {{ parameter.name | caseSnake | overrideIdentifier }}: Option<&str>,
+{% set fnParams = fnParams | merge([ (parameter.name | caseSnake | overrideIdentifier) ~ ': Option<&str>' ]) %}
 {% elseif inputTypeRaw starts with 'impl IntoIterator' %}
-        {{ parameter.name | caseSnake | overrideIdentifier }}: Option<Vec<String>>,
+{% set fnParams = fnParams | merge([ (parameter.name | caseSnake | overrideIdentifier) ~ ': Option<Vec<String>>' ]) %}
 {% else %}
-        {{ parameter.name | caseSnake | overrideIdentifier }}: Option<{{ inputTypeRaw | rustType }}>,
+{% set fnParams = fnParams | merge([ (parameter.name | caseSnake | overrideIdentifier) ~ ': Option<' ~ (inputTypeRaw | rustType) ~ '>' ]) %}
 {% endif %}
 {% endif %}
 {% endfor %}
-    ) -> {{ method | returnType(spec, 'crate') | rustType }} {
+
+    {{ method.description | rustdocComment(4) }}
+{% if (method | parameters('all')) | length > 6 %}
+    #[allow(clippy::too_many_arguments)]
+{% endif %}
+{{ fnParams | rustfmtFn(4, 'pub async fn ' ~ ((method | methodName) | caseSnake | overrideIdentifier), method | returnType(spec, 'crate') | rustType) }}
 {% set uploadIdParameter = method | uploadIdParameter %}
 {% set uploadIDRequired = false %}
 {% if uploadIdParameter %}
@@ -83,17 +84,17 @@ impl {{ service.name | caseUcfirst }} {
 {% for parameter in (method | parameters('query')) %}
 {% if parameter.required and not (parameter | schemaNullable) %}
 {% if uploadIdParameter and parameter.name == uploadIdParameter.name %}
-        params.insert("{{ parameter.name }}".to_string(), json!({{ parameter.name | caseSnake | overrideIdentifier }}_str));
+{{ [ '"' ~ parameter.name ~ '".to_string()', 'json!(' ~ (parameter.name | caseSnake | overrideIdentifier) ~ '_str)' ] | rustfmtCall(8, 'params.insert') }}
 {% else %}
-        params.insert("{{ parameter.name }}".to_string(), json!({{ parameter | paramValue(parameter.name | caseSnake | overrideIdentifier) }}));
+{{ [ '"' ~ parameter.name ~ '".to_string()', 'json!(' ~ (parameter | paramValue(parameter.name | caseSnake | overrideIdentifier)) ~ ')' ] | rustfmtCall(8, 'params.insert') }}
 {% endif %}
 {% else %}
 {% set inputTypeRaw = parameter | inputType %}
         if let Some(value) = {{ parameter.name | caseSnake | overrideIdentifier }} {
 {% if inputTypeRaw == 'impl Into<String>' %}
-            params.insert("{{ parameter.name }}".to_string(), json!(value));
+{{ [ '"' ~ parameter.name ~ '".to_string()', 'json!(value)' ] | rustfmtCall(12, 'params.insert') }}
 {% else %}
-            params.insert("{{ parameter.name }}".to_string(), json!({{ parameter | paramValue('value') }}));
+{{ [ '"' ~ parameter.name ~ '".to_string()', 'json!(' ~ (parameter | paramValue('value')) ~ ')' ] | rustfmtCall(12, 'params.insert') }}
 {% endif %}
         }
 {% endif %}
@@ -102,17 +103,17 @@ impl {{ service.name | caseUcfirst }} {
 {% if (parameter | schemaType) != 'file' %}
 {% if parameter.required and not (parameter | schemaNullable) %}
 {% if uploadIdParameter and parameter.name == uploadIdParameter.name %}
-        params.insert("{{ parameter.name }}".to_string(), json!({{ parameter.name | caseSnake | overrideIdentifier }}_str));
+{{ [ '"' ~ parameter.name ~ '".to_string()', 'json!(' ~ (parameter.name | caseSnake | overrideIdentifier) ~ '_str)' ] | rustfmtCall(8, 'params.insert') }}
 {% else %}
-        params.insert("{{ parameter.name }}".to_string(), json!({{ parameter | paramValue(parameter.name | caseSnake | overrideIdentifier) }}));
+{{ [ '"' ~ parameter.name ~ '".to_string()', 'json!(' ~ (parameter | paramValue(parameter.name | caseSnake | overrideIdentifier)) ~ ')' ] | rustfmtCall(8, 'params.insert') }}
 {% endif %}
 {% else %}
 {% set inputTypeRaw = parameter | inputType %}
         if let Some(value) = {{ parameter.name | caseSnake | overrideIdentifier }} {
 {% if inputTypeRaw == 'impl Into<String>' %}
-            params.insert("{{ parameter.name }}".to_string(), json!(value));
+{{ [ '"' ~ parameter.name ~ '".to_string()', 'json!(value)' ] | rustfmtCall(12, 'params.insert') }}
 {% else %}
-            params.insert("{{ parameter.name }}".to_string(), json!({{ parameter | paramValue('value') }}));
+{{ [ '"' ~ parameter.name ~ '".to_string()', 'json!(' ~ (parameter | paramValue('value')) ~ ')' ] | rustfmtCall(12, 'params.insert') }}
 {% endif %}
         }
 {% endif %}
@@ -123,19 +124,27 @@ impl {{ service.name | caseUcfirst }} {
         let mut api_headers = HashMap::new();
 {% for parameter in (method | parameters('header')) %}
 {% if parameter.required %}
-        api_headers.insert("{{ parameter.name }}".to_string(), {{ parameter | paramValue(parameter.name | caseSnake | overrideIdentifier) }}.to_string());
+{{ [ '"' ~ parameter.name ~ '".to_string()', (parameter | paramValue(parameter.name | caseSnake | overrideIdentifier)) ~ '.to_string()' ] | rustfmtCall(8, 'api_headers.insert') }}
 {% else %}
         if let Some(value) = {{ parameter.name | caseSnake | overrideIdentifier }} {
-            api_headers.insert("{{ parameter.name }}".to_string(), {{ parameter | paramValue('value') }}.to_string());
+{{ [ '"' ~ parameter.name ~ '".to_string()', (parameter | paramValue('value')) ~ '.to_string()' ] | rustfmtCall(12, 'api_headers.insert') }}
         }
 {% endif %}
 {% endfor %}
 {% for key, header in (method | methodHeaders) %}
-        api_headers.insert("{{ key }}".to_string(), "{{ header }}".to_string());
+{{ [ '"' ~ key ~ '".to_string()', '"' ~ header ~ '".to_string()' ] | rustfmtCall(8, 'api_headers.insert') }}
 {% endfor %}
 {% endif %}
 
-        let path = "{{ method.path }}".to_string(){% for parameter in (method | parameters('path')) %}.replace("{{ '{' }}{{ parameter.name }}{{ '}' }}", &{% if (parameter.extensions['x-sdk-source']|default('')) == 'security' %}self.client.get_headers().get("x-appwrite-{{ parameter.extensions['x-sdk-config'] | caseLower }}").cloned().unwrap_or_default(){% else %}{{ parameter | paramValue(parameter.name | caseSnake | overrideIdentifier) }}.to_string(){% endif %}){% endfor %};
+{% set pathReplaces = [] %}
+{% for parameter in (method | parameters('path')) %}
+{% if (parameter.extensions['x-sdk-source']|default('')) == 'security' %}
+{% set pathReplaces = pathReplaces | merge(['.replace("{' ~ parameter.name ~ '}", &self.client.get_headers().get("x-appwrite-' ~ (parameter.extensions['x-sdk-config'] | caseLower) ~ '").cloned().unwrap_or_default())']) %}
+{% else %}
+{% set pathReplaces = pathReplaces | merge(['.replace("{' ~ parameter.name ~ '}", &' ~ (parameter | paramValue(parameter.name | caseSnake | overrideIdentifier)) ~ '.to_string())']) %}
+{% endif %}
+{% endfor %}
+{{ pathReplaces | rustfmtPath(8, method.path) }}
 
 {% set hasFileParam = false %}
 {% set fileParamName = '' %}
@@ -152,16 +161,15 @@ impl {{ service.name | caseUcfirst }} {
 {% endif %}
 {% endfor %}
 {% if hasFileParam %}
-        self.client.file_upload(&path, {% if hasHeaders %}Some(api_headers){% else %}None{% endif %}, params, "{{ fileParamKey }}", {{ fileParamName }}, {% if uploadIdParam %}{% if uploadIDRequired %}Some({{ uploadIdParam }}_str){% else %}{{ uploadIdParam }}_str{% endif %}{% else %}None{% endif %}).await
+{{ [ '&path', hasHeaders ? 'Some(api_headers)' : 'None', 'params', '"' ~ fileParamKey ~ '"', fileParamName, uploadIdParam ? (uploadIDRequired ? 'Some(' ~ uploadIdParam ~ '_str)' : uploadIdParam ~ '_str') : 'None' ] | rustfmtClientAwait(8, 'file_upload') }}
 {% elseif (method | methodType) == 'webAuth' %}
-        self.client.call_location(Method::{{ method.method.value | upper }}, &path, {% if hasHeaders %}Some(api_headers){% else %}None{% endif %}, Some(params)).await
+{{ [ 'Method::' ~ (method.method.value | upper), '&path', hasHeaders ? 'Some(api_headers)' : 'None', 'Some(params)' ] | rustfmtClientAwait(8, 'call_location') }}
 {% elseif (method | methodType) == 'location' %}
-        self.client.call_bytes(Method::{{ method.method.value | upper }}, &path, {% if hasHeaders %}Some(api_headers){% else %}None{% endif %}, Some(params)).await
+{{ [ 'Method::' ~ (method.method.value | upper), '&path', hasHeaders ? 'Some(api_headers)' : 'None', 'Some(params)' ] | rustfmtClientAwait(8, 'call_bytes') }}
 {% else %}
-        self.client.call(Method::{{ method.method.value | upper }}, &path, {% if hasHeaders %}Some(api_headers){% else %}None{% endif %}, Some(params)).await
+{{ [ 'Method::' ~ (method.method.value | upper), '&path', hasHeaders ? 'Some(api_headers)' : 'None', 'Some(params)' ] | rustfmtClientAwait(8, 'call') }}
 {% endif %}
     }
-
 {% endif %}
 {% endfor %}
 }


### PR DESCRIPTION
## Summary

- make Rust templates emit rustfmt-clean source, helpers, and tests without post-generation formatting
- layout signatures, calls, path replaces, and method chains in the generator to match rustfmt 1.83 defaults (`max_width` 100, `fn_call_width`/`chain_width` 60)
- add `cargo +1.83.0 fmt --check --all` to validation CI for the Rust server SDK
- document the Rust generation and rustfmt check in AGENTS.md

```text
before: generate Rust SDK -> rustfmt reports generated files
after:  generate Rust SDK -> rustfmt reports no changes
```

Part of #1813.

## Test plan

- [x] `rm -rf examples/rust && php example.php rust server`
- [x] `(cd examples/rust && cargo +1.83.0 fmt --check --all)`
- [x] `(cd examples/rust && cargo +1.83.0 test --lib)`
- [x] `composer lint-twig`
- [x] `composer refactor:check`
- [x] `vendor/bin/phpcs src/SDK/Language/Rust.php`
- [ ] Validation CI `rust (server)` is green
- [ ] Greptile review is 5/5


Made with [Cursor](https://cursor.com)