### PR TITLE
Resolve request model parameters through schema references

### DIFF
--- a/src/SDK/Language.php
+++ b/src/SDK/Language.php
@@ -401,16 +401,8 @@ abstract class Language
 
     protected function getSchemaModel(Schema|Parameter $value): ?string
     {
-        $schema = $this->getSchema($value);
-        $models = $this->getSchemaModels($schema);
-        if (\count($models) === 1) {
-            return $models[0];
-        }
-        if ($schema instanceof ArraySchema) {
-            return $schema->items->extensions['x-model'] ?? $schema->extensions['x-model'] ?? null;
-        }
-
-        return $schema->extensions['x-model'] ?? null;
+        $models = $this->getSchemaModels($value);
+        return \count($models) === 1 ? $models[0] : null;
     }
 
     protected function getArraySchemaModel(Schema|Parameter $value): ?string

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -1609,15 +1609,8 @@ class SDK
 
     protected function getSchemaModel(Schema|Parameter $value): string
     {
-        $schema = $this->getSchema($value);
-        $models = $this->getSchemaModels($schema);
-        if (\count($models) === 1) {
-            return $models[0];
-        }
-        if ($schema instanceof ArraySchema) {
-            return (string) ($schema->items->extensions['x-model'] ?? $schema->extensions['x-model'] ?? '');
-        }
-        return (string) ($schema->extensions['x-model'] ?? '');
+        $models = $this->getSchemaModels($value);
+        return \count($models) === 1 ? $models[0] : '';
     }
 
     /** @return list<string> */

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -542,9 +542,8 @@
                 "type": "object",
                 "properties": {
                   "player": {
-                    "type": "object",
+                    "$ref": "#\/components\/schemas\/player",
                     "description": "Player object.",
-                    "x-model": "player",
                     "default": null
                   }
                 },
@@ -613,7 +612,6 @@
                   "players": {
                     "type": "array",
                     "description": "Array of player objects.",
-                    "x-model": "player",
                     "default": null,
                     "items": {
                       "$ref": "#\/components\/schemas\/player"
@@ -691,9 +689,8 @@
                 "type": "object",
                 "properties": {
                   "payload": {
-                    "type": "object",
+                    "$ref": "#\/components\/schemas\/zzexcludedmethodpayload",
                     "description": "Excluded general fixture payload.",
-                    "x-model": "zzexcludedmethodpayload",
                     "default": null
                   }
                 },
@@ -2537,9 +2534,8 @@
                 "type": "object",
                 "properties": {
                   "payload": {
-                    "type": "object",
+                    "$ref": "#\/components\/schemas\/zzexcludedpayload",
                     "description": "Excluded fixture payload.",
-                    "x-model": "zzexcludedpayload",
                     "default": null
                   }
                 },

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -542,7 +542,11 @@
                 "type": "object",
                 "properties": {
                   "player": {
-                    "$ref": "#\/components\/schemas\/player",
+                    "allOf": [
+                      {
+                        "$ref": "#\/components\/schemas\/player"
+                      }
+                    ],
                     "description": "Player object.",
                     "default": null
                   }
@@ -689,7 +693,11 @@
                 "type": "object",
                 "properties": {
                   "payload": {
-                    "$ref": "#\/components\/schemas\/zzexcludedmethodpayload",
+                    "allOf": [
+                      {
+                        "$ref": "#\/components\/schemas\/zzexcludedmethodpayload"
+                      }
+                    ],
                     "description": "Excluded general fixture payload.",
                     "default": null
                   }
@@ -2534,7 +2542,11 @@
                 "type": "object",
                 "properties": {
                   "payload": {
-                    "$ref": "#\/components\/schemas\/zzexcludedpayload",
+                    "allOf": [
+                      {
+                        "$ref": "#\/components\/schemas\/zzexcludedpayload"
+                      }
+                    ],
                     "description": "Excluded fixture payload.",
                     "default": null
                   }


### PR DESCRIPTION
## Summary

- replace the non-standard `x-model` extension in the e2e OpenAPI fixture with a standard `$ref` to the request model schema
- remove the `x-model` fallbacks from the shared schema model helpers so model resolution only follows `$ref`, `items`, and composite members

The Appwrite OpenAPI producer never emitted `x-model` (verified against the published 2.0.x client, server, and console specs), so this only affects the fixture and the generator's legacy fallback.

## Output change

Go, PHP, and every array-typed request model parameter already resolved to the request model type. Web, Node, React Native, and Python typed object-valued request model parameters as `object` / `Dict[str, Any]` because their type resolution only followed `$ref`. With the fixture using a reference, those four now emit `Models.Player` / `Player`, matching the other languages and the array variants. Request bodies are unchanged. All other generated files are identical.

Related to [CLO-4377](https://linear.app/appwrite/issue/CLO-4377/openapi3-standards).

## Validation

- `composer lint`
- `composer refactor:check`
- generated every SDK from the fixture for console, server, and client before and after; only the Web, Node, React Native, and Python service files for the two request model methods differ, as described above
- Web, Node, and React Native: `npm run lint` and `npm run analyse` pass; the only Prettier warnings are pre-existing in the baseline output for the same fixture (`(Models.Player)[]` parenthesised arrays), tracked separately
- Python: `black --check` passes