### PR TITLE
feat: select the SDK platform from x-appwrite.platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,26 @@ jobs:
       - name: Run Tests
         run: composer test tests/e2e/${{ matrix.sdk }}Test.php
 
+  generation:
+    name: Checks / Generation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup PHP with PECL extension
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: '8.5'
+          extensions: curl
+
+      - name: Install
+        run: composer install
+
+      - name: Run Tests
+        run: composer test -- --testsuite Generation
+
   lint:
     name: Checks / Lint
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .dart_tool
 /vendor/
 /tests/e2e/sdks
+/tests/generation/sdks
 /.vscode
 .vs
 .phpunit.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,12 +357,16 @@ composer update --ignore-platform-reqs --optimize-autoloader --no-plugins --no-s
 
 ## Running Tests
 
-The tests in `tests/e2e/` generate an SDK from `tests/resources/spec-openapi3.json` into `tests/e2e/sdks/` and run it in Docker against a mock API. Parser behavior is tested by `utopia-php/openapi` rather than this repository. The mock server (`./mock-server`) is started in `setUp()` and removed in `tearDown()` (`docker compose down`); after interrupted runs, clean up with `cd mock-server && docker compose down`.
+Both suites generate from the shared fixture `tests/resources/spec-openapi3.json`. Parser behavior is tested by `utopia-php/openapi` rather than this repository.
 
-Do not add unit tests for generator contracts that should be exercised through the generated SDKs. Add or extend the relevant e2e fixture and language paths instead.
+- **`tests/generation/`** proves the *shape* of what the generator emits: for every language and platform it generates into `tests/generation/sdks/` and checks the tree against declarative tables. Excluded fixtures must never appear, platform-bound fixtures (`x-appwrite.platforms` on operations, method aliases and security schemes) must appear on their platforms alone, enums must be declared, Go comments must not carry HTML entities. Fixture tokens are single lowercase `zz*` words so they survive every language's identifier casing. No Docker, runs in seconds.
+- **`tests/e2e/`** proves *behavior*: each language test generates into `tests/e2e/sdks/`, compiles the SDK in Docker and runs `tests/e2e/languages/<lang>` against the mock API, comparing the printed lines to `expectedOutput`. The mock server (`./mock-server`) is started in `setUp()` and removed in `tearDown()` (`docker compose down`); after interrupted runs, clean up with `cd mock-server && docker compose down`.
+
+Put a check where it belongs: something the SDK *does* goes in a language script and `expectedOutput`; something the tree *contains or lacks* goes in a `GenerationTest` table. Do not add unit tests for generator internals that either suite can express.
 
 ```bash
-vendor/bin/phpunit tests/e2e/PHP85Test.php # one language e2e (needs Docker)
+vendor/bin/phpunit --testsuite Generation   # every language, no Docker
+vendor/bin/phpunit tests/e2e/PHP85Test.php  # one language e2e (needs Docker)
 ```
 
 If local PHP is missing, is not the required version, or has extension issues, use the matching PHP Docker image as a fallback for that command.

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\E2E\\": "tests/e2e/"
+            "Tests\\E2E\\": "tests/e2e/",
+            "Tests\\Generation\\": "tests/generation/"
         }
     },
     "require": {

--- a/example.php
+++ b/example.php
@@ -114,9 +114,7 @@ try {
         if (isset($config['exclude'])) {
             $sdk->setExclude($config['exclude']);
         }
-        if (isset($config['platform'])) {
-            $sdk->setPlatform($config['platform']);
-        }
+        $sdk->setPlatform($config['platform'] ?? $GLOBALS['platform']);
 
         return $sdk;
     }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,6 +8,7 @@
 
     <!-- Exclude SDKs and resources for performance reasons -->
     <exclude-pattern>./tests/e2e/sdks</exclude-pattern>
+    <exclude-pattern>./tests/generation/sdks</exclude-pattern>
     <exclude-pattern>./tests/e2e/languages</exclude-pattern>
     <exclude-pattern>./tests/e2e/tmp</exclude-pattern>
     <exclude-pattern>./tests/resources</exclude-pattern>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,8 +5,13 @@
          bootstrap="vendor/autoload.php"
          colors="true">
     <testsuites>
+        <testsuite name="Generation">
+            <directory>./tests/generation/</directory>
+            <exclude>./tests/generation/sdks</exclude>
+        </testsuite>
         <testsuite name="E2E">
             <directory>./tests/e2e/</directory>
+            <exclude>./tests/e2e/sdks</exclude>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -20,6 +20,7 @@ return RectorConfig::configure()
     ->withSkipPath(__DIR__ . '/vendor')
     ->withSkipPath(__DIR__ . '/tests/resources')
     ->withSkipPath(__DIR__ . '/tests/e2e/sdks/*')
+    ->withSkipPath(__DIR__ . '/tests/generation/sdks/*')
     ->withPhpSets(php85: true)
     ->withPreparedSets(
         deadCode: true,

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -532,6 +532,10 @@ class SDK
 
         $operations = [];
         foreach ($this->spec->operations() as $operation) {
+            if (!$this->isAvailable($operation->extensions['x-appwrite']['platforms'] ?? null)) {
+                continue;
+            }
+
             $operation = $this->annotateSecurityPathParameters($operation);
             $aliases = $operation->extensions['x-appwrite']['methods'] ?? [];
             if (!\is_array($aliases) || $aliases === []) {
@@ -542,7 +546,7 @@ class SDK
             }
 
             foreach ($aliases as $alias) {
-                if (!\is_array($alias)) {
+                if (!\is_array($alias) || !$this->isAvailable($alias['platforms'] ?? null)) {
                     continue;
                 }
 
@@ -558,12 +562,33 @@ class SDK
         return $this->operationsByServiceCache = $operations;
     }
 
+    /**
+     * Whether an `x-appwrite.platforms` list admits the platform this SDK is
+     * generated for. Operations, method aliases and security schemes carry
+     * one; a missing list means available everywhere, as does generating
+     * without a platform.
+     */
+    protected function isAvailable(mixed $platforms): bool
+    {
+        $platform = $this->getParam('platform');
+
+        return $platform === '' || !\is_array($platforms) || \in_array($platform, $platforms, true);
+    }
+
+    /** A security scheme by name, or null when unknown or not offered on this platform. */
+    protected function getSecurityScheme(string $name): ?SecurityScheme
+    {
+        $scheme = $this->spec->securitySchemes[$name] ?? null;
+
+        return $scheme instanceof SecurityScheme && $this->isAvailable($scheme->extensions['x-appwrite']['platforms'] ?? null) ? $scheme : null;
+    }
+
     protected function annotateSecurityPathParameters(Operation $operation): Operation
     {
         $securityParameters = [];
         foreach ($operation->security[0]->schemes ?? [] as $schemeName => $scopes) {
-            $scheme = $this->spec->securitySchemes[$schemeName] ?? null;
-            if ($scheme === null || ($scheme->extensions['x-appwrite']['location'] ?? '') !== 'path') {
+            $scheme = $this->getSecurityScheme($schemeName);
+            if (!$scheme instanceof SecurityScheme || ($scheme->extensions['x-appwrite']['location'] ?? '') !== 'path') {
                 continue;
             }
             $parameterName = (string) ($scheme->extensions['x-appwrite']['param'] ?? $scheme->name ?? $schemeName);
@@ -1738,7 +1763,11 @@ class SDK
     protected function getGlobalHeaders(): array
     {
         $headers = [];
-        foreach ($this->spec->securitySchemes as $name => $scheme) {
+        foreach (\array_keys($this->spec->securitySchemes) as $name) {
+            $scheme = $this->getSecurityScheme($name);
+            if (!$scheme instanceof SecurityScheme) {
+                continue;
+            }
             if (
                 ($scheme->type === SecuritySchemeType::API_KEY && $scheme->location === ParameterLocation::HEADER)
                 || ($scheme->type === SecuritySchemeType::HTTP && $scheme->scheme === 'bearer')
@@ -1823,8 +1852,8 @@ class SDK
         $schemes = [];
         $pathSchemes = [];
         foreach (\array_keys($auth) as $name) {
-            $scheme = $this->spec->securitySchemes[$name] ?? null;
-            if ($scheme === null) {
+            $scheme = $this->getSecurityScheme((string) $name);
+            if (!$scheme instanceof SecurityScheme) {
                 continue;
             }
             if (($scheme->extensions['x-appwrite']['location'] ?? '') === 'path' && $scheme->name !== null) {
@@ -1841,8 +1870,8 @@ class SDK
     {
         $schemes = [];
         foreach ($operation->security[0]->schemes ?? [] as $name => $scopes) {
-            $scheme = $this->spec->securitySchemes[$name] ?? null;
-            if ($scheme === null) {
+            $scheme = $this->getSecurityScheme($name);
+            if (!$scheme instanceof SecurityScheme) {
                 continue;
             }
             if (($scheme->extensions['x-appwrite']['location'] ?? '') === 'path') {

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -315,6 +315,9 @@ class SDK
     public function setPlatform(string $platform): SDK
     {
         $this->setParam('platform', $platform);
+        $this->operationsByServiceCache = null;
+        $this->filteredServicesCache = null;
+        $this->filteredModelDataCache = null;
 
         return $this;
     }
@@ -786,6 +789,9 @@ class SDK
     {
         $clientMethods = [];
         foreach ($this->spec->operations() as $method) {
+            if (!$this->isAvailable($method->extensions['x-appwrite']['platforms'] ?? null)) {
+                continue;
+            }
             foreach ($method->tags as $serviceName) {
                 if ($this->isClientMethod($method, $serviceName)) {
                     $clientMethods[$serviceName][$this->methodName($method)] = $method;

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -6,13 +6,9 @@ namespace Tests\E2E;
 
 use Exception;
 use Override;
-use RecursiveIteratorIterator;
-use RecursiveDirectoryIterator;
-use FilesystemIterator;
 use Throwable;
 use Appwrite\SDK\Language;
 use Appwrite\SDK\SDK;
-use Utopia\OpenAPI\Model\StringSchema;
 use Utopia\OpenAPI\Parser;
 use PHPUnit\Framework\TestCase;
 use Twig\Error\LoaderError;
@@ -94,18 +90,6 @@ abstract class Base extends TestCase
 
     protected const LARGE_FILE_RESPONSES = [
         'POST:/v1/mock/tests/general/upload:passed',
-    ];
-
-    protected const EXCLUDED_FIXTURE_TOKENS = [
-        'zzexcludedservice',
-        'zzexcludedpayload',
-        'zzexcludedresult',
-        'zzexcludedstatus',
-        'zzexcludedchild',
-        'zzexcludedchildstatus',
-        'zzexcludedmethodpayload',
-        'zzexcludedmethodresult',
-        'zzexcludedmethodstatus',
     ];
 
     /**
@@ -476,9 +460,6 @@ abstract class Base extends TestCase
             throw new Exception('Failed to parse spec.');
         }
 
-        $this->assertOpenEnumsAllowAnyString();
-        $this->assertEnumKeysAreValid();
-
         $sdk = new SDK($this->getLanguage(), Parser::parse($spec));
 
         $sdk
@@ -519,9 +500,6 @@ abstract class Base extends TestCase
         $this->rmdirRecursive($dir);
 
         $sdk->generate(__DIR__ . '/sdks/' . $this->language);
-        $this->assertOpenEnumSuggestionsGenerated($dir);
-        $this->assertExcludedFixtureWasRemoved($dir);
-        $this->assertCommentsAreNotHtmlEscaped($dir);
 
         /**
          * Build SDK
@@ -578,164 +556,6 @@ abstract class Base extends TestCase
         }
     }
 
-    private function assertEnumKeysAreValid(): void
-    {
-        $specification = Parser::parse([
-            'openapi' => '3.1.0',
-            'info' => ['title' => 'test', 'version' => '1.0.0'],
-            'paths' => ['/test' => ['get' => [
-                'operationId' => 'testEnumKeys',
-                'parameters' => [
-                    ['name' => 'localized', 'in' => 'query', 'schema' => [
-                        'type' => 'string',
-                        'enum' => ['រាជធានី', 'ខេត្ត', 'Test'],
-                    ]],
-                    ['name' => 'annotated', 'in' => 'query', 'schema' => [
-                        'title' => 'ProvinceType',
-                        'oneOf' => [
-                            ['const' => 'រាជធានី', 'title' => 'Capital'],
-                            ['const' => 'ខេត្ត', 'title' => 'Province'],
-                            ['const' => 'Test', 'title' => 'Test'],
-                        ],
-                    ]],
-                    ['name' => 'unsafe', 'in' => 'query', 'schema' => [
-                        'type' => 'string',
-                        'enum' => ['123', '-'],
-                    ]],
-                ],
-                'responses' => ['200' => ['description' => 'ok']],
-            ]]],
-        ]);
-        [$localized, $annotated, $unsafe] = $specification->paths['/test']->operations['get']->parameters;
-        $language = $this->getLanguage();
-
-        $this->assertSame(['Value1', 'Value2', 'Test'], $language->resolveEnumKeys($localized));
-        $this->assertSame(['Capital', 'Province', 'Test'], $language->resolveEnumKeys($annotated));
-        $this->assertSame(['Value123', 'Value2'], $language->resolveEnumKeys($unsafe));
-    }
-
-    private function assertOpenEnumsAllowAnyString(): void
-    {
-        $enum = [
-            'title' => 'WebhookEvent',
-            'oneOf' => [
-                ['const' => 'user.created', 'title' => 'UserCreated'],
-                ['const' => 'user.updated', 'title' => 'UserUpdated'],
-            ],
-        ];
-        $specification = Parser::parse([
-            'openapi' => '3.1.0',
-            'info' => ['title' => 'test', 'version' => '1.0.0'],
-            'paths' => ['/test' => ['get' => [
-                'operationId' => 'testOpenEnums',
-                'parameters' => [
-                    ['name' => 'plainScalar', 'in' => 'query', 'schema' => ['type' => 'string']],
-                    ['name' => 'closedScalar', 'in' => 'query', 'schema' => $enum],
-                    ['name' => 'openScalar', 'in' => 'query', 'schema' => ['anyOf' => [$enum, ['type' => 'string']]]],
-                    ['name' => 'plainArray', 'in' => 'query', 'schema' => ['type' => 'array', 'items' => ['type' => 'string']]],
-                    ['name' => 'closedArray', 'in' => 'query', 'schema' => ['type' => 'array', 'items' => $enum]],
-                    ['name' => 'openArray', 'in' => 'query', 'schema' => ['type' => 'array', 'items' => ['anyOf' => [$enum, ['type' => 'string']]]]],
-                ],
-                'responses' => ['200' => ['description' => 'ok']],
-            ]]],
-        ]);
-        [$plainScalar, $closedScalar, $openScalar, $plainArray, $closedArray, $openArray] = $specification->paths['/test']->operations['get']->parameters;
-        $language = $this->getLanguage();
-        $permission = '["read(\\"any\\")"]';
-        $this->assertTrue($language->isPermissionString($permission));
-        $this->assertSame([[
-            'action' => 'read',
-            'role' => 'any',
-            'id' => null,
-            'innerRole' => null,
-        ]], $language->extractPermissionParts($permission));
-        foreach ([$closedScalar, $closedArray, $openScalar, $openArray] as $parameter) {
-            $enumSchema = $language->getEnumSchema($parameter);
-            $this->assertInstanceOf(StringSchema::class, $enumSchema);
-            $this->assertSame(['user.created', 'user.updated'], $enumSchema->enum);
-            $this->assertSame(['UserCreated', 'UserUpdated'], $enumSchema->enumKeys);
-            $this->assertSame('WebhookEvent', $enumSchema->enumName);
-        }
-        $this->assertFalse($language->isOpenStringEnum($closedScalar));
-        $this->assertFalse($language->isOpenStringEnum($closedArray));
-        $this->assertTrue($language->isOpenStringEnum($openScalar));
-        $this->assertTrue($language->isOpenStringEnum($openArray));
-        $this->assertTrue($language->usesEnumType($closedScalar));
-        $this->assertTrue($language->usesEnumType($closedArray));
-        $this->assertSame($language->keepsOpenEnumType(), $language->usesEnumType($openScalar));
-        $this->assertSame($language->keepsOpenEnumType(), $language->usesEnumType($openArray));
-        $this->assertStringContainsString('user.created', $language->getSuggestedEnumExample($openScalar));
-        $this->assertStringContainsString('user.created', $language->getSuggestedEnumExample($openArray));
-        if ($language->keepsOpenEnumType()) {
-            $this->assertSame('(WebhookEvent | (string & {}))', $language->getTypeName($openScalar, $specification));
-            $this->assertSame('(WebhookEvent | (string & {}))[]', $language->getTypeName($openArray, $specification));
-
-            return;
-        }
-
-        $this->assertSame(
-            $language->getTypeName($plainScalar, $specification),
-            $language->getTypeName($openScalar, $specification),
-        );
-        $this->assertSame(
-            $language->getTypeName($plainArray, $specification),
-            $language->getTypeName($openArray, $specification),
-        );
-    }
-
-    private function assertOpenEnumSuggestionsGenerated(string $dir): void
-    {
-        $expectations = [
-            'web' => ['src/enums/webhook-event.ts', 'UserCreated', 'src/enums/localized-status.ts', 'Value1', 'src/enums/province-type.ts', 'Capital'],
-            'node' => ['src/enums/webhook-event.ts', 'UserCreated', 'src/enums/localized-status.ts', 'Value1', 'src/enums/province-type.ts', 'Capital'],
-            'react-native' => ['src/enums/webhook-event.ts', 'UserCreated', 'src/enums/localized-status.ts', 'Value1', 'src/enums/province-type.ts', 'Capital'],
-            'deno' => ['src/enums/webhook-event.ts', 'UserCreated', 'src/enums/localized-status.ts', 'Value1', 'src/enums/province-type.ts', 'Capital'],
-            'php' => ['src/Appwrite/Enums/WebhookEvent.php', 'public const USERCREATED', 'src/Appwrite/Enums/LocalizedStatus.php', 'public static function VALUE1', 'src/Appwrite/Enums/ProvinceType.php', 'public static function CAPITAL'],
-            'python' => ['appwrite/enums/webhook_event.py', 'USERCREATED = "user.created"', 'appwrite/enums/localized_status.py', 'VALUE1 = "រាជធានី"', 'appwrite/enums/province_type.py', 'CAPITAL = "រាជធានី"'],
-            'ruby' => ['lib/appwrite/enums/webhook_event.rb', "USERCREATED = 'user.created'", 'lib/appwrite/enums/localized_status.rb', "VALUE1 = 'រាជធានី'", 'lib/appwrite/enums/province_type.rb', "CAPITAL = 'រាជធានី'"],
-            'dart' => ['lib/src/enums/webhook_event.dart', 'static const String userCreated', 'lib/src/enums/localized_status.dart', 'value1(value:', 'lib/src/enums/province_type.dart', 'capital(value:'],
-            'flutter' => ['lib/src/enums/webhook_event.dart', 'static const String userCreated', 'lib/src/enums/localized_status.dart', 'value1(value:', 'lib/src/enums/province_type.dart', 'capital(value:'],
-            'kotlin' => ['src/main/kotlin/io/appwrite/enums/WebhookEvent.kt', 'const val USERCREATED', 'src/main/kotlin/io/appwrite/enums/LocalizedStatus.kt', 'VALUE1("', 'src/main/kotlin/io/appwrite/enums/ProvinceType.kt', 'CAPITAL("'],
-            'android' => ['library/src/main/java/io/appwrite/enums/WebhookEvent.kt', 'const val USERCREATED', 'library/src/main/java/io/appwrite/enums/LocalizedStatus.kt', 'VALUE1("', 'library/src/main/java/io/appwrite/enums/ProvinceType.kt', 'CAPITAL("'],
-            'swift' => ['Sources/AppwriteEnums/WebhookEvent.swift', 'public static let userCreated', 'Sources/AppwriteEnums/LocalizedStatus.swift', 'case value1', 'Sources/AppwriteEnums/ProvinceType.swift', 'case capital'],
-            'apple' => ['Sources/AppwriteEnums/WebhookEvent.swift', 'public static let userCreated', 'Sources/AppwriteEnums/LocalizedStatus.swift', 'case value1', 'Sources/AppwriteEnums/ProvinceType.swift', 'case capital'],
-            'dotnet' => ['Appwrite/Enums/WebhookEvent.cs', 'public const string UserCreated', 'Appwrite/Enums/LocalizedStatus.cs', 'public static LocalizedStatus Value1', 'Appwrite/Enums/ProvinceType.cs', 'public static ProvinceType Capital'],
-            'unity' => ['Assets/Runtime/Core/Enums/WebhookEvent.cs', 'public const string UserCreated', 'Assets/Runtime/Core/Enums/LocalizedStatus.cs', 'public static LocalizedStatus Value1', 'Assets/Runtime/Core/Enums/ProvinceType.cs', 'public static ProvinceType Capital'],
-            'rust' => ['src/enums/webhook_event.rs', 'pub const UserCreated', 'src/enums/localized_status.rs', 'Value1,', 'src/enums/province_type.rs', 'Capital,'],
-        ];
-
-        if (!isset($expectations[$this->language])) {
-            return;
-        }
-
-        [
-            $relativePath,
-            $knownValueDeclaration,
-            $localizedPath,
-            $localizedDeclaration,
-            $annotatedPath,
-            $annotatedDeclaration,
-        ] = $expectations[$this->language];
-        $path = $dir . '/' . $relativePath;
-        $this->assertFileExists($path);
-        $contents = file_get_contents($path);
-        $this->assertIsString($contents);
-        $this->assertStringContainsString($knownValueDeclaration, $contents);
-        $this->assertStringContainsString('user.updated', $contents);
-
-        foreach (
-            [
-                [$localizedPath, $localizedDeclaration],
-                [$annotatedPath, $annotatedDeclaration],
-            ] as [$enumPath, $declaration]
-        ) {
-            $this->assertFileExists($dir . '/' . $enumPath);
-            $enumContents = file_get_contents($dir . '/' . $enumPath);
-            $this->assertIsString($enumContents);
-            $this->assertStringContainsString($declaration, $enumContents);
-        }
-    }
-
     private function rmdirRecursive(string $dir): void
     {
         if (!\is_dir($dir)) {
@@ -752,80 +572,6 @@ abstract class Base extends TestCase
             }
         }
         \rmdir($dir);
-    }
-
-    private function assertExcludedFixtureWasRemoved(string $dir): void
-    {
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS)
-        );
-
-        foreach ($iterator as $file) {
-            $path = \strtolower((string) $file->getPathname());
-
-            foreach (self::EXCLUDED_FIXTURE_TOKENS as $token) {
-                $this->assertStringNotContainsString($token, $path, "Excluded fixture leaked into generated path: {$path}");
-            }
-
-            if (!$file->isFile()) {
-                continue;
-            }
-
-            $contents = \file_get_contents($file->getPathname());
-
-            if ($contents === false) {
-                continue;
-            }
-
-            $contents = \strtolower($contents);
-
-            foreach (self::EXCLUDED_FIXTURE_TOKENS as $token) {
-                $this->assertStringNotContainsString(
-                    $token,
-                    $contents,
-                    "Excluded fixture leaked into generated file: {$file->getPathname()}"
-                );
-            }
-        }
-    }
-
-    /**
-     * Twig autoescapes to HTML, so a description that reaches the template through an
-     * unsafe filter arrives in the source as `&quot;` rather than `"`. Go doc comments
-     * are read as plain text, so the entity is what the reader sees.
-     *
-     * Scoped to the generated models: the CLI ships hand-written Go that escapes HTML
-     * as its job, and those entities are the payload rather than a leak.
-     */
-    private function assertCommentsAreNotHtmlEscaped(string $dir): void
-    {
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS)
-        );
-
-        foreach ($iterator as $file) {
-            if (!$file->isFile() || $file->getExtension() !== 'go') {
-                continue;
-            }
-
-            if (!\str_contains((string) $file->getPath(), '/models')) {
-                continue;
-            }
-
-            $contents = \file_get_contents($file->getPathname());
-
-            if ($contents === false) {
-                continue;
-            }
-
-            foreach (['&quot;', '&#039;', '&amp;', '&lt;', '&gt;'] as $entity) {
-                $this->assertStringNotContainsString(
-                    $entity,
-                    $contents,
-                    "HTML entity {$entity} leaked into generated source: {$file->getPathname()}"
-                );
-            }
-        }
     }
 
     public function getLanguage(): Language

--- a/tests/generation/GenerationTest.php
+++ b/tests/generation/GenerationTest.php
@@ -1,0 +1,394 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Generation;
+
+use Appwrite\SDK\Language;
+use Appwrite\SDK\Language\Android;
+use Appwrite\SDK\Language\Apple;
+use Appwrite\SDK\Language\CLI;
+use Appwrite\SDK\Language\Dart;
+use Appwrite\SDK\Language\Deno;
+use Appwrite\SDK\Language\DotNet;
+use Appwrite\SDK\Language\Flutter;
+use Appwrite\SDK\Language\Go;
+use Appwrite\SDK\Language\GraphQL;
+use Appwrite\SDK\Language\HTTP;
+use Appwrite\SDK\Language\Kotlin;
+use Appwrite\SDK\Language\Node;
+use Appwrite\SDK\Language\PHP;
+use Appwrite\SDK\Language\Python;
+use Appwrite\SDK\Language\ReactNative;
+use Appwrite\SDK\Language\REST;
+use Appwrite\SDK\Language\Ruby;
+use Appwrite\SDK\Language\Rust;
+use Appwrite\SDK\Language\Swift;
+use Appwrite\SDK\Language\Unity;
+use Appwrite\SDK\Language\Web;
+use Appwrite\SDK\SDK;
+use FilesystemIterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use Utopia\OpenAPI\Model\StringSchema;
+use Utopia\OpenAPI\Parser;
+
+/**
+ * What the generator emits, for every language and platform, from the shared
+ * fixture. Nothing here is compiled or run: `tests/e2e/` proves the generated
+ * SDKs behave, this suite proves the generated trees contain what they should
+ * and nothing they should not.
+ */
+final class GenerationTest extends TestCase
+{
+    private const string FIXTURE = __DIR__ . '/../resources/spec-openapi3.json';
+
+    private const string OUTPUT = __DIR__ . '/sdks';
+
+    private const array PLATFORMS = ['client', 'server', 'console'];
+
+    /**
+     * Fixture tokens and the platforms whose generated tree may contain them.
+     * An empty list means the token must never appear. Every token is a single
+     * lowercase word so it survives each language's identifier casing.
+     */
+    private const array TOKENS = [
+        'zzexcludedservice' => [],
+        'zzexcludedpayload' => [],
+        'zzexcludedresult' => [],
+        'zzexcludedstatus' => [],
+        'zzexcludedchild' => [],
+        'zzexcludedchildstatus' => [],
+        'zzexcludedmethodpayload' => [],
+        'zzexcludedmethodresult' => [],
+        'zzexcludedmethodstatus' => [],
+        'zzconsoleonly' => ['console'],
+        'zzplatformclientalias' => ['client'],
+        'zzplatformserveralias' => ['server'],
+        'zzserveronlyheader' => ['server'],
+    ];
+
+    /**
+     * Where each language declares the fixture enums, and the declaration each
+     * kind of enum value takes: a titled `oneOf` branch, a value without a safe
+     * identifier, and an annotated localized value.
+     *
+     * @var array<string, array{string, string, string, string, string, string}>
+     */
+    private const array ENUM_DECLARATIONS = [
+        'web' => ['src/enums/webhook-event.ts', 'UserCreated', 'src/enums/localized-status.ts', 'Value1', 'src/enums/province-type.ts', 'Capital'],
+        'node' => ['src/enums/webhook-event.ts', 'UserCreated', 'src/enums/localized-status.ts', 'Value1', 'src/enums/province-type.ts', 'Capital'],
+        'react-native' => ['src/enums/webhook-event.ts', 'UserCreated', 'src/enums/localized-status.ts', 'Value1', 'src/enums/province-type.ts', 'Capital'],
+        'deno' => ['src/enums/webhook-event.ts', 'UserCreated', 'src/enums/localized-status.ts', 'Value1', 'src/enums/province-type.ts', 'Capital'],
+        'php' => ['src/Appwrite/Enums/WebhookEvent.php', 'public const USERCREATED', 'src/Appwrite/Enums/LocalizedStatus.php', 'public static function VALUE1', 'src/Appwrite/Enums/ProvinceType.php', 'public static function CAPITAL'],
+        'python' => ['appwrite/enums/webhook_event.py', 'USERCREATED = "user.created"', 'appwrite/enums/localized_status.py', 'VALUE1 = "រាជធានី"', 'appwrite/enums/province_type.py', 'CAPITAL = "រាជធានី"'],
+        'ruby' => ['lib/appwrite/enums/webhook_event.rb', "USERCREATED = 'user.created'", 'lib/appwrite/enums/localized_status.rb', "VALUE1 = 'រាជធានី'", 'lib/appwrite/enums/province_type.rb', "CAPITAL = 'រាជធានី'"],
+        'dart' => ['lib/src/enums/webhook_event.dart', 'static const String userCreated', 'lib/src/enums/localized_status.dart', 'value1(value:', 'lib/src/enums/province_type.dart', 'capital(value:'],
+        'flutter' => ['lib/src/enums/webhook_event.dart', 'static const String userCreated', 'lib/src/enums/localized_status.dart', 'value1(value:', 'lib/src/enums/province_type.dart', 'capital(value:'],
+        'kotlin' => ['src/main/kotlin/io/appwrite/enums/WebhookEvent.kt', 'const val USERCREATED', 'src/main/kotlin/io/appwrite/enums/LocalizedStatus.kt', 'VALUE1("', 'src/main/kotlin/io/appwrite/enums/ProvinceType.kt', 'CAPITAL("'],
+        'android' => ['library/src/main/java/io/appwrite/enums/WebhookEvent.kt', 'const val USERCREATED', 'library/src/main/java/io/appwrite/enums/LocalizedStatus.kt', 'VALUE1("', 'library/src/main/java/io/appwrite/enums/ProvinceType.kt', 'CAPITAL("'],
+        'swift' => ['Sources/AppwriteEnums/WebhookEvent.swift', 'public static let userCreated', 'Sources/AppwriteEnums/LocalizedStatus.swift', 'case value1', 'Sources/AppwriteEnums/ProvinceType.swift', 'case capital'],
+        'apple' => ['Sources/AppwriteEnums/WebhookEvent.swift', 'public static let userCreated', 'Sources/AppwriteEnums/LocalizedStatus.swift', 'case value1', 'Sources/AppwriteEnums/ProvinceType.swift', 'case capital'],
+        'dotnet' => ['Appwrite/Enums/WebhookEvent.cs', 'public const string UserCreated', 'Appwrite/Enums/LocalizedStatus.cs', 'public static LocalizedStatus Value1', 'Appwrite/Enums/ProvinceType.cs', 'public static ProvinceType Capital'],
+        'unity' => ['Runtime/Core/Enums/WebhookEvent.cs', 'public const string UserCreated', 'Runtime/Core/Enums/LocalizedStatus.cs', 'public static LocalizedStatus Value1', 'Runtime/Core/Enums/ProvinceType.cs', 'public static ProvinceType Capital'],
+        'rust' => ['src/enums/webhook_event.rs', 'pub const UserCreated', 'src/enums/localized_status.rs', 'Value1,', 'src/enums/province_type.rs', 'Capital,'],
+    ];
+
+    /** @var array<string, array<string, string>> generated tree per language and platform */
+    private static array $generated = [];
+
+    /** @return iterable<string, array{string}> */
+    public static function languages(): iterable
+    {
+        foreach (\array_keys(self::languageClasses()) as $name) {
+            yield $name => [$name];
+        }
+    }
+
+    /** @return array<string, class-string<Language>> */
+    private static function languageClasses(): array
+    {
+        return [
+            'php' => PHP::class,
+            'web' => Web::class,
+            'node' => Node::class,
+            'deno' => Deno::class,
+            'cli' => CLI::class,
+            'ruby' => Ruby::class,
+            'python' => Python::class,
+            'dart' => Dart::class,
+            'flutter' => Flutter::class,
+            'react-native' => ReactNative::class,
+            'go' => Go::class,
+            'swift' => Swift::class,
+            'apple' => Apple::class,
+            'dotnet' => DotNet::class,
+            'android' => Android::class,
+            'kotlin' => Kotlin::class,
+            'unity' => Unity::class,
+            'rust' => Rust::class,
+            'rest' => REST::class,
+            'graphql' => GraphQL::class,
+        ];
+    }
+
+    private function language(string $name): Language
+    {
+        $language = new (self::languageClasses()[$name])();
+        if ($language instanceof CLI) {
+            $language->setExecutableName('appwrite');
+        }
+
+        return $language;
+    }
+
+    /**
+     * The generated tree for a language and platform, generated once per run,
+     * as lowercase path => lowercase contents.
+     *
+     * @return array<string, string>
+     */
+    private function generate(string $name, string $platform): array
+    {
+        if (isset(self::$generated[$name][$platform])) {
+            return self::$generated[$name][$platform];
+        }
+
+        $dir = self::OUTPUT . '/' . $name . '/' . $platform;
+        $this->removeDirectory($dir);
+
+        $sdk = new SDK($this->language($name), Parser::parse((string) \file_get_contents(self::FIXTURE)));
+        $sdk
+            ->setName('test')
+            ->setVersion('0.0.1')
+            ->setPlatform($platform)
+            ->setNamespace(\in_array($name, ['android', 'kotlin'], true) ? 'io.appwrite' : 'appwrite')
+            ->setExclude([
+                'services' => [
+                    ['name' => 'zzexcludedservice'],
+                ],
+                'methods' => [
+                    ['name' => 'createExcludedGeneralFixture'],
+                ],
+            ])
+            ->setTest('true')
+            ->generate($dir);
+
+        $files = [];
+        $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS));
+        foreach ($iterator as $file) {
+            if ($file->isFile()) {
+                $files[\substr((string) $file->getPathname(), \strlen($dir) + 1)] = \strtolower((string) \file_get_contents($file->getPathname()));
+            }
+        }
+
+        return self::$generated[$name][$platform] = $files;
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!\is_dir($dir)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($iterator as $file) {
+            $file->isDir() ? \rmdir($file->getPathname()) : \unlink($file->getPathname());
+        }
+        \rmdir($dir);
+    }
+
+    /** @return list<string> paths whose name or contents carry the token */
+    private function filesContaining(array $files, string $token): array
+    {
+        $matches = [];
+        foreach ($files as $path => $contents) {
+            if (\str_contains(\strtolower((string) $path), $token) || \str_contains($contents, $token)) {
+                $matches[] = $path;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * Excluded fixtures never leak, and platform-bound fixtures appear on their
+     * platforms alone. Presence is asserted only where the language renders the
+     * token at all, so a target without header setters or alias descriptions
+     * still proves it leaks nothing.
+     */
+    #[DataProvider('languages')]
+    public function testFixtureSelection(string $name): void
+    {
+        $trees = [];
+        foreach (self::PLATFORMS as $platform) {
+            $trees[$platform] = $this->generate($name, $platform);
+        }
+
+        foreach (self::TOKENS as $token => $platforms) {
+            $found = [];
+            foreach ($trees as $platform => $files) {
+                $paths = $this->filesContaining($files, $token);
+                if ($paths !== []) {
+                    $found[$platform] = $paths;
+                }
+            }
+
+            foreach (\array_diff(\array_keys($found), $platforms) as $platform) {
+                $this->fail("{$name}/{$platform} leaks `{$token}`: " . \implode(', ', $found[$platform]));
+            }
+
+            if ($found !== []) {
+                $this->assertSame($platforms, \array_keys($found), "{$name} renders `{$token}` on some platforms but not all of: " . \implode(', ', $platforms));
+            }
+        }
+    }
+
+    #[DataProvider('languages')]
+    public function testEnumsAreDeclared(string $name): void
+    {
+        if (!isset(self::ENUM_DECLARATIONS[$name])) {
+            $this->markTestSkipped("{$name} declares no enums.");
+        }
+
+        [$knownPath, $knownDeclaration, $localizedPath, $localizedDeclaration, $annotatedPath, $annotatedDeclaration] = self::ENUM_DECLARATIONS[$name];
+        $files = $this->generate($name, 'server');
+
+        foreach ([[$knownPath, $knownDeclaration], [$knownPath, 'user.updated'], [$localizedPath, $localizedDeclaration], [$annotatedPath, $annotatedDeclaration]] as [$path, $declaration]) {
+            $this->assertArrayHasKey($path, $files, "{$name} did not generate {$path}");
+            $this->assertStringContainsString(\strtolower($declaration), $files[$path], "{$name}: {$path} lacks `{$declaration}`");
+        }
+    }
+
+    /**
+     * Twig autoescapes to HTML, so a description that reaches a template through
+     * an unsafe filter arrives as `&quot;` rather than `"`. Go doc comments are
+     * read as plain text, so the entity is what the reader sees.
+     */
+    public function testGoModelCommentsAreNotHtmlEscaped(): void
+    {
+        $models = \array_filter($this->generate('go', 'server'), static fn(string $path): bool => \str_starts_with($path, 'models/') && \str_ends_with($path, '.go'), ARRAY_FILTER_USE_KEY);
+        $this->assertNotEmpty($models);
+
+        foreach ($models as $path => $contents) {
+            foreach (['&quot;', '&#039;', '&amp;', '&lt;', '&gt;'] as $entity) {
+                $this->assertStringNotContainsString($entity, $contents, "HTML entity {$entity} leaked into go: {$path}");
+            }
+        }
+    }
+
+    #[DataProvider('languages')]
+    public function testEnumKeysAreValid(string $name): void
+    {
+        $specification = Parser::parse([
+            'openapi' => '3.1.0',
+            'info' => ['title' => 'test', 'version' => '1.0.0'],
+            'paths' => ['/test' => ['get' => [
+                'operationId' => 'testEnumKeys',
+                'parameters' => [
+                    ['name' => 'localized', 'in' => 'query', 'schema' => [
+                        'type' => 'string',
+                        'enum' => ['រាជធានី', 'ខេត្ត', 'Test'],
+                    ]],
+                    ['name' => 'annotated', 'in' => 'query', 'schema' => [
+                        'title' => 'ProvinceType',
+                        'oneOf' => [
+                            ['const' => 'រាជធានី', 'title' => 'Capital'],
+                            ['const' => 'ខេត្ត', 'title' => 'Province'],
+                            ['const' => 'Test', 'title' => 'Test'],
+                        ],
+                    ]],
+                    ['name' => 'unsafe', 'in' => 'query', 'schema' => [
+                        'type' => 'string',
+                        'enum' => ['123', '-'],
+                    ]],
+                ],
+                'responses' => ['200' => ['description' => 'ok']],
+            ]]],
+        ]);
+        [$localized, $annotated, $unsafe] = $specification->paths['/test']->operations['get']->parameters;
+        $language = $this->language($name);
+
+        $this->assertSame(['Value1', 'Value2', 'Test'], $language->resolveEnumKeys($localized));
+        $this->assertSame(['Capital', 'Province', 'Test'], $language->resolveEnumKeys($annotated));
+        $this->assertSame(['Value123', 'Value2'], $language->resolveEnumKeys($unsafe));
+    }
+
+    #[DataProvider('languages')]
+    public function testOpenEnumsAllowAnyString(string $name): void
+    {
+        $enum = [
+            'title' => 'WebhookEvent',
+            'oneOf' => [
+                ['const' => 'user.created', 'title' => 'UserCreated'],
+                ['const' => 'user.updated', 'title' => 'UserUpdated'],
+            ],
+        ];
+        $specification = Parser::parse([
+            'openapi' => '3.1.0',
+            'info' => ['title' => 'test', 'version' => '1.0.0'],
+            'paths' => ['/test' => ['get' => [
+                'operationId' => 'testOpenEnums',
+                'parameters' => [
+                    ['name' => 'plainScalar', 'in' => 'query', 'schema' => ['type' => 'string']],
+                    ['name' => 'closedScalar', 'in' => 'query', 'schema' => $enum],
+                    ['name' => 'openScalar', 'in' => 'query', 'schema' => ['anyOf' => [$enum, ['type' => 'string']]]],
+                    ['name' => 'plainArray', 'in' => 'query', 'schema' => ['type' => 'array', 'items' => ['type' => 'string']]],
+                    ['name' => 'closedArray', 'in' => 'query', 'schema' => ['type' => 'array', 'items' => $enum]],
+                    ['name' => 'openArray', 'in' => 'query', 'schema' => ['type' => 'array', 'items' => ['anyOf' => [$enum, ['type' => 'string']]]]],
+                ],
+                'responses' => ['200' => ['description' => 'ok']],
+            ]]],
+        ]);
+        [$plainScalar, $closedScalar, $openScalar, $plainArray, $closedArray, $openArray] = $specification->paths['/test']->operations['get']->parameters;
+        $language = $this->language($name);
+        $permission = '["read(\\"any\\")"]';
+        $this->assertTrue($language->isPermissionString($permission));
+        $this->assertSame([[
+            'action' => 'read',
+            'role' => 'any',
+            'id' => null,
+            'innerRole' => null,
+        ]], $language->extractPermissionParts($permission));
+        foreach ([$closedScalar, $closedArray, $openScalar, $openArray] as $parameter) {
+            $enumSchema = $language->getEnumSchema($parameter);
+            $this->assertInstanceOf(StringSchema::class, $enumSchema);
+            $this->assertSame(['user.created', 'user.updated'], $enumSchema->enum);
+            $this->assertSame(['UserCreated', 'UserUpdated'], $enumSchema->enumKeys);
+            $this->assertSame('WebhookEvent', $enumSchema->enumName);
+        }
+        $this->assertFalse($language->isOpenStringEnum($closedScalar));
+        $this->assertFalse($language->isOpenStringEnum($closedArray));
+        $this->assertTrue($language->isOpenStringEnum($openScalar));
+        $this->assertTrue($language->isOpenStringEnum($openArray));
+        $this->assertTrue($language->usesEnumType($closedScalar));
+        $this->assertTrue($language->usesEnumType($closedArray));
+        $this->assertSame($language->keepsOpenEnumType(), $language->usesEnumType($openScalar));
+        $this->assertSame($language->keepsOpenEnumType(), $language->usesEnumType($openArray));
+        $this->assertStringContainsString('user.created', $language->getSuggestedEnumExample($openScalar));
+        $this->assertStringContainsString('user.created', $language->getSuggestedEnumExample($openArray));
+        if ($language instanceof HTTP) {
+            return;
+        }
+        if ($language->keepsOpenEnumType()) {
+            $this->assertSame('(WebhookEvent | (string & {}))', $language->getTypeName($openScalar, $specification));
+            $this->assertSame('(WebhookEvent | (string & {}))[]', $language->getTypeName($openArray, $specification));
+
+            return;
+        }
+
+        $this->assertSame(
+            $language->getTypeName($plainScalar, $specification),
+            $language->getTypeName($openScalar, $specification),
+        );
+        $this->assertSame(
+            $language->getTypeName($plainArray, $specification),
+            $language->getTypeName($openArray, $specification),
+        );
+    }
+}

--- a/tests/generation/GenerationTest.php
+++ b/tests/generation/GenerationTest.php
@@ -71,6 +71,16 @@ final class GenerationTest extends TestCase
     ];
 
     /**
+     * Targets that render no header setters or no alias descriptions, so the
+     * tokens carried by those never appear in their trees on any platform.
+     */
+    private const array UNRENDERED = [
+        'cli' => ['zzserveronlyheader'],
+        'rest' => ['zzplatformclientalias', 'zzplatformserveralias', 'zzserveronlyheader'],
+        'graphql' => ['zzplatformclientalias', 'zzplatformserveralias', 'zzserveronlyheader'],
+    ];
+
+    /**
      * Where each language declares the fixture enums, and the declaration each
      * kind of enum value takes: a titled `oneOf` branch, a value without a safe
      * identifier, and an annotated localized value.
@@ -218,9 +228,7 @@ final class GenerationTest extends TestCase
 
     /**
      * Excluded fixtures never leak, and platform-bound fixtures appear on their
-     * platforms alone. Presence is asserted only where the language renders the
-     * token at all, so a target without header setters or alias descriptions
-     * still proves it leaks nothing.
+     * platforms alone, except where the target renders no such token at all.
      */
     #[DataProvider('languages')]
     public function testFixtureSelection(string $name): void
@@ -243,9 +251,12 @@ final class GenerationTest extends TestCase
                 $this->fail("{$name}/{$platform} leaks `{$token}`: " . \implode(', ', $found[$platform]));
             }
 
-            if ($found !== []) {
-                $this->assertSame($platforms, \array_keys($found), "{$name} renders `{$token}` on some platforms but not all of: " . \implode(', ', $platforms));
+            if (\in_array($token, self::UNRENDERED[$name] ?? [], true)) {
+                $this->assertSame([], $found, "{$name} now renders `{$token}`; drop it from UNRENDERED");
+                continue;
             }
+
+            $this->assertSame($platforms, \array_keys($found), "{$name} lacks `{$token}` on: " . \implode(', ', \array_diff($platforms, \array_keys($found))));
         }
     }
 

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -94,7 +94,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -172,7 +171,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -251,7 +249,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -330,7 +327,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -409,7 +405,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -490,7 +485,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -559,7 +553,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -637,6 +630,10 @@
             {
               "name": "createExcludedGeneralFixture",
               "namespace": "general",
+              "platforms": [
+                "client",
+                "server"
+              ],
               "auth": {
                 "Project": []
               }
@@ -704,7 +701,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -782,7 +778,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -861,7 +856,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -940,7 +934,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -1019,7 +1012,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -1100,7 +1092,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -1146,7 +1137,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -1191,7 +1181,8 @@
           "rate-key": "url:{url},ip:{ip}",
           "scope": "public",
           "platforms": [
-            "client"
+            "client",
+            "server"
           ],
           "packaging": false,
           "auth": {
@@ -1234,7 +1225,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -1282,7 +1272,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -1321,7 +1310,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -1381,7 +1369,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -1528,7 +1515,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -1574,7 +1560,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -1625,7 +1610,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -1803,7 +1787,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -1845,7 +1828,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -1891,7 +1873,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -1949,7 +1930,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -1995,7 +1975,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -2126,7 +2105,6 @@
           "scope": "public",
           "platforms": [
             "client",
-            "server",
             "server"
           ],
           "packaging": false,
@@ -2284,6 +2262,105 @@
             }
           }
         ]
+      }
+    },
+    "\/mock\/tests\/general\/zzconsoleonly": {
+      "get": {
+        "summary": "Console Only Fixture",
+        "operationId": "generalZzconsoleonly",
+        "tags": [
+          "general"
+        ],
+        "description": "Fixture-only method available to console SDKs alone; verifies platform selection drops it elsewhere.",
+        "x-appwrite": {
+          "weight": 302,
+          "demo": "general\/zzconsoleonly.md",
+          "rate-limit": 0,
+          "rate-time": 3600,
+          "rate-key": "url:{url},ip:{ip}",
+          "scope": "public",
+          "packaging": false,
+          "platforms": [
+            "console"
+          ]
+        },
+        "security": [
+          {
+            "Project": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Any",
+            "content": {
+              "application\/json": {
+                "schema": {
+                  "$ref": "#\/components\/schemas\/any"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "\/mock\/tests\/general\/platform-alias": {
+      "get": {
+        "summary": "Platform Alias Fixture",
+        "operationId": "generalGetPlatformAlias",
+        "tags": [
+          "general"
+        ],
+        "description": "Fixture-only method whose alias differs per platform; verifies alias selection.",
+        "x-appwrite": {
+          "weight": 303,
+          "demo": "general\/platform-alias.md",
+          "rate-limit": 0,
+          "rate-time": 3600,
+          "rate-key": "url:{url},ip:{ip}",
+          "scope": "public",
+          "packaging": false,
+          "platforms": [
+            "client",
+            "server"
+          ],
+          "methods": [
+            {
+              "name": "zzplatformalias",
+              "namespace": "general",
+              "platforms": [
+                "client"
+              ],
+              "description": "zzplatformclientalias variant."
+            },
+            {
+              "name": "zzplatformalias",
+              "namespace": "general",
+              "platforms": [
+                "server"
+              ],
+              "description": "zzplatformserveralias variant."
+            }
+          ]
+        },
+        "security": [
+          {
+            "Project": [],
+            "Key": [],
+            "JWT": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Any",
+            "content": {
+              "application\/json": {
+                "schema": {
+                  "$ref": "#\/components\/schemas\/any"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "\/mock\/tests\/graphql": {
@@ -2933,6 +3010,17 @@
         "name": "X-Appwrite-Session",
         "description": "The user session to authenticate with",
         "in": "header"
+      },
+      "Zzserveronlyheader": {
+        "type": "apiKey",
+        "name": "X-Appwrite-Zzserveronlyheader",
+        "description": "Fixture-only header offered to server SDKs alone.",
+        "in": "header",
+        "x-appwrite": {
+          "platforms": [
+            "server"
+          ]
+        }
       },
       "Locale": {
         "type": "apiKey",


### PR DESCRIPTION
## Summary

Appwrite publishes one OpenAPI document per SDK platform, and the generator trusts each document to be pre-filtered. appwrite/appwrite#13502 made the operation-level `x-appwrite.platforms` the effective SDK availability and gave every method alias its own list. This PR teaches the generator to select from that metadata, which is the generator half of consolidating the three documents into one.

- Operations, method aliases in `x-appwrite.methods[]`, and security schemes whose `x-appwrite.platforms` exclude `sdk.platform` are skipped. A missing list, or generating without a platform, means available everywhere. Unknown names such as Cloud's `manager` never match.
- Filtering a security scheme also removes it from the client's global header setters and from every operation's security requirement, so a client SDK generated from a document that also carries `Key` does not grow a `setKey()`.
- `example.php` sets the platform for every target, as the SDKs task in appwrite/appwrite already does.

`x-appwrite.auth` is left as is. It is a per-platform slice of the security requirement, and how a canonical document expresses it is a separate decision on the appwrite side.

## Testing pattern

`tests/e2e/Base.php` mixed three kinds of assertion: runtime behaviour compared against `expectedOutput`, greps of the generated tree for `zz*` fixture tokens, and unit checks of `Language` methods. This PR splits them.

- `tests/generation/GenerationTest.php` is a new suite that generates the fixture for every language and platform with no Docker and checks the trees against declarative tables. Excluded fixtures must never appear, platform-bound fixtures must appear on their platforms alone, enums must be declared, Go model comments must not carry HTML entities. The enum unit checks move here and run once per language instead of once per Docker job.
- `tests/e2e/` keeps only runtime behaviour.
- The fixture gains a console-only operation, an alias with a client variant and a server variant, and a server-only security scheme, plus the accurate `platforms` lists the e2e tests already relied on.

Generated trees under `tests/generation/sdks/` are ignored by git, phpcs, rector and PHPUnit discovery. CI gains a `Checks / Generation` job.

## Validation

- Regenerated all 24 targets from the current cloud `latest` client, server and console documents before and after: byte-identical on every platform.
- `vendor/bin/phpunit --testsuite Generation`: 81 tests, 908 assertions, 4 skipped (languages without enums).
- `vendor/bin/phpunit tests/e2e/PHP85Test.php`: passed.
- `composer lint`, `composer refactor:check`, `composer lint-twig`: clean.

Related to [CLO-4377](https://linear.app/appwrite/issue/CLO-4377/openapi3-standards).
