### PR TITLE
fix: generate GraphQL examples without content type headers

### DIFF
--- a/templates/graphql/docs/example.md.twig
+++ b/templates/graphql/docs/example.md.twig
@@ -17,9 +17,8 @@
         {%~ endif %}
         {%~ endfor %}
 {% endmacro %}
-{% for key,header in (method | methodHeaders) %}
-{% if (key | caseLower) == 'content-type' %}
-{% if header == 'multipart/form-data' %}
+{% set headers = method | methodHeaders %}
+{% if (headers['content-type'] | default('')) == 'multipart/form-data' %}
 {% set boundary = 'cec8e8123c05ba25' %}
 {{ method.method.value | caseUpper }} {{ method | fullPath }}{% for security in (method | securityQueries) %}{% if loop.first %}?{% else %}&{% endif %}{{ security.name }}={{ security.extensions['x-appwrite']['demo'] | raw }}{% endfor %} HTTP/1.1
 Host: {{ ((spec | endpoint) | split('/'))[2] }}
@@ -78,6 +77,4 @@ mutation {
     }
 }
 {% endif %}
-{% endif %}
-{% endfor %}
 ```


### PR DESCRIPTION
## Summary

- select multipart rendering from the operation content type once
- render normal GraphQL queries and mutations even when an operation has no `content-type` header

## Verification

- `php example.php graphql client` — 174 examples, none missing an operation
- `php example.php graphql server` — 710 examples, none missing an operation
- `composer lint-twig`
- `composer refactor:check`