### PR TITLE
fix(python): alias a model that collides with a service enum

### DIFF
--- a/src/SDK/Language/Python.php
+++ b/src/SDK/Language/Python.php
@@ -527,9 +527,10 @@ class Python extends Language
      *
      * Must stay identical to the `-> ...` annotation the service template
      * emits: a multi-model response is a `Union[...]`, and a model whose name
-     * collides with its own service is imported under a `Model` suffix.
+     * collides with its own service, or with an enum that service imports, is
+     * imported under a `Model` suffix.
      */
-    protected function getResponseType(Operation $method, string $serviceName = ''): string
+    protected function getResponseType(Operation $method, ?Tag $service = null, ?Specification $spec = null): string
     {
         $models = \array_filter(
             $this->getOperationResponseModels($method),
@@ -540,19 +541,65 @@ class Python extends Language
         }
 
         $names = \array_map(
-            fn(string $model): string => $this->getServiceModelTypeName($model, $serviceName),
+            fn(string $model): string => $this->getServiceModelName($model, $service, $spec),
             \array_values($models)
         );
 
         return \count($names) > 1 ? 'Union[' . \implode(', ', $names) . ']' : $names[0];
     }
 
-    protected function getServiceModelTypeName(string $model, string $serviceName): string
+    /**
+     * The name a model is imported under inside a service module.
+     *
+     * A model is aliased with a `Model` suffix when its name collides with the
+     * service itself or with an enum the same service imports: two
+     * `from .. import Addon` lines shadow one another, and the enum landing in
+     * `_parse_response()` raises `AttributeError` on `model_validate`.
+     */
+    protected function getServiceModelName(string $model, ?Tag $service, ?Specification $spec): string
     {
         $name = $this->toPascalCase($model);
-        return $serviceName !== '' && $name === $this->toPascalCase($serviceName)
+        if (!$service instanceof Tag) {
+            return $name;
+        }
+
+        if ($name === $this->toPascalCase($service->name)) {
+            return $name . 'Model';
+        }
+
+        return \in_array($name, $this->getServiceEnumNames($service, $spec), true)
             ? $name . 'Model'
             : $name;
+    }
+
+    /**
+     * Every enum name a service module imports, in the form the service
+     * template writes it.
+     *
+     * @return list<string>
+     */
+    protected function getServiceEnumNames(Tag $service, ?Specification $spec): array
+    {
+        if (!$spec instanceof Specification) {
+            return [];
+        }
+
+        $names = [];
+        foreach ($spec->operations() as $operation) {
+            if (!\in_array($service->name, $operation->tags, true)) {
+                continue;
+            }
+
+            foreach ($this->getOperationParameters($operation) as $parameter) {
+                if (!$this->usesEnumType($parameter)) {
+                    continue;
+                }
+
+                $names[] = $this->getServiceEnumName($parameter, $spec);
+            }
+        }
+
+        return \array_values(\array_unique($names));
     }
 
     protected function getServicePropertyType(Schema|Parameter $value, Specification $spec): string
@@ -989,7 +1036,8 @@ class Python extends Language
             new TwigFilter('formatCall', fn(string $statement): string => $this->formatCall($statement)),
             new TwigFilter('modelPropertyNullable', fn(Schema $value): bool => !($value instanceof ArraySchema) && $value->nullable),
             new TwigFilter('getModelFieldName', fn(Schema $value, array $properties): string => $this->getModelFieldName($value, $properties)),
-            new TwigFilter('getResponseType', fn(Operation $method, string $serviceName = ''): string => $this->getResponseType($method, $serviceName)),
+            new TwigFilter('getResponseType', fn(Operation $method, ?Tag $service = null, ?Specification $spec = null): string => $this->getResponseType($method, $service, $spec)),
+            new TwigFilter('getServiceModelName', fn(string $model, ?Tag $service = null, ?Specification $spec = null): string => $this->getServiceModelName($model, $service, $spec)),
             new TwigFilter('formatParamValue', function (string $paramName, string $paramType, bool $isMultipartFormData): string {
                 if ($isMultipartFormData && $paramType === self::TYPE_BOOLEAN) {
                     return "str({$paramName}).lower() if type({$paramName}) is bool else {$paramName}";

--- a/templates/python/base/requests/api.twig
+++ b/templates/python/base/requests/api.twig
@@ -28,22 +28,22 @@
 {% for modelName, conditions in responseDiscriminator %}
 
         if {% for field, expectedValue in conditions %}response.get('{{ field }}') == '{{ expectedValue }}'{% if not loop.last %} and {% endif %}{% endfor %}:
-            return self._parse_response(response, model={% if (modelName | caseUcfirst) == (service.name | caseUcfirst) %}{{ modelName | caseUcfirst }}Model{% else %}{{ modelName | caseUcfirst }}{% endif %})
+            return self._parse_response(response, model={{ modelName | getServiceModelName(service, spec) }})
 {% endfor %}
 
         raise AppwriteException('Unable to match response to any known model')
 {% else %}
 
-        return self._parse_response(response, model={% if ((method | responseModel) | caseUcfirst) == (service.name | caseUcfirst) %}{{ (method | responseModel) | caseUcfirst }}Model{% else %}{{ (method | responseModel) | caseUcfirst }}{% endif %})
+        return self._parse_response(response, model={{ (method | responseModel) | getServiceModelName(service, spec) }})
 {% endif %}
 {% elseif (method | responseModel) and (method | responseModel) != 'any' %}
 {% set isGenericResponse = (method | responseModel) | hasGenericType(spec) %}
 {% if isGenericResponse %}
 
-        return {% if ((method | responseModel) | caseUcfirst) == (service.name | caseUcfirst) %}{{ (method | responseModel) | caseUcfirst }}Model{% else %}{{ (method | responseModel) | caseUcfirst }}{% endif %}.with_data(response, model_type)
+        return {{ (method | responseModel) | getServiceModelName(service, spec) }}.with_data(response, model_type)
 {% else %}
 
-        return self._parse_response(response, model={% if ((method | responseModel) | caseUcfirst) == (service.name | caseUcfirst) %}{{ (method | responseModel) | caseUcfirst }}Model{% else %}{{ (method | responseModel) | caseUcfirst }}{% endif %})
+        return self._parse_response(response, model={{ (method | responseModel) | getServiceModelName(service, spec) }})
 {% endif %}
 {% else %}
 

--- a/templates/python/base/requests/file.twig
+++ b/templates/python/base/requests/file.twig
@@ -37,17 +37,17 @@
 {% for modelName, conditions in responseDiscriminator %}
 
         if {% for field, expectedValue in conditions %}response.get('{{ field }}') == '{{ expectedValue }}'{% if not loop.last %} and {% endif %}{% endfor %}:
-            return self._parse_response(response, model={% if (modelName | caseUcfirst) == (service.name | caseUcfirst) %}{{ modelName | caseUcfirst }}Model{% else %}{{ modelName | caseUcfirst }}{% endif %})
+            return self._parse_response(response, model={{ modelName | getServiceModelName(service, spec) }})
 {% endfor %}
 
         raise AppwriteException('Unable to match response to any known model')
 {% else %}
 
-        return self._parse_response(response, model={% if ((method | responseModel) | caseUcfirst) == (service.name | caseUcfirst) %}{{ (method | responseModel) | caseUcfirst }}Model{% else %}{{ (method | responseModel) | caseUcfirst }}{% endif %})
+        return self._parse_response(response, model={{ (method | responseModel) | getServiceModelName(service, spec) }})
 {% endif %}
 {% elseif (method | responseModel) and (method | responseModel) != 'any' %}
 
-        return self._parse_response(response, model={% if ((method | responseModel) | caseUcfirst) == (service.name | caseUcfirst) %}{{ (method | responseModel) | caseUcfirst }}Model{% else %}{{ (method | responseModel) | caseUcfirst }}{% endif %})
+        return self._parse_response(response, model={{ (method | responseModel) | getServiceModelName(service, spec) }})
 {% else %}
 
         return response

--- a/templates/python/package/services/service.py.twig
+++ b/templates/python/package/services/service.py.twig
@@ -22,33 +22,27 @@ from ..enums.{{ (parameter | enumName) | caseSnake }} import {{ (parameter | enu
 {% set modelName = (parameter | schemaModel) %}
 {% if modelName %}
 {% if modelName not in added %}
-{% if (modelName | caseUcfirst) == (service.name | caseUcfirst) %}
-from ..models.{{ modelName | caseSnake }} import {{ modelName | caseUcfirst }} as {{ modelName | caseUcfirst }}Model
-{% else %}
-from ..models.{{ modelName | caseSnake }} import {{ modelName | caseUcfirst }}
-{% endif %}
+{% set modelRef = modelName | getServiceModelName(service, spec) %}
+from ..models.{{ modelName | caseSnake }} import {{ modelName | caseUcfirst }}{% if modelRef != (modelName | caseUcfirst) %} as {{ modelRef }}{% endif %}
+
 {% set added = added|merge([modelName]) %}
 {% endif %}
 {% endif %}
 {% endfor %}
 {% if (method | responseModel) and (method | responseModel) != 'any' %}
 {% if (method | responseModel) not in added %}
-{% if ((method | responseModel) | caseUcfirst) == (service.name | caseUcfirst) %}
-from ..models.{{ (method | responseModel) | caseSnake }} import {{ (method | responseModel) | caseUcfirst }} as {{ (method | responseModel) | caseUcfirst }}Model
-{% else %}
-from ..models.{{ (method | responseModel) | caseSnake }} import {{ (method | responseModel) | caseUcfirst }}
-{% endif %}
+{% set modelRef = (method | responseModel) | getServiceModelName(service, spec) %}
+from ..models.{{ (method | responseModel) | caseSnake }} import {{ (method | responseModel) | caseUcfirst }}{% if modelRef != ((method | responseModel) | caseUcfirst) %} as {{ modelRef }}{% endif %}
+
 {% set added = added|merge([(method | responseModel)]) %}
 {% endif %}
 {% endif %}
 {% if (method | responseModels)|length > 1 %}
 {% for responseModel in (method | responseModels) %}
 {% if responseModel and responseModel != 'any' and responseModel not in added %}
-{% if (responseModel | caseUcfirst) == (service.name | caseUcfirst) %}
-from ..models.{{ responseModel | caseSnake }} import {{ responseModel | caseUcfirst }} as {{ responseModel | caseUcfirst }}Model
-{% else %}
-from ..models.{{ responseModel | caseSnake }} import {{ responseModel | caseUcfirst }}
-{% endif %}
+{% set modelRef = responseModel | getServiceModelName(service, spec) %}
+from ..models.{{ responseModel | caseSnake }} import {{ responseModel | caseUcfirst }}{% if modelRef != (responseModel | caseUcfirst) %} as {{ modelRef }}{% endif %}
+
 {% set added = added|merge([responseModel]) %}
 {% endif %}
 {% endfor %}
@@ -99,11 +93,11 @@ str
 {% elseif (method | methodType) == 'location' %}
 bytes
 {% elseif validResponseModels|length > 1 %}
-Union[{% for responseModel in validResponseModels %}{% if not loop.first %}, {% endif %}{% if (responseModel | caseUcfirst) == (service.name | caseUcfirst) %}{{ responseModel | caseUcfirst }}Model{% else %}{{ responseModel | caseUcfirst }}{% endif %}{% endfor %}]
+Union[{% for responseModel in validResponseModels %}{% if not loop.first %}, {% endif %}{{ responseModel | getServiceModelName(service, spec) }}{% endfor %}]
 {% elseif validResponseModels|length == 1 %}
-{% if (validResponseModels[0] | caseUcfirst) == (service.name | caseUcfirst) %}{{ validResponseModels[0] | caseUcfirst }}Model{% else %}{{ validResponseModels[0] | caseUcfirst }}{% endif %}
+{{ validResponseModels[0] | getServiceModelName(service, spec) }}
 {% elseif (method | responseModel) and (method | responseModel) != 'any' %}
-{% if isGenericResponse %}{% if ((method | responseModel) | caseUcfirst) == (service.name | caseUcfirst) %}{{ (method | responseModel) | caseUcfirst }}Model{% else %}{{ (method | responseModel) | caseUcfirst }}{% endif %}[T]{% elseif ((method | responseModel) | caseUcfirst) == (service.name | caseUcfirst) %}{{ (method | responseModel) | caseUcfirst }}Model{% else %}{{ (method | responseModel) | caseUcfirst }}{% endif %}
+{{ (method | responseModel) | getServiceModelName(service, spec) }}{% if isGenericResponse %}[T]{% endif %}
 {% else %}
 Dict[str, Any]
 {% endif %}
@@ -142,12 +136,12 @@ Dict[str, Any]
             Authentication response as a string
 {% elseif (method | methodType) == 'location' %}        bytes
             Response as bytes
-{% elseif validResponseModels|length > 1 %}        {{ method | getResponseType(service.name) }}
+{% elseif validResponseModels|length > 1 %}        {{ method | getResponseType(service, spec) }}
             API response as one of the typed response models
-{% elseif validResponseModels|length == 1 %}        {{ method | getResponseType(service.name) }}
+{% elseif validResponseModels|length == 1 %}        {{ method | getResponseType(service, spec) }}
             API response as a typed Pydantic model
-{% elseif (method | responseModel) and (method | responseModel) != 'any' %}{% if isGenericResponse %}        {% if ((method | responseModel) | caseUcfirst) == (service.name | caseUcfirst) %}{{ (method | responseModel) | caseUcfirst }}Model{% else %}{{ (method | responseModel) | caseUcfirst }}{% endif %}[T]
-{% else %}        {{ method | getResponseType(service.name) }}
+{% elseif (method | responseModel) and (method | responseModel) != 'any' %}{% if isGenericResponse %}        {{ (method | responseModel) | getServiceModelName(service, spec) }}[T]
+{% else %}        {{ method | getResponseType(service, spec) }}
 {% endif %}            API response as a typed Pydantic model
 {% else %}        Dict[str, Any]
             API response as a dictionary


### PR DESCRIPTION
## What does this PR do?

`appwrite_console/services/organizations.py` imported `Addon` twice — the response model, then the enum `get_addon_price` takes:

```python
from ..models.addon import Addon
from ..enums.addon import Addon      # shadows the model
```

The second import wins, so four methods passed the enum to `_parse_response()`:

```python
    def get_addon(self, organization_id: str, addon_id: str) -> Addon:
        ...
        return self._parse_response(response, model=Addon)   # AttributeError
```

`AttributeError: type object 'Addon' has no attribute 'model_validate'` on `get_addon`, `create_baa_addon`, `create_premium_geo_db_addon` and `confirm_addon_payment`.

The templates already alias a model whose name collides with its own service (`Project` → `ProjectModel`). This extends that rule to a collision with an enum the same service imports, and moves the decision into one `getServiceModelName` filter — the `(model | caseUcfirst) == (service.name | caseUcfirst)` comparison was duplicated across ten template sites (imports, return annotations, docstring `Returns` blocks, `model=` arguments, `Union[...]` members), which is why the enum case was missed in all of them at once.

After:

```python
from ..models.addon import Addon as AddonModel
from ..enums.addon import Addon

    def get_addon(self, organization_id: str, addon_id: str) -> AddonModel:
        return self._parse_response(response, model=AddonModel)

    def get_addon_price(self, organization_id: str, addon: Addon) -> AddonPrice:
```

## Test Plan

```bash
rm -rf examples/python && php example.php python console
(cd examples/python && find appwrite test -name '*.py' -print0 | xargs -0 python -m black --check)   # 606 files unchanged
(cd examples/python && python -m black --check setup.py && python -m compileall -q appwrite)
composer lint && composer lint-twig && composer refactor:check
php example.php python server    # other platforms still generate
```

Asserted on the generated console SDK:

```
module Addon        -> <enum 'Addon'>
module AddonModel   -> <class 'appwrite.models.addon.Addon'>  model_validate: True
get_addon_price addon annotation -> <enum 'Addon'>
get_addon return                 -> <class 'appwrite.models.addon.Addon'>
```

The pre-existing service-name collision is unchanged: `project.py` still imports `Project as ProjectModel` and annotates `-> ProjectModel`. Docstring `Returns` blocks track the annotations, so the two cannot drift.

## Related PRs and Issues

Found reviewing the regenerated Console Python SDK in appwrite/sdk-for-console-python#8. Follows #1849.

## Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
