### PR TITLE
refactor: extension key enums and platform-keyed auth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,6 +284,7 @@ public function getFiles(): array
 | Which files get generated | `src/SDK/Language/<Lang>.php` → `getFiles()` |
 | Type mappings for a language | `src/SDK/Language/<Lang>.php` → `getTypeName()` |
 | Available Twig filters | `src/SDK/SDK.php` (around line 62) |
+| Vendor extensions the generator reads | `src/SDK/Extension.php` and `src/SDK/Extension/Appwrite.php`; add a case before reading a new key |
 | Canonical spec parser and DTOs | `utopia-php/openapi` (VCS dependency) |
 | SDK grouping and filtering | `src/SDK/SDK.php` |
 | Generation orchestration | `src/SDK/SDK.php` → `generate()` |

--- a/src/SDK/Extension.php
+++ b/src/SDK/Extension.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Appwrite\SDK;
+
+/**
+ * The vendor extensions the generator reads from an OpenAPI document.
+ */
+enum Extension: string
+{
+    /** Appwrite metadata on operations and security schemes; its keys are the {@see Extension\Appwrite} cases. */
+    case APPWRITE = 'x-appwrite';
+
+    /** On a security scheme: the SDK platforms whose examples configure it as a credential. */
+    case SDK_CREDENTIALS = 'x-sdk-credentials';
+
+    /** On a component schema: generated as a request model rather than a response model. */
+    case REQUEST_MODEL = 'x-request-model';
+
+    /** On a discriminator: a mapping keyed by a combination of property values. */
+    case MAPPING = 'x-mapping';
+
+    /** Generator annotation on a path parameter filled from a security scheme. */
+    case SDK_SOURCE = 'x-sdk-source';
+
+    /** Generator annotation naming the client config key that fills such a parameter. */
+    case SDK_CONFIG = 'x-sdk-config';
+}

--- a/src/SDK/Extension.php
+++ b/src/SDK/Extension.php
@@ -12,9 +12,6 @@ enum Extension: string
     /** Appwrite metadata on operations and security schemes; its keys are the {@see Extension\Appwrite} cases. */
     case APPWRITE = 'x-appwrite';
 
-    /** On a security scheme: the SDK platforms whose examples configure it as a credential. */
-    case SDK_CREDENTIALS = 'x-sdk-credentials';
-
     /** On a component schema: generated as a request model rather than a response model. */
     case REQUEST_MODEL = 'x-request-model';
 

--- a/src/SDK/Extension/Appwrite.php
+++ b/src/SDK/Extension/Appwrite.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Appwrite\SDK\Extension;
+
+/**
+ * The keys of the `x-appwrite` extension the generator reads.
+ */
+enum Appwrite: string
+{
+    /** SDK platforms an operation, method alias or security scheme is available on. */
+    case PLATFORMS = 'platforms';
+
+    /** Method aliases generated from one operation. */
+    case METHODS = 'methods';
+
+    /** Content types an operation produces when no response declares content. */
+    case PRODUCES = 'produces';
+
+    /** Whether an operation is part of a packaging flow. */
+    case PACKAGING = 'packaging';
+
+    /** On a security scheme: `path` when the scheme is supplied as a path parameter. */
+    case LOCATION = 'location';
+
+    /** On a path-bound security scheme: the path parameter it fills. */
+    case PARAM = 'param';
+
+    /** On a path-bound security scheme: the client config key that fills it. */
+    case CONFIG = 'config';
+
+    /** On a security scheme: configured by examples whenever an operation accepts it. */
+    case OPTIONAL = 'optional';
+}

--- a/src/SDK/Extension/Appwrite.php
+++ b/src/SDK/Extension/Appwrite.php
@@ -32,4 +32,7 @@ enum Appwrite: string
 
     /** On a security scheme: configured by examples whenever an operation accepts it. */
     case OPTIONAL = 'optional';
+
+    /** On a security scheme: the SDK platforms whose examples configure it as a credential. */
+    case CREDENTIALS = 'credentials';
 }

--- a/src/SDK/Extension/Appwrite.php
+++ b/src/SDK/Extension/Appwrite.php
@@ -33,6 +33,6 @@ enum Appwrite: string
     /** On a security scheme: configured by examples whenever an operation accepts it. */
     case OPTIONAL = 'optional';
 
-    /** On a security scheme: the SDK platforms whose examples configure it as a credential. */
-    case CREDENTIALS = 'credentials';
+    /** Schemes an example configures on the client, flat or keyed by SDK platform. */
+    case AUTH = 'auth';
 }

--- a/src/SDK/Language.php
+++ b/src/SDK/Language.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\SDK;
 
+use Appwrite\SDK\Extension;
 use Utopia\OpenAPI\Model\AnySchema;
 use Normalizer;
 use Utopia\OpenAPI\Model\ArraySchema;
@@ -627,7 +628,7 @@ abstract class Language
     {
         $parameters = \array_values(\array_filter(
             $operation->parameters,
-            static fn(Parameter $parameter): bool => ($parameter->extensions['x-sdk-source'] ?? '') !== 'security',
+            static fn(Parameter $parameter): bool => ($parameter->extensions[Extension::SDK_SOURCE->value] ?? '') !== 'security',
         ));
         foreach ($operation->requestBody?->content ?? [] as $mediaType) {
             if (!$mediaType->schema instanceof ObjectSchema) {

--- a/src/SDK/Language/CLI.php
+++ b/src/SDK/Language/CLI.php
@@ -2,6 +2,8 @@
 
 namespace Appwrite\SDK\Language;
 
+use Appwrite\SDK\Extension;
+use Appwrite\SDK\Extension\Appwrite;
 use Appwrite\SDK\Language\Concern\CliCommandSurface;
 use Override;
 use Utopia\OpenAPI\Model\Operation;
@@ -269,7 +271,7 @@ class CLI extends Go
                     $variable,
                     $flagType,
                     $sdkType,
-                    (bool) ($method->extensions['x-appwrite']['packaging'] ?? false),
+                    (bool) ($method->extensions[Extension::APPWRITE->value][Appwrite::PACKAGING->value] ?? false),
                 );
 
                 if ($decode !== null) {

--- a/src/SDK/Language/Rust.php
+++ b/src/SDK/Language/Rust.php
@@ -2,6 +2,8 @@
 
 namespace Appwrite\SDK\Language;
 
+use Appwrite\SDK\Extension;
+use Appwrite\SDK\Extension\Appwrite;
 use Utopia\OpenAPI\Model\ArraySchema;
 use Utopia\OpenAPI\Model\Operation;
 use Utopia\OpenAPI\Model\Parameter;
@@ -559,7 +561,7 @@ class Rust extends Language
             }
         }
         if ($produces === []) {
-            $produces = $method->extensions['x-appwrite']['produces'] ?? [];
+            $produces = $method->extensions[Extension::APPWRITE->value][Appwrite::PRODUCES->value] ?? [];
         }
         return $produces;
     }

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\SDK;
 
