### PR TITLE
fix(cli): ignore unchanged file notifications

### DIFF
--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -1014,6 +1014,11 @@ class CLI extends Go
             ],
             [
                 'scope'         => 'copy',
+                'destination'   => 'internal/watch/watch_test.go',
+                'template'      => 'cli/internal/watch/watch_test.go',
+            ],
+            [
+                'scope'         => 'copy',
                 'destination'   => 'internal/prompt/prompt.go',
                 'template'      => 'cli/internal/prompt/prompt.go',
             ],

--- a/templates/cli/internal/watch/watch.go
+++ b/templates/cli/internal/watch/watch.go
@@ -1,6 +1,7 @@
 package watch
 
 import (
+	"crypto/sha256"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -21,10 +22,11 @@ type Ignored func(relative string) bool
 
 // Watcher reports changes beneath a directory.
 type Watcher struct {
-	watcher *fsnotify.Watcher
-	root    string
-	ignored Ignored
-	done    chan struct{}
+	watcher      *fsnotify.Watcher
+	root         string
+	ignored      Ignored
+	fingerprints map[string][sha256.Size]byte
+	done         chan struct{}
 }
 
 // Start watches a directory tree, calling changed with each relative,
@@ -39,7 +41,13 @@ func Start(root string, ignored Ignored, changed func(string)) (*Watcher, error)
 		return nil, err
 	}
 
-	w := &Watcher{watcher: watcher, root: root, ignored: ignored, done: make(chan struct{})}
+	w := &Watcher{
+		watcher:      watcher,
+		root:         root,
+		ignored:      ignored,
+		fingerprints: make(map[string][sha256.Size]byte),
+		done:         make(chan struct{}),
+	}
 
 	if err := w.addTree(root); err != nil {
 		watcher.Close()
@@ -60,16 +68,24 @@ func (w *Watcher) addTree(directory string) error {
 			// while the user is editing.
 			return nil
 		}
-		if !entry.IsDir() {
-			return nil
-		}
-
 		relative, err := w.relative(path)
 		if err != nil {
 			return nil
 		}
 		if relative != "" && w.ignored(relative) {
-			return filepath.SkipDir
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+
+		if !entry.IsDir() {
+			if fingerprint, err := fingerprint(path); err == nil {
+				w.fingerprints[relative] = fingerprint
+			}
+
+			return nil
 		}
 
 		return w.watcher.Add(path)
@@ -124,15 +140,61 @@ func (w *Watcher) handle(event fsnotify.Event, changed func(string)) {
 		return
 	}
 
-	if event.Has(fsnotify.Create) {
-		if info, err := os.Stat(event.Name); err == nil && info.IsDir() {
+	info, statErr := os.Stat(event.Name)
+	if statErr == nil && info.IsDir() {
+		if event.Has(fsnotify.Create) {
 			// A directory created after the initial walk has to be registered
 			// or nothing inside it is ever seen.
 			_ = w.addTree(event.Name)
+			changed(relative)
 		}
+
+		// Directory metadata is not part of the function bundle.
+		return
+	}
+	if statErr != nil {
+		// A missing file is a real change only when it, or a directory beneath
+		// it, existed in the last snapshot. Unknown paths can disappear between
+		// the event and the stat.
+		removed := false
+		prefix := strings.TrimSuffix(relative, "/") + "/"
+		for known := range w.fingerprints {
+			if known == relative || strings.HasPrefix(known, prefix) {
+				delete(w.fingerprints, known)
+				removed = true
+			}
+		}
+		if removed {
+			changed(relative)
+		}
+
+		return
+	}
+
+	fingerprint, err := fingerprint(event.Name)
+	if err != nil {
+		return
+	}
+
+	previous, existed := w.fingerprints[relative]
+	w.fingerprints[relative] = fingerprint
+	if existed && previous == fingerprint {
+		return
 	}
 
 	changed(relative)
+}
+
+// fingerprint identifies file contents rather than filesystem metadata.
+// Editors and monorepo tools commonly touch or chmod source files without
+// changing them; treating those notifications as edits creates reload loops.
+func fingerprint(path string) ([sha256.Size]byte, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return [sha256.Size]byte{}, err
+	}
+
+	return sha256.Sum256(contents), nil
 }
 
 // Close stops watching.

--- a/templates/cli/internal/watch/watch_test.go
+++ b/templates/cli/internal/watch/watch_test.go
@@ -1,0 +1,60 @@
+package watch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWatcherIgnoresMetadataOnlyChanges(t *testing.T) {
+	directory := t.TempDir()
+	path := filepath.Join(directory, "main.ts")
+	if err := os.WriteFile(path, []byte("export const value = 1;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changes := make(chan string, 2)
+	watcher, err := Start(directory, func(string) bool { return false }, func(path string) {
+		changes <- path
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer watcher.Close()
+
+	future := time.Now().Add(time.Minute)
+	if err := os.Chtimes(path, future, future); err != nil {
+		t.Fatal(err)
+	}
+
+	assertNoChange(t, changes, "timestamp update")
+
+	if err := os.WriteFile(path, []byte("export const value = 1;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	assertNoChange(t, changes, "same-content rewrite")
+
+	if err := os.WriteFile(path, []byte("export const value = 2;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case changed := <-changes:
+		if changed != "main.ts" {
+			t.Fatalf("changed path = %q, want main.ts", changed)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("content update was not reported")
+	}
+}
+
+func assertNoChange(t *testing.T, changes <-chan string, operation string) {
+	t.Helper()
+
+	select {
+	case changed := <-changes:
+		t.Fatalf("%s reported %q as changed", operation, changed)
+	case <-time.After(500 * time.Millisecond):
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Prevents `appwrite run function` from rebuilding or hot-swapping when a watched file receives a filesystem notification but its contents have not changed.

Monorepo tooling can touch, chmod, or rewrite source files with identical contents. The CLI previously treated every `fsnotify` event as a source edit, which could create a continuous local function reload loop.

The watcher now snapshots file content hashes and only reports additions, removals, or actual content changes. Directory metadata events are ignored, while newly created directories continue to be watched.

A watcher test covers timestamp-only updates, same-content rewrites, and real content changes.

## How was it tested?

- Regenerated the CLI with `php example.php cli`
- `go test -mod=mod ./...`
- `go vet -mod=mod ./...`
- `go build -mod=mod ./...`
- `gofmt`
- `composer refactor:check`
- `composer lint-twig`
- Reproduced with a staging-linked Bun monorepo function:
  - repeated unchanged rewrites of `LibraryService/main.ts` and `LibraryService/types.ts` caused zero reloads
  - a real edit to `LibraryService/types.ts` caused exactly one hot-swap
