### PR TITLE
Infer SDK method types from OpenAPI

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -450,16 +450,16 @@
         },
         {
             "name": "utopia-php/openapi",
-            "version": "0.2.0",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/openapi.git",
-                "reference": "d74fe62fcb16f810986ad91a2727604e5f83e63e"
+                "reference": "725109d69e298ae8d88f1ffc05f6d86624233abd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/openapi/zipball/d74fe62fcb16f810986ad91a2727604e5f83e63e",
-                "reference": "d74fe62fcb16f810986ad91a2727604e5f83e63e",
+                "url": "https://api.github.com/repos/utopia-php/openapi/zipball/725109d69e298ae8d88f1ffc05f6d86624233abd",
+                "reference": "725109d69e298ae8d88f1ffc05f6d86624233abd",
                 "shasum": ""
             },
             "require": {
@@ -484,9 +484,9 @@
             "description": "Framework-independent OpenAPI 2.0, 3.0, and 3.1 parser with an immutable canonical model",
             "support": {
                 "issues": "https://github.com/utopia-php/openapi/issues",
-                "source": "https://github.com/utopia-php/openapi/tree/0.2.0"
+                "source": "https://github.com/utopia-php/openapi/tree/0.2.1"
             },
-            "time": "2026-08-21T04:56:47+00:00"
+            "time": "2026-09-04T16:56:24+00:00"
         }
     ],
     "packages-dev": [

--- a/src/SDK/Language.php
+++ b/src/SDK/Language.php
@@ -130,16 +130,20 @@ abstract class Language
     /**
      * Derive SDK transport behavior from standard OpenAPI operation fields.
      */
-    public function getMethodType(Operation $operation): string|false
+    public function getMethodType(Operation $operation, ?Specification $spec = null): string|false
     {
         $type = $operation->extensions['x-appwrite']['type'] ?? '';
         if (\is_string($type) && $type !== '') {
             return $type;
         }
 
-        $requestSchema = $operation->requestBody?->content[self::MULTIPART_MEDIA_TYPE]?->schema ?? null;
+        $requestSchema = $this->resolveSchema(
+            $operation->requestBody?->content[self::MULTIPART_MEDIA_TYPE]?->schema ?? null,
+            $spec,
+        );
         if ($requestSchema instanceof ObjectSchema) {
             foreach ($requestSchema->properties as $property) {
+                $property = $this->resolveSchema($property, $spec);
                 if ($property instanceof StringSchema && $property->format === 'binary') {
                     return 'upload';
                 }
@@ -153,10 +157,11 @@ abstract class Language
         foreach ($operation->responses as $status => $response) {
             $status = (int) $status;
             foreach ($response->content as $contentType => $mediaType) {
+                $schema = $this->resolveSchema($mediaType->schema, $spec);
                 if (
                     \str_contains(\strtolower($contentType), 'json')
-                    || !$mediaType->schema instanceof StringSchema
-                    || $mediaType->schema->format !== 'binary'
+                    || !$schema instanceof StringSchema
+                    || $schema->format !== 'binary'
                 ) {
                     continue;
                 }
@@ -170,6 +175,20 @@ abstract class Language
         }
 
         return false;
+    }
+
+    private function resolveSchema(?Schema $schema, ?Specification $spec): ?Schema
+    {
+        $visited = [];
+        while ($schema instanceof ReferenceSchema && $spec instanceof Specification) {
+            $name = $this->normalizeSchemaReference($schema->reference);
+            if (isset($visited[$name]) || !isset($spec->schemas[$name])) {
+                break;
+            }
+            $visited[$name] = true;
+            $schema = $spec->schemas[$name];
+        }
+        return $schema;
     }
 
     /**

--- a/src/SDK/Language.php
+++ b/src/SDK/Language.php
@@ -13,6 +13,7 @@ use Utopia\OpenAPI\Model\ObjectSchema;
 use Utopia\OpenAPI\Model\Operation;
 use Utopia\OpenAPI\Model\Parameter;
 use Utopia\OpenAPI\Model\ParameterLocation;
+use Utopia\OpenAPI\Model\ReferenceSchema;
 use Utopia\OpenAPI\Model\Schema;
 use Utopia\OpenAPI\Model\StringSchema;
 use Utopia\OpenAPI\Specification;

--- a/src/SDK/Language.php
+++ b/src/SDK/Language.php
@@ -20,6 +20,8 @@ use Utopia\OpenAPI\Specification;
 
 abstract class Language
 {
+    private const string MULTIPART_MEDIA_TYPE = 'multipart/form-data';
+
     public const TYPE_INTEGER = 'integer';
     public const TYPE_NUMBER = 'number';
     public const TYPE_STRING = 'string';
@@ -123,6 +125,47 @@ abstract class Language
         }
 
         return \lcfirst(\substr($operation->id, \strlen($serviceName)));
+    }
+
+    /**
+     * Derive SDK transport behavior from standard OpenAPI operation fields.
+     */
+    public function getMethodType(Operation $operation): string|false
+    {
+        $type = $operation->extensions['x-appwrite']['type'] ?? '';
+        if (\is_string($type) && $type !== '') {
+            return $type;
+        }
+
+        $requestSchema = $operation->requestBody?->content[self::MULTIPART_MEDIA_TYPE]?->schema ?? null;
+        if ($requestSchema instanceof ObjectSchema) {
+            foreach ($requestSchema->properties as $property) {
+                if ($property instanceof StringSchema && $property->format === 'binary') {
+                    return 'upload';
+                }
+            }
+        }
+
+        if (\in_array('graphql', $operation->tags, true)) {
+            return 'graphql';
+        }
+
+        foreach ($operation->responses as $status => $response) {
+            $status = (int) $status;
+            foreach ($response->content as $mediaType) {
+                if (!$mediaType->schema instanceof StringSchema || $mediaType->schema->format !== 'binary') {
+                    continue;
+                }
+                if ($status >= 300 && $status < 400) {
+                    return 'webAuth';
+                }
+                if ($status >= 200 && $status < 300) {
+                    return 'location';
+                }
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/SDK/Language.php
+++ b/src/SDK/Language.php
@@ -132,11 +132,6 @@ abstract class Language
      */
     public function getMethodType(Operation $operation, ?Specification $spec = null): string|false
     {
-        $type = $operation->extensions['x-appwrite']['type'] ?? '';
-        if (\is_string($type) && $type !== '') {
-            return $type;
-        }
-
         $requestSchema = $operation->requestBody?->content[self::MULTIPART_MEDIA_TYPE]?->schema ?? null;
         if ($requestSchema !== null && $spec instanceof Specification) {
             $requestSchema = $spec->resolveSchema($requestSchema);

--- a/src/SDK/Language.php
+++ b/src/SDK/Language.php
@@ -13,7 +13,6 @@ use Utopia\OpenAPI\Model\ObjectSchema;
 use Utopia\OpenAPI\Model\Operation;
 use Utopia\OpenAPI\Model\Parameter;
 use Utopia\OpenAPI\Model\ParameterLocation;
-use Utopia\OpenAPI\Model\ReferenceSchema;
 use Utopia\OpenAPI\Model\Schema;
 use Utopia\OpenAPI\Model\StringSchema;
 use Utopia\OpenAPI\Specification;
@@ -137,13 +136,13 @@ abstract class Language
             return $type;
         }
 
-        $requestSchema = $this->resolveSchema(
-            $operation->requestBody?->content[self::MULTIPART_MEDIA_TYPE]?->schema ?? null,
-            $spec,
-        );
+        $requestSchema = $operation->requestBody?->content[self::MULTIPART_MEDIA_TYPE]?->schema ?? null;
+        if ($requestSchema !== null && $spec instanceof Specification) {
+            $requestSchema = $spec->resolveSchema($requestSchema);
+        }
         if ($requestSchema instanceof ObjectSchema) {
             foreach ($requestSchema->properties as $property) {
-                $property = $this->resolveSchema($property, $spec);
+                $property = $spec?->resolveSchema($property) ?? $property;
                 if ($property instanceof StringSchema && $property->format === 'binary') {
                     return 'upload';
                 }
@@ -157,7 +156,10 @@ abstract class Language
         foreach ($operation->responses as $status => $response) {
             $status = (int) $status;
             foreach ($response->content as $contentType => $mediaType) {
-                $schema = $this->resolveSchema($mediaType->schema, $spec);
+                $schema = $mediaType->schema;
+                if ($schema !== null && $spec instanceof Specification) {
+                    $schema = $spec->resolveSchema($schema);
+                }
                 if (
                     \str_contains(\strtolower($contentType), 'json')
                     || !$schema instanceof StringSchema
@@ -175,20 +177,6 @@ abstract class Language
         }
 
         return false;
-    }
-
-    private function resolveSchema(?Schema $schema, ?Specification $spec): ?Schema
-    {
-        $visited = [];
-        while ($schema instanceof ReferenceSchema && $spec instanceof Specification) {
-            $name = $this->normalizeSchemaReference($schema->reference);
-            if (isset($visited[$name]) || !isset($spec->schemas[$name])) {
-                break;
-            }
-            $visited[$name] = true;
-            $schema = $spec->schemas[$name];
-        }
-        return $schema;
     }
 
     /**

--- a/src/SDK/Language.php
+++ b/src/SDK/Language.php
@@ -152,8 +152,12 @@ abstract class Language
 
         foreach ($operation->responses as $status => $response) {
             $status = (int) $status;
-            foreach ($response->content as $mediaType) {
-                if (!$mediaType->schema instanceof StringSchema || $mediaType->schema->format !== 'binary') {
+            foreach ($response->content as $contentType => $mediaType) {
+                if (
+                    \str_contains(\strtolower($contentType), 'json')
+                    || !$mediaType->schema instanceof StringSchema
+                    || $mediaType->schema->format !== 'binary'
+                ) {
                     continue;
                 }
                 if ($status >= 300 && $status < 400) {

--- a/src/SDK/Language/Apple.php
+++ b/src/SDK/Language/Apple.php
@@ -514,7 +514,7 @@ class Apple extends Swift
     #[Override]
     protected function getReturnType(Operation $method, Specification $spec, string $generic = 'T'): string
     {
-        if (($method->extensions['x-appwrite']['type'] ?? '') === 'webAuth') {
+        if ($this->getMethodType($method) === 'webAuth') {
             return 'Bool';
         }
 

--- a/src/SDK/Language/Apple.php
+++ b/src/SDK/Language/Apple.php
@@ -514,7 +514,7 @@ class Apple extends Swift
     #[Override]
     protected function getReturnType(Operation $method, Specification $spec, string $generic = 'T'): string
     {
-        if ($this->getMethodType($method) === 'webAuth') {
+        if ($this->getMethodType($method, $spec) === 'webAuth') {
             return 'Bool';
         }
 

--- a/src/SDK/Language/Concern/CliCommandSurface.php
+++ b/src/SDK/Language/Concern/CliCommandSurface.php
@@ -371,7 +371,7 @@ trait CliCommandSurface
     protected function isCliGraphQLInput(Parameter $parameter, Operation $method, Tag $service): bool
     {
         return $service->name === 'graphql'
-            && ($method->extensions['x-appwrite']['type'] ?? '') === 'graphql'
+            && $this->getMethodType($method) === 'graphql'
             && $parameter->name === 'query';
     }
 
@@ -385,7 +385,7 @@ trait CliCommandSurface
             };
         }
 
-        if ($service->name === 'graphql' && ($method->extensions['x-appwrite']['type'] ?? '') === 'graphql') {
+        if ($service->name === 'graphql' && $this->getMethodType($method) === 'graphql') {
             return match ($this->getMethodName($method)) {
                 'query' => 'Execute a GraphQL query.',
                 'mutation' => 'Execute a GraphQL mutation.',

--- a/src/SDK/Language/Go.php
+++ b/src/SDK/Language/Go.php
@@ -442,7 +442,7 @@ class Go extends Language
 
     protected function getReturnType(Operation $method, Specification $spec, string $namespace, string $generic = 'map[string]interface{}'): string
     {
-        $type = $method->extensions['x-appwrite']['type'] ?? '';
+        $type = $this->getMethodType($method);
         if ($type === 'webAuth') {
             return 'bool';
         }

--- a/src/SDK/Language/Go.php
+++ b/src/SDK/Language/Go.php
@@ -442,7 +442,7 @@ class Go extends Language
 
     protected function getReturnType(Operation $method, Specification $spec, string $namespace, string $generic = 'map[string]interface{}'): string
     {
-        $type = $this->getMethodType($method);
+        $type = $this->getMethodType($method, $spec);
         if ($type === 'webAuth') {
             return 'bool';
         }

--- a/src/SDK/Language/Kotlin.php
+++ b/src/SDK/Language/Kotlin.php
@@ -673,7 +673,7 @@ class Kotlin extends Language
     {
         return [
             new TwigFilter('returnType', function (Operation $method, Specification $spec, string $namespace, string $generic = 'T'): string {
-                $methodType = $method->extensions['x-appwrite']['type'] ?? '';
+                $methodType = $this->getMethodType($method);
                 if ($methodType === 'webAuth') {
                     return 'String';
                 }

--- a/src/SDK/Language/Kotlin.php
+++ b/src/SDK/Language/Kotlin.php
@@ -673,7 +673,7 @@ class Kotlin extends Language
     {
         return [
             new TwigFilter('returnType', function (Operation $method, Specification $spec, string $namespace, string $generic = 'T'): string {
-                $methodType = $this->getMethodType($method);
+                $methodType = $this->getMethodType($method, $spec);
                 if ($methodType === 'webAuth') {
                     return 'String';
                 }

--- a/src/SDK/Language/Node.php
+++ b/src/SDK/Language/Node.php
@@ -64,7 +64,7 @@ class Node extends Web
     #[Override]
     public function getReturn(Operation $method, Specification $spec): string
     {
-        return match ($this->getMethodType($method)) {
+        return match ($this->getMethodType($method, $spec)) {
             'webAuth' => 'Promise<string>',
             'location' => 'Promise<ArrayBuffer>',
             default => parent::getReturn($method, $spec),

--- a/src/SDK/Language/Node.php
+++ b/src/SDK/Language/Node.php
@@ -64,7 +64,7 @@ class Node extends Web
     #[Override]
     public function getReturn(Operation $method, Specification $spec): string
     {
-        return match ($method->extensions['x-appwrite']['type'] ?? '') {
+        return match ($this->getMethodType($method)) {
             'webAuth' => 'Promise<string>',
             'location' => 'Promise<ArrayBuffer>',
             default => parent::getReturn($method, $spec),

--- a/src/SDK/Language/PHP.php
+++ b/src/SDK/Language/PHP.php
@@ -615,7 +615,7 @@ class PHP extends Language
 
     protected function getReturn(Operation $method, ?Specification $spec = null): string
     {
-        if ((\count($method->responses) === 1 && isset($method->responses[204])) || \in_array($this->getMethodType($method), ['location', 'webAuth'], true)) {
+        if ((\count($method->responses) === 1 && isset($method->responses[204])) || \in_array($this->getMethodType($method, $spec), ['location', 'webAuth'], true)) {
             return 'string';
         }
 

--- a/src/SDK/Language/PHP.php
+++ b/src/SDK/Language/PHP.php
@@ -615,7 +615,7 @@ class PHP extends Language
 
     protected function getReturn(Operation $method, ?Specification $spec = null): string
     {
-        if ((\count($method->responses) === 1 && isset($method->responses[204])) || \in_array($method->extensions['x-appwrite']['type'] ?? '', ['location', 'webAuth'], true)) {
+        if ((\count($method->responses) === 1 && isset($method->responses[204])) || \in_array($this->getMethodType($method), ['location', 'webAuth'], true)) {
             return 'string';
         }
 

--- a/src/SDK/Language/ReactNative.php
+++ b/src/SDK/Language/ReactNative.php
@@ -198,7 +198,7 @@ class ReactNative extends Web
     #[Override]
     public function getReturn(Operation $method, Specification $spec): string
     {
-        return match ($this->getMethodType($method)) {
+        return match ($this->getMethodType($method, $spec)) {
             'webAuth' => 'void | URL',
             'location' => 'Promise<ArrayBuffer>',
             default => parent::getReturn($method, $spec),

--- a/src/SDK/Language/ReactNative.php
+++ b/src/SDK/Language/ReactNative.php
@@ -198,7 +198,7 @@ class ReactNative extends Web
     #[Override]
     public function getReturn(Operation $method, Specification $spec): string
     {
-        return match ($method->extensions['x-appwrite']['type'] ?? '') {
+        return match ($this->getMethodType($method)) {
             'webAuth' => 'void | URL',
             'location' => 'Promise<ArrayBuffer>',
             default => parent::getReturn($method, $spec),

--- a/src/SDK/Language/Rust.php
+++ b/src/SDK/Language/Rust.php
@@ -518,7 +518,7 @@ class Rust extends Language
 
     protected function getReturnType(Operation $method): string
     {
-        return match ($method->extensions['x-appwrite']['type'] ?? '') {
+        return match ($this->getMethodType($method)) {
             'webAuth' => 'crate::error::Result<String>',
             'location' => 'crate::error::Result<Vec<u8>>',
             default => $this->getResponseReturnType($method),

--- a/src/SDK/Language/Rust.php
+++ b/src/SDK/Language/Rust.php
@@ -516,9 +516,9 @@ class Rust extends Language
         };
     }
 
-    protected function getReturnType(Operation $method): string
+    protected function getReturnType(Operation $method, Specification $spec): string
     {
-        return match ($this->getMethodType($method)) {
+        return match ($this->getMethodType($method, $spec)) {
             'webAuth' => 'crate::error::Result<String>',
             'location' => 'crate::error::Result<Vec<u8>>',
             default => $this->getResponseReturnType($method),
@@ -593,7 +593,7 @@ class Rust extends Language
             new TwigFilter("rustfmtChain", fn(string $suffix, int $indent, string $receiver): string => $this->rustfmtChain($indent, $receiver, $suffix), ["is_safe" => ["html"]]),
             new TwigFilter("rustfmtHeaderInsert", fn(string $valueExpr, int $indent, string $key): string => $this->rustfmtHeaderInsert($indent, $key, $valueExpr), ["is_safe" => ["html"]]),
             new TwigFilter("propertyType", fn(Schema $property, ?Specification $spec = null, string $generic = "serde_json::Value"): string => $this->getTypeName($property, $spec)),
-            new TwigFilter("returnType", fn(Operation $method, Specification $spec, string $namespace, string $generic = "serde_json::Value"): string => $this->getReturnType($method)),
+            new TwigFilter("returnType", fn(Operation $method, Specification $spec, string $namespace, string $generic = "serde_json::Value"): string => $this->getReturnType($method, $spec)),
             new TwigFilter("caseEnumKey", fn(string $value): string => $this->toPascalCase($value)),
             new TwigFilter("docsArgumentExample", function (Schema|Parameter $param, string $crateName): string {
                 if ($this->getSchemaType($param) === self::TYPE_FILE) {

--- a/src/SDK/Language/Swift.php
+++ b/src/SDK/Language/Swift.php
@@ -533,7 +533,7 @@ class Swift extends Language
 
     protected function getReturnType(Operation $method, Specification $spec, string $generic = 'T'): string
     {
-        $methodType = $this->getMethodType($method);
+        $methodType = $this->getMethodType($method, $spec);
         if ($methodType === 'webAuth') {
             return 'String?';
         }

--- a/src/SDK/Language/Swift.php
+++ b/src/SDK/Language/Swift.php
@@ -533,7 +533,7 @@ class Swift extends Language
 
     protected function getReturnType(Operation $method, Specification $spec, string $generic = 'T'): string
     {
-        $methodType = $method->extensions['x-appwrite']['type'] ?? '';
+        $methodType = $this->getMethodType($method);
         if ($methodType === 'webAuth') {
             return 'String?';
         }

--- a/src/SDK/Language/Web.php
+++ b/src/SDK/Language/Web.php
@@ -409,7 +409,7 @@ class Web extends JS
 
     public function getReturn(Operation $method, Specification $spec): string
     {
-        $type = $method->extensions['x-appwrite']['type'] ?? '';
+        $type = $this->getMethodType($method);
         if ($type === 'webAuth') {
             return 'void | string';
         }

--- a/src/SDK/Language/Web.php
+++ b/src/SDK/Language/Web.php
@@ -409,7 +409,7 @@ class Web extends JS
 
     public function getReturn(Operation $method, Specification $spec): string
     {
-        $type = $this->getMethodType($method);
+        $type = $this->getMethodType($method, $spec);
         if ($type === 'webAuth') {
             return 'void | string';
         }

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -160,7 +160,7 @@ class SDK
             ? $this->language->getSuggestedEnumExample($value)
             : $this->language->getParamExample($value), ['is_safe' => ['html']]));
         $this->twig->addFilter(new TwigFilter('methodName', fn(Operation $operation): string => $this->methodName($operation)));
-        $this->twig->addFilter(new TwigFilter('methodType', fn(Operation $operation): string|false => $this->methodType($operation)));
+        $this->twig->addFilter(new TwigFilter('methodType', fn(Operation $operation): string|false => $this->language->getMethodType($operation, $this->spec)));
         $this->twig->addFilter(new TwigFilter('parameters', fn(Operation $operation, string $location = 'all'): array => $this->getOperationParameters($operation, $location)));
         $this->twig->addFilter(new TwigFilter('responseModel', fn(Operation $operation): string => $this->getResponseModel($operation)));
         $this->twig->addFilter(new TwigFilter('responseModels', fn(Operation $operation): array => $this->getValidResponseModels($operation)));
@@ -1166,7 +1166,7 @@ class SDK
             }
         }
 
-        return isset($excludeIndex['types'][$this->methodType($method) ?: '']);
+        return isset($excludeIndex['types'][$this->language->getMethodType($method, $this->spec) ?: '']);
     }
 
     protected function getExcludedDefinitions(): array
@@ -1292,7 +1292,7 @@ class SDK
             }
         }
 
-        if ($operation instanceof Operation && \in_array($this->methodType($operation), $types, true)) {
+        if ($operation instanceof Operation && \in_array($this->language->getMethodType($operation, $this->spec), $types, true)) {
             return true;
         }
         return \in_array($params['definitionName'] ?? '', $definitions, true);
@@ -1300,17 +1300,17 @@ class SDK
 
     protected function hasUploads(array $methods): bool
     {
-        return array_any($methods, fn(Operation $method): bool => $this->methodType($method) === 'upload');
+        return array_any($methods, fn(Operation $method): bool => $this->language->getMethodType($method, $this->spec) === 'upload');
     }
 
     protected function hasLocation(array $methods): bool
     {
-        return array_any($methods, fn(Operation $method): bool => $this->methodType($method) === 'location');
+        return array_any($methods, fn(Operation $method): bool => $this->language->getMethodType($method, $this->spec) === 'location');
     }
 
     protected function hasWebAuth(array $methods): bool
     {
-        return array_any($methods, fn(Operation $method): bool => $this->methodType($method) === 'webAuth');
+        return array_any($methods, fn(Operation $method): bool => $this->language->getMethodType($method, $this->spec) === 'webAuth');
     }
 
     protected function isConsoleOnly(string $serviceName): bool
@@ -1500,11 +1500,6 @@ class SDK
     protected function methodName(Operation $operation): string
     {
         return $this->language->getMethodName($operation);
-    }
-
-    protected function methodType(Operation $operation): string|false
-    {
-        return $this->language->getMethodType($operation, $this->spec);
     }
 
     protected function uploadIdParameter(Operation $operation): ?Parameter
@@ -1807,7 +1802,7 @@ class SDK
 
         // Insertion order is the emitted order, and the GraphQL marker comes
         // before the negotiated headers in every published SDK.
-        if ($this->methodType($operation) === 'graphql') {
+        if ($this->language->getMethodType($operation, $this->spec) === 'graphql') {
             $headers['x-sdk-graphql'] = 'true';
         }
 

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -1504,7 +1504,7 @@ class SDK
 
     protected function methodType(Operation $operation): string|false
     {
-        return $this->language->getMethodType($operation);
+        return $this->language->getMethodType($operation, $this->spec);
     }
 
     protected function uploadIdParameter(Operation $operation): ?Parameter

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -1504,23 +1504,7 @@ class SDK
 
     protected function methodType(Operation $operation): string|false
     {
-        $type = $operation->extensions['x-appwrite']['type'] ?? '';
-        if (\is_string($type) && $type !== '') {
-            return $type;
-        }
-
-        $schema = $operation->requestBody?->content[self::MULTIPART_MEDIA_TYPE]?->schema ?? null;
-        if (!$schema instanceof ObjectSchema) {
-            return false;
-        }
-
-        foreach ($schema->properties as $property) {
-            if ($property instanceof StringSchema && $property->format === 'binary') {
-                return 'upload';
-            }
-        }
-
-        return false;
+        return $this->language->getMethodType($operation);
     }
 
     protected function uploadIdParameter(Operation $operation): ?Parameter

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -35,7 +35,6 @@
         "x-appwrite": {
           "group": null,
           "cookies": false,
-          "type": "",
           "demo": "ping\/get.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -90,7 +89,6 @@
         "x-appwrite": {
           "weight": 270,
           "cookies": false,
-          "type": "",
           "demo": "bar\/get.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a get request.",
           "rate-limit": 0,
@@ -174,7 +172,6 @@
         "x-appwrite": {
           "weight": 271,
           "cookies": false,
-          "type": "",
           "demo": "bar\/post.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a post request.",
           "rate-limit": 0,
@@ -259,7 +256,6 @@
         "x-appwrite": {
           "weight": 273,
           "cookies": false,
-          "type": "",
           "demo": "bar\/put.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a put request.",
           "rate-limit": 0,
@@ -344,7 +340,6 @@
         "x-appwrite": {
           "weight": 272,
           "cookies": false,
-          "type": "",
           "demo": "bar\/patch.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a patch request.",
           "rate-limit": 0,
@@ -429,7 +424,6 @@
         "x-appwrite": {
           "weight": 274,
           "cookies": false,
-          "type": "",
           "demo": "bar\/delete.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a delete request.",
           "rate-limit": 0,
@@ -516,7 +510,6 @@
         "x-appwrite": {
           "weight": 300,
           "cookies": false,
-          "type": "",
           "demo": "general\/create-player.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterCreate a player with request model.",
           "rate-limit": 0,
@@ -588,7 +581,6 @@
         "x-appwrite": {
           "weight": 301,
           "cookies": false,
-          "type": "",
           "demo": "general\/create-players.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterCreate players with array of request models.",
           "rate-limit": 0,
@@ -663,7 +655,6 @@
         "x-appwrite": {
           "weight": 301,
           "cookies": false,
-          "type": "",
           "demo": "general\/excluded-method.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master",
           "rate-limit": 0,
@@ -743,7 +734,6 @@
         "x-appwrite": {
           "weight": 265,
           "cookies": false,
-          "type": "",
           "demo": "foo\/get.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a get request.",
           "rate-limit": 0,
@@ -827,7 +817,6 @@
         "x-appwrite": {
           "weight": 266,
           "cookies": false,
-          "type": "",
           "demo": "foo\/post.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a post request.",
           "rate-limit": 0,
@@ -912,7 +901,6 @@
         "x-appwrite": {
           "weight": 268,
           "cookies": false,
-          "type": "",
           "demo": "foo\/put.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a put request.",
           "rate-limit": 0,
@@ -997,7 +985,6 @@
         "x-appwrite": {
           "weight": 267,
           "cookies": false,
-          "type": "",
           "demo": "foo\/patch.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a patch request.",
           "rate-limit": 0,
@@ -1082,7 +1069,6 @@
         "x-appwrite": {
           "weight": 269,
           "cookies": false,
-          "type": "",
           "demo": "foo\/delete.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a delete request.",
           "rate-limit": 0,
@@ -1169,7 +1155,6 @@
         "x-appwrite": {
           "weight": 285,
           "cookies": false,
-          "type": "",
           "demo": "general\/error400.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a 400 failed request.",
           "rate-limit": 0,
@@ -1221,7 +1206,6 @@
         "x-appwrite": {
           "weight": 286,
           "cookies": false,
-          "type": "",
           "demo": "general\/error500.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a 500 failed request.",
           "rate-limit": 0,
@@ -1273,7 +1257,6 @@
         "x-appwrite": {
           "weight": 287,
           "cookies": false,
-          "type": "",
           "demo": "general\/error502.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a 502 bad gateway.",
           "rate-limit": 0,
@@ -1321,7 +1304,6 @@
         "x-appwrite": {
           "weight": 276,
           "cookies": false,
-          "type": "location",
           "demo": "general\/download.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a file download request.",
           "rate-limit": 0,
@@ -1375,7 +1357,6 @@
         "x-appwrite": {
           "weight": 282,
           "cookies": false,
-          "type": "",
           "demo": "general\/empty.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock an empty response.",
           "rate-limit": 0,
@@ -1420,7 +1401,6 @@
         "x-appwrite": {
           "weight": 284,
           "cookies": false,
-          "type": "",
           "demo": "general\/list-rows.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a queryable list request.",
           "rate-limit": 0,
@@ -1486,7 +1466,6 @@
         "x-appwrite": {
           "weight": 284,
           "cookies": false,
-          "type": "",
           "demo": "general\/enum.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock an enum parameter.",
           "rate-limit": 0,
@@ -1639,7 +1618,6 @@
         "x-appwrite": {
           "weight": 281,
           "cookies": false,
-          "type": "",
           "demo": "general\/get-cookie.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a cookie response.",
           "rate-limit": 0,
@@ -1691,7 +1669,6 @@
         "x-appwrite": {
           "weight": 275,
           "cookies": false,
-          "type": "",
           "demo": "general\/headers.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterReturn headers from the request",
           "rate-limit": 0,
@@ -1748,7 +1725,6 @@
         "x-appwrite": {
           "weight": 283,
           "cookies": false,
-          "type": "",
           "demo": "general\/nullable.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a nullable parameter.",
           "rate-limit": 0,
@@ -1834,7 +1810,6 @@
         "x-appwrite": {
           "weight": 1,
           "cookies": false,
-          "type": "",
           "demo": "functions\/create-execution.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterCreate a new function execution.",
           "rate-limit": 0,
@@ -1938,7 +1913,6 @@
         "x-appwrite": {
           "weight": 278,
           "cookies": false,
-          "type": "",
           "demo": "general\/redirect.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a redirect request.",
           "rate-limit": 0,
@@ -1986,7 +1960,6 @@
         "x-appwrite": {
           "weight": 279,
           "cookies": false,
-          "type": "",
           "demo": "general\/redirected.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a redirected request.",
           "rate-limit": 0,
@@ -2038,7 +2011,6 @@
         "x-appwrite": {
           "weight": 280,
           "cookies": false,
-          "type": "",
           "demo": "general\/get-path.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock an encoded path parameter request.",
           "rate-limit": 0,
@@ -2102,7 +2074,6 @@
         "x-appwrite": {
           "weight": 280,
           "cookies": false,
-          "type": "",
           "demo": "general\/set-cookie.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a set cookie request.",
           "rate-limit": 0,
@@ -2290,7 +2261,6 @@
         "x-appwrite": {
           "weight": 265,
           "cookies": false,
-          "type": "webAuth",
           "demo": "general\/oauth2.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a oauth2 request.",
           "rate-limit": 10,
@@ -2322,7 +2292,15 @@
         ],
         "responses": {
           "301": {
-            "description": "No content"
+            "description": "No content",
+            "content": {
+              "text\/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
           }
         },
         "parameters": [
@@ -2393,7 +2371,6 @@
         "x-appwrite": {
           "weight": 302,
           "cookies": false,
-          "type": "",
           "demo": "mock\/get-union.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master",
           "rate-limit": 0,
@@ -2471,7 +2448,6 @@
         "x-appwrite": {
           "weight": 303,
           "cookies": false,
-          "type": "",
           "demo": "zzexcludedservice\/get.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master",
           "rate-limit": 0,
@@ -2520,7 +2496,6 @@
         "x-appwrite": {
           "weight": 304,
           "cookies": false,
-          "type": "",
           "demo": "zzexcludedservice\/post.md",
           "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master",
           "rate-limit": 0,

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -2437,6 +2437,72 @@
         ]
       }
     },
+    "\/mock\/tests\/graphql": {
+      "post": {
+        "summary": "GraphQL query",
+        "operationId": "graphqlQuery",
+        "tags": [
+          "graphql"
+        ],
+        "description": "Execute a GraphQL query.",
+        "x-appwrite": {
+          "weight": 302,
+          "cookies": false,
+          "demo": "graphql\/query.md",
+          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master",
+          "rate-limit": 0,
+          "rate-time": 3600,
+          "rate-key": "url:{url},ip:{ip}",
+          "scope": "public",
+          "platforms": [
+            "client",
+            "server"
+          ],
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
+        },
+        "security": [
+          {
+            "Project": [],
+            "Key": [],
+            "JWT": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "GraphQL response",
+            "content": {
+              "application\/json": {
+                "schema": {
+                  "$ref": "#\/components\/schemas\/mock"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application\/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "description": "GraphQL document.",
+                    "example": "query { __typename }"
+                  }
+                },
+                "required": [
+                  "query"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
     "\/mock\/tests\/zzexcludedservice": {
       "get": {
         "summary": "Get Excluded Fixture",


### PR DESCRIPTION
## Summary

- infer all SDK-specific method types from standard OpenAPI operation fields
- centralize method-type resolution in the base language implementation
- replace direct `x-appwrite.type` reads across language and CLI code
- remove `x-appwrite.type` completely from the e2e specification fixture
- remove the legacy `x-appwrite.type` fallback so method behavior is determined exclusively from standard OpenAPI fields

## Inference

- `upload`: multipart request containing a binary string property
- `location`: successful response containing a binary string schema
- `webAuth`: redirect response containing a binary string schema
- `graphql`: operation tagged `graphql`

## Validation

- `composer lint`
- `composer refactor:check`
- `composer lint-twig`
- regenerated PHP, Web, Node, Ruby, Python, Dart, Flutter, React Native, Go, Swift, Apple, .NET, Android, Kotlin, Rust, and CLI SDKs
- confirmed the extension-backed and inferred e2e specifications generate identical trees for all targets above
- removed every type extension from generated Appwrite client, server, and console specs and confirmed output parity for Web, Node, Go, and CLI
- confirmed inferred method counts against the production specifications for upload, location, webAuth, and GraphQL operations
- verified generated Go/CLI with `gofmt` and generated Rust with rustfmt 1.83.0

This enables a follow-up Appwrite PR to remove `x-appwrite.type` from generated specifications entirely.

Related to [CLO-4377](https://linear.app/appwrite/issue/CLO-4377/openapi3-standards).