+use Appwrite\SDK\Extension\Appwrite;
 use Utopia\OpenAPI\Model\AnySchema;
 use Utopia\OpenAPI\Model\ArraySchema;
 use Utopia\OpenAPI\Model\BooleanSchema;
@@ -23,6 +24,7 @@ use Utopia\OpenAPI\Model\ReferenceSchema;
 use Utopia\OpenAPI\Model\RequestBody;
 use Utopia\OpenAPI\Model\Response;
 use Utopia\OpenAPI\Model\Schema;
+use Utopia\OpenAPI\Model\SecurityRequirement;
 use Utopia\OpenAPI\Model\SecurityScheme;
 use Utopia\OpenAPI\Model\SecuritySchemeType;
 use Utopia\OpenAPI\Model\StringSchema;
@@ -178,7 +180,7 @@ class SDK
         $this->twig->addFilter(new TwigFilter('uploadIdParameter', $this->uploadIdParameter(...)));
         $this->twig->addFilter(new TwigFilter('produces', fn(Operation $operation): array => $this->getProduces($operation)));
         $this->twig->addFilter(new TwigFilter('endpoint', fn(Specification $spec): string => $spec->servers[0]->url ?? 'https://example.com'));
-        $this->twig->addFilter(new TwigFilter('appwrite', fn(Operation|SecurityScheme $value, string $key, mixed $default = null): mixed => $value->extensions['x-appwrite'][$key] ?? $default));
+        $this->twig->addFilter(new TwigFilter('appwrite', fn(Operation|SecurityScheme $value, string $key, mixed $default = null): mixed => $value->extensions[Extension::APPWRITE->value][$key] ?? $default));
         $this->twig->addFilter(new TwigFilter('extension', fn(Schema|Parameter $value, string $key, mixed $default = null): mixed => $this->getSchema($value)->extensions[$key] ?? $default));
         $this->twig->addFilter(new TwigFilter('methodHeaders', fn(Operation $operation): array => $this->getMethodHeaders($operation)));
         $this->twig->addFilter(new TwigFilter('responseDiscriminator', fn(Operation $operation): array => $this->getResponseDiscriminator($operation)));
@@ -535,12 +537,12 @@ class SDK
 
         $operations = [];
         foreach ($this->spec->operations() as $operation) {
-            if (!$this->isAvailable($operation->extensions['x-appwrite']['platforms'] ?? null)) {
+            if (!$this->isAvailable($operation->extensions[Extension::APPWRITE->value][Appwrite::PLATFORMS->value] ?? null)) {
                 continue;
             }
 
             $operation = $this->annotateSecurityPathParameters($operation);
-            $aliases = $operation->extensions['x-appwrite']['methods'] ?? [];
+            $aliases = $operation->extensions[Extension::APPWRITE->value][Appwrite::METHODS->value] ?? [];
             if (!\is_array($aliases) || $aliases === []) {
                 foreach ($operation->tags as $serviceName) {
                     $operations[$serviceName][] = $operation;
@@ -583,7 +585,7 @@ class SDK
     {
         $scheme = $this->spec->securitySchemes[$name] ?? null;
 
-        return $scheme instanceof SecurityScheme && $this->isAvailable($scheme->extensions['x-appwrite']['platforms'] ?? null) ? $scheme : null;
+        return $scheme instanceof SecurityScheme && $this->isAvailable($scheme->extensions[Extension::APPWRITE->value][Appwrite::PLATFORMS->value] ?? null) ? $scheme : null;
     }
 
     protected function annotateSecurityPathParameters(Operation $operation): Operation
@@ -591,11 +593,11 @@ class SDK
         $securityParameters = [];
         foreach ($operation->security[0]->schemes ?? [] as $schemeName => $scopes) {
             $scheme = $this->getSecurityScheme($schemeName);
-            if (!$scheme instanceof SecurityScheme || ($scheme->extensions['x-appwrite']['location'] ?? '') !== 'path') {
+            if (!$scheme instanceof SecurityScheme || ($scheme->extensions[Extension::APPWRITE->value][Appwrite::LOCATION->value] ?? '') !== 'path') {
                 continue;
             }
-            $parameterName = (string) ($scheme->extensions['x-appwrite']['param'] ?? $scheme->name ?? $schemeName);
-            $securityParameters[$parameterName] = (string) ($scheme->extensions['x-appwrite']['config'] ?? $scheme->name ?? $schemeName);
+            $parameterName = (string) ($scheme->extensions[Extension::APPWRITE->value][Appwrite::PARAM->value] ?? $scheme->name ?? $schemeName);
+            $securityParameters[$parameterName] = (string) ($scheme->extensions[Extension::APPWRITE->value][Appwrite::CONFIG->value] ?? $scheme->name ?? $schemeName);
         }
         if ($securityParameters === []) {
             return $operation;
@@ -622,8 +624,8 @@ class SDK
                 allowReserved: $parameter->allowReserved,
                 extensions: [
                     ...$parameter->extensions,
-                    'x-sdk-source' => 'security',
-                    'x-sdk-config' => $config,
+                    Extension::SDK_SOURCE->value => 'security',
+                    Extension::SDK_CONFIG->value => $config,
                 ],
             );
         }
@@ -650,8 +652,7 @@ class SDK
     protected function createAliasedOperation(Operation $operation, array $alias, string $serviceName): Operation
     {
         $methodName = (string) ($alias['name'] ?? $this->methodName($operation));
-        $appwrite = $operation->extensions['x-appwrite'] ?? [];
-        $appwrite['auth'] = $alias['auth'] ?? [];
+        $appwrite = $operation->extensions[Extension::APPWRITE->value] ?? [];
         if (isset($alias['deprecated'])) {
             $appwrite['deprecated'] = $alias['deprecated'];
         } else {
@@ -659,7 +660,7 @@ class SDK
         }
 
         $extensions = $operation->extensions;
-        $extensions['x-appwrite'] = $appwrite;
+        $extensions[Extension::APPWRITE->value] = $appwrite;
 
         return new Operation(
             id: $serviceName . \ucfirst($methodName),
@@ -672,7 +673,9 @@ class SDK
             parameters: $operation->parameters,
             requestBody: $this->createAliasedRequestBody($operation->requestBody, $alias),
             responses: $this->createAliasedResponses($operation, $alias),
-            security: $operation->security,
+            security: \is_array($alias['security'] ?? null)
+                ? \array_map(static fn(array $requirement): SecurityRequirement => new SecurityRequirement($requirement), $alias['security'])
+                : $operation->security,
             servers: $operation->servers,
             externalDocumentation: $operation->externalDocumentation,
             extensions: $extensions,
@@ -789,7 +792,7 @@ class SDK
     {
         $clientMethods = [];
         foreach ($this->spec->operations() as $method) {
-            if (!$this->isAvailable($method->extensions['x-appwrite']['platforms'] ?? null)) {
+            if (!$this->isAvailable($method->extensions[Extension::APPWRITE->value][Appwrite::PLATFORMS->value] ?? null)) {
                 continue;
             }
             foreach ($method->tags as $serviceName) {
@@ -971,7 +974,7 @@ class SDK
             if (!isset($reachable[$name])) {
                 continue;
             }
-            if ($schema->extensions['x-request-model'] ?? false) {
+            if ($schema->extensions[Extension::REQUEST_MODEL->value] ?? false) {
                 $requestModels[$name] = $schema;
             } else {
                 $definitions[$name] = $schema;
@@ -1571,7 +1574,7 @@ class SDK
         $parameters = [];
         if ($location !== 'body') {
             foreach ($operation->parameters as $parameter) {
-                if ($location === 'all' && ($parameter->extensions['x-sdk-source'] ?? '') === 'security') {
+                if ($location === 'all' && ($parameter->extensions[Extension::SDK_SOURCE->value] ?? '') === 'security') {
                     continue;
                 }
                 if ($location === 'all' || $parameter->location->value === $location) {
@@ -1660,15 +1663,6 @@ class SDK
                 \array_push($models, ...$this->getSchemaModels($member));
             }
             return \array_values(\array_unique($models));
-        }
-        foreach (['x-oneOf', 'x-anyOf'] as $key) {
-            if (!\is_array($schema->extensions[$key] ?? null)) {
-                continue;
-            }
-            return \array_values(\array_filter(\array_map(
-                fn(array $member): string => $this->normalizeSchemaReference((string) ($member['$ref'] ?? '')),
-                $schema->extensions[$key],
-            )));
         }
         return [];
     }
@@ -1818,7 +1812,7 @@ class SDK
             }
         }
         if ($produces === []) {
-            $produces = $operation->extensions['x-appwrite']['produces'] ?? [];
+            $produces = $operation->extensions[Extension::APPWRITE->value][Appwrite::PRODUCES->value] ?? [];
         }
         return $produces;
     }
@@ -1848,21 +1842,34 @@ class SDK
         return $headers;
     }
 
-    /** @return array<string, SecurityScheme> */
+    /**
+     * The schemes an example configures on the client before calling a method:
+     * the security requirement's first scheme, at most one further scheme whose
+     * `x-sdk-credentials` names this platform, and every optional or path-bound
+     * scheme.
+     *
+     * @return array<string, SecurityScheme>
+     */
     protected function getOperationAuthSchemes(Operation $operation): array
     {
-        $auth = $operation->extensions['x-appwrite']['auth'] ?? [];
-        if (!\is_array($auth)) {
-            return [];
-        }
+        $credential = false;
         $schemes = [];
         $pathSchemes = [];
-        foreach (\array_keys($auth) as $name) {
+        foreach (\array_keys($operation->security[0]->schemes ?? []) as $name) {
             $scheme = $this->getSecurityScheme((string) $name);
             if (!$scheme instanceof SecurityScheme) {
                 continue;
             }
-            if (($scheme->extensions['x-appwrite']['location'] ?? '') === 'path' && $scheme->name !== null) {
+            if ($schemes !== [] || $pathSchemes !== []) {
+                $appwrite = $scheme->extensions[Extension::APPWRITE->value] ?? [];
+                $always = ($appwrite['optional'] ?? false) === true || ($appwrite['location'] ?? '') === 'path';
+                $documented = !$credential && \in_array($this->getParam('platform'), $scheme->extensions[Extension::SDK_CREDENTIALS->value] ?? [], true);
+                if (!$always && !$documented) {
+                    continue;
+                }
+                $credential = $credential || $documented;
+            }
+            if (($scheme->extensions[Extension::APPWRITE->value][Appwrite::LOCATION->value] ?? '') === 'path' && $scheme->name !== null) {
                 $pathSchemes[\ucfirst($this->helperCamelCase($scheme->name))] = $scheme;
             } else {
                 $schemes[$name] = $scheme;
@@ -1880,7 +1887,7 @@ class SDK
             if (!$scheme instanceof SecurityScheme) {
                 continue;
             }
-            if (($scheme->extensions['x-appwrite']['location'] ?? '') === 'path') {
+            if (($scheme->extensions[Extension::APPWRITE->value][Appwrite::LOCATION->value] ?? '') === 'path') {
                 if (!$location instanceof ParameterLocation) {
                     $schemes[$name] = $scheme;
                 }
@@ -1913,7 +1920,7 @@ class SDK
     {
         $cases = [];
 
-        $extended = $discriminator->extensions['x-mapping'] ?? null;
+        $extended = $discriminator->extensions[Extension::MAPPING->value] ?? null;
         if (\is_array($extended)) {
             foreach ($extended as $reference => $conditions) {
                 if (!\is_array($conditions)) {

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -1845,7 +1845,7 @@ class SDK
     /**
      * The schemes an example configures on the client before calling a method:
      * the security requirement's first scheme, at most one further scheme whose
-     * `x-sdk-credentials` names this platform, and every optional or path-bound
+     * `x-appwrite.credentials` names this platform, and every optional or path-bound
      * scheme.
      *
      * @return array<string, SecurityScheme>
@@ -1863,7 +1863,7 @@ class SDK
             if ($schemes !== [] || $pathSchemes !== []) {
                 $appwrite = $scheme->extensions[Extension::APPWRITE->value] ?? [];
                 $always = ($appwrite[Appwrite::OPTIONAL->value] ?? false) === true || ($appwrite[Appwrite::LOCATION->value] ?? '') === 'path';
-                $documented = !$credential && \in_array($this->getParam('platform'), $scheme->extensions[Extension::SDK_CREDENTIALS->value] ?? [], true);
+                $documented = !$credential && \in_array($this->getParam('platform'), $appwrite[Appwrite::CREDENTIALS->value] ?? [], true);
                 if (!$always && !$documented) {
                     continue;
                 }

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -2,13 +2,13 @@
 
 namespace Appwrite\SDK;
 
-use Appwrite\SDK\Extension\Appwrite;
 use Utopia\OpenAPI\Model\AnySchema;
 use Utopia\OpenAPI\Model\ArraySchema;
 use Utopia\OpenAPI\Model\BooleanSchema;
 use Utopia\OpenAPI\Model\CompositeSchema;
 use MatthiasMullie\Minify\JS;
 use MatthiasMullie\Minify\CSS;
+use Appwrite\SDK\Extension\Appwrite;
 use Exception;
 use Throwable;
 use Utopia\OpenAPI\Model\Composition;
@@ -24,7 +24,6 @@ use Utopia\OpenAPI\Model\ReferenceSchema;
 use Utopia\OpenAPI\Model\RequestBody;
 use Utopia\OpenAPI\Model\Response;
 use Utopia\OpenAPI\Model\Schema;
-use Utopia\OpenAPI\Model\SecurityRequirement;
 use Utopia\OpenAPI\Model\SecurityScheme;
 use Utopia\OpenAPI\Model\SecuritySchemeType;
 use Utopia\OpenAPI\Model\StringSchema;
@@ -653,6 +652,7 @@ class SDK
     {
         $methodName = (string) ($alias['name'] ?? $this->methodName($operation));
         $appwrite = $operation->extensions[Extension::APPWRITE->value] ?? [];
+        $appwrite['auth'] = $alias['auth'] ?? [];
         if (isset($alias['deprecated'])) {
             $appwrite['deprecated'] = $alias['deprecated'];
         } else {
@@ -673,9 +673,7 @@ class SDK
             parameters: $operation->parameters,
             requestBody: $this->createAliasedRequestBody($operation->requestBody, $alias),
             responses: $this->createAliasedResponses($operation, $alias),
-            security: \is_array($alias['security'] ?? null)
-                ? \array_map(static fn(array $requirement): SecurityRequirement => new SecurityRequirement($requirement), $alias['security'])
-                : $operation->security,
+            security: $operation->security,
             servers: $operation->servers,
             externalDocumentation: $operation->externalDocumentation,
             extensions: $extensions,
@@ -1843,31 +1841,27 @@ class SDK
     }
 
     /**
-     * The schemes an example configures on the client before calling a method:
-     * the security requirement's first scheme, at most one further scheme whose
-     * `x-appwrite.credentials` names this platform, and every optional or path-bound
-     * scheme.
+     * The schemes an example configures on the client before calling a method.
+     *
+     * A per-platform document lists them flat; the canonical document keys them
+     * by platform, since client and console examples configure the project only
+     * while server examples add one credential.
      *
      * @return array<string, SecurityScheme>
      */
     protected function getOperationAuthSchemes(Operation $operation): array
     {
-        $credential = false;
+        $auth = $operation->extensions[Extension::APPWRITE->value][Appwrite::AUTH->value] ?? [];
+        if (!\is_array($auth)) {
+            return [];
+        }
+        $auth = $auth[$this->getParam('platform')] ?? $auth;
         $schemes = [];
         $pathSchemes = [];
-        foreach (\array_keys($operation->security[0]->schemes ?? []) as $name) {
+        foreach (\array_keys($auth) as $name) {
             $scheme = $this->getSecurityScheme((string) $name);
             if (!$scheme instanceof SecurityScheme) {
                 continue;
-            }
-            if ($schemes !== [] || $pathSchemes !== []) {
-                $appwrite = $scheme->extensions[Extension::APPWRITE->value] ?? [];
-                $always = ($appwrite[Appwrite::OPTIONAL->value] ?? false) === true || ($appwrite[Appwrite::LOCATION->value] ?? '') === 'path';
-                $documented = !$credential && \in_array($this->getParam('platform'), $appwrite[Appwrite::CREDENTIALS->value] ?? [], true);
-                if (!$always && !$documented) {
-                    continue;
-                }
-                $credential = $credential || $documented;
             }
             if (($scheme->extensions[Extension::APPWRITE->value][Appwrite::LOCATION->value] ?? '') === 'path' && $scheme->name !== null) {
                 $pathSchemes[\ucfirst($this->helperCamelCase($scheme->name))] = $scheme;

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -1862,7 +1862,7 @@ class SDK
             }
             if ($schemes !== [] || $pathSchemes !== []) {
                 $appwrite = $scheme->extensions[Extension::APPWRITE->value] ?? [];
-                $always = ($appwrite['optional'] ?? false) === true || ($appwrite['location'] ?? '') === 'path';
+                $always = ($appwrite[Appwrite::OPTIONAL->value] ?? false) === true || ($appwrite[Appwrite::LOCATION->value] ?? '') === 'path';
                 $documented = !$credential && \in_array($this->getParam('platform'), $scheme->extensions[Extension::SDK_CREDENTIALS->value] ?? [], true);
                 if (!$always && !$documented) {
                     continue;

--- a/tests/generation/GenerationTest.php
+++ b/tests/generation/GenerationTest.php
@@ -53,6 +53,11 @@ final class GenerationTest extends TestCase
      * Fixture tokens and the platforms whose generated tree may contain them.
      * An empty list means the token must never appear. Every token is a single
      * lowercase word so it survives each language's identifier casing.
+     *
+     * `zzcredentialdemo` is the demo value of a scheme offered everywhere but
+     * documented as a credential on server alone, so it reaches the examples of
+     * the derived-auth fixture and the server alias only through
+     * `x-sdk-credentials`.
      */
     private const array TOKENS = [
         'zzexcludedservice' => [],
@@ -68,16 +73,18 @@ final class GenerationTest extends TestCase
         'zzplatformclientalias' => ['client'],
         'zzplatformserveralias' => ['server'],
         'zzserveronlyheader' => ['server'],
+        'zzcredentialdemo' => ['server'],
     ];
 
     /**
-     * Targets that render no header setters or no alias descriptions, so the
-     * tokens carried by those never appear in their trees on any platform.
+     * Targets that render no header setters, alias descriptions or example
+     * credentials, so the tokens carried by those never appear in their trees.
      */
     private const array UNRENDERED = [
-        'cli' => ['zzserveronlyheader'],
-        'rest' => ['zzplatformclientalias', 'zzplatformserveralias', 'zzserveronlyheader'],
-        'graphql' => ['zzplatformclientalias', 'zzplatformserveralias', 'zzserveronlyheader'],
+        'cli' => ['zzserveronlyheader', 'zzcredentialdemo'],
+        'unity' => ['zzcredentialdemo'],
+        'rest' => ['zzplatformclientalias', 'zzplatformserveralias', 'zzserveronlyheader', 'zzcredentialdemo'],
+        'graphql' => ['zzplatformclientalias', 'zzplatformserveralias', 'zzserveronlyheader', 'zzcredentialdemo'],
     ];
 
     /**

--- a/tests/generation/GenerationTest.php
+++ b/tests/generation/GenerationTest.php
@@ -262,7 +262,7 @@ final class GenerationTest extends TestCase
 
     /**
      * Example credentials come from the security requirement and
-     * `x-sdk-credentials` alone. The derived-auth fixture requires
+     * `x-appwrite.credentials` alone. The derived-auth fixture requires
      * `Project, Key, JWT`, so server examples configure the project and the
      * first server credential, Key, and client examples the project only. The
      * server alias carries its own `Project, JWT` requirement, so its example

--- a/tests/generation/GenerationTest.php
+++ b/tests/generation/GenerationTest.php
@@ -267,6 +267,33 @@ final class GenerationTest extends TestCase
         }
     }
 
+    /**
+     * Example credentials come from the security requirement and
+     * `x-sdk-credentials` alone: the derived-auth fixture requires
+     * `Project, Zzcredential, Key, JWT`, and the server alias carries its own
+     * `Project, Zzcredential` requirement.
+     */
+    public function testExampleCredentialsAreDerived(): void
+    {
+        $examples = [
+            ['server', 'docs/examples/general/zzderivedauth.md', ['->setproject(', '->setzzcredential('], ['->setkey(', '->setjwt(']],
+            ['client', 'docs/examples/general/zzderivedauth.md', ['->setproject('], ['->setzzcredential(', '->setkey(', '->setjwt(']],
+            ['server', 'docs/examples/general/zzplatformalias.md', ['->setproject(', '->setzzcredential('], ['->setkey(', '->setjwt(']],
+            ['client', 'docs/examples/general/zzplatformalias.md', ['->setproject('], ['->setzzcredential(', '->setkey(', '->setjwt(']],
+        ];
+
+        foreach ($examples as [$platform, $path, $present, $absent]) {
+            $files = $this->generate('php', $platform);
+            $this->assertArrayHasKey($path, $files, "php/{$platform} did not generate {$path}");
+            foreach ($present as $call) {
+                $this->assertStringContainsString($call, $files[$path], "php/{$platform} {$path} lacks {$call}");
+            }
+            foreach ($absent as $call) {
+                $this->assertStringNotContainsString($call, $files[$path], "php/{$platform} {$path} configures {$call}");
+            }
+        }
+    }
+
     #[DataProvider('languages')]
     public function testEnumsAreDeclared(string $name): void
     {

--- a/tests/generation/GenerationTest.php
+++ b/tests/generation/GenerationTest.php
@@ -261,14 +261,11 @@ final class GenerationTest extends TestCase
     }
 
     /**
-     * Example credentials come from the security requirement and
-     * `x-appwrite.credentials` alone. The derived-auth fixture requires
-     * `Project, Key, JWT`, so server examples configure the project and the
-     * first server credential, Key, and client examples the project only. The
-     * server alias carries its own `Project, JWT` requirement, so its example
-     * configures JWT instead of the operation's Key.
+     * A canonical document keys `x-appwrite.auth` by platform. The fixture's
+     * platform-auth operation lists `Project` for client and `Project, Key` for
+     * server, and the server alias variant lists `Project, JWT`.
      */
-    public function testExampleCredentialsAreDerived(): void
+    public function testExampleCredentialsFollowPlatformAuth(): void
     {
         $examples = [
             ['server', 'docs/examples/general/zzderivedauth.md', ['->setproject(', '->setkey('], ['->setjwt(', '->setsession(']],

--- a/tests/generation/GenerationTest.php
+++ b/tests/generation/GenerationTest.php
@@ -53,11 +53,6 @@ final class GenerationTest extends TestCase
      * Fixture tokens and the platforms whose generated tree may contain them.
      * An empty list means the token must never appear. Every token is a single
      * lowercase word so it survives each language's identifier casing.
-     *
-     * `zzcredentialdemo` is the demo value of a scheme offered everywhere but
-     * documented as a credential on server alone, so it reaches the examples of
-     * the derived-auth fixture and the server alias only through
-     * `x-sdk-credentials`.
      */
     private const array TOKENS = [
         'zzexcludedservice' => [],
@@ -73,18 +68,16 @@ final class GenerationTest extends TestCase
         'zzplatformclientalias' => ['client'],
         'zzplatformserveralias' => ['server'],
         'zzserveronlyheader' => ['server'],
-        'zzcredentialdemo' => ['server'],
     ];
 
     /**
-     * Targets that render no header setters, alias descriptions or example
-     * credentials, so the tokens carried by those never appear in their trees.
+     * Targets that render no header setters or no alias descriptions, so the
+     * tokens carried by those never appear in their trees on any platform.
      */
     private const array UNRENDERED = [
-        'cli' => ['zzserveronlyheader', 'zzcredentialdemo'],
-        'unity' => ['zzcredentialdemo'],
-        'rest' => ['zzplatformclientalias', 'zzplatformserveralias', 'zzserveronlyheader', 'zzcredentialdemo'],
-        'graphql' => ['zzplatformclientalias', 'zzplatformserveralias', 'zzserveronlyheader', 'zzcredentialdemo'],
+        'cli' => ['zzserveronlyheader'],
+        'rest' => ['zzplatformclientalias', 'zzplatformserveralias', 'zzserveronlyheader'],
+        'graphql' => ['zzplatformclientalias', 'zzplatformserveralias', 'zzserveronlyheader'],
     ];
 
     /**
@@ -269,17 +262,19 @@ final class GenerationTest extends TestCase
 
     /**
      * Example credentials come from the security requirement and
-     * `x-sdk-credentials` alone: the derived-auth fixture requires
-     * `Project, Zzcredential, Key, JWT`, and the server alias carries its own
-     * `Project, Zzcredential` requirement.
+     * `x-sdk-credentials` alone. The derived-auth fixture requires
+     * `Project, Key, JWT`, so server examples configure the project and the
+     * first server credential, Key, and client examples the project only. The
+     * server alias carries its own `Project, JWT` requirement, so its example
+     * configures JWT instead of the operation's Key.
      */
     public function testExampleCredentialsAreDerived(): void
     {
         $examples = [
-            ['server', 'docs/examples/general/zzderivedauth.md', ['->setproject(', '->setzzcredential('], ['->setkey(', '->setjwt(']],
-            ['client', 'docs/examples/general/zzderivedauth.md', ['->setproject('], ['->setzzcredential(', '->setkey(', '->setjwt(']],
-            ['server', 'docs/examples/general/zzplatformalias.md', ['->setproject(', '->setzzcredential('], ['->setkey(', '->setjwt(']],
-            ['client', 'docs/examples/general/zzplatformalias.md', ['->setproject('], ['->setzzcredential(', '->setkey(', '->setjwt(']],
+            ['server', 'docs/examples/general/zzderivedauth.md', ['->setproject(', '->setkey('], ['->setjwt(', '->setsession(']],
+            ['client', 'docs/examples/general/zzderivedauth.md', ['->setproject('], ['->setkey(', '->setjwt(', '->setsession(']],
+            ['server', 'docs/examples/general/zzplatformalias.md', ['->setproject(', '->setjwt('], ['->setkey(', '->setsession(']],
+            ['client', 'docs/examples/general/zzplatformalias.md', ['->setproject('], ['->setkey(', '->setjwt(', '->setsession(']],
         ];
 
         foreach ($examples as [$platform, $path, $present, $absent]) {

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -2205,7 +2205,7 @@
               "security": [
                 {
                   "Project": [],
-                  "Zzcredential": []
+                  "JWT": []
                 }
               ]
             }
@@ -2255,7 +2255,6 @@
         "security": [
           {
             "Project": [],
-            "Zzcredential": [],
             "Key": [],
             "JWT": []
           }
@@ -2915,18 +2914,6 @@
         "name": "X-Appwrite-Session",
         "description": "The user session to authenticate with",
         "in": "header",
-        "x-sdk-credentials": [
-          "server"
-        ]
-      },
-      "Zzcredential": {
-        "type": "apiKey",
-        "name": "X-Appwrite-Zzcredential",
-        "description": "Fixture-only credential that server examples configure.",
-        "in": "header",
-        "x-appwrite": {
-          "demo": "zzcredentialdemo"
-        },
         "x-sdk-credentials": [
           "server"
         ]

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -2891,11 +2891,11 @@
         "description": "Your secret API key",
         "in": "header",
         "x-appwrite": {
-          "demo": "919c2d18fb5d4...a2ae413da83346ad2"
-        },
-        "x-sdk-credentials": [
-          "server"
-        ]
+          "demo": "919c2d18fb5d4...a2ae413da83346ad2",
+          "credentials": [
+            "server"
+          ]
+        }
       },
       "JWT": {
         "type": "apiKey",
@@ -2903,20 +2903,22 @@
         "description": "Your secret JSON Web Token",
         "in": "header",
         "x-appwrite": {
-          "demo": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ..."
-        },
-        "x-sdk-credentials": [
-          "server"
-        ]
+          "demo": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ...",
+          "credentials": [
+            "server"
+          ]
+        }
       },
       "Session": {
         "type": "apiKey",
         "name": "X-Appwrite-Session",
         "description": "The user session to authenticate with",
         "in": "header",
-        "x-sdk-credentials": [
-          "server"
-        ]
+        "x-appwrite": {
+          "credentials": [
+            "server"
+          ]
+        }
       },
       "Zzserveronlyheader": {
         "type": "apiKey",

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -79,7 +79,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 270,
           "demo": "bar\/get.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -153,7 +152,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 271,
           "demo": "bar\/post.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -228,7 +226,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 273,
           "demo": "bar\/put.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -303,7 +300,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 272,
           "demo": "bar\/patch.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -378,7 +374,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 274,
           "demo": "bar\/delete.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -455,7 +450,6 @@
         ],
         "description": "Create a new player using a request model.",
         "x-appwrite": {
-          "weight": 300,
           "demo": "general\/create-player.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -520,7 +514,6 @@
         ],
         "description": "Create multiple players using an array of request models.",
         "x-appwrite": {
-          "weight": 301,
           "demo": "general\/create-players.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -584,7 +577,6 @@
         ],
         "description": "Fixture-only general method used to verify method exclusion does not remove the whole service.",
         "x-appwrite": {
-          "weight": 301,
           "demo": "general\/excluded-method.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -659,7 +651,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 265,
           "demo": "foo\/get.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -733,7 +724,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 266,
           "demo": "foo\/post.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -808,7 +798,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 268,
           "demo": "foo\/put.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -883,7 +872,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 267,
           "demo": "foo\/patch.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -958,7 +946,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 269,
           "demo": "foo\/delete.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -1035,7 +1022,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 285,
           "demo": "general\/error400.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -1077,7 +1063,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 286,
           "demo": "general\/error500.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -1119,7 +1104,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 287,
           "demo": "general\/error502.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -1159,7 +1143,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 276,
           "demo": "general\/download.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -1202,7 +1185,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 282,
           "demo": "general\/empty.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -1237,7 +1219,6 @@
         ],
         "description": "Mock a queryable list request.",
         "x-appwrite": {
-          "weight": 284,
           "demo": "general\/list-rows.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -1293,7 +1274,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 284,
           "demo": "general\/enum.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -1436,7 +1416,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 281,
           "demo": "general\/get-cookie.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -1478,7 +1457,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 275,
           "demo": "general\/headers.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -1525,7 +1503,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 283,
           "demo": "general\/nullable.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -1601,7 +1578,6 @@
         ],
         "description": "Create a new function execution.",
         "x-appwrite": {
-          "weight": 1,
           "demo": "functions\/create-execution.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -1696,7 +1672,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 278,
           "demo": "general\/redirect.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -1734,7 +1709,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 279,
           "demo": "general\/redirected.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -1776,7 +1750,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 280,
           "demo": "general\/get-path.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -1830,7 +1803,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 280,
           "demo": "general\/set-cookie.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -1872,7 +1844,6 @@
         ],
         "description": "",
         "x-appwrite": {
-          "weight": 277,
           "demo": "general\/upload.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -1999,7 +1970,6 @@
         ],
         "description": "OAuth 2",
         "x-appwrite": {
-          "weight": 265,
           "demo": "general\/oauth2.md",
           "rate-limit": 10,
           "rate-time": 3600,
@@ -2100,7 +2070,6 @@
         ],
         "description": "Test union response types",
         "x-appwrite": {
-          "weight": 302,
           "demo": "mock\/get-union.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -2169,7 +2138,6 @@
         ],
         "description": "Fixture-only method available to console SDKs alone; verifies platform selection drops it elsewhere.",
         "x-appwrite": {
-          "weight": 302,
           "demo": "general\/zzconsoleonly.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -2208,7 +2176,6 @@
         ],
         "description": "Fixture-only method whose alias differs per platform; verifies alias selection.",
         "x-appwrite": {
-          "weight": 303,
           "demo": "general\/platform-alias.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -2274,7 +2241,6 @@
         ],
         "description": "Fixture-only method without x-appwrite.auth; example credentials derive from the security requirement.",
         "x-appwrite": {
-          "weight": 304,
           "demo": "general\/zzderivedauth.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -2317,7 +2283,6 @@
         ],
         "description": "Execute a GraphQL query.",
         "x-appwrite": {
-          "weight": 302,
           "demo": "graphql\/query.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -2378,7 +2343,6 @@
         ],
         "description": "Fixture-only service used to verify excluded services do not leak generated artifacts.",
         "x-appwrite": {
-          "weight": 303,
           "demo": "zzexcludedservice\/get.md",
           "rate-limit": 0,
           "rate-time": 3600,
@@ -2418,7 +2382,6 @@
         ],
         "description": "Fixture-only request model path used to verify excluded services also exclude models.",
         "x-appwrite": {
-          "weight": 304,
           "demo": "zzexcludedservice\/post.md",
           "rate-limit": 0,
           "rate-time": 3600,

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -45,7 +45,14 @@
             "console"
           ],
           "packaging": false,
-          "public": true
+          "public": true,
+          "auth": {
+            "Project": [],
+            "Admin": [],
+            "Key": [],
+            "JWT": [],
+            "Session": []
+          }
         },
         "security": [
           {
@@ -88,7 +95,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -161,7 +171,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -235,7 +248,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -309,7 +325,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -383,7 +402,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -459,7 +481,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -523,7 +548,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -587,6 +615,9 @@
             "server"
           ],
           "packaging": false,
+          "auth": {
+            "Project": []
+          },
           "methods": [
             {
               "name": "createExcludedGeneralFixture",
@@ -594,7 +625,10 @@
               "platforms": [
                 "client",
                 "server"
-              ]
+              ],
+              "auth": {
+                "Project": []
+              }
             }
           ]
         },
@@ -660,7 +694,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -733,7 +770,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -807,7 +847,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -881,7 +924,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -955,7 +1001,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -1031,7 +1080,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -1072,7 +1124,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -1113,7 +1168,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -1152,7 +1210,11 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": [],
+            "ImpersonateUserId": []
+          }
         },
         "security": [
           {
@@ -1194,7 +1256,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -1228,7 +1293,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -1283,7 +1351,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -1425,7 +1496,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -1466,7 +1540,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -1512,7 +1589,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -1586,7 +1666,10 @@
           "platforms": [
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -1682,6 +1765,9 @@
             "server"
           ],
           "packaging": false,
+          "auth": {
+            "Project": []
+          },
           "produces": [
             "text\/html"
           ]
@@ -1718,7 +1804,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -1759,7 +1848,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -1812,7 +1904,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -1853,7 +1948,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -1980,6 +2078,9 @@
             "server"
           ],
           "packaging": false,
+          "auth": {
+            "Project": []
+          },
           "produces": [
             "text\/plain"
           ]
@@ -2079,7 +2180,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -2193,7 +2297,10 @@
               "platforms": [
                 "client"
               ],
-              "description": "zzplatformclientalias variant."
+              "description": "zzplatformclientalias variant.",
+              "auth": {
+                "Project": []
+              }
             },
             {
               "name": "zzplatformalias",
@@ -2202,12 +2309,12 @@
                 "server"
               ],
               "description": "zzplatformserveralias variant.",
-              "security": [
-                {
+              "auth": {
+                "server": {
                   "Project": [],
                   "JWT": []
                 }
-              ]
+              }
             }
           ]
         },
@@ -2234,12 +2341,12 @@
     },
     "\/mock\/tests\/general\/zzderivedauth": {
       "get": {
-        "summary": "Derived Auth Fixture",
+        "summary": "Platform Auth Fixture",
         "operationId": "generalZzderivedauth",
         "tags": [
           "general"
         ],
-        "description": "Fixture-only method without x-appwrite.auth; example credentials derive from the security requirement.",
+        "description": "Fixture-only method whose example credentials are keyed by platform, as in the canonical document.",
         "x-appwrite": {
           "demo": "general\/zzderivedauth.md",
           "rate-limit": 0,
@@ -2250,7 +2357,16 @@
           "platforms": [
             "client",
             "server"
-          ]
+          ],
+          "auth": {
+            "client": {
+              "Project": []
+            },
+            "server": {
+              "Project": [],
+              "Key": []
+            }
+          }
         },
         "security": [
           {
@@ -2291,7 +2407,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -2351,7 +2470,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -2390,7 +2512,10 @@
             "client",
             "server"
           ],
-          "packaging": false
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
         },
         "security": [
           {
@@ -2891,10 +3016,7 @@
         "description": "Your secret API key",
         "in": "header",
         "x-appwrite": {
-          "demo": "919c2d18fb5d4...a2ae413da83346ad2",
-          "credentials": [
-            "server"
-          ]
+          "demo": "919c2d18fb5d4...a2ae413da83346ad2"
         }
       },
       "JWT": {
@@ -2903,22 +3025,14 @@
         "description": "Your secret JSON Web Token",
         "in": "header",
         "x-appwrite": {
-          "demo": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ...",
-          "credentials": [
-            "server"
-          ]
+          "demo": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ..."
         }
       },
       "Session": {
         "type": "apiKey",
         "name": "X-Appwrite-Session",
         "description": "The user session to authenticate with",
-        "in": "header",
-        "x-appwrite": {
-          "credentials": [
-            "server"
-          ]
-        }
+        "in": "header"
       },
       "Zzserveronlyheader": {
         "type": "apiKey",

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -45,14 +45,7 @@
             "console"
           ],
           "packaging": false,
-          "public": true,
-          "auth": {
-            "Project": [],
-            "Admin": [],
-            "Key": [],
-            "JWT": [],
-            "Session": []
-          }
+          "public": true
         },
         "security": [
           {
@@ -96,10 +89,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -173,10 +163,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -251,10 +238,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -329,10 +313,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -407,10 +388,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -487,10 +465,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -555,10 +530,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -623,9 +595,6 @@
             "server"
           ],
           "packaging": false,
-          "auth": {
-            "Project": []
-          },
           "methods": [
             {
               "name": "createExcludedGeneralFixture",
@@ -633,10 +602,7 @@
               "platforms": [
                 "client",
                 "server"
-              ],
-              "auth": {
-                "Project": []
-              }
+              ]
             }
           ]
         },
@@ -703,10 +669,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -780,10 +743,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -858,10 +818,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -936,10 +893,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -1014,10 +968,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -1094,10 +1045,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -1139,10 +1087,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -1184,10 +1129,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -1227,11 +1169,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": [],
-            "ImpersonateUserId": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -1274,10 +1212,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -1312,10 +1247,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -1371,10 +1303,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -1517,10 +1446,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -1562,10 +1488,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -1612,10 +1535,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -1690,10 +1610,7 @@
           "platforms": [
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -1790,9 +1707,6 @@
             "server"
           ],
           "packaging": false,
-          "auth": {
-            "Project": []
-          },
           "produces": [
             "text\/html"
           ]
@@ -1830,10 +1744,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -1875,10 +1786,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -1932,10 +1840,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -1977,10 +1882,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -2108,9 +2010,6 @@
             "server"
           ],
           "packaging": false,
-          "auth": {
-            "Project": []
-          },
           "produces": [
             "text\/plain"
           ]
@@ -2211,10 +2110,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -2338,13 +2234,62 @@
               "platforms": [
                 "server"
               ],
-              "description": "zzplatformserveralias variant."
+              "description": "zzplatformserveralias variant.",
+              "security": [
+                {
+                  "Project": [],
+                  "Zzcredential": []
+                }
+              ]
             }
           ]
         },
         "security": [
           {
             "Project": [],
+            "Key": [],
+            "JWT": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Any",
+            "content": {
+              "application\/json": {
+                "schema": {
+                  "$ref": "#\/components\/schemas\/any"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "\/mock\/tests\/general\/zzderivedauth": {
+      "get": {
+        "summary": "Derived Auth Fixture",
+        "operationId": "generalZzderivedauth",
+        "tags": [
+          "general"
+        ],
+        "description": "Fixture-only method without x-appwrite.auth; example credentials derive from the security requirement.",
+        "x-appwrite": {
+          "weight": 304,
+          "demo": "general\/zzderivedauth.md",
+          "rate-limit": 0,
+          "rate-time": 3600,
+          "rate-key": "url:{url},ip:{ip}",
+          "scope": "public",
+          "packaging": false,
+          "platforms": [
+            "client",
+            "server"
+          ]
+        },
+        "security": [
+          {
+            "Project": [],
+            "Zzcredential": [],
             "Key": [],
             "JWT": []
           }
@@ -2382,10 +2327,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -2446,10 +2388,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -2489,10 +2428,7 @@
             "client",
             "server"
           ],
-          "packaging": false,
-          "auth": {
-            "Project": []
-          }
+          "packaging": false
         },
         "security": [
           {
@@ -2994,7 +2930,10 @@
         "in": "header",
         "x-appwrite": {
           "demo": "919c2d18fb5d4...a2ae413da83346ad2"
-        }
+        },
+        "x-sdk-credentials": [
+          "server"
+        ]
       },
       "JWT": {
         "type": "apiKey",
@@ -3003,13 +2942,31 @@
         "in": "header",
         "x-appwrite": {
           "demo": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ..."
-        }
+        },
+        "x-sdk-credentials": [
+          "server"
+        ]
       },
       "Session": {
         "type": "apiKey",
         "name": "X-Appwrite-Session",
         "description": "The user session to authenticate with",
-        "in": "header"
+        "in": "header",
+        "x-sdk-credentials": [
+          "server"
+        ]
+      },
+      "Zzcredential": {
+        "type": "apiKey",
+        "name": "X-Appwrite-Zzcredential",
+        "description": "Fixture-only credential that server examples configure.",
+        "in": "header",
+        "x-appwrite": {
+          "demo": "zzcredentialdemo"
+        },
+        "x-sdk-credentials": [
+          "server"
+        ]
       },
       "Zzserveronlyheader": {
         "type": "apiKey",


### PR DESCRIPTION
## Summary

Follow-up to #1880, preparing the generator for one canonical OpenAPI document.

- **Extension keys are enums.** `Appwrite\SDK\Extension` holds every top-level vendor extension the generator reads (`x-appwrite`, `x-request-model`, `x-mapping`, and the generator's own `x-sdk-source` / `x-sdk-config` annotations); `Appwrite\SDK\Extension\Appwrite` holds the keys read under `x-appwrite` (`platforms`, `methods`, `auth`, `produces`, `packaging`, `location`, `param`, `config`, `optional`). Every string read in `SDK.php`, `Language.php`, `CLI.php` and `Rust.php` goes through them, so the full set the generator depends on is visible in two files.
- **`x-appwrite.auth` may be keyed by platform.** A per-platform document lists the example credentials flat; the canonical document has to carry all three, so it keys them by platform and the generator reads `auth[platform]`, falling back to the flat form. No behaviour change for existing documents.

```diff
 "x-appwrite": {
-  "auth": { "Project": [], "Session": [] }        // one per document today
+  "auth": {
+    "client":  { "Project": [] },
+    "server":  { "Project": [], "Session": [] },
+    "console": { "Project": [] }
+  }
 }
```

- The `x-oneOf` / `x-anyOf` fallback appears in no fixture or published spec and is removed. The fixture-only `x-appwrite.weight` is dropped from the fixture.

## Tests

- Fixture gains a platform-auth operation with keyed `auth` and a keyed `auth` on the server alias variant.
- `testExampleCredentialsFollowPlatformAuth()` asserts the exact setters in those examples on both platforms: server shows `setKey()` for the operation and `setJWT()` for the alias, client shows `setProject()` alone.

## Validation

- `vendor/bin/phpunit --testsuite Generation`: 82 tests, 1115 assertions.
- `composer lint`, `composer refactor:check`: clean.

Related to [CLO-4377](https://linear.app/appwrite/issue/CLO-4377/openapi3-standards).
