### PR TITLE
chore(cli): pin the Go SDK to v7.2.0-rc.5

### DIFF
--- a/templates/cli/go.mod.twig
+++ b/templates/cli/go.mod.twig
@@ -7,7 +7,7 @@ go 1.26.5
 // so anything added by hand to the generated file is lost on the next run.
 require (
 {% if not sdk.test %}
-	github.com/appwrite/sdk-for-go/v7 v7.2.0-rc.3
+	github.com/appwrite/sdk-for-go/v7 v7.2.0-rc.5
 {% endif %}
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0


### PR DESCRIPTION
The generated CLI does not compile against the pinned `v7.2.0-rc.3`. Three things the 1.9.x spec now produces are missing from it:

- `tablesdb.CreateCutover` — the spec renamed `cutoverMigration` to `createCutover`, and rc.3 still ships `CutoverMigration`
- `project.UpdateOAuth2Cloudflare`
- `project.UpdateOAuth2Resend`

```
internal/cmd/services/tablesdb.go:813:27: service.CreateCutover undefined
internal/cmd/services/project.go:1261:25: undefined: project.UpdateOAuth2CloudflareOption
internal/cmd/services/project.go:2389:25: undefined: project.UpdateOAuth2ResendOption
```

All three landed in [sdk-for-go v7.2.0-rc.5](https://github.com/appwrite/sdk-for-go/releases/tag/v7.2.0-rc.5), which is released and indexed on `proxy.golang.org`.

This is the only reference to the Go SDK version in the templates.

## Verification

Generating `console-cli` against a checkout with this pin applied gives a tree where `go build ./...`, `go vet ./...` and `go test ./...` all pass. Against rc.3 the build fails with the errors above.