### PR TITLE
fix: require OpenAPI parser 0.2.1 for schema resolution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "ext-mbstring": "*",
         "matthiasmullie/minify": "^1.3",
         "twig/twig": "^3.28",
-        "utopia-php/openapi": "^0.2.0"
+        "utopia-php/openapi": "^0.2.1"
     },
     "require-dev": {
         "brianium/paratest": "^7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "77e7a4731ea9da7386763085af21d33e",
+    "content-hash": "fc53280e54d5e462f425f4b12674b5b8",
     "packages": [
         {
             "name": "matthiasmullie/minify",


### PR DESCRIPTION
## Summary
- Raise the `utopia-php/openapi` requirement from `^0.2.0` to `^0.2.1`.
- Refresh only the Composer lock content hash; the lock already selects parser 0.2.1. No package versions, references, or other metadata change.

## Root cause
`Language::getMethodType()` calls `Specification::resolveSchema()` when inferring upload and binary-response transports. That API was added in parser 0.2.1, but the generator's published manifest still allows 0.2.0. Downstream consumers can therefore install an incompatible parser even though this repository's own lock masks the problem. The minimum requirement must match the API used, including storage preview URL inference.

## Validation
- `composer update --lock --no-install --no-plugins --no-scripts --no-interaction`: no dependency changes; no security advisories.
- `composer validate --strict`: valid.
- `composer install --no-plugins --no-scripts --no-interaction --prefer-dist` and `composer check-platform-reqs`: passed on PHP 8.5.10.
- Compared lock JSON before/after: content hash is the only change.
- `vendor/bin/phpunit tests/e2e/WebNodeTest.php`: passed, 1 test / 1449 assertions, using the existing generated SDK contract.
- `php example.php web console`: generated successfully from the current 2.0.x Console spec.
- Generated Web SDK: `npm ci && npm run format:check && npm run lint && npm run analyse && npm run build`: all passed.
- Built SDK smoke check: `Storage.getFilePreview` returns a synchronous URL string with the correct preview path, project, and width for both object and positional arguments.
- `git diff --check`: passed.

No templates or test fixtures changed; no new unit tests. The downstream Cloud lane independently pins released generator 4.7.8 and parser 0.2.1 and owns the published-artifact/Console-preview gate. This PR does not publish or deploy anything.