### PR TITLE
Remove x-appwrite.edit from OpenAPI fixture

### DIFF
--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -88,7 +88,6 @@
         "x-appwrite": {
           "weight": 270,
           "demo": "bar\/get.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a get request.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -170,7 +169,6 @@
         "x-appwrite": {
           "weight": 271,
           "demo": "bar\/post.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a post request.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -253,7 +251,6 @@
         "x-appwrite": {
           "weight": 273,
           "demo": "bar\/put.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a put request.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -336,7 +333,6 @@
         "x-appwrite": {
           "weight": 272,
           "demo": "bar\/patch.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a patch request.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -419,7 +415,6 @@
         "x-appwrite": {
           "weight": 274,
           "demo": "bar\/delete.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a delete request.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -504,7 +499,6 @@
         "x-appwrite": {
           "weight": 300,
           "demo": "general\/create-player.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterCreate a player with request model.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -574,7 +568,6 @@
         "x-appwrite": {
           "weight": 301,
           "demo": "general\/create-players.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterCreate players with array of request models.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -647,7 +640,6 @@
         "x-appwrite": {
           "weight": 301,
           "demo": "general\/excluded-method.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -725,7 +717,6 @@
         "x-appwrite": {
           "weight": 265,
           "demo": "foo\/get.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a get request.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -807,7 +798,6 @@
         "x-appwrite": {
           "weight": 266,
           "demo": "foo\/post.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a post request.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -890,7 +880,6 @@
         "x-appwrite": {
           "weight": 268,
           "demo": "foo\/put.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a put request.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -973,7 +962,6 @@
         "x-appwrite": {
           "weight": 267,
           "demo": "foo\/patch.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a patch request.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -1056,7 +1044,6 @@
         "x-appwrite": {
           "weight": 269,
           "demo": "foo\/delete.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a delete request.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -1141,7 +1128,6 @@
         "x-appwrite": {
           "weight": 285,
           "demo": "general\/error400.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a 400 failed request.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -1191,7 +1177,6 @@
         "x-appwrite": {
           "weight": 286,
           "demo": "general\/error500.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a 500 failed request.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -1241,7 +1226,6 @@
         "x-appwrite": {
           "weight": 287,
           "demo": "general\/error502.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a 502 bad gateway.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -1287,7 +1271,6 @@
         "x-appwrite": {
           "weight": 276,
           "demo": "general\/download.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a file download request.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -1339,7 +1322,6 @@
         "x-appwrite": {
           "weight": 282,
           "demo": "general\/empty.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock an empty response.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -1382,7 +1364,6 @@
         "x-appwrite": {
           "weight": 284,
           "demo": "general\/list-rows.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a queryable list request.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -1446,7 +1427,6 @@
         "x-appwrite": {
           "weight": 284,
           "demo": "general\/enum.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock an enum parameter.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -1597,7 +1577,6 @@
         "x-appwrite": {
           "weight": 281,
           "demo": "general\/get-cookie.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a cookie response.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -1647,7 +1626,6 @@
         "x-appwrite": {
           "weight": 275,
           "demo": "general\/headers.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterReturn headers from the request",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -1702,7 +1680,6 @@
         "x-appwrite": {
           "weight": 283,
           "demo": "general\/nullable.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a nullable parameter.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -1786,7 +1763,6 @@
         "x-appwrite": {
           "weight": 1,
           "demo": "functions\/create-execution.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterCreate a new function execution.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -1888,7 +1864,6 @@
         "x-appwrite": {
           "weight": 278,
           "demo": "general\/redirect.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a redirect request.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -1934,7 +1909,6 @@
         "x-appwrite": {
           "weight": 279,
           "demo": "general\/redirected.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a redirected request.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -1984,7 +1958,6 @@
         "x-appwrite": {
           "weight": 280,
           "demo": "general\/get-path.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock an encoded path parameter request.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -2046,7 +2019,6 @@
         "x-appwrite": {
           "weight": 280,
           "demo": "general\/set-cookie.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a set cookie request.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -2096,7 +2068,6 @@
         "x-appwrite": {
           "weight": 277,
           "demo": "general\/upload.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a file upload request.",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -2231,7 +2202,6 @@
         "x-appwrite": {
           "weight": 265,
           "demo": "general\/oauth2.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/masterMock a oauth2 request.",
           "rate-limit": 10,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -2340,7 +2310,6 @@
         "x-appwrite": {
           "weight": 302,
           "demo": "mock\/get-union.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -2416,7 +2385,6 @@
         "x-appwrite": {
           "weight": 302,
           "demo": "graphql\/query.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -2481,7 +2449,6 @@
         "x-appwrite": {
           "weight": 303,
           "demo": "zzexcludedservice\/get.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",
@@ -2528,7 +2495,6 @@
         "x-appwrite": {
           "weight": 304,
           "demo": "zzexcludedservice\/post.md",
-          "edit": "https:\/\/github.com\/appwrite\/appwrite\/edit\/master",
           "rate-limit": 0,
           "rate-time": 3600,
           "rate-key": "url:{url},ip:{ip}",


### PR DESCRIPTION
## Summary

- remove the unused `x-appwrite.edit` metadata from the OpenAPI fixture
- verify SDK generation does not depend on source-edit URLs

Neither SDK Generator nor the current documentation API explorer consumes this field.

Related to [CLO-4377](https://linear.app/appwrite/issue/CLO-4377/openapi3-standards).

## Validation

- `composer lint`
- `composer refactor:check`
- `composer lint-twig`
- generated every SDK from the fixture before and after removal
- confirmed all generated SDK trees are identical