### PR TITLE
chore: generate examples from the 2.0.x specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ php example.php <target> <platform> <format>
 
 `<platform>` can be `console`, `client`, or `server`. If omitted, it defaults to `console`.
 
-`<format>` can be `openapi3` or `swagger2`. If omitted, it defaults to `openapi3`. Both formats produce identical SDKs.
+`<format>` can be `openapi3` or `swagger2`. If omitted, it defaults to `openapi3`. Remote OpenAPI 3 generation uses the current `2.0.x` specs; because Swagger 2 documents are not published for `2.0.x`, remote Swagger 2 generation uses the latest available `1.8.x` specs.
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ use Appwrite\SDK\Language\PHP;
 use Utopia\OpenAPI\Parser;
 
 // Parse an OpenAPI 2, 3.0, or 3.1 document into the canonical specification model.
-$version = '1.9.x';
+$version = '2.0.x';
 $platform = 'server';
 $content = file_get_contents("https://raw.githubusercontent.com/appwrite/specs/main/specs/{$version}/open-api3-{$version}-{$platform}.json");
 $spec = Parser::parse($content);
@@ -86,7 +86,7 @@ $spec = Parser::parse([
     'info' => [
         'title' => 'Appwrite',
         'description' => 'Appwrite backend as a service',
-        'version' => '1.9.x',
+        'version' => '2.0.x',
         'license' => [
             'name' => 'BSD-3-Clause',
             'url' => 'https://raw.githubusercontent.com/appwrite/appwrite/master/LICENSE',
@@ -99,7 +99,7 @@ $sdk = new SDK(new Skills(), $spec);
 
 $sdk
     ->setName('Appwrite')
-    ->setVersion('1.9.x')
+    ->setVersion('2.0.x')
 ;
 
 $sdk->generate(__DIR__ . '/examples/skills');

--- a/example.php
+++ b/example.php
@@ -33,6 +33,7 @@ use Appwrite\SDK\Language\ZedExtension;
 final class Config
 {
     public const string VERSION = '2.0.x';
+    public const string SWAGGER2_VERSION = '1.8.x';
     public const string SPECS_URL = 'https://raw.githubusercontent.com/appwrite/specs/main/specs';
     public const string TITLE = 'Appwrite';
     public const string DESCRIPTION = 'Appwrite backend as a service';
@@ -154,7 +155,7 @@ try {
         throw new Exception("Unsupported spec format: $specFormat (expected 'openapi3' or 'swagger2')");
     }
 
-    $version = Config::VERSION;
+    $version = $specFormat === 'swagger2' ? Config::SWAGGER2_VERSION : Config::VERSION;
     $sdkTargets = [
         'php',
         'unity',

--- a/example.php
+++ b/example.php
@@ -32,7 +32,7 @@ use Appwrite\SDK\Language\ZedExtension;
 
 final class Config
 {
-    public const string VERSION = '1.9.x';
+    public const string VERSION = '2.0.x';
     public const string SPECS_URL = 'https://raw.githubusercontent.com/appwrite/specs/main/specs';
     public const string TITLE = 'Appwrite';
     public const string DESCRIPTION = 'Appwrite backend as a service';


### PR DESCRIPTION
## Summary

- point `example.php` and the README at the `2.0.x` OpenAPI 3 specs published in appwrite/specs
- self-hosted 2.0.0 is the current release, so local example generation should track it instead of 1.9.x

Only the OpenAPI 3 documents are published for 2.0.x. The `swagger2` format option in `example.php` still works for older versions but has no 2.0.x document to fetch.

Related to [CLO-4766](https://linear.app/appwrite/issue/CLO-4766/prepare-self-hosted-20-release).

## Validation

- regenerated Web (client), Go (server), PHP (server), and CLI from the 2.0.x specs
- `gofmt -l` clean for Go and CLI output
- CLI: `go build ./... && go vet ./... && go test ./...` pass