### PR TITLE
Infer upload method type from OpenAPI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -359,6 +359,8 @@ composer update --ignore-platform-reqs --optimize-autoloader --no-plugins --no-s
 
 The tests in `tests/e2e/` generate an SDK from `tests/resources/spec-openapi3.json` into `tests/e2e/sdks/` and run it in Docker against a mock API. Parser behavior is tested by `utopia-php/openapi` rather than this repository. The mock server (`./mock-server`) is started in `setUp()` and removed in `tearDown()` (`docker compose down`); after interrupted runs, clean up with `cd mock-server && docker compose down`.
 
+Do not add unit tests for generator contracts that should be exercised through the generated SDKs. Add or extend the relevant e2e fixture and language paths instead.
+
 ```bash
 vendor/bin/phpunit tests/e2e/PHP85Test.php # one language e2e (needs Docker)
 ```

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -1504,7 +1504,23 @@ class SDK
 
     protected function methodType(Operation $operation): string|false
     {
-        return $operation->extensions['x-appwrite']['type'] ?? false;
+        $type = $operation->extensions['x-appwrite']['type'] ?? '';
+        if (\is_string($type) && $type !== '') {
+            return $type;
+        }
+
+        $schema = $operation->requestBody?->content[self::MULTIPART_MEDIA_TYPE]?->schema ?? null;
+        if (!$schema instanceof ObjectSchema) {
+            return false;
+        }
+
+        foreach ($schema->properties as $property) {
+            if ($property instanceof StringSchema && $property->format === 'binary') {
+                return 'upload';
+            }
+        }
+
+        return false;
     }
 
     protected function uploadIdParameter(Operation $operation): ?Parameter

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -2154,7 +2154,6 @@
         "x-appwrite": {
           "weight": 277,
           "cookies": false,
-          "type": "",
           "demo": "general\/upload.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a file upload request.",
           "rate-limit": 0,


### PR DESCRIPTION
## Summary

- infer upload methods from a standard `multipart/form-data` request body containing a binary string property
- retain `x-appwrite.type` as a backwards-compatible fallback for non-standard method behavior
- remove the redundant empty type from the upload e2e fixture
- document that generated SDK contracts should be covered through e2e paths rather than unit tests

## Validation

- `composer lint`
- `composer refactor:check`
- regenerated Go, Dart, Flutter, and Rust fixtures
- confirmed legacy `x-appwrite.type: upload` and inferred upload specifications generate identical trees for those SDKs
- `gofmt` check for generated Go SDK
- `cargo +1.83.0 fmt --check --all` for generated Rust SDK

Related to [CLO-4377](https://linear.app/appwrite/issue/CLO-4377/openapi3-standards).
