### PR TITLE
fix(android,kotlin): encode explicit JSON nulls on TablesDB update and upsert

### DIFF
--- a/src/SDK/Language/Android.php
+++ b/src/SDK/Language/Android.php
@@ -142,6 +142,11 @@ class Android extends Kotlin
             ],
             [
                 'scope'         => 'default',
+                'destination'   => '/library/src/test/java/{{ sdk.namespace | caseSlash }}/JsonRequestBodyTest.kt',
+                'template'      => '/android/library/src/test/java/io/package/JsonRequestBodyTest.kt.twig',
+            ],
+            [
+                'scope'         => 'default',
                 'destination'   => '/library/src/main/java/{{ sdk.namespace | caseSlash }}/extensions/TypeExtensions.kt',
                 'template'      => '/android/library/src/main/java/io/package/extensions/TypeExtensions.kt.twig',
             ],

--- a/src/SDK/Language/Kotlin.php
+++ b/src/SDK/Language/Kotlin.php
@@ -136,7 +136,7 @@ class Kotlin extends Language
             self::TYPE_ARRAY => $this->isUntypedNestedArray($parameter, $schema)
                 ? 'List<List<Any>>'
                 : 'List<' . $this->getTypeName($this->getArraySchema($parameter) ?? $schema) . '>',
-            self::TYPE_OBJECT => 'Any',
+            self::TYPE_OBJECT => 'Map<String, Any?>',
             default => 'Any',
         };
     }
@@ -565,6 +565,11 @@ class Kotlin extends Language
                 'scope'         => 'default',
                 'destination'   => '/src/main/kotlin/{{ sdk.namespace | caseSlash }}/extensions/JsonExtensions.kt',
                 'template'      => '/kotlin/src/main/kotlin/io/appwrite/extensions/JsonExtensions.kt.twig',
+            ],
+            [
+                'scope'         => 'default',
+                'destination'   => '/src/test/kotlin/{{ sdk.namespace | caseSlash }}/JsonRequestBodyTest.kt',
+                'template'      => '/kotlin/src/test/kotlin/io/appwrite/JsonRequestBodyTest.kt.twig',
             ],
             [
                 'scope'         => 'default',

--- a/templates/android/library/src/main/java/io/package/Client.kt.twig
+++ b/templates/android/library/src/main/java/io/package/Client.kt.twig
@@ -7,7 +7,7 @@ import {{ sdk.namespace | caseDot }}.cookies.ListenableCookieJar
 import {{ sdk.namespace | caseDot }}.cookies.stores.SharedPreferencesCookieStore
 import {{ sdk.namespace | caseDot }}.exceptions.{{ spec.info.title | caseUcfirst }}Exception
 import {{ sdk.namespace | caseDot }}.extensions.fromJson
-import {{ sdk.namespace | caseDot }}.extensions.toJson
+import {{ sdk.namespace | caseDot }}.extensions.toJsonRequestBody
 import {{ sdk.namespace | caseDot }}.models.InputFile
 import {{ sdk.namespace | caseDot }}.models.UploadProgress
 import kotlinx.coroutines.CoroutineScope
@@ -281,24 +281,22 @@ class Client @JvmOverloads constructor(
     {%~ endfor %}
 
     /**
-     * Send the HTTP request
+     * Prepare the HTTP request
      *
      * @param method
      * @param path
      * @param headers
      * @param params
      *
-     * @return [T]
+     * @return [Request]
      */
     @Throws({{ spec.info.title | caseUcfirst }}Exception::class)
-    suspend fun <T> call(
+    suspend fun prepareRequest(
         method: String,
         path: String,
         headers: Map<String, String> = mapOf(),
         params: Map<String, Any?> = mapOf(),
-        responseType: Class<T>,
-        converter: ((Any) -> T)? = null
-    ): T {
+    ): Request {
         val filteredParams = params.filterValues { it != null }
 
         val requestHeaders = this.headers.toHeaders().newBuilder()
@@ -327,13 +325,12 @@ class Client @JvmOverloads constructor(
                     }
                 }
             }
-            val request = Request.Builder()
+
+            return Request.Builder()
                 .url(httpBuilder.build())
                 .headers(requestHeaders)
                 .get()
                 .build()
-
-            return awaitResponse(request, responseType, converter)
         }
 
         val body = if (MultipartBody.FORM.toString() == headers["content-type"]) {
@@ -360,17 +357,38 @@ class Client @JvmOverloads constructor(
             }
             builder.build()
         } else {
-            filteredParams
-                .toJson()
+            params
+                .toJsonRequestBody()
                 .toRequestBody("application/json".toMediaType())
         }
 
-        val request = Request.Builder()
+        return Request.Builder()
             .url(httpBuilder.build())
             .headers(requestHeaders)
             .method(method, body)
             .build()
+    }
 
