### PR TITLE
fix(php): drop the false ext-protobuf provide from the generated SDK

### DIFF
--- a/templates/php/composer.json.twig
+++ b/templates/php/composer.json.twig
@@ -37,14 +37,6 @@
         "phpunit/phpunit": "^12",
         "rector/rector": "^2.2"
     },
-    "provide": {
-        "ext-protobuf": "*"
-    },
-    "config": {
-        "platform": {
-            "ext-protobuf": "1.0"
-        }
-    },
     "prefer-stable": true,
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
The generated `composer.json` advertised an extension it does not implement:

```json
"provide": { "ext-protobuf": "*" },
"config": { "platform": { "ext-protobuf": "1.0" } }
```

Composer honours `provide` across the entire dependency graph, so the SDK silently satisfied `ext-protobuf` for anything else in a consumer's tree — a dependency that genuinely needed the native extension would resolve and then fail at runtime instead of at install time.

## Why it was there

`utopia-php/telemetry` hard-required the extension, reached transitively:

```
sdk-for-php → utopia-php/client → utopia-php/pools → utopia-php/telemetry → ext-protobuf
```

Without the claim, `composer require appwrite/appwrite` failed for anyone without a native extension whose only effect is faster protobuf encoding. So the hack was load-bearing and could not be removed here alone.

[utopia-php/monorepo#166](https://github.com/utopia-php/monorepo/pull/166) fixed that at the source — telemetry never touches a `Google\Protobuf` class, and `open-telemetry/gen-otlp-protobuf` upstream hard-requires the pure-PHP `google/protobuf` while listing the extension under `suggest`. Released as `utopia-php/telemetry` 0.4.7, now on Packagist with `ext-protobuf` in `suggest`.

No other constraint needed moving: `pools` already allows `^0.4.6`, which resolves to 0.4.7.

## Verification

With `protobuf.so` disabled in php.ini, using the regenerated SDK:

```
- Locking utopia-php/pools (2.0.2)
- Locking utopia-php/telemetry (0.4.7)
Writing lock file
```

`composer install` completes, and on that install:

- Pint passed
- PHPStan level 5 — no errors
- 693 tests, 877 assertions, all passing

## Ordering

This depends on `utopia-php/telemetry` 0.4.7, which is already published — so it is safe to merge now. Regenerating any PHP SDK before that release would have produced an uninstallable package.