### PR TITLE
fix(php): stop emitting trailing blank lines and HTML-escaped descriptions

### DIFF
--- a/templates/php/docs/example.md.twig
+++ b/templates/php/docs/example.md.twig
@@ -32,11 +32,10 @@ $client = (new Client())
 
 ${{ service.name | caseCamel }} = new {{ service.name | caseUcfirst }}($client);
 
-$result = ${{ service.name | caseCamel }}->{{ (method | methodName) | caseCamel }}({% if (method | parameters('all')) | length == 0 %});{% endif %}
-
-    {%~ for parameter in (method | parameters('all')) %}
-    {{ parameter.name | caseCamel }}: {% if (parameter | enumValues) | length > 0%}{{ parameter | enumExample }}{% else%}{{ parameter | paramExample }}{% endif %}{% if not loop.last %},{% endif %}{% if not parameter.required %} // optional{% endif %}
-
-    {%~ endfor -%}
-{% if (method | parameters('all')) | length > 0 %});{% endif %}{{ '\n' }}
+$result = ${{ service.name | caseCamel }}->{{ (method | methodName) | caseCamel }}(
+{%- for parameter in (method | parameters('all')) -%}
+    {{ '\n' }}    {{ parameter.name | caseCamel }}: {% if (parameter | enumValues) | length > 0%}{{ parameter | enumExample }}{% else%}{{ parameter | paramExample }}{% endif %}{% if not loop.last %},{% endif %}{% if not parameter.required %} // optional{% endif %}
+{%- endfor -%}
+{%- if (method | parameters('all')) | length > 0 %}{{ '\n' }}{% endif -%}
+);
 ```

--- a/templates/php/docs/service.md.twig
+++ b/templates/php/docs/service.md.twig
@@ -7,7 +7,7 @@
 ```
 {% if method.description %}
 
-** {{ method.description }} **
+** {{ method.description | raw }} **
 {% endif %}
 
 {% if (method | parameters('all')) is not empty  %}

--- a/templates/php/src/Services/Service.php.twig
+++ b/templates/php/src/Services/Service.php.twig
@@ -52,7 +52,7 @@ class {{ service.name | caseUcfirst }} extends Service
 {% set deprecated_message = '' %}
     /**
 {% if method.description %}
-{{ method.description | split('\n') | map(line => line | trim) | join('\n') | trim | wrap(75, '     * ') | replace({'     * \n': '     *\n'}) }}
+{{ method.description | split('\n') | map(line => line | trim) | join('\n') | trim | wrap(75, '     * ') | replace({'     * \n': '     *\n'}) | raw }}
      *
 {% endif %}
      * @throws {{ namespace | split('\\') | last | caseUcfirst}}Exception


### PR DESCRIPTION
Two cosmetic defects showed up across the whole PHP SDK while reviewing the 29.0.0 release diff. Both are template-only; no generated behaviour changes.

## Trailing blank lines in every example

`templates/php/docs/example.md.twig` closed the call with `{{ '\n' }}` on a template line that already ended in a newline, so every one of the ~700 generated examples carried a blank line before the closing fence. For a method with no parameters the blank line that separates the call from the parameter loop survived too, giving two.

```php
$result = $account->get();


```

The tail is rebuilt so the only newlines emitted are the explicit ones, which gives the same output for both shapes with nothing trailing:

```php
$result = $account->get();
```
```php
$result = $account->updateName(
    name: '<NAME>'
);
```

## `&#039;` in docblocks and service docs

`wrap` is registered with `is_safe => html`, but the docblock chain in `templates/php/src/Services/Service.php.twig` ends in `replace`, which Twig does not mark safe — so the whole expression was autoescaped and every apostrophe in a description rendered as `&#039;` inside a PHP comment. 81 occurrences per generated SDK:

```php
    /**
     * Get a list of all the project&#039;s analyzer reports. You can use the query
     * params to filter your results.
```

`templates/php/docs/service.md.twig` printed `method.description` bare for the same result, while the `parameter.description` a few lines below it already used `raw`. Both now use `raw`.

## Verification

Regenerated the server PHP SDK against the 1.9.x spec:

- `&#039;` occurrences in `src/` and `docs/`: 81 → 0
- Examples verified for all three shapes: no parameters, one required parameter, five optional parameters
- `composer lint` (Pint) passed, `composer analyse` (PHPStan level 5) clean, 693 tests pass on PHP 8.5.9
- `composer lint-twig` clean across all 584 templates

The two remaining `&quot;` in `docs/messaging.md` and `docs/teams.md` come from an explicit `| escape` on the parameter-default column and are left alone — they render correctly as `["users"]` in the markdown table.