+    /**
+     * Send the HTTP request
+     *
+     * @param method
+     * @param path
+     * @param headers
+     * @param params
+     *
+     * @return [T]
+     */
+    @Throws({{ spec.info.title | caseUcfirst }}Exception::class)
+    suspend fun <T> call(
+        method: String,
+        path: String,
+        headers: Map<String, String> = mapOf(),
+        params: Map<String, Any?> = mapOf(),
+        responseType: Class<T>,
+        converter: ((Any) -> T)? = null
+    ): T {
+        val request = prepareRequest(method, path, headers, params)
         return awaitResponse(request, responseType, converter)
     }
 

--- a/templates/android/library/src/main/java/io/package/extensions/JsonExtensions.kt.twig
+++ b/templates/android/library/src/main/java/io/package/extensions/JsonExtensions.kt.twig
@@ -10,8 +10,29 @@ val gson: Gson = GsonBuilder()
     .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
     .create()
 
+/**
+ * Request-body Gson. Default Gson omits nulls, which would drop keys the
+ * caller set to null inside nested maps such as `data`. Appwrite PATCH/upsert
+ * treats a missing key as "leave unchanged", so those nulls must be encoded.
+ */
+val requestGson: Gson = GsonBuilder()
+    .serializeNulls()
+    .setNumberToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+    .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+    .create()
+
 fun Any.toJson(): String =
     gson.toJson(this)
+
+fun Any.toJsonWithNulls(): String =
+    requestGson.toJson(this)
+
+/**
+ * JSON request body: omit top-level keys the caller did not pass (optional
+ * method params default to null), but keep explicit nulls in nested maps.
+ */
+fun Map<String, Any?>.toJsonRequestBody(): String =
+    filterValues { it != null }.toJsonWithNulls()
 
 fun <T> String.fromJson(clazz: Class<T>): T =
     gson.fromJson(this, clazz)

--- a/templates/android/library/src/test/java/io/package/JsonRequestBodyTest.kt.twig
+++ b/templates/android/library/src/test/java/io/package/JsonRequestBodyTest.kt.twig
@@ -1,0 +1,33 @@
+package {{ sdk.namespace | caseDot }}
+
+import {{ sdk.namespace | caseDot }}.extensions.toJson
+import {{ sdk.namespace | caseDot }}.extensions.toJsonRequestBody
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class JsonRequestBodyTest {
+    @Test
+    fun jsonRequestBodyPreservesNestedNullsAndOmitsOptionalParams() {
+        val params = mapOf(
+            "data" to mapOf(
+                "backgroundType" to "SOLID_COLOR",
+                "solidColorIndex" to null,
+                "title" to null,
+            ),
+            "permissions" to null,
+        )
+
+        val body = params.toJsonRequestBody()
+        assertTrue(body.contains("\"solidColorIndex\":null"))
+        assertTrue(body.contains("\"title\":null"))
+        assertTrue(body.contains("\"backgroundType\":\"SOLID_COLOR\""))
+        assertFalse(body.contains("permissions"))
+
+        // Default Gson still omits nulls so Query/Operator JSON stays compact.
+        val withoutNulls = params.filterValues { it != null }.toJson()
+        assertFalse(withoutNulls.contains("\"solidColorIndex\":null"))
+        assertFalse(withoutNulls.contains("\"title\":null"))
+        assertTrue(withoutNulls.contains("\"backgroundType\":\"SOLID_COLOR\""))
+    }
+}

--- a/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/Client.kt.twig
@@ -2,7 +2,7 @@ package {{ sdk.namespace | caseDot }}
 
 import {{ sdk.namespace | caseDot }}.exceptions.{{ spec.info.title | caseUcfirst }}Exception
 import {{ sdk.namespace | caseDot }}.extensions.fromJson
-import {{ sdk.namespace | caseDot }}.extensions.toJson
+import {{ sdk.namespace | caseDot }}.extensions.toJsonRequestBody
 import {{ sdk.namespace | caseDot }}.models.InputFile
 import {{ sdk.namespace | caseDot }}.models.UploadProgress
 import kotlinx.coroutines.CoroutineScope
@@ -298,8 +298,8 @@ class Client @JvmOverloads constructor(
             }
             builder.build()
         } else {
-            filteredParams
-                .toJson()
+            params
+                .toJsonRequestBody()
                 .toRequestBody("application/json".toMediaType())
         }
 

--- a/templates/kotlin/src/main/kotlin/io/appwrite/extensions/JsonExtensions.kt.twig
+++ b/templates/kotlin/src/main/kotlin/io/appwrite/extensions/JsonExtensions.kt.twig
@@ -10,8 +10,29 @@ val gson: Gson = GsonBuilder()
     .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
     .create()
 
+/**
+ * Request-body Gson. Default Gson omits nulls, which would drop keys the
+ * caller set to null inside nested maps such as `data`. Appwrite PATCH/upsert
+ * treats a missing key as "leave unchanged", so those nulls must be encoded.
+ */
+val requestGson: Gson = GsonBuilder()
+    .serializeNulls()
+    .setNumberToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+    .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+    .create()
+
 fun Any.toJson(): String =
     gson.toJson(this)
+
+fun Any.toJsonWithNulls(): String =
+    requestGson.toJson(this)
+
+/**
+ * JSON request body: omit top-level keys the caller did not pass (optional
+ * method params default to null), but keep explicit nulls in nested maps.
+ */
+fun Map<String, Any?>.toJsonRequestBody(): String =
+    filterValues { it != null }.toJsonWithNulls()
 
 fun <T> String.fromJson(clazz: Class<T>): T =
     gson.fromJson(this, clazz)

--- a/templates/kotlin/src/test/kotlin/io/appwrite/JsonRequestBodyTest.kt.twig
+++ b/templates/kotlin/src/test/kotlin/io/appwrite/JsonRequestBodyTest.kt.twig
@@ -2,6 +2,9 @@ package {{ sdk.namespace | caseDot }}
 
 import {{ sdk.namespace | caseDot }}.extensions.toJson
 import {{ sdk.namespace | caseDot }}.extensions.toJsonRequestBody
+import kotlinx.coroutines.runBlocking
+import okhttp3.MultipartBody
+import okio.Buffer
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -29,5 +32,70 @@ class JsonRequestBodyTest {
         assertFalse(withoutNulls.contains("\"solidColorIndex\":null"))
         assertFalse(withoutNulls.contains("\"title\":null"))
         assertTrue(withoutNulls.contains("\"backgroundType\":\"SOLID_COLOR\""))
+    }
+
+    @Test
+    fun jsonPatchBodyPreservesNestedNullsAndOmitsOptionalParams() = runBlocking {
+        val request = Client().prepareRequest(
+            method = "PATCH",
+            path = "/v1/tablesdb/db/tables/tbl/rows/row",
+            headers = mapOf("content-type" to "application/json"),
+            params = mapOf(
+                "data" to mapOf(
+                    "backgroundType" to "SOLID_COLOR",
+                    "solidColorIndex" to null,
+                ),
+                "permissions" to null,
+            ),
+        )
+
+        val body = requestBodyUtf8(request.body!!)
+        assertTrue(body.contains("\"solidColorIndex\":null"))
+        assertTrue(body.contains("\"backgroundType\":\"SOLID_COLOR\""))
+        assertFalse(body.contains("permissions"))
+    }
+
+    @Test
+    fun getOmitsNullQueryParams() = runBlocking {
+        val request = Client().prepareRequest(
+            method = "GET",
+            path = "/v1/mock/tests/foo",
+            params = mapOf(
+                "x" to "1",
+                "empty" to null,
+            ),
+        )
+
+        val url = request.url.toString()
+        assertTrue(url.contains("x=1"))
+        assertFalse(url.contains("empty"))
+        assertFalse(url.contains("null"))
+    }
+
+    @Test
+    fun multipartOmitsNullParts() = runBlocking {
+        val request = Client().prepareRequest(
+            method = "POST",
+            path = "/v1/storage/files",
+            headers = mapOf("content-type" to MultipartBody.FORM.toString()),
+            params = mapOf(
+                "fileId" to "abc",
+                "permissions" to null,
+            ),
+        )
+
+        val body = request.body as MultipartBody
+        val dispositions = body.parts.map { part ->
+            part.headers?.get("Content-Disposition").orEmpty()
+        }
+        assertTrue(dispositions.any { it.contains("fileId") })
+        assertFalse(dispositions.any { it.contains("permissions") })
+        assertFalse(requestBodyUtf8(body).contains("null"))
+    }
+
+    private fun requestBodyUtf8(body: okhttp3.RequestBody): String {
+        val buffer = Buffer()
+        body.writeTo(buffer)
+        return buffer.readUtf8()
     }
 }

--- a/templates/kotlin/src/test/kotlin/io/appwrite/JsonRequestBodyTest.kt.twig
+++ b/templates/kotlin/src/test/kotlin/io/appwrite/JsonRequestBodyTest.kt.twig
@@ -1,0 +1,33 @@
+package {{ sdk.namespace | caseDot }}
+
+import {{ sdk.namespace | caseDot }}.extensions.toJson
+import {{ sdk.namespace | caseDot }}.extensions.toJsonRequestBody
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class JsonRequestBodyTest {
+    @Test
+    fun jsonRequestBodyPreservesNestedNullsAndOmitsOptionalParams() {
+        val params = mapOf(
+            "data" to mapOf(
+                "backgroundType" to "SOLID_COLOR",
+                "solidColorIndex" to null,
+                "title" to null,
+            ),
+            "permissions" to null,
+        )
+
+        val body = params.toJsonRequestBody()
+        assertTrue(body.contains("\"solidColorIndex\":null"))
+        assertTrue(body.contains("\"title\":null"))
+        assertTrue(body.contains("\"backgroundType\":\"SOLID_COLOR\""))
+        assertFalse(body.contains("permissions"))
+
+        // Default Gson still omits nulls so Query/Operator JSON stays compact.
+        val withoutNulls = params.filterValues { it != null }.toJson()
+        assertFalse(withoutNulls.contains("\"solidColorIndex\":null"))
+        assertFalse(withoutNulls.contains("\"title\":null"))
+        assertTrue(withoutNulls.contains("\"backgroundType\":\"SOLID_COLOR\""))
+    }
+}

--- a/tests/e2e/languages/android/Tests.kt
+++ b/tests/e2e/languages/android/Tests.kt
@@ -13,7 +13,6 @@ import io.appwrite.Operator
 import io.appwrite.Condition
 import io.appwrite.enums.MockType
 import io.appwrite.extensions.fromJson
-import io.appwrite.extensions.toJson
 import io.appwrite.models.Error
 import io.appwrite.models.InputFile
 import io.appwrite.models.Mock
@@ -29,8 +28,12 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
+import okhttp3.MultipartBody
 import okhttp3.Response
+import okio.Buffer
 import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -470,6 +473,80 @@ class ServiceTest {
             mock = general.headers()
             writeToFile(mock.result)
         }
+    }
+
+    @Test
+    fun testClientJsonBodyPreservesNestedNullsAndOmitsOptionalParams() = runBlocking {
+        val client = Client(ApplicationProvider.getApplicationContext())
+            .setProject("123456")
+            .setSelfSigned(true)
+        val request = client.prepareRequest(
+            method = "PATCH",
+            path = "/v1/tablesdb/db/tables/tbl/rows/row",
+            headers = mapOf("content-type" to "application/json"),
+            params = mapOf(
+                "data" to mapOf(
+                    "backgroundType" to "SOLID_COLOR",
+                    "solidColorIndex" to null,
+                ),
+                "permissions" to null,
+            )
+        )
+
+        val body = requestBodyUtf8(request.body!!)
+        assertTrue(body.contains("\"solidColorIndex\":null"))
+        assertTrue(body.contains("\"backgroundType\":\"SOLID_COLOR\""))
+        assertFalse(body.contains("permissions"))
+    }
+
+    @Test
+    fun testClientGetOmitsNullQueryParams() = runBlocking {
+        val client = Client(ApplicationProvider.getApplicationContext())
+            .setProject("123456")
+            .setSelfSigned(true)
+        val request = client.prepareRequest(
+            method = "GET",
+            path = "/v1/mock/tests/foo",
+            params = mapOf(
+                "x" to "1",
+                "empty" to null,
+            )
+        )
+
+        val url = request.url.toString()
+        assertTrue(url.contains("x=1"))
+        assertFalse(url.contains("empty"))
+        assertFalse(url.contains("null"))
+    }
+
+    @Test
+    fun testClientMultipartOmitsNullParts() = runBlocking {
+        val client = Client(ApplicationProvider.getApplicationContext())
+            .setProject("123456")
+            .setSelfSigned(true)
+        val request = client.prepareRequest(
+            method = "POST",
+            path = "/v1/storage/files",
+            headers = mapOf("content-type" to MultipartBody.FORM.toString()),
+            params = mapOf(
+                "fileId" to "abc",
+                "permissions" to null,
+            )
+        )
+
+        val body = request.body as MultipartBody
+        val dispositions = body.parts.map { part ->
+            part.headers?.get("Content-Disposition").orEmpty()
+        }
+        assertTrue(dispositions.any { it.contains("fileId") })
+        assertFalse(dispositions.any { it.contains("permissions") })
+        assertFalse(requestBodyUtf8(body).contains("null"))
+    }
+
+    private fun requestBodyUtf8(body: okhttp3.RequestBody): String {
+        val buffer = Buffer()
+        body.writeTo(buffer)
+        return buffer.readUtf8()
     }
 
     private fun writeToFile(string: String?) {

--- a/tests/e2e/languages/android/Tests.kt
+++ b/tests/e2e/languages/android/Tests.kt
@@ -475,6 +475,23 @@ class ServiceTest {
         }
     }
 
+    private fun writeToFile(string: String?) {
+        val text = "${string ?: ""}\n"
+        File("result.txt").appendText(text)
+    }
+
+    private fun parse(json: String): String? {
+        return try {
+            json.fromJson<Map<String, Any>>()["result"] as? String
+        } catch (exception: Exception) {
+            null
+        }
+    }
+}
+
+@Config(manifest=Config.NONE)
+@RunWith(AndroidJUnit4::class)
+class RequestNullEncodingTest {
     @Test
     fun testClientJsonBodyPreservesNestedNullsAndOmitsOptionalParams() = runBlocking {
         val client = Client(ApplicationProvider.getApplicationContext())
@@ -547,18 +564,5 @@ class ServiceTest {
         val buffer = Buffer()
         body.writeTo(buffer)
         return buffer.readUtf8()
-    }
-
-    private fun writeToFile(string: String?) {
-        val text = "${string ?: ""}\n"
-        File("result.txt").appendText(text)
-    }
-
-    private fun parse(json: String): String? {
-        return try {
-            json.fromJson<Map<String, Any>>()["result"] as? String
-        } catch (exception: Exception) {
-            null
-        }
     }
 }

--- a/tests/e2e/languages/kotlin/Tests.kt
+++ b/tests/e2e/languages/kotlin/Tests.kt
@@ -308,6 +308,21 @@ class ServiceTest {
         }
     }
 
+    private fun writeToFile(string: String?) {
+        val text = "${string ?: ""}\n"
+        File("result.txt").appendText(text)
+    }
+
+    private fun parse(json: String): String? {
+        return try {
+            json.fromJson<Map<String, Any>>()["result"] as? String
+        } catch (exception: Exception) {
+            null
+        }
+    }
+}
+
+class RequestNullEncodingTest {
     @Test
     fun testClientJsonBodyPreservesNestedNullsAndOmitsOptionalParams() = runBlocking {
         val client = Client()
@@ -380,18 +395,5 @@ class ServiceTest {
         val buffer = Buffer()
         body.writeTo(buffer)
         return buffer.readUtf8()
-    }
-
-    private fun writeToFile(string: String?) {
-        val text = "${string ?: ""}\n"
-        File("result.txt").appendText(text)
-    }
-
-    private fun parse(json: String): String? {
-        return try {
-            json.fromJson<Map<String, Any>>()["result"] as? String
-        } catch (exception: Exception) {
-            null
-        }
     }
 }

--- a/tests/e2e/languages/kotlin/Tests.kt
+++ b/tests/e2e/languages/kotlin/Tests.kt
@@ -10,7 +10,6 @@ import io.appwrite.Condition
 import io.appwrite.enums.MockType
 import io.appwrite.exceptions.AppwriteException
 import io.appwrite.extensions.fromJson
-import io.appwrite.extensions.toJson
 import io.appwrite.models.Error
 import io.appwrite.models.InputFile
 import io.appwrite.models.Mock
@@ -19,7 +18,11 @@ import io.appwrite.services.Bar
 import io.appwrite.services.Foo
 import io.appwrite.services.General
 import kotlinx.coroutines.runBlocking
+import okhttp3.MultipartBody
 import okhttp3.Response
+import okio.Buffer
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.io.File
@@ -303,6 +306,80 @@ class ServiceTest {
             mock = general.headers()
             writeToFile(mock.result)
         }
+    }
+
+    @Test
+    fun testClientJsonBodyPreservesNestedNullsAndOmitsOptionalParams() = runBlocking {
+        val client = Client()
+            .setProject("123456")
+            .setSelfSigned(true)
+        val request = client.prepareRequest(
+            method = "PATCH",
+            path = "/v1/tablesdb/db/tables/tbl/rows/row",
+            headers = mapOf("content-type" to "application/json"),
+            params = mapOf(
+                "data" to mapOf(
+                    "backgroundType" to "SOLID_COLOR",
+                    "solidColorIndex" to null,
+                ),
+                "permissions" to null,
+            )
+        )
+
+        val body = requestBodyUtf8(request.body!!)
+        assertTrue(body.contains("\"solidColorIndex\":null"))
+        assertTrue(body.contains("\"backgroundType\":\"SOLID_COLOR\""))
+        assertFalse(body.contains("permissions"))
+    }
+
+    @Test
+    fun testClientGetOmitsNullQueryParams() = runBlocking {
+        val client = Client()
+            .setProject("123456")
+            .setSelfSigned(true)
+        val request = client.prepareRequest(
+            method = "GET",
+            path = "/v1/mock/tests/foo",
+            params = mapOf(
+                "x" to "1",
+                "empty" to null,
+            )
+        )
+
+        val url = request.url.toString()
+        assertTrue(url.contains("x=1"))
+        assertFalse(url.contains("empty"))
+        assertFalse(url.contains("null"))
+    }
+
+    @Test
+    fun testClientMultipartOmitsNullParts() = runBlocking {
+        val client = Client()
+            .setProject("123456")
+            .setSelfSigned(true)
+        val request = client.prepareRequest(
+            method = "POST",
+            path = "/v1/storage/files",
+            headers = mapOf("content-type" to MultipartBody.FORM.toString()),
+            params = mapOf(
+                "fileId" to "abc",
+                "permissions" to null,
+            )
+        )
+
+        val body = request.body as MultipartBody
+        val dispositions = body.parts.map { part ->
+            part.headers?.get("Content-Disposition").orEmpty()
+        }
+        assertTrue(dispositions.any { it.contains("fileId") })
+        assertFalse(dispositions.any { it.contains("permissions") })
+        assertFalse(requestBodyUtf8(body).contains("null"))
+    }
+
+    private fun requestBodyUtf8(body: okhttp3.RequestBody): String {
+        val buffer = Buffer()
+        body.writeTo(buffer)
+        return buffer.readUtf8()
     }
 
     private fun writeToFile(string: String?) {


### PR DESCRIPTION
## Problem

When updating or upserting a TablesDB/Databases row from the Android (and Kotlin) SDK, sending a Kotlin `null` for an attribute such as `solidColorIndex` did not clear the stored value. Appwrite still returned the previous integer.

The string `"null"` appeared to work for string and relationship attributes because it is a non-null JSON string, so it was sent. Integers rejected it as the wrong JSON type (`"null"` is not JSON `null`). That workaround is not the fix.

Appwrite PATCH/upsert treats a **missing key** as “leave unchanged” and JSON **`null`** as “set this attribute to null”. The SDK was dropping the key.

## Cause

Two separate null-handling layers, only one of which was wrong for nested document data:

1. **Top-level optional params** are placed in `apiParams` with Kotlin defaults of `null` when the caller omits them. `params.filterValues { it != null }` correctly drops those so omitted optionals are not sent as JSON null (which would wipe fields the user did not intend to change).
2. **Nested maps** such as `data` (`mapOf("solidColorIndex" to null)`) survived that filter, then were encoded with Gson. Gson omits nulls unless `serializeNulls()` is enabled, so `"solidColorIndex": null` never appeared in the body.

The default Gson is still used for `fromJson` and for Query/Operator helpers (`Query.isNull` must stay `{"method":"isNull","attribute":"name"}` without `"values":null`).

## Fix

- Add a request-body Gson with `serializeNulls()` and `Map.toJsonRequestBody()`, which:
  - omits **top-level** null keys (optional method params the caller did not pass)
  - encodes **nested** explicit nulls as JSON `null`
- JSON POST/PUT/PATCH bodies use that helper.
- GET query params and multipart form parts still omit nulls (no `?foo=null`, no stringified null parts).
- Type untyped object params as `Map` so callers can write `mapOf("solidColorIndex" to null)` without a non-null `Any` bound.
- Android `Client` now exposes `prepareRequest()` (same as Kotlin) so request encoding can be unit-tested.

Generated `sdk-for-android` / `sdk-for-kotlin` are not edited here; this lands in the generator and will flow into those repos on the next SDK release.

## Cloud e2e (Gson replica of `Client.call`)

Ran against Appwrite Cloud TablesDB on a disposable table (`solidColorIndex` integer nullable, `label` string nullable). Seed row: `solidColorIndex=3`, `label=hello`. Encoding used Gson 2.11 with the same `ToNumberPolicy.LONG_OR_DOUBLE` as the templates: current SDK = `filterValues { it != null }` then default Gson; this PR = that filter then `serializeNulls()`.

No Cloud credentials in this PR.

Current SDK, upsert Kotlin `null` on the integer (key dropped):

```json
{"data":{"backgroundType":"solid"}}
```

```
HTTP 200  solidColorIndex=3  (unchanged)
```

Current SDK, PATCH with only `null` (empty `data`):

```json
{"data":{}}
```

```
HTTP 400  row_missing_payload
"The row data and permissions are missing. You must provide either row data or permissions to be updated."
GET after: solidColorIndex=3
```

Current SDK, string `"null"` on the integer:

```json
{"data":{"solidColorIndex":"null","backgroundType":"solid"}}
```

```
HTTP 400  row_invalid_structure
Attribute "solidColorIndex" has invalid format. Value must be a valid signed 64-bit integer.
```

Current SDK, string `"null"` on a string column (writes the literal, does not clear):

```json
{"data":{"label":"null","backgroundType":"solid","solidColorIndex":3}}
```

```
HTTP 200  label="null"
```

This PR, upsert JSON `null` on the integer:

```json
{"data":{"solidColorIndex":null,"backgroundType":"solid","label":"hello"}}
```

```
HTTP 200  solidColorIndex=null
```

This PR, PATCH JSON `null` on the integer:

```json
{"data":{"solidColorIndex":null}}
```

```
HTTP 200  solidColorIndex=null  label=hello
```

This PR, upsert JSON `null` on the string (integer left alone):

```json
{"data":{"label":null,"backgroundType":"solid","solidColorIndex":3}}
```

```
HTTP 200  label=null  solidColorIndex=3
```

This PR, PATCH only `label` (omitted integer still leave-unchanged):

```json
{"data":{"label":"changed"}}
```

```
HTTP 200  label=changed  solidColorIndex=3
```

Top-level omitted optionals stay omitted under the new encoder (`permissions` / `transactionId` not sent as JSON null).

## Tests

CI (`Tests / KotlinJava17`, `Android16Java17`, `Android5Java17`) failed with:

```
Failed asserting that null matches expected 'x-sdk-name: kotlin; x-sdk-platform: server; x-sdk-language: kotlin; x-sdk-version: 0.0.1'.
```

(and the Android equivalent). Gradle itself was green. PHPUnit reads `result.txt` after `./gradlew test && cat result.txt`. Extra `@Test` methods lived in `ServiceTest`, whose `@Before setUp()` deletes `result.txt` before every method, so a later `prepareRequest` test wiped the SDK header line.

Fix: move those checks to `RequestNullEncodingTest` in the same `Tests.kt` files so they do not share that setup. Locally, after generating from `tests/resources/spec-openapi3.json`, `RequestNullEncodingTest` (3/3) and `JsonRequestBodyTest` passed and `result.txt` still contained the `x-sdk-name` line.

- Generated Kotlin `JsonRequestBodyTest`: JSON body contains `"solidColorIndex":null`, omitted optional params are dropped, GET omits null query params, multipart omits null parts.
- Generated Android encoder test for the same JSON body behavior.
- e2e Android/Kotlin `Tests.kt` still exercise `prepareRequest` for JSON/GET/multipart, in a separate class.
