### PR TITLE
fix: prevent empty GraphQL SDK examples

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -70,6 +70,13 @@ jobs:
           - sdk: rust
             platform: server
 
+          # Documentation targets
+          - sdk: graphql
+            platform: client
+
+          - sdk: graphql
+            platform: server
+
           # Tooling targets
           - sdk: zed-extension
             platform: console
@@ -374,6 +381,16 @@ jobs:
             zed-extension)
               cargo +1.86.0 fmt --check
               cargo +1.86.0 check --target wasm32-wasip1
+              ;;
+            graphql)
+              invalid=0
+              while IFS= read -r -d '' example; do
+                if ! grep -Eq '^(query|mutation) \{|^POST .+ HTTP/1\.1$' "$example"; then
+                  echo "GraphQL example has no operation: $example"
+                  invalid=1
+                fi
+              done < <(find docs/examples -type f -name '*.md' -print0)
+              exit "$invalid"
               ;;
             *)
               echo "Unknown SDK: ${{ matrix.sdk }}"

--- a/templates/graphql/docs/example.md.twig
+++ b/templates/graphql/docs/example.md.twig
@@ -17,9 +17,8 @@
         {%~ endif %}
         {%~ endfor %}
 {% endmacro %}
-{% for key,header in (method | methodHeaders) %}
-{% if (key | caseLower) == 'content-type' %}
-{% if header == 'multipart/form-data' %}
+{% set headers = method | methodHeaders %}
+{% if (headers['content-type'] | default('')) == 'multipart/form-data' %}
 {% set boundary = 'cec8e8123c05ba25' %}
 {{ method.method.value | caseUpper }} {{ method | fullPath }}{% for security in (method | securityQueries) %}{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}={{ security.extensions['x-appwrite']['demo'] | raw }}{% endfor %} HTTP/1.1
 Host: {{ ((spec | endpoint) | split('/'))[2] }}
@@ -78,6 +77,4 @@ mutation {
     }
 }
 {% endif %}
-{% endif %}
-{% endfor %}
 ```


### PR DESCRIPTION
## Summary

- render standard GraphQL examples independently of request headers
- keep multipart rendering selected by the operation content type
- validate generated client and server GraphQL examples in CI

## Verification

- `php example.php graphql client`
- `php example.php graphql server`
- generated 710 server examples with zero missing operations
- `composer lint-twig`
- `composer refactor:check`