### PR TITLE
Remove offline and global attribute extensions from OpenAPI fixture

### DIFF
--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -98,9 +98,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -179,9 +176,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "\/mock\/tests\/bar",
-          "offline-key": "{required}",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -261,9 +255,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -343,9 +334,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -425,9 +413,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -509,9 +494,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -578,9 +560,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -649,9 +628,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           },
@@ -727,9 +703,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -808,9 +781,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -890,9 +860,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -972,9 +939,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -1054,9 +1018,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -1138,9 +1099,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -1187,9 +1145,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -1234,9 +1189,6 @@
             "client"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -1281,9 +1233,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": [],
             "ImpersonateUserId": []
@@ -1332,9 +1281,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -1374,9 +1320,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -1437,9 +1380,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -1587,9 +1527,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -1636,9 +1573,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -1690,9 +1624,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -1771,9 +1702,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -1874,9 +1802,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           },
@@ -1919,9 +1844,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -1968,9 +1890,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -2029,9 +1948,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -2078,9 +1994,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -2212,9 +2125,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           },
@@ -2319,9 +2229,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -2458,9 +2365,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -2504,9 +2408,6 @@
             "server"
           ],
           "packaging": false,
-          "offline-model": "",
-          "offline-key": "",
-          "offline-response-key": "$id",
           "auth": {
             "Project": []
           }
@@ -2556,85 +2457,67 @@
   "tags": [
     {
       "name": "account",
-      "description": "The Account service allows you to authenticate and manage a user account.",
-      "x-globalAttributes": []
+      "description": "The Account service allows you to authenticate and manage a user account."
     },
     {
       "name": "avatars",
-      "description": "The Avatars service aims to help you complete everyday tasks related to your app image, icons, and avatars.",
-      "x-globalAttributes": []
+      "description": "The Avatars service aims to help you complete everyday tasks related to your app image, icons, and avatars."
     },
     {
       "name": "databases",
-      "description": "The Databases service allows you to create structured collections of documents, query and filter lists of documents",
-      "x-globalAttributes": [
-        "databaseId"
-      ]
+      "description": "The Databases service allows you to create structured collections of documents, query and filter lists of documents"
     },
     {
       "name": "locale",
-      "description": "The Locale service allows you to customize your app based on your users' location.",
-      "x-globalAttributes": []
+      "description": "The Locale service allows you to customize your app based on your users' location."
     },
     {
       "name": "health",
-      "description": "The Health service allows you to both validate and monitor your Appwrite server's health.",
-      "x-globalAttributes": []
+      "description": "The Health service allows you to both validate and monitor your Appwrite server's health."
     },
     {
       "name": "projects",
-      "description": "The Project service allows you to manage all the projects in your Appwrite server.",
-      "x-globalAttributes": []
+      "description": "The Project service allows you to manage all the projects in your Appwrite server."
     },
     {
       "name": "project",
-      "description": "The Project service allows you to manage all the projects in your Appwrite server.",
-      "x-globalAttributes": []
+      "description": "The Project service allows you to manage all the projects in your Appwrite server."
     },
     {
       "name": "storage",
-      "description": "The Storage service allows you to manage your project files.",
-      "x-globalAttributes": []
+      "description": "The Storage service allows you to manage your project files."
     },
     {
       "name": "teams",
-      "description": "The Teams service allows you to group users of your project and to enable them to share read and write access to your project resources",
-      "x-globalAttributes": []
+      "description": "The Teams service allows you to group users of your project and to enable them to share read and write access to your project resources"
     },
     {
       "name": "users",
-      "description": "The Users service allows you to manage your project users.",
-      "x-globalAttributes": []
+      "description": "The Users service allows you to manage your project users."
     },
     {
       "name": "functions",
-      "description": "The Functions Service allows you view, create and manage your Cloud Functions.",
-      "x-globalAttributes": []
+      "description": "The Functions Service allows you view, create and manage your Cloud Functions."
     },
     {
       "name": "proxy",
-      "description": "The Proxy Service allows you to configure actions for your domains beyond DNS configuration.",
-      "x-globalAttributes": []
+      "description": "The Proxy Service allows you to configure actions for your domains beyond DNS configuration."
     },
     {
       "name": "graphql",
-      "description": "The GraphQL API allows you to query and mutate your Appwrite server using GraphQL.",
-      "x-globalAttributes": []
+      "description": "The GraphQL API allows you to query and mutate your Appwrite server using GraphQL."
     },
     {
       "name": "console",
-      "description": "The Console service allows you to interact with console relevant informations.",
-      "x-globalAttributes": []
+      "description": "The Console service allows you to interact with console relevant informations."
     },
     {
       "name": "migrations",
-      "description": "The Migrations service allows you to migrate third-party data to your Appwrite project.",
-      "x-globalAttributes": []
+      "description": "The Migrations service allows you to migrate third-party data to your Appwrite project."
     },
     {
       "name": "zzexcludedservice",
-      "description": "Fixture-only excluded service used by tests.",
-      "x-globalAttributes": []
+      "description": "Fixture-only excluded service used by tests."
     }
   ],
   "components": {


### PR DESCRIPTION
## Summary

- remove `x-appwrite.offline-key`, `x-appwrite.offline-model`, and `x-appwrite.offline-response-key` from the e2e OpenAPI fixture
- remove the tag-level `x-globalAttributes` extension from the same fixture

None of these fields are emitted by the Appwrite OpenAPI producer any more (verified against the published 2.0.x client, server, and console specs), and SDK Generator, the documentation API explorer, and the website reference pages have no reads for them.

Related to [CLO-4377](https://linear.app/appwrite/issue/CLO-4377/openapi3-standards).

## Validation

- `composer lint`
- `composer refactor:check`
- generated every SDK from the fixture for the console, server, and client platforms before and after the removal
- confirmed all generated SDK trees are identical