### PR TITLE
fix(android): make endpoint setters callable from Java

### DIFF
--- a/src/SDK/Language/Android.php
+++ b/src/SDK/Language/Android.php
@@ -147,6 +147,11 @@ class Android extends Kotlin
             ],
             [
                 'scope'         => 'default',
+                'destination'   => '/library/src/test/java/{{ sdk.namespace | caseSlash }}/ClientJavaInteropTest.java',
+                'template'      => '/android/library/src/test/java/io/package/ClientJavaInteropTest.java.twig',
+            ],
+            [
+                'scope'         => 'default',
                 'destination'   => '/library/src/main/java/{{ sdk.namespace | caseSlash }}/extensions/TypeExtensions.kt',
                 'template'      => '/android/library/src/main/java/io/package/extensions/TypeExtensions.kt.twig',
             ],

--- a/templates/android/library/src/main/java/io/package/Client.kt.twig
+++ b/templates/android/library/src/main/java/io/package/Client.kt.twig
@@ -45,7 +45,9 @@ import kotlin.coroutines.resume
 
 class Client @JvmOverloads constructor(
     context: Context,
+    @set:JvmSynthetic
     var endpoint: String = "{{(spec | endpoint)}}",
+    @set:JvmSynthetic
     var endpointRealtime: String? = null,
     private var selfSigned: Boolean = false
 ) : CoroutineScope {

--- a/templates/android/library/src/test/java/io/package/ClientJavaInteropTest.java.twig
+++ b/templates/android/library/src/test/java/io/package/ClientJavaInteropTest.java.twig
@@ -1,0 +1,25 @@
+package {{ sdk.namespace | caseDot }};
+
+import static org.junit.Assert.assertEquals;
+
+import android.content.Context;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+@Config(manifest = Config.NONE)
+@RunWith(AndroidJUnit4.class)
+public final class ClientJavaInteropTest {
+    @Test
+    public void endpointSettersAreFluentFromJava() {
+        Context context = ApplicationProvider.getApplicationContext();
+        Client client = new Client(context)
+            .setEndpoint("https://cloud.appwrite.io/v1")
+            .setEndpointRealtime("wss://cloud.appwrite.io/v1");
+
+        assertEquals("https://cloud.appwrite.io/v1", client.getEndpoint());
+        assertEquals("wss://cloud.appwrite.io/v1", client.getEndpointRealtime());
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes Java interoperability for the Android SDK's fluent `setEndpoint()` and `setEndpointRealtime()` methods.

The generated Kotlin `endpoint` and `endpointRealtime` properties exposed Java property setters with the same names and parameter types as the fluent setters. Because the methods differed only by return type, Java callers received an ambiguous method compilation error.

This PR adds `@set:JvmSynthetic` to the generated property setters. This preserves Kotlin property access, keeps the generated property setters in the JVM ABI, and ensures Java callers resolve to the fluent setters.

It also adds a generated Java regression test that calls both fluent setters and verifies their values.

## Test Plan

- Regenerated the Android SDK from the local test specification.
- Reproduced the original `javac` ambiguity.
- Ran the generated Java interoperability regression test.
- Ran `./gradlew :library:build -x lint`.
- Ran `./gradlew :library:testDebugUnitTest`.
- Ran ktlint 1.8.0 on the affected generated Kotlin output.
- Ran Twig lint across all 585 templates.
- Ran PHP CodeSniffer and Rector checks.
- Ran `git diff --check`.
- Verified with `javap` that the property setters remain in the JVM ABI with the `ACC_SYNTHETIC` flag.

## Related PRs and Issues

Fixes appwrite/sdk-for-android#132

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.