### PR TITLE
fix(python): stop breaking short calls across lines

### DIFF
--- a/src/SDK/Language/Python.php
+++ b/src/SDK/Language/Python.php
@@ -18,6 +18,12 @@ use Twig\TwigFilter;
 
 class Python extends Language
 {
+    /**
+     * Black's line length for generated SDKs, kept in step with the `[tool.black]`
+     * block in `templates/python/pyproject.toml.twig`.
+     */
+    public const int LINE_LENGTH = 120;
+
     #[Override]
     protected $params = [
         'pipPackage' => 'packageName',
@@ -739,6 +745,112 @@ class Python extends Language
         return \is_string($json) ? $json : 'None';
     }
 
+    /**
+     * Collapses a call rendered on one line, or explodes its arguments with a magic
+     * trailing comma when the line is longer than Black's configured line length.
+     * Black keeps a call that fits on one line as it is, so emitting the exploded
+     * form unconditionally leaves generated code broken across lines for no reason.
+     * The line length is set in `templates/python/pyproject.toml.twig`.
+     */
+    protected function formatCall(string $statement): string
+    {
+        $lines = \explode("\n", $statement);
+        $line = \array_pop($lines);
+
+        if ($line === null || \strlen(\rtrim($line)) <= self::LINE_LENGTH) {
+            return $statement;
+        }
+
+        $line = \rtrim($line);
+        if (!\str_ends_with($line, ')')) {
+            return $statement;
+        }
+
+        $depth = 0;
+        $open = null;
+        for ($position = \strlen($line) - 1; $position >= 0; $position--) {
+            $character = $line[$position];
+            if ($character === ')') {
+                $depth++;
+            } elseif ($character === '(') {
+                $depth--;
+                if ($depth === 0) {
+                    $open = $position;
+                    break;
+                }
+            }
+        }
+
+        if ($open === null) {
+            return $statement;
+        }
+
+        $indent = \strlen($line) - \strlen(\ltrim($line));
+        $arguments = \substr($line, $open + 1, -1);
+        if (\trim($arguments) === '') {
+            return $statement;
+        }
+
+        $exploded = [\substr($line, 0, $open + 1)];
+        foreach ($this->splitArguments($arguments) as $argument) {
+            $exploded[] = \str_repeat(' ', $indent + 4) . $argument . ',';
+        }
+        $exploded[] = \str_repeat(' ', $indent) . ')';
+
+        $lines[] = \implode("\n", $exploded);
+
+        return \implode("\n", $lines);
+    }
+
+    /**
+     * @return array<string>
+     */
+    protected function splitArguments(string $arguments): array
+    {
+        $split = [];
+        $argument = '';
+        $depth = 0;
+        $quote = null;
+
+        for ($position = 0, $length = \strlen($arguments); $position < $length; $position++) {
+            $character = $arguments[$position];
+
+            if ($quote !== null) {
+                $argument .= $character;
+                if ($character === $quote && $arguments[$position - 1] !== '\\') {
+                    $quote = null;
+                }
+                continue;
+            }
+
+            if ($character === "'" || $character === '"') {
+                $quote = $character;
+                $argument .= $character;
+                continue;
+            }
+
+            if ($character === ',' && $depth === 0) {
+                $split[] = \trim($argument);
+                $argument = '';
+                continue;
+            }
+
+            if (\in_array($character, ['(', '[', '{'], true)) {
+                $depth++;
+            } elseif (\in_array($character, [')', ']', '}'], true)) {
+                $depth--;
+            }
+
+            $argument .= $character;
+        }
+
+        if (\trim($argument) !== '') {
+            $split[] = \trim($argument);
+        }
+
+        return $split;
+    }
+
     protected function formatDocstring(string $description, int $indent): string
     {
         $lines = \explode("\n", \str_replace("\r\n", "\n", \trim($description)));
@@ -839,6 +951,7 @@ class Python extends Language
             new TwigFilter('getModelPropertyType', fn(Schema $value, string $ownerName, Specification $spec): string => $this->getModelPropertyType($value, $spec)),
             new TwigFilter('formatDocstring', fn(string $description, int $indent): string => $this->formatDocstring($description, $indent)),
             new TwigFilter('formatModelFieldType', fn(string $type): string => $this->formatModelFieldType($type)),
+            new TwigFilter('formatCall', fn(string $statement): string => $this->formatCall($statement)),
             new TwigFilter('modelPropertyNullable', fn(Schema $value): bool => !($value instanceof ArraySchema) && $value->nullable),
             new TwigFilter('getModelFieldName', fn(Schema $value, array $properties): string => $this->getModelFieldName($value, $properties)),
             new TwigFilter('getResponseType', fn(Operation $method, string $serviceName = ''): string => $this->getResponseType($method, $serviceName)),

--- a/src/SDK/Language/Python.php
+++ b/src/SDK/Language/Python.php
@@ -746,6 +746,41 @@ class Python extends Language
     }
 
     /**
+     * Maps every character of a line to whether it sits inside a Python string
+     * literal, so a parenthesis written in an alias such as 'name(legacy)' is not
+     * read as call syntax while matching delimiters.
+     *
+     * @return array<bool>
+     */
+    protected function quotedPositions(string $line): array
+    {
+        $quoted = [];
+        $quote = null;
+
+        for ($position = 0, $length = \strlen($line); $position < $length; $position++) {
+            $character = $line[$position];
+
+            if ($quote !== null) {
+                $quoted[$position] = true;
+                if ($character === $quote && $line[$position - 1] !== '\\') {
+                    $quote = null;
+                }
+                continue;
+            }
+
+            if ($character === "'" || $character === '"') {
+                $quote = $character;
+                $quoted[$position] = true;
+                continue;
+            }
+
+            $quoted[$position] = false;
+        }
+
+        return $quoted;
+    }
+
+    /**
      * Collapses a call rendered on one line, or explodes its arguments with a magic
      * trailing comma when the line is longer than Black's configured line length.
      * Black keeps a call that fits on one line as it is, so emitting the exploded
@@ -766,9 +801,18 @@ class Python extends Language
             return $statement;
         }
 
+        $quoted = $this->quotedPositions($line);
+        if ($quoted[\strlen($line) - 1]) {
+            return $statement;
+        }
+
         $depth = 0;
         $open = null;
         for ($position = \strlen($line) - 1; $position >= 0; $position--) {
+            if ($quoted[$position]) {
+                continue;
+            }
+
             $character = $line[$position];
             if ($character === ')') {
                 $depth++;
@@ -810,21 +854,12 @@ class Python extends Language
         $split = [];
         $argument = '';
         $depth = 0;
-        $quote = null;
+        $quoted = $this->quotedPositions($arguments);
 
         for ($position = 0, $length = \strlen($arguments); $position < $length; $position++) {
             $character = $arguments[$position];
 
-            if ($quote !== null) {
-                $argument .= $character;
-                if ($character === $quote && $arguments[$position - 1] !== '\\') {
-                    $quote = null;
-                }
-                continue;
-            }
-
-            if ($character === "'" || $character === '"') {
-                $quote = $character;
+            if ($quoted[$position]) {
                 $argument .= $character;
                 continue;
             }

--- a/templates/python/base/params.twig
+++ b/templates/python/base/params.twig
@@ -12,13 +12,11 @@
 {% for parameter in (method | parameters('query')) -%}
 {% if not parameter.required %}
         if {{ parameter.name | escapeKeyword | caseSnake }} is not None:
-            api_params['{{ parameter.name }}'] = self._normalize_value(
-                {{ parameter.name | escapeKeyword | caseSnake }},
-            )
+{% set queryParam %}            api_params['{{ parameter.name }}'] = self._normalize_value({{ parameter.name | escapeKeyword | caseSnake }}){% endset %}
+{{ queryParam | formatCall | raw }}
 {% else %}
-        api_params['{{ parameter.name }}'] = self._normalize_value(
-            {{ parameter.name | escapeKeyword | caseSnake }},
-        )
+{% set queryParam %}        api_params['{{ parameter.name }}'] = self._normalize_value({{ parameter.name | escapeKeyword | caseSnake }}){% endset %}
+{{ queryParam | formatCall | raw }}
 {% endif -%}
 {% endfor -%}
 {% for parameter in (method | parameters('body'))|merge(method.parameters.formData|default([])) -%}
@@ -27,13 +25,11 @@
 {% set formattedValue = paramName | formatParamValue((parameter | schemaType), isMultipart) -%}
 {% if not parameter.required %}
         if {{ paramName }} is not None:
-            api_params['{{ parameter.name }}'] = self._normalize_value(
-                {{ formattedValue }},
-            )
+{% set bodyParam %}            api_params['{{ parameter.name }}'] = self._normalize_value({{ formattedValue }}){% endset %}
+{{ bodyParam | formatCall | raw }}
 {% else %}
-        api_params['{{ parameter.name }}'] = self._normalize_value(
-            {{ formattedValue }},
-        )
+{% set bodyParam %}        api_params['{{ parameter.name }}'] = self._normalize_value({{ formattedValue }}){% endset %}
+{{ bodyParam | formatCall | raw }}
 {% endif -%}
 {% endfor -%}
 {% endif %}

--- a/templates/python/package/models/model.py.twig
+++ b/templates/python/package/models/model.py.twig
@@ -65,10 +65,8 @@ class {{ definitionName | caseUcfirst }}(AppwriteModel{% if isGeneric %}, Generi
 {% set baseType = property | getModelPropertyType(definitionName, spec) | raw %}
 {% set propType %}{% if (property | schemaModel) and (property | schemaModel) | hasGenericType(spec) %}{{ baseType | replace({((property | schemaModel) | caseUcfirst): ((property | schemaModel) | caseUcfirst) ~ '[T]'}) }}{% else %}{{ baseType }}{% endif %}{% endset %}
 {% set fieldType %}{% if not (property | schemaRequired) %}Optional[{{ propType | trim }}]{% else %}{{ propType | trim }}{% endif %}{% endset %}
-    {{ property | getModelFieldName(definition.properties) }}: {{ fieldType | trim | formatModelFieldType | raw }} = Field(
-        {% if (property | schemaRequired) %}...{% else %}default=None{% endif %},
-        alias='{{ (property | schemaName) }}',
-    )
+{% set field %}    {{ property | getModelFieldName(definition.properties) }}: {{ fieldType | trim | formatModelFieldType | raw }} = Field({% if (property | schemaRequired) %}...{% else %}default=None{% endif %}, alias='{{ (property | schemaName) }}'){% endset %}
+{{ field | formatCall | raw }}
 {% endfor %}
 {% endif %}
 {% if isGeneric %}


### PR DESCRIPTION
## What does this PR do?

The Python templates emitted `Field(...)` and `self._normalize_value(...)` pre-exploded with a magic trailing comma:

```python
    id: str = Field(
        ...,
        alias='$id',
    )
```

```python
        if queries is not None:
            api_params['queries'] = self._normalize_value(
                queries,
            )
```

Black only breaks a call that does not fit the configured line length, and the magic trailing comma then pins it open — so every one-argument model field and query parameter in every generated SDK was split across four lines for no reason. The published diff for a routine release is dominated by that reflow.

The templates now render the call on one line and a new `formatCall` filter explodes the arguments only when the line is longer than Black's configured length (`line-length = 120`, set in `templates/python/pyproject.toml.twig`), so the output stays Black-clean in both directions:

```python
    id: str = Field(..., alias='$id')
    app_vcs_providers_with_repository_creation: List[Any] = Field(
        ...,
        alias='_APP_VCS_PROVIDERS_WITH_REPOSITORY_CREATION',
    )
```

Rule 7 in `AGENTS.md` still holds: the fix is in the templates, with no post-generation formatting step.

## Test Plan

```bash
rm -rf examples/python && php example.php python console
(cd examples/python && find appwrite test -name '*.py' -print0 | xargs -0 python -m black --check)   # 606 files unchanged
(cd examples/python && python -m black --check setup.py)                                             # 1 file unchanged
(cd examples/python && python -m compileall -q appwrite)
composer lint && composer lint-twig && composer refactor:check
```

Verified on the generated console SDK that short calls collapse, the 14 call sites that genuinely exceed 120 columns still explode, and no `Field(` or `_normalize_value(` line exceeds the limit.

## Related PRs and Issues

Noticed while releasing the Console Python SDK 0.6.0 (appwrite/sdk-for-console-python#8), where the reflow accounted for most of the diff.

## Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
