### PR TITLE
fix(cli): resolve wildcard function template tags

### DIFF
--- a/templates/cli/internal/cmd/initfunction.go
+++ b/templates/cli/internal/cmd/initfunction.go
@@ -575,8 +575,15 @@ func runInitFunction(command *cobra.Command, options initFunctionOptions) error 
 	repositoryURL := fmt.Sprintf("https://github.com/%s/%s", template.Owner, template.Repository)
 	clone := fmt.Sprintf("git clone --single-branch --depth 1 --sparse %s .", repositoryURL)
 	if template.Reference != "" {
+		reference := template.Reference
+		if template.ReferenceType == "tag" {
+			reference, err = resolveGitTag(templatesDir, repositoryURL, reference)
+			if err != nil {
+				return err
+			}
+		}
 		clone = fmt.Sprintf("git clone --single-branch --depth 1 --branch %s --sparse %s .",
-			template.Reference, repositoryURL)
+			reference, repositoryURL)
 	}
 	if err := runGit(templatesDir, clone); err != nil {
 		return err

--- a/templates/cli/internal/cmd/initfunction.go
+++ b/templates/cli/internal/cmd/initfunction.go
@@ -573,7 +573,7 @@ func runInitFunction(command *cobra.Command, options initFunctionOptions) error 
 	defer os.RemoveAll(templatesDir)
 
 	repositoryURL := fmt.Sprintf("https://github.com/%s/%s", template.Owner, template.Repository)
-	clone := fmt.Sprintf("git clone --single-branch --depth 1 --sparse %s .", repositoryURL)
+	cloneArguments := []string{"clone", "--single-branch", "--depth", "1"}
 	if template.Reference != "" {
 		reference := template.Reference
 		if template.ReferenceType == "tag" {
@@ -582,13 +582,14 @@ func runInitFunction(command *cobra.Command, options initFunctionOptions) error 
 				return err
 			}
 		}
-		clone = fmt.Sprintf("git clone --single-branch --depth 1 --branch %s --sparse %s .",
-			reference, repositoryURL)
+		cloneArguments = append(cloneArguments, "--branch", reference)
 	}
-	if err := runGit(templatesDir, clone); err != nil {
+	cloneArguments = append(cloneArguments, "--sparse", repositoryURL, ".")
+	if err := runGitCommand(templatesDir, cloneArguments...); err != nil {
 		return err
 	}
-	if err := runGit(templatesDir, "git sparse-checkout add "+template.RootDirectory); err != nil {
+	if err := runGitCommand(templatesDir, "sparse-checkout", "add",
+		template.RootDirectory); err != nil {
 		return err
 	}
 	if err := os.RemoveAll(filepath.Join(templatesDir, ".git")); err != nil {

--- a/templates/cli/internal/cmd/initfunction_test.go
+++ b/templates/cli/internal/cmd/initfunction_test.go
@@ -306,6 +306,28 @@ func TestResolveGitTagLeavesConcreteReferenceUnchanged(t *testing.T) {
 	}
 }
 
+func TestRunGitCommandPassesRemoteValuesLiterally(t *testing.T) {
+	directory := t.TempDir()
+	marker := filepath.Join(directory, "executed")
+	value := "0.3.1; touch " + marker
+	configPath := filepath.Join(directory, "config")
+
+	if err := runGitCommand(directory, "config", "--file", configPath,
+		"template.reference", value); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("shell syntax in argument was executed: %v", err)
+	}
+	contents, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(contents), value) {
+		t.Fatalf("config does not contain literal value %q:\n%s", value, contents)
+	}
+}
+
 func TestValidateRuntimeAndSpecificationChoices(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		response.Header().Set("content-type", "application/json")

--- a/templates/cli/internal/cmd/initfunction_test.go
+++ b/templates/cli/internal/cmd/initfunction_test.go
@@ -260,6 +260,52 @@ func TestAvailableFunctionDirectoryAddsNumericSuffix(t *testing.T) {
 	}
 }
 
+func TestStarterFunctionTemplateKeepsWildcardTagVersion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/functions/templates/starter" {
+			t.Errorf("path = %s", request.URL.Path)
+		}
+		response.Header().Set("content-type", "application/json")
+		_, _ = response.Write([]byte(`{"providerRepositoryId":"templates","providerOwner":"appwrite","providerVersion":"0.3.*","runtimes":[{"name":"bun-1.3","providerRootDirectory":"./bun/starter"}]}`))
+	}))
+	defer server.Close()
+
+	template, err := getStarterFunctionTemplate(client.New(server.URL, "test"), "bun-1.3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if template.Reference != "0.3.*" || template.ReferenceType != "tag" ||
+		template.RootDirectory != "bun/starter" {
+		t.Fatalf("template = %#v", template)
+	}
+}
+
+func TestGitTagFromRemoteOutputSelectsFirstVersionSortedTag(t *testing.T) {
+	output := "4eb58cb2\trefs/tags/0.3.1\n7717e63c\trefs/tags/0.3.0\n"
+	tag, err := gitTagFromRemoteOutput("0.3.*", output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tag != "0.3.1" {
+		t.Fatalf("tag = %q, want 0.3.1", tag)
+	}
+
+	if _, err := gitTagFromRemoteOutput("9.*", ""); err == nil ||
+		!strings.Contains(err.Error(), "no git tag matches template version 9.*") {
+		t.Fatalf("missing tag error = %v", err)
+	}
+}
+
+func TestResolveGitTagLeavesConcreteReferenceUnchanged(t *testing.T) {
+	tag, err := resolveGitTag(t.TempDir(), "not-a-repository", "0.3.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tag != "0.3.1" {
+		t.Fatalf("tag = %q, want 0.3.1", tag)
+	}
+}
+
 func TestValidateRuntimeAndSpecificationChoices(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		response.Header().Set("content-type", "application/json")

--- a/templates/cli/internal/cmd/initscaffold.go
+++ b/templates/cli/internal/cmd/initscaffold.go
@@ -45,6 +45,40 @@ func runGit(directory string, script string) error {
 	return gitError(fmt.Sprintf("%s\n%s", err, strings.TrimSpace(string(output))))
 }
 
+// resolveGitTag turns a tag pattern from template metadata (for example,
+// "0.3.*") into the newest matching concrete tag. Git clone accepts a tag or
+// branch name for --branch, but does not expand ref patterns itself.
+func resolveGitTag(directory, repository, pattern string) (string, error) {
+	if !strings.ContainsAny(pattern, "*?[") {
+		return pattern, nil
+	}
+
+	command := exec.Command("git", "ls-remote", "--refs", "--tags",
+		"--sort=-version:refname", repository, pattern)
+	command.Dir = directory
+	output, err := command.CombinedOutput()
+	if err != nil {
+		return "", gitError(fmt.Sprintf("%s\n%s", err,
+			strings.TrimSpace(string(output))))
+	}
+
+	return gitTagFromRemoteOutput(pattern, string(output))
+}
+
+func gitTagFromRemoteOutput(pattern, output string) (string, error) {
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		if tag := strings.TrimPrefix(fields[1], "refs/tags/"); tag != fields[1] {
+			return tag, nil
+		}
+	}
+
+	return "", fmt.Errorf("no git tag matches template version %s", pattern)
+}
+
 // gitError translates a git failure into an actionable suggestion.
 //
 // Two failures are common enough to be worth naming: a git too old for

--- a/templates/cli/internal/cmd/initscaffold.go
+++ b/templates/cli/internal/cmd/initscaffold.go
@@ -35,6 +35,17 @@ func runGit(directory string, script string) error {
 		command = exec.Command("sh", "-c", script)
 	}
 
+	return executeGit(command, directory)
+}
+
+// runGitCommand invokes Git without a shell. Use it when arguments contain
+// values received from an API or remote repository, so ref names and paths are
+// passed literally rather than interpreted as shell syntax.
+func runGitCommand(directory string, arguments ...string) error {
+	return executeGit(exec.Command("git", arguments...), directory)
+}
+
+func executeGit(command *exec.Cmd, directory string) error {
 	command.Dir = directory
 
 	output, err := command.CombinedOutput()


### PR DESCRIPTION
## Summary

Resolve wildcard starter-template versions returned by Appwrite before cloning function source.

Appwrite 1.9.6 returns starter metadata similar to:

```json
{
  "providerOwner": "appwrite",
  "providerRepositoryId": "templates",
  "providerVersion": "0.3.*",
  "runtimes": [
    {
      "name": "bun-1.3",
      "providerRootDirectory": "./bun/starter"
    }
  ]
}
```

The CLI treated `providerVersion` as a literal branch/tag and generated:

```sh
git clone --single-branch --depth 1 --branch 0.3.* --sparse \
  https://github.com/appwrite/templates .
```

`git clone --branch` only accepts a concrete ref. It does not expand tag patterns, so initialization failed with:

```text
Error: exit status 128
Cloning into '.'...
fatal: Remote branch 0.3.* not found in upstream origin
```

This also explains why searching the CLI or server source for a hard-coded `0.3.*` did not find the cause: the value comes from the `/functions/templates/starter` API response.

## Fix

For tag references containing a Git ref pattern (`*`, `?`, or `[`), the CLI now resolves the newest matching remote tag first:

```sh
git ls-remote --refs --tags --sort=-version:refname \
  https://github.com/appwrite/templates '0.3.*'
```

The current response is version-sorted as:

```text
4eb58cb2... refs/tags/0.3.1
7717e63c... refs/tags/0.3.0
```

The CLI extracts `0.3.1` and passes that concrete tag to `git clone --branch`. Concrete tags and branch references such as `main` retain their existing behavior.

The original wildcard remains in the template metadata used for deployment; resolution is limited to the local Git clone that requires a concrete ref.

## Tests

Added coverage for:

- parsing the Bun 1.3 starter response with `providerVersion: "0.3.*"`
- selecting the first version-sorted concrete tag
- returning an actionable error when no tag matches
- leaving concrete tag references unchanged without a remote lookup

### Live OSS verification

Reproduced with CLI 27.2.0 against `https://oss.appwrite.org/v1` (Appwrite 1.9.6). Before the change, `init function` reached `/functions/templates/starter` and failed exactly as reported:

```text
GET /v1/functions/templates/starter 200
fatal: Remote branch 0.3.* not found in upstream origin
```

Built the regenerated CLI and repeated the same flow against the same project. It resolved `0.3.*` to `0.3.1`, cloned the starter, and completed:

```text
GET /v1/functions/templates/starter 200
Success: Initialized function
```

The OSS project's runtime allowlist currently exposes Node 16, PHP 8, Ruby 3, and Python 3.9, so the end-to-end initialization used `node-16.0`. The failing clone path and starter-template version are shared across runtimes; the mocked API regression test specifically covers the `bun-1.3` metadata returned by Appwrite 1.9.6.

### Commands

```sh
php example.php cli
test -z "$(gofmt -l examples/cli)"
(cd examples/cli && go mod tidy && go build ./... && go vet ./... && go test ./...)
composer lint-twig
composer refactor:check
uvx djlint templates/cli/internal/cmd/initfunction.go \
  templates/cli/internal/cmd/initfunction_test.go \
  templates/cli/internal/cmd/initscaffold.go --lint
```
