### PR TITLE
Remove implementation-coupled E2E checks

### DIFF
--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -12,8 +12,6 @@ use FilesystemIterator;
 use Throwable;
 use Appwrite\SDK\Language;
 use Appwrite\SDK\SDK;
-use Utopia\OpenAPI\Model\Operation;
-use Utopia\OpenAPI\Model\Parameter;
 use Utopia\OpenAPI\Model\StringSchema;
 use Utopia\OpenAPI\Parser;
 use PHPUnit\Framework\TestCase;
@@ -478,7 +476,6 @@ abstract class Base extends TestCase
         }
 
         $this->assertOpenEnumsAllowAnyString();
-        $this->assertUploadIdParameterInference();
         $this->assertEnumKeysAreValid();
 
         $sdk = new SDK($this->getLanguage(), Parser::parse($spec));
@@ -668,20 +665,6 @@ abstract class Base extends TestCase
         $this->assertSame($language->keepsOpenEnumType(), $language->usesEnumType($openArray));
         $this->assertStringContainsString('user.created', $language->getSuggestedEnumExample($openScalar));
         $this->assertStringContainsString('user.created', $language->getSuggestedEnumExample($openArray));
-        $sdk = new class ($language, $specification) extends SDK {
-            /** @param list<StringSchema> $schemas @return list<StringSchema> */
-            public function mergeEnumsForTest(array $schemas): array
-            {
-                return $this->mergeEnums($schemas);
-            }
-        };
-        $mergedEnums = $sdk->mergeEnumsForTest([
-            new StringSchema(title: 'SharedEnum', enum: ['known'], open: true),
-            new StringSchema(title: 'SharedEnum', enum: ['known'], open: false),
-        ]);
-        $this->assertCount(1, $mergedEnums);
-        $this->assertFalse($mergedEnums[0]->open, 'A closed use must keep a shared enum type closed.');
-
         if ($language->keepsOpenEnumType()) {
             $this->assertSame('(WebhookEvent | (string & {}))', $language->getTypeName($openScalar, $specification));
             $this->assertSame('(WebhookEvent | (string & {}))[]', $language->getTypeName($openArray, $specification));
@@ -697,66 +680,6 @@ abstract class Base extends TestCase
             $language->getTypeName($plainArray, $specification),
             $language->getTypeName($openArray, $specification),
         );
-    }
-
-    private function assertUploadIdParameterInference(): void
-    {
-        $multipart = static fn(array $properties, array $required = []): array => [
-            'requestBody' => ['content' => ['multipart/form-data' => ['schema' => [
-                'type' => 'object',
-                'properties' => $properties,
-                'required' => $required,
-            ]]]],
-            'responses' => ['200' => ['description' => 'ok']],
-        ];
-        $file = ['type' => 'string', 'format' => 'binary'];
-        $string = ['type' => 'string'];
-        $specification = Parser::parse([
-            'openapi' => '3.0.0',
-            'info' => ['title' => 'test', 'version' => '1.0.0'],
-            'paths' => [
-                '/file' => ['post' => $multipart(
-                    ['fileId' => $string, 'file' => $file],
-                    ['fileId', 'file'],
-                )],
-                '/code' => ['post' => $multipart(['code' => $file], ['code'])],
-                '/optional' => ['post' => $multipart(['fileId' => $string, 'file' => $file], ['file'])],
-                '/malformed' => ['post' => $multipart([
-                    'fileId' => ['type' => 'integer'],
-                    'file' => $file,
-                ])],
-                '/multiple' => ['post' => $multipart([
-                    'archive' => $file,
-                    'archiveId' => $string,
-                    'file' => $file,
-                ])],
-                '/json' => ['post' => [
-                    'requestBody' => ['content' => ['application/json' => ['schema' => [
-                        'type' => 'object',
-                        'properties' => ['fileId' => $string, 'file' => $file],
-                    ]]]],
-                    'responses' => ['200' => ['description' => 'ok']],
-                ]],
-            ],
-        ]);
-        $sdk = new class ($this->getLanguage(), $specification) extends SDK {
-            public function uploadIdParameterForTest(Operation $operation): ?Parameter
-            {
-                return $this->uploadIdParameter($operation);
-            }
-        };
-
-        $fileId = $sdk->uploadIdParameterForTest($specification->paths['/file']->operations['post']);
-        $this->assertInstanceOf(Parameter::class, $fileId);
-        $this->assertSame('fileId', $fileId->name);
-        $this->assertTrue($fileId->required);
-        $this->assertNotInstanceOf(Parameter::class, $sdk->uploadIdParameterForTest($specification->paths['/code']->operations['post']));
-        $optional = $sdk->uploadIdParameterForTest($specification->paths['/optional']->operations['post']);
-        $this->assertInstanceOf(Parameter::class, $optional);
-        $this->assertFalse($optional->required);
-        $this->assertNotInstanceOf(Parameter::class, $sdk->uploadIdParameterForTest($specification->paths['/malformed']->operations['post']));
-        $this->assertNotInstanceOf(Parameter::class, $sdk->uploadIdParameterForTest($specification->paths['/multiple']->operations['post']));
-        $this->assertNotInstanceOf(Parameter::class, $sdk->uploadIdParameterForTest($specification->paths['/json']->operations['post']));
     }
 
     private function assertOpenEnumSuggestionsGenerated(string $dir): void

--- a/tests/e2e/CLIGo126Test.php
+++ b/tests/e2e/CLIGo126Test.php
@@ -45,35 +45,11 @@ final class CLIGo126Test extends Base
     protected array $expectedOutput = [
         ...Base::FOO_RESPONSES,
         ...Base::BAR_RESPONSES,
-        ...Base::UPLOAD_RESPONSES,
+        ...Base::UPLOAD_RESPONSE,
+        ...Base::UPLOAD_RESPONSE,
         ...Base::CLI_HEADERS_RESPONSES,
         'CLI_CONFORMANCE:passed',
     ];
-
-    #[Override]
-    public function testHTTPSuccess(): void
-    {
-        $language = new class () extends CLI {
-            /**
-             * @return array{0: string, 1: array{var: string, source: string, helper: string, cleanup?: string}|null}
-             */
-            public function convertForTest(string $variable, string $flagType, string $sdkType): array
-            {
-                return $this->convertToSdkType($variable, $flagType, $sdkType);
-            }
-        };
-
-        [$expression, $decode] = $language->convertForTest('rows', '[]string', '[]interface{}');
-
-        $this->assertSame('rowsDecoded', $expression);
-        $this->assertSame([
-            'var' => 'rowsDecoded',
-            'source' => 'rows',
-            'helper' => 'DecodeSlice[interface{}]',
-        ], $decode);
-
-        parent::testHTTPSuccess();
-    }
 
     #[Override]
     public function getLanguage(): CLI

--- a/tests/e2e/CLIWasmTest.php
+++ b/tests/e2e/CLIWasmTest.php
@@ -47,7 +47,8 @@ final class CLIWasmTest extends Base
     protected array $expectedOutput = [
         ...Base::FOO_RESPONSES,
         ...Base::BAR_RESPONSES,
-        ...Base::UPLOAD_RESPONSES,
+        ...Base::UPLOAD_RESPONSE,
+        ...Base::UPLOAD_RESPONSE,
         ...Base::CLI_HEADERS_RESPONSES,
         'CLI_CONFORMANCE:passed',
     ];

--- a/tests/e2e/WebChromiumTest.php
+++ b/tests/e2e/WebChromiumTest.php
@@ -42,8 +42,10 @@ final class WebChromiumTest extends Base
         ...Base::BAR_RESPONSES, // Object params
         ...Base::GENERAL_RESPONSES,
         ...Base::PATH_PARAM_RESPONSES,
-        ...Base::UPLOAD_RESPONSES,
-        ...Base::UPLOAD_RESPONSES, // Object params
+        ...Base::UPLOAD_RESPONSE,
+        ...Base::LARGE_FILE_RESPONSES,
+        ...Base::UPLOAD_RESPONSE, // Object params
+        ...Base::LARGE_FILE_RESPONSES,
         ...Base::ENUM_RESPONSES,
         ...Base::MODEL_RESPONSES,
         ...Base::UNION_RESPONSES,

--- a/tests/e2e/WebNodeTest.php
+++ b/tests/e2e/WebNodeTest.php
@@ -43,12 +43,10 @@ final class WebNodeTest extends Base
         ...Base::BAR_RESPONSES, // Object params
         ...Base::GENERAL_RESPONSES,
         ...Base::PATH_PARAM_RESPONSES,
-        ...Base::UPLOAD_RESPONSES,
         ...Base::ENUM_RESPONSES,
         ...Base::MODEL_RESPONSES,
         ...Base::UNION_RESPONSES,
         ...Base::EXCEPTION_RESPONSES,
-        ...Base::REALTIME_RESPONSES,
         ...Base::QUERY_HELPER_RESPONSES,
         ...Base::PERMISSION_HELPER_RESPONSES,
         ...Base::ID_HELPER_RESPONSES,

--- a/tests/e2e/languages/cli-wasm/harness.mjs
+++ b/tests/e2e/languages/cli-wasm/harness.mjs
@@ -86,10 +86,6 @@ for (const file of ['file.png', 'large_file.mp4']) {
         '--file', join('..', '..', '..', 'resources', file),
     ))
 }
-// Preserve the shared expectation indices for unsupported chunked variants.
-console.log('POST:/v1/mock/tests/general/upload:passed')
-console.log('POST:/v1/mock/tests/general/upload:passed')
-
 console.log(headers)
 
 run('general', 'redirect')

--- a/tests/e2e/languages/cli/main.go
+++ b/tests/e2e/languages/cli/main.go
@@ -76,12 +76,6 @@ func main() {
 			"--x", "string", "--y", "123", "--z", "string in array",
 			"--file", filepath.Join("..", "..", "..", "resources", file)))
 	}
-	// UPLOAD_RESPONSES expects four entries and the CLI exercises two: it has no
-	// chunked variants of its own. Echoed rather than skipped so the indices of
-	// everything after this still line up.
-	fmt.Println("POST:/v1/mock/tests/general/upload:passed")
-	fmt.Println("POST:/v1/mock/tests/general/upload:passed")
-
 	fmt.Println(headers)
 
 	// Run for their exit status, not their output: neither is in the expectation

--- a/tests/e2e/languages/web/index.html
+++ b/tests/e2e/languages/web/index.html
@@ -211,9 +211,6 @@
             );
             console.log(response.result);
 
-            console.log('POST:/v1/mock/tests/general/upload:passed'); // Skip InputFile tests
-            console.log('POST:/v1/mock/tests/general/upload:passed'); // Skip InputFile tests
-
             // Upload (Object params)
             response = await general.upload({
                 x: 'string',
@@ -230,9 +227,6 @@
                 file: document.getElementById("file2").files[0]
             });
             console.log(response.result);
-
-            console.log('POST:/v1/mock/tests/general/upload:passed'); // Skip InputFile tests
-            console.log('POST:/v1/mock/tests/general/upload:passed'); // Skip InputFile tests
 
             response = await general.enum(MockType.First);
             console.log(response.result);

--- a/tests/e2e/languages/web/node.js
+++ b/tests/e2e/languages/web/node.js
@@ -126,11 +126,6 @@ async function start() {
 
     response = await general.getPath({ pathId: 'grant/special&id' });
     console.log(response.result);
-  
-    console.log('POST:/v1/mock/tests/general/upload:passed'); // Skip file upload test on Node.js
-    console.log('POST:/v1/mock/tests/general/upload:passed'); // Skip big file upload test on Node.js
-    console.log('POST:/v1/mock/tests/general/upload:passed'); // Skip file upload test on Node.js
-    console.log('POST:/v1/mock/tests/general/upload:passed'); // Skip big file upload test on Node.js
 
     response = await general.enum(MockType.First);
     console.log(response.result);
@@ -189,14 +184,6 @@ async function start() {
     } catch(error) {
         console.log(error.message);
     }
-
-    console.log('WS:/v1/realtime:passed'); // Skip realtime test on Node.js
-    console.log('WS:/v1/realtime:passed'); // Skip realtime query test on Node.js
-    console.log('Realtime failed!'); // Skip realtime query failure test on Node.js
-    console.log('Realtime unsubscribe:passed'); // Skip new realtime API tests on Node.js
-    console.log('Realtime update:passed');
-    console.log('Realtime presence:passed'); // Skip realtime presence test on Node.js
-    console.log('Realtime disconnect:passed');
 
     // Query helper tests
     console.log(Query.equal("released", [true]));


### PR DESCRIPTION
## Summary

- remove E2E assertions that expose protected generator and CLI implementation details
- stop printing synthetic success output for unsupported Web, CLI, and CLI WASM cases
- keep the existing positional output protocol while aligning expectations with behavior that is actually exercised

## Tests

- `composer test tests/e2e/WebNodeTest.php`
- `vendor/bin/phpunit tests/e2e/WebChromiumTest.php`
- `composer test tests/e2e/CLIGo126Test.php`
- `vendor/bin/phpunit tests/e2e/CLIWasmTest.php`
- `composer lint -- --report=full tests/e2e/Base.php tests/e2e/CLIGo126Test.php tests/e2e/CLIWasmTest.php tests/e2e/WebNodeTest.php tests/e2e/WebChromiumTest.php`
- `composer refactor:check`
- PHP and Node syntax checks
- `gofmt` verification
- `git diff --check`