### PR TITLE
fix: generate runnable array examples for Go SDK

### DIFF
--- a/src/SDK/Language/Go.php
+++ b/src/SDK/Language/Go.php
@@ -304,17 +304,16 @@ class Go extends Language
                 case self::TYPE_OBJECT:
                     $output .= 'map[string] interface{}{}';
                 break;
+                
                 case self::TYPE_ARRAY:
                 $typeName = $this->getTypeName($param);
-               if (str_contains($typeName, 'string')) {
-               $output .= '[]string{"example"}';
-               } elseif (str_contains($typeName, 'int') || str_contains($typeName, 'float64') || str_contains($typeName, 'int64')) {
-               $output .= $typeName . '{0}';
-               } elseif (str_contains($typeName, 'bool')) {
-               $output .= $typeName . '{false}';
-               } else {
-               $output .= $typeName . '{}';
-               }
+                $output .= match ($typeName) {
+               '[]string' => '[]string{"example"}',
+               '[]int', '[]int64', '[]float64' => $typeName . '{0}',
+               '[]bool' => $typeName . '{false}',
+                default => $typeName . '{}',
+                 };
+                
                break;
                 
                 case self::TYPE_FILE:

--- a/src/SDK/Language/Go.php
+++ b/src/SDK/Language/Go.php
@@ -302,11 +302,21 @@ class Go extends Language
                     $output .= '""';
                     break;
                 case self::TYPE_OBJECT:
-                    $output .= 'map[string]interface{}{}';
-                    break;
+                    $output .= 'map[string] interface{}{}';
+                break;
                 case self::TYPE_ARRAY:
-                    $output .= $this->getTypeName($param) . '{"example"}';
-                    break;
+                $typeName = $this->getTypeName($param);
+               if (str_contains($typeName, 'string')) {
+               $output .= '[]string{"example"}';
+               } elseif (str_contains($typeName, 'int') || str_contains($typeName, 'float64') || str_contains($typeName, 'int64')) {
+               $output .= $typeName . '{0}';
+               } elseif (str_contains($typeName, 'bool')) {
+               $output .= $typeName . '{false}';
+               } else {
+               $output .= $typeName . '{}';
+               }
+               break;
+                
                 case self::TYPE_FILE:
                     $output .= 'file.NewInputFile("/path/to/file.png", "file.png")';
                     break;

--- a/src/SDK/Language/Go.php
+++ b/src/SDK/Language/Go.php
@@ -305,7 +305,7 @@ class Go extends Language
                     $output .= 'map[string]interface{}{}';
                     break;
                 case self::TYPE_ARRAY:
-                    $output .= $this->getTypeName($param) . '{}';
+                    $output .= $this->getTypeName($param) . '{"example"}';
                     break;
                 case self::TYPE_FILE:
                     $output .= 'file.NewInputFile("/path/to/file.png", "file.png")';

--- a/src/SDK/Language/Go.php
+++ b/src/SDK/Language/Go.php
@@ -302,20 +302,17 @@ class Go extends Language
                     $output .= '""';
                     break;
                 case self::TYPE_OBJECT:
-                    $output .= 'map[string] interface{}{}';
-                break;
-                
+                    $output .= 'map[string]interface{}{}';
+                    break;
                 case self::TYPE_ARRAY:
-                $typeName = $this->getTypeName($param);
-                $output .= match ($typeName) {
-               '[]string' => '[]string{"example"}',
-               '[]int', '[]int64', '[]float64' => $typeName . '{0}',
-               '[]bool' => $typeName . '{false}',
-                default => $typeName . '{}',
-                 };
-                
-               break;
-                
+                    $typeName = $this->getTypeName($param);
+                    $output .= match ($typeName) {
+                        '[]string' => '[]string{"example"}',
+                        '[]int', '[]int64', '[]float64' => $typeName . '{0}',
+                        '[]bool' => $typeName . '{false}',
+                        default => $typeName . '{}',
+                    };
+                    break;
                 case self::TYPE_FILE:
                     $output .= 'file.NewInputFile("/path/to/file.png", "file.png")';
                     break;


### PR DESCRIPTION
Currently Go examples for array params generate empty '[]string{}' which is not helpful.  This change makes it generate '[]string{"example"}' so examples are runnable and clear for developers. Related to recent fix : generate runnable Go examples

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

(Provide a description of what this PR does.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work.)

## Related PRs and Issues

(If this PR is related to any other PR or resolves any issue or related to any issue link all related PR and issues here.)

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

(Write your answer here.)