### PR TITLE
fix: quote CLI string examples with whitespace

### DIFF
--- a/src/SDK/Language/Concern/CliCommandSurface.php
+++ b/src/SDK/Language/Concern/CliCommandSurface.php
@@ -556,7 +556,7 @@ trait CliCommandSurface
             self::TYPE_OBJECT => '\'{ "key": "value" }\'',
             self::TYPE_NUMBER, self::TYPE_INTEGER => (string) $example,
             self::TYPE_BOOLEAN => $example ? 'true' : 'false',
-            self::TYPE_STRING => \preg_match('/\s/', (string) $example)
+            self::TYPE_STRING => \preg_match('/[^A-Za-z0-9_@%+=:,\.\/-]/', (string) $example)
                 ? "'" . \str_replace("'", "'\"'\"'", (string) $example) . "'"
                 : (string) $example,
             self::TYPE_FILE => "'path/to/file.png'",

--- a/src/SDK/Language/Concern/CliCommandSurface.php
+++ b/src/SDK/Language/Concern/CliCommandSurface.php
@@ -556,7 +556,9 @@ trait CliCommandSurface
             self::TYPE_OBJECT => '\'{ "key": "value" }\'',
             self::TYPE_NUMBER, self::TYPE_INTEGER => (string) $example,
             self::TYPE_BOOLEAN => $example ? 'true' : 'false',
-            self::TYPE_STRING => (string) $example,
+            self::TYPE_STRING => \preg_match('/\s/', (string) $example)
+                ? "'" . \str_replace("'", "'\"'\"'", (string) $example) . "'"
+                : (string) $example,
             self::TYPE_FILE => "'path/to/file.png'",
             default => '',
         };


### PR DESCRIPTION
## Summary

- quote generated CLI string examples when they contain shell-unsafe characters
- escape embedded single quotes using POSIX shell-safe quoting
- fix generated commands such as `--default Hello World` and values such as `don't`

Fixes the Greptile finding on appwrite/sdk-for-cli#362.

## Validation

- `php example.php cli`
- `composer refactor:check`
- `composer lint`
- `composer lint-twig`
- `test -z "$(gofmt -l examples/cli)"`
- `git diff --check`