### PR TITLE
fix: send Swift object arrays as JSON and keep trailing Web positional arguments

### DIFF
--- a/mock-server/app/http.php
+++ b/mock-server/app/http.php
@@ -19,6 +19,7 @@ use Utopia\Swoole\Response as UtopiaSwooleResponse;
 use Utopia\Validator\Text;
 use Utopia\Validator\Integer;
 use Utopia\Validator\ArrayList;
+use Utopia\Validator\Assoc;
 use Utopia\Validator\Host;
 use Utopia\Validator\Nullable;
 use Utopia\Validator\WhiteList;
@@ -545,6 +546,26 @@ App::get('/v1/mock/tests/general/list-rows')
         $response->json(['result' => \json_encode($queries)]);
     });
 
+App::get('/v1/mock/tests/general/optional')
+    ->desc('Get Optional')
+    ->groups(['mock'])
+    ->label('scope', 'public')
+    ->label('sdk.auth', [APP_AUTH_TYPE_SESSION, APP_AUTH_TYPE_KEY, APP_AUTH_TYPE_JWT])
+    ->label('sdk.namespace', 'general')
+    ->label('sdk.method', 'getOptional')
+    ->label('sdk.description', 'Mock a request whose parameters are all optional.')
+    ->label('sdk.response.code', Response::STATUS_CODE_OK)
+    ->label('sdk.response.type', Response::CONTENT_TYPE_JSON)
+    ->label('sdk.response.model', Response::MODEL_MOCK)
+    ->label('sdk.mock', true)
+    ->param('width', -1, new Integer(true), 'Sample optional numeric param', true)
+    ->param('height', -1, new Integer(true), 'Sample optional numeric param', true)
+    ->param('name', '', new Text(100), 'Sample optional string param', true)
+    ->inject('response')
+    ->action(function (int $width, int $height, string $name, UtopiaSwooleResponse $response) {
+        $response->json(['result' => "width={$width},height={$height},name={$name}"]);
+    });
+
 App::post('/v1/mock/tests/general/nullable')
     ->desc('Nullable Test')
     ->groups(['mock'])
@@ -604,6 +625,31 @@ App::post('/v1/mock/tests/general/models/array')
     ->param('players', [], new ArrayList(new PlayerValidator(), APP_LIMIT_ARRAY_PARAMS_SIZE), 'Array of player objects.', model: Player::class)
     ->action(function (array $players) {
         /** @var Player[] $players */
+    });
+
+App::post('/v1/mock/tests/general/documents')
+    ->desc('Create Documents')
+    ->groups(['mock'])
+    ->label('scope', 'public')
+    ->label('sdk.auth', [APP_AUTH_TYPE_SESSION, APP_AUTH_TYPE_KEY, APP_AUTH_TYPE_JWT])
+    ->label('sdk.namespace', 'general')
+    ->label('sdk.method', 'createDocuments')
+    ->label('sdk.description', 'Create documents from an array of plain objects.')
+    ->label('sdk.response.code', Response::STATUS_CODE_OK)
+    ->label('sdk.response.type', Response::CONTENT_TYPE_JSON)
+    ->label('sdk.response.model', Response::MODEL_MOCK)
+    ->label('sdk.mock', true)
+    ->param('documents', [], new ArrayList(new Assoc(), APP_LIMIT_ARRAY_PARAMS_SIZE), 'Array of document objects.')
+    ->action(function (array $documents) {
+        if ($documents === []) {
+            throw new Exception(Exception::GENERAL_MOCK, 'Documents must not be empty');
+        }
+
+        foreach ($documents as $document) {
+            if (!\is_array($document) || !isset($document['$id'])) {
+                throw new Exception(Exception::GENERAL_MOCK, 'Each document must be an object with an $id');
+            }
+        }
     });
 
 App::get('/v1/mock/tests/union')

--- a/src/SDK/Language/Swift.php
+++ b/src/SDK/Language/Swift.php
@@ -2,6 +2,7 @@
 
 namespace Appwrite\SDK\Language;
 
+use stdClass;
 use Utopia\OpenAPI\Model\AnySchema;
 use Utopia\OpenAPI\Model\ArraySchema;
 use Utopia\OpenAPI\Model\ObjectSchema;
@@ -458,7 +459,7 @@ class Swift extends Language
                         $output .= $this->getPermissionExample($example);
                         break;
                     }
-                    $decoded = json_decode((string) $example, true);
+                    $decoded = json_decode((string) $example);
                     $output .= is_array($decoded) ? $this->jsonToSwiftLiteral($decoded) : $example;
                     break;
                 case self::TYPE_BOOLEAN:
@@ -468,12 +469,8 @@ class Swift extends Language
                     $output .= "\"{$example}\"";
                     break;
                 case self::TYPE_OBJECT:
-                    $decoded = json_decode((string) $example, true);
-                    if ($decoded && is_array($decoded)) {
-                        $output .= $this->jsonToSwiftLiteral($decoded);
-                    } else {
-                        $output .= '[:]';
-                    }
+                    $decoded = json_decode((string) $example);
+                    $output .= is_object($decoded) ? $this->jsonToSwiftLiteral($decoded) : '[:]';
                     break;
             }
         }
@@ -484,43 +481,68 @@ class Swift extends Language
     /**
      * Converts a decoded JSON value into a Swift array or dictionary literal.
      *
-     * JSON objects become `[key: value]` dictionaries and JSON lists become
-     * `[value, ...]` arrays; a Swift example must not carry JavaScript-style
-     * `{ ... }` object literals.
+     * The value must be decoded without the associative flag so that JSON
+     * objects arrive as `stdClass` and JSON lists as arrays; PHP arrays alone
+     * cannot tell an empty `{}` from an empty `[]`. Objects become `[key: value]`
+     * dictionaries and lists become `[value, ...]` arrays, because a Swift
+     * example must not carry JavaScript-style `{ ... }` object literals.
      */
-    protected function jsonToSwiftLiteral(array $data, int $indent = 0): string
+    protected function jsonToSwiftLiteral(array|stdClass $data, int $indent = 0): string
     {
-        if ($data === []) {
-            return '[:]';
+        $isList = is_array($data);
+        $entries = $isList ? $data : get_object_vars($data);
+
+        if ($entries === []) {
+            return $isList ? '[]' : '[:]';
         }
 
         $baseIndent = str_repeat('    ', $indent);
         $itemIndent = str_repeat('    ', $indent + 1);
-        $isList = array_is_list($data);
         $output = "[\n";
 
-        $keys = array_keys($data);
+        $keys = array_keys($entries);
         foreach ($keys as $index => $key) {
-            $node = $data[$key];
-
-            if (is_array($node)) {
-                $value = $this->jsonToSwiftLiteral($node, $indent + 1);
-            } elseif (is_string($node)) {
-                $value = '"' . $node . '"';
-            } elseif (is_bool($node)) {
-                $value = $node ? 'true' : 'false';
-            } elseif (is_null($node)) {
-                $value = 'nil';
-            } else {
-                $value = $node;
-            }
-
+            $value = $this->swiftLiteral($entries[$key], $indent + 1);
             $comma = ($index < count($keys) - 1) ? ',' : '';
-            $entry = $isList ? $value : '"' . $key . '": ' . $value;
+            $entry = $isList ? $value : $this->swiftString((string) $key) . ': ' . $value;
             $output .= '    ' . $itemIndent . $entry . $comma . "\n";
         }
 
         return $output . ('    ' . $baseIndent . ']');
+    }
+
+    protected function swiftLiteral(mixed $value, int $indent): string
+    {
+        return match (true) {
+            is_array($value), $value instanceof stdClass => $this->jsonToSwiftLiteral($value, $indent),
+            is_string($value) => $this->swiftString($value),
+            is_bool($value) => $value ? 'true' : 'false',
+            is_null($value) => 'nil',
+            default => (string) $value,
+        };
+    }
+
+    /**
+     * Renders a Swift string literal. Backslashes and quotes are escaped so
+     * JSON content such as `say "hi"` or `\(name)` survives as text, and control
+     * characters use Swift's `\u{...}` form.
+     */
+    protected function swiftString(string $value): string
+    {
+        $escaped = preg_replace_callback(
+            '/[\\"\x00-\x1F]/',
+            fn(array $match): string => match ($match[0]) {
+                '\\' => '\\\\',
+                '"' => '\\"',
+                "\n" => '\\n',
+                "\r" => '\\r',
+                "\t" => '\\t',
+                default => sprintf('\\u{%X}', ord($match[0])),
+            },
+            $value
+        );
+
+        return '"' . $escaped . '"';
     }
 
     public function getModelToMapValue(Schema $property, string $propertyName, bool $required): string

--- a/src/SDK/Language/Swift.php
+++ b/src/SDK/Language/Swift.php
@@ -454,7 +454,12 @@ class Swift extends Language
                     $output .= $example;
                     break;
                 case self::TYPE_ARRAY:
-                    $output .= $this->isPermissionString($example) ? $this->getPermissionExample($example) : $example;
+                    if ($this->isPermissionString($example)) {
+                        $output .= $this->getPermissionExample($example);
+                        break;
+                    }
+                    $decoded = json_decode((string) $example, true);
+                    $output .= is_array($decoded) ? $this->jsonToSwiftLiteral($decoded) : $example;
                     break;
                 case self::TYPE_BOOLEAN:
                     $output .= ($example) ? 'true' : 'false';
@@ -465,7 +470,7 @@ class Swift extends Language
                 case self::TYPE_OBJECT:
                     $decoded = json_decode((string) $example, true);
                     if ($decoded && is_array($decoded)) {
-                        $output .= $this->jsonToSwiftDict($decoded);
+                        $output .= $this->jsonToSwiftLiteral($decoded);
                     } else {
                         $output .= '[:]';
                     }
@@ -477,9 +482,13 @@ class Swift extends Language
     }
 
     /**
-     * Converts JSON Object To Swift Native Dictionary
+     * Converts a decoded JSON value into a Swift array or dictionary literal.
+     *
+     * JSON objects become `[key: value]` dictionaries and JSON lists become
+     * `[value, ...]` arrays; a Swift example must not carry JavaScript-style
+     * `{ ... }` object literals.
      */
-    protected function jsonToSwiftDict(array $data, int $indent = 0): string
+    protected function jsonToSwiftLiteral(array $data, int $indent = 0): string
     {
         if ($data === []) {
             return '[:]';
@@ -487,6 +496,7 @@ class Swift extends Language
 
         $baseIndent = str_repeat('    ', $indent);
         $itemIndent = str_repeat('    ', $indent + 1);
+        $isList = array_is_list($data);
         $output = "[\n";
 
         $keys = array_keys($data);
@@ -494,7 +504,7 @@ class Swift extends Language
             $node = $data[$key];
 
             if (is_array($node)) {
-                $value = $this->jsonToSwiftDict($node, $indent + 1);
+                $value = $this->jsonToSwiftLiteral($node, $indent + 1);
             } elseif (is_string($node)) {
                 $value = '"' . $node . '"';
             } elseif (is_bool($node)) {
@@ -506,7 +516,8 @@ class Swift extends Language
             }
 
             $comma = ($index < count($keys) - 1) ? ',' : '';
-            $output .= '    ' . $itemIndent . '"' . $key . '": ' . $value . $comma . "\n";
+            $entry = $isList ? $value : '"' . $key . '": ' . $value;
+            $output .= '    ' . $itemIndent . $entry . $comma . "\n";
         }
 
         return $output . ('    ' . $baseIndent . ']');

--- a/src/SDK/Language/Web.php
+++ b/src/SDK/Language/Web.php
@@ -502,9 +502,13 @@ class Web extends JS
      * onto one operand per line. Emitting the pre-broken form keeps the generated
      * SDK formatter-clean without a post-generation pass.
      *
+     * When every parameter is optional, an omitted first argument only selects
+     * the object form when nothing follows it; `getPhoto(undefined, 128)` must
+     * still dispatch positionally or the trailing arguments are discarded.
+     *
      * @param array<int, string> $keys
      */
-    protected function formatOverloadCondition(bool $hasRequired, array $keys): string
+    protected function formatOverloadCondition(bool $hasRequired, array $keys, bool $hasRest = false): string
     {
         $indent = str_repeat(' ', 12);
         $shape = [
@@ -531,8 +535,11 @@ class Web extends JS
             // so Prettier indents its operands one level deeper.
             $nested = $indent . str_repeat(' ', 4);
             $body = implode(' &&' . "\n" . $nested, $shape);
+            $omitted = $hasRest
+                ? "(typeof paramsOrFirst === 'undefined' && rest.length === 0)"
+                : "typeof paramsOrFirst === 'undefined'";
 
-            return '!paramsOrFirst ||' . "\n" . $indent . '(' . $body . ')';
+            return $omitted . ' ||' . "\n" . $indent . '(' . $body . ')';
         }
 
         return implode(' &&' . "\n" . $indent, $shape);
@@ -1061,7 +1068,9 @@ class Web extends JS
                     }
                 }
 
-                return $this->formatOverloadCondition($hasRequired, $keys);
+                $hasRest = count($params) > 1;
+
+                return $this->formatOverloadCondition($hasRequired, $keys, $hasRest);
             }, ['is_safe' => ['html']]),
         ]);
     }

--- a/templates/apple/Sources/Client.swift.twig
+++ b/templates/apple/Sources/Client.swift.twig
@@ -619,7 +619,7 @@ open class Client {
             {
                 encodedParams[key] = param
             } else if let encodable = param as? Encodable {
-                encodedParams[key] = try encodable.toJson()
+                encodedParams[key] = try encodable.toJsonObject()
             } else if let param = param {
                 encodedParams[key] = String(describing: param)
             }

--- a/templates/cli/internal/watch/watch.go
+++ b/templates/cli/internal/watch/watch.go
@@ -6,19 +6,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/fsnotify/fsnotify"
 )
-
-// settle is how long a path stays quiet before its events are inspected.
-//
-// A save is rarely one event: os.WriteFile and most editors truncate and then
-// write, and some write a temporary file and rename it over the original.
-// Fingerprinting between those steps sees an empty or half-written file and
-// reports a change that never happened. Waiting for the burst to end means
-// the fingerprint describes the file the user actually saved.
-const settle = 50 * time.Millisecond
 
 // Replaces chokidar for `run`'s live reload.
 //
@@ -116,9 +106,6 @@ func (w *Watcher) relative(path string) (string, error) {
 }
 
 func (w *Watcher) run(changed func(string)) {
-	pending := make(map[string]fsnotify.Event)
-	var settled <-chan time.Time
-
 	for {
 		select {
 		case <-w.done:
@@ -128,18 +115,7 @@ func (w *Watcher) run(changed func(string)) {
 			if !ok {
 				return
 			}
-			merged := pending[event.Name]
-			merged.Name = event.Name
-			merged.Op |= event.Op
-			pending[event.Name] = merged
-			settled = time.After(settle)
-
-		case <-settled:
-			settled = nil
-			for name, event := range pending {
-				delete(pending, name)
-				w.handle(event, changed)
-			}
+			w.handle(event, changed)
 
 		case _, ok := <-w.watcher.Errors:
 			if !ok {

--- a/templates/cli/internal/watch/watch.go
+++ b/templates/cli/internal/watch/watch.go
@@ -6,9 +6,19 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 )
+
+// settle is how long a path stays quiet before its events are inspected.
+//
+// A save is rarely one event: os.WriteFile and most editors truncate and then
+// write, and some write a temporary file and rename it over the original.
+// Fingerprinting between those steps sees an empty or half-written file and
+// reports a change that never happened. Waiting for the burst to end means
+// the fingerprint describes the file the user actually saved.
+const settle = 50 * time.Millisecond
 
 // Replaces chokidar for `run`'s live reload.
 //
@@ -106,6 +116,9 @@ func (w *Watcher) relative(path string) (string, error) {
 }
 
 func (w *Watcher) run(changed func(string)) {
+	pending := make(map[string]fsnotify.Event)
+	var settled <-chan time.Time
+
 	for {
 		select {
 		case <-w.done:
@@ -115,7 +128,18 @@ func (w *Watcher) run(changed func(string)) {
 			if !ok {
 				return
 			}
-			w.handle(event, changed)
+			merged := pending[event.Name]
+			merged.Name = event.Name
+			merged.Op |= event.Op
+			pending[event.Name] = merged
+			settled = time.After(settle)
+
+		case <-settled:
+			settled = nil
+			for name, event := range pending {
+				delete(pending, name)
+				w.handle(event, changed)
+			}
 
 		case _, ok := <-w.watcher.Errors:
 			if !ok {

--- a/templates/swift/Sources/Client.swift.twig
+++ b/templates/swift/Sources/Client.swift.twig
@@ -620,7 +620,7 @@ open class Client {
             {
                 encodedParams[key] = param
             } else if let encodable = param as? Encodable {
-                encodedParams[key] = try encodable.toJson()
+                encodedParams[key] = try encodable.toJsonObject()
             } else if let param = param {
                 encodedParams[key] = String(describing: param)
             }

--- a/templates/swift/Sources/JSONCodable/Codable+JSON.swift.twig
+++ b/templates/swift/Sources/JSONCodable/Codable+JSON.swift.twig
@@ -9,6 +9,13 @@ extension Encodable {
     public func toJson() throws -> String {
         return String(data: try jsonEncoder.encode(self), encoding: .utf8)!
     }
+
+    /// Encodes the value into a Foundation JSON object so it can be nested in
+    /// a larger `JSONSerialization` payload without being double-encoded.
+    public func toJsonObject() throws -> Any {
+        return try JSONSerialization.jsonObject(
+            with: jsonEncoder.encode(self), options: [.fragmentsAllowed])
+    }
 }
 
 extension String {

--- a/tests/e2e/AppleSwift61Test.php
+++ b/tests/e2e/AppleSwift61Test.php
@@ -41,6 +41,7 @@ final class AppleSwift61Test extends Base
         ...Base::DOWNLOAD_RESPONSES,
         ...Base::ENUM_RESPONSES,
         ...Base::MODEL_RESPONSES,
+        ...Base::OBJECT_ARRAY_RESPONSES,
         ...Base::EXCEPTION_RESPONSES,
         ...Base::REALTIME_RESPONSES,
         ...Base::COOKIE_RESPONSES,

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -71,6 +71,15 @@ abstract class Base extends TestCase
         'POST:/v1/mock/tests/general/models/array:passed',
     ];
 
+    protected const OBJECT_ARRAY_RESPONSES = [
+        'POST:/v1/mock/tests/general/documents:passed',
+    ];
+
+    protected const OPTIONAL_PARAM_RESPONSES = [
+        'width=-1,height=128,name=omitted',
+        'width=0,height=64,name=zero',
+    ];
+
     protected const UNION_RESPONSES = [
         'GET:/v1/mock/tests/union:passed',
         'test-data',

--- a/tests/e2e/Node18Test.php
+++ b/tests/e2e/Node18Test.php
@@ -49,6 +49,7 @@ final class Node18Test extends Base
         ...Base::DOWNLOAD_RESPONSES,
         ...Base::ENUM_RESPONSES,
         ...Base::MODEL_RESPONSES,
+        ...Base::OPTIONAL_PARAM_RESPONSES,
         ...Base::EXCEPTION_RESPONSES,
         ...Base::OAUTH_RESPONSES,
         ...Base::QUERY_HELPER_RESPONSES,

--- a/tests/e2e/Node20Test.php
+++ b/tests/e2e/Node20Test.php
@@ -49,6 +49,7 @@ final class Node20Test extends Base
         ...Base::DOWNLOAD_RESPONSES,
         ...Base::ENUM_RESPONSES,
         ...Base::MODEL_RESPONSES,
+        ...Base::OPTIONAL_PARAM_RESPONSES,
         ...Base::EXCEPTION_RESPONSES,
         ...Base::OAUTH_RESPONSES,
         ...Base::QUERY_HELPER_RESPONSES,

--- a/tests/e2e/Node26Test.php
+++ b/tests/e2e/Node26Test.php
@@ -49,6 +49,7 @@ final class Node26Test extends Base
         ...Base::DOWNLOAD_RESPONSES,
         ...Base::ENUM_RESPONSES,
         ...Base::MODEL_RESPONSES,
+        ...Base::OPTIONAL_PARAM_RESPONSES,
         ...Base::EXCEPTION_RESPONSES,
         ...Base::OAUTH_RESPONSES,
         ...Base::QUERY_HELPER_RESPONSES,

--- a/tests/e2e/ReactNativeTest.php
+++ b/tests/e2e/ReactNativeTest.php
@@ -49,6 +49,7 @@ final class ReactNativeTest extends Base
         ...Base::DOWNLOAD_RESPONSES,
         ...Base::ENUM_RESPONSES,
         ...Base::MODEL_RESPONSES,
+        ...Base::OPTIONAL_PARAM_RESPONSES,
         ...Base::EXCEPTION_RESPONSES,
         ...Base::REALTIME_RESPONSES,
         ...Base::QUERY_HELPER_RESPONSES,

--- a/tests/e2e/Swift61Test.php
+++ b/tests/e2e/Swift61Test.php
@@ -41,6 +41,7 @@ final class Swift61Test extends Base
         ...Base::DOWNLOAD_RESPONSES,
         ...Base::ENUM_RESPONSES,
         ...Base::MODEL_RESPONSES,
+        ...Base::OBJECT_ARRAY_RESPONSES,
         ...Base::EXCEPTION_RESPONSES,
         ...Base::OAUTH_RESPONSES,
         ...Base::QUERY_HELPER_RESPONSES,

--- a/tests/e2e/WebChromiumTest.php
+++ b/tests/e2e/WebChromiumTest.php
@@ -48,6 +48,7 @@ final class WebChromiumTest extends Base
         ...Base::LARGE_FILE_RESPONSES,
         ...Base::ENUM_RESPONSES,
         ...Base::MODEL_RESPONSES,
+        ...Base::OPTIONAL_PARAM_RESPONSES,
         ...Base::UNION_RESPONSES,
         ...Base::EXCEPTION_RESPONSES,
         ...Base::REALTIME_RESPONSES,

--- a/tests/e2e/WebNodeTest.php
+++ b/tests/e2e/WebNodeTest.php
@@ -45,6 +45,7 @@ final class WebNodeTest extends Base
         ...Base::PATH_PARAM_RESPONSES,
         ...Base::ENUM_RESPONSES,
         ...Base::MODEL_RESPONSES,
+        ...Base::OPTIONAL_PARAM_RESPONSES,
         ...Base::UNION_RESPONSES,
         ...Base::EXCEPTION_RESPONSES,
         ...Base::QUERY_HELPER_RESPONSES,

--- a/tests/e2e/languages/apple/Tests.swift
+++ b/tests/e2e/languages/apple/Tests.swift
@@ -4,6 +4,7 @@ import Foundation
 import FoundationNetworking
 #endif
 import Appwrite
+import JSONCodable
 import AppwriteEnums
 import AsyncHTTPClient
 import NIO
@@ -187,6 +188,12 @@ class Tests: XCTestCase {
         mock = try await general.createPlayers(players: [
             Player(id: "player1", name: "John Doe", score: 100),
             Player(id: "player2", name: "Jane Doe", score: 200)
+        ])
+        print(mock.result)
+
+        mock = try await general.createDocuments(documents: [
+            AnyCodable(["$id": "one", "title": "hello"]),
+            AnyCodable(["$id": "two", "title": "world"])
         ])
         print(mock.result)
 

--- a/tests/e2e/languages/node/test.js
+++ b/tests/e2e/languages/node/test.js
@@ -219,6 +219,13 @@ async function start() {
     ]);
     console.log(response.result);
 
+    // All-optional positional params keep their trailing arguments
+    response = await general.getOptional(undefined, 128, 'omitted');
+    console.log(response.result);
+
+    response = await general.getOptional(0, 64, 'zero');
+    console.log(response.result);
+
     try {
         response = await general.error400();
     } catch(error) {

--- a/tests/e2e/languages/react-native/browser.js
+++ b/tests/e2e/languages/react-native/browser.js
@@ -142,6 +142,13 @@ import {
     ]);
     console.log(response.result);
 
+    // All-optional positional params keep their trailing arguments
+    response = await general.getOptional(undefined, 128, 'omitted');
+    console.log(response.result);
+
+    response = await general.getOptional(0, 64, 'zero');
+    console.log(response.result);
+
     // Exception responses
     try {
         response = await general.error400();

--- a/tests/e2e/languages/swift/Tests.swift
+++ b/tests/e2e/languages/swift/Tests.swift
@@ -4,6 +4,7 @@ import Foundation
 import FoundationNetworking
 #endif
 import Appwrite
+import JSONCodable
 import AsyncHTTPClient
 import NIO
 
@@ -128,6 +129,12 @@ class Tests: XCTestCase {
         mock = try await general.createPlayers(players: [
             Player(id: "player1", name: "John Doe", score: 100),
             Player(id: "player2", name: "Jane Doe", score: 200)
+        ])
+        print(mock.result)
+
+        mock = try await general.createDocuments(documents: [
+            AnyCodable(["$id": "one", "title": "hello"]),
+            AnyCodable(["$id": "two", "title": "world"])
         ])
         print(mock.result)
 

--- a/tests/e2e/languages/web/index.html
+++ b/tests/e2e/languages/web/index.html
@@ -245,6 +245,13 @@
             ]);
             console.log(response.result);
 
+            // All-optional positional params keep their trailing arguments
+            response = await general.getOptional(undefined, 128, 'omitted');
+            console.log(response.result);
+
+            response = await general.getOptional(0, 64, 'zero');
+            console.log(response.result);
+
             // Union types test - returns `mock` type
             response = await general.getUnion({ type: 'mock' });
             console.log(response.result);

--- a/tests/e2e/languages/web/node.js
+++ b/tests/e2e/languages/web/node.js
@@ -140,6 +140,13 @@ async function start() {
     ]);
     console.log(response.result);
 
+    // All-optional positional params keep their trailing arguments
+    response = await general.getOptional(undefined, 128, 'omitted');
+    console.log(response.result);
+
+    response = await general.getOptional(0, 64, 'zero');
+    console.log(response.result);
+
     // Union types test - returns `mock` type
     response = await general.getUnion({ type: 'mock' });
     console.log(response.result);

--- a/tests/generation/GenerationTest.php
+++ b/tests/generation/GenerationTest.php
@@ -286,6 +286,32 @@ final class GenerationTest extends TestCase
         }
     }
 
+    /**
+     * A JSON example for an untyped object array must render as Swift
+     * dictionary literals, not as the JavaScript-style `{ ... }` the spec carries.
+     */
+    #[DataProvider('swiftLanguages')]
+    public function testObjectArrayExamplesUseSwiftLiterals(string $name, string $platform): void
+    {
+        $files = $this->generate($name, $platform);
+        $path = 'docs/examples/general/create-documents.md';
+
+        $this->assertArrayHasKey($path, $files, "{$name}/{$platform} did not generate {$path}");
+        $this->assertStringContainsString('"$id": "one"', $files[$path]);
+        $this->assertStringNotContainsString('{', $files[$path]);
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function swiftLanguages(): array
+    {
+        return [
+            'swift' => ['swift', 'server'],
+            'apple' => ['apple', 'client'],
+        ];
+    }
+
     #[DataProvider('languages')]
     public function testEnumsAreDeclared(string $name): void
     {

--- a/tests/generation/GenerationTest.php
+++ b/tests/generation/GenerationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Generation;
 
+use Iterator;
 use Appwrite\SDK\Language;
 use Appwrite\SDK\Language\Android;
 use Appwrite\SDK\Language\Apple;
@@ -288,28 +289,33 @@ final class GenerationTest extends TestCase
 
     /**
      * A JSON example for an untyped object array must render as Swift
-     * dictionary literals, not as the JavaScript-style `{ ... }` the spec carries.
+     * dictionary literals, not as the JavaScript-style `{ ... }` the spec
+     * carries. Quotes inside example strings must stay escaped, and an empty
+     * array example must stay an array rather than becoming a dictionary.
      */
     #[DataProvider('swiftLanguages')]
     public function testObjectArrayExamplesUseSwiftLiterals(string $name, string $platform): void
     {
         $files = $this->generate($name, $platform);
-        $path = 'docs/examples/general/create-documents.md';
 
-        $this->assertArrayHasKey($path, $files, "{$name}/{$platform} did not generate {$path}");
-        $this->assertStringContainsString('"$id": "one"', $files[$path]);
-        $this->assertStringNotContainsString('{', $files[$path]);
+        $documents = 'docs/examples/general/create-documents.md';
+        $this->assertArrayHasKey($documents, $files, "{$name}/{$platform} did not generate {$documents}");
+        $this->assertStringContainsString('"$id": "one"', $files[$documents]);
+        $this->assertStringContainsString('"title": "say \\"hello\\""', $files[$documents]);
+        $this->assertStringNotContainsString('{', $files[$documents]);
+
+        $oauth = 'docs/examples/general/oauth-2.md';
+        $this->assertArrayHasKey($oauth, $files, "{$name}/{$platform} did not generate {$oauth}");
+        $this->assertStringContainsString('scopes: []', $files[$oauth]);
     }
 
     /**
-     * @return array<string, array{string, string}>
+     * @return Iterator<string, array{string, string}>
      */
-    public static function swiftLanguages(): array
+    public static function swiftLanguages(): Iterator
     {
-        return [
-            'swift' => ['swift', 'server'],
-            'apple' => ['apple', 'client'],
-        ];
+        yield 'swift' => ['swift', 'server'];
+        yield 'apple' => ['apple', 'client'];
     }
 
     #[DataProvider('languages')]

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -596,6 +596,73 @@
         }
       }
     },
+    "\/mock\/tests\/general\/documents": {
+      "post": {
+        "summary": "Create Documents",
+        "operationId": "generalCreateDocuments",
+        "tags": [
+          "general"
+        ],
+        "description": "Create documents from an array of plain objects.",
+        "x-appwrite": {
+          "demo": "general\/create-documents.md",
+          "rate-limit": 0,
+          "rate-time": 3600,
+          "rate-key": "url:{url},ip:{ip}",
+          "scope": "public",
+          "platforms": [
+            "client",
+            "server"
+          ],
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
+        },
+        "security": [
+          {
+            "Project": [],
+            "Key": [],
+            "JWT": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Mock",
+            "content": {
+              "application\/json": {
+                "schema": {
+                  "$ref": "#\/components\/schemas\/mock"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application\/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "documents": {
+                    "type": "array",
+                    "description": "Array of document objects.",
+                    "default": null,
+                    "example": "[{\"$id\":\"one\",\"title\":\"hello\"}]",
+                    "items": {
+                      "type": "object"
+                    }
+                  }
+                },
+                "required": [
+                  "documents"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
     "\/mock\/tests\/general\/excluded-method": {
       "post": {
         "summary": "Create Excluded General Fixture",
@@ -1569,6 +1636,84 @@
             }
           }
         }
+      }
+    },
+    "\/mock\/tests\/general\/optional": {
+      "get": {
+        "summary": "Get Optional",
+        "operationId": "generalGetOptional",
+        "tags": [
+          "general"
+        ],
+        "description": "Mock a request whose parameters are all optional.",
+        "x-appwrite": {
+          "demo": "general\/get-optional.md",
+          "rate-limit": 0,
+          "rate-time": 3600,
+          "rate-key": "url:{url},ip:{ip}",
+          "scope": "public",
+          "platforms": [
+            "client",
+            "server"
+          ],
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
+        },
+        "security": [
+          {
+            "Project": [],
+            "Key": [],
+            "JWT": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Mock",
+            "content": {
+              "application\/json": {
+                "schema": {
+                  "$ref": "#\/components\/schemas\/mock"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "width",
+            "description": "Sample optional numeric param",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": -1
+            }
+          },
+          {
+            "name": "height",
+            "description": "Sample optional numeric param",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": -1
+            }
+          },
+          {
+            "name": "name",
+            "description": "Sample optional string param",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        ]
       }
     },
     "\/mock\/tests\/general\/nullable": {

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -648,7 +648,7 @@
                     "type": "array",
                     "description": "Array of document objects.",
                     "default": null,
-                    "example": "[{\"$id\":\"one\",\"title\":\"hello\"}]",
+                    "example": "[{\"$id\":\"one\",\"title\":\"say \\\"hello\\\"\"}]",
                     "items": {
                       "type": "object"
                     }


### PR DESCRIPTION
## What does this PR do?

Three generator fixes for bugs found in the generated Apple, Web and React Native SDKs.

### 1. Swift / Apple sent object arrays as JSON text

`Client.buildJSON` ran every `Encodable` parameter through `toJson()`, which returns a `String`, and embedded that string in the body.

```swift
try await databases.createDocuments(databaseId: "db", collectionId: "col", documents: [
    ["$id": "one", "title": "hello"]
])
```

Before:

```json
{"documents":"[{\"$id\":\"one\",\"title\":\"hello\"}]"}
```

After:

```json
{"documents":[{"$id":"one","title":"hello"}]}
```

`Encodable` gains `toJsonObject()`, which decodes the encoded bytes back into a Foundation object, and both Client templates use it. Same root cause as the `createOperations` report.

### 2. Swift docs examples were not valid Swift

Array examples were copied from the spec verbatim.

Before:

```swift
operations: [
    {
        "action": "create",
        "data": {
            "name": "Walter O'Brien"
        }
    }
]
```

After:

```swift
operations: [
    [
        "action": "create",
        "data": [
            "name": "Walter O'Brien"
        ]
    ]
]
```

### 3. Web / Node / React Native dropped trailing positional arguments

For all-optional methods the overload guard was `!paramsOrFirst || ...`, so an `undefined` or `0` first argument selected the object form and discarded everything after it.

```ts
avatars.getPhoto(undefined, 128, 80, 'png', 'g', 'userB');
```

Before, the request had no query at all:

```
GET /avatars/photo
```

After:

```
GET /avatars/photo?height=128&quality=80&output=png&rating=g&userId=userB
```

Generated guard:

```ts
if (
    (typeof paramsOrFirst === 'undefined' && rest.length === 0) ||
    (paramsOrFirst &&
        typeof paramsOrFirst === 'object' &&
        !Array.isArray(paramsOrFirst))
) {
```

### Not changed

The positional `createFile(bucket, id, file, permissions, onProgress)` form now reads the callback as `folder` because the spec appended `folder`. The positional form is deprecated and TypeScript rejects the old shape, so this stays a documented break.

## Test Plan

- Generation suite: Swift and Apple `docs/examples/general/create-documents.md` must contain `"$id": "one"` and no `{`. Fails on `main`.
- e2e fixture adds `POST /mock/tests/general/documents` (untyped object array, rejects a string or empty array) and `GET /mock/tests/general/optional` (echoes its three optional params).

Swift and Apple:

```swift
mock = try await general.createDocuments(documents: [
    AnyCodable(["$id": "one", "title": "hello"]),
    AnyCodable(["$id": "two", "title": "world"])
])
// POST:/v1/mock/tests/general/documents:passed
```

Web, Node and React Native:

```js
await general.getOptional(undefined, 128, 'omitted'); // width=-1,height=128,name=omitted
await general.getOptional(0, 64, 'zero');             // width=0,height=64,name=zero
```

Run locally: Generation suite (84 tests), `WebNodeTest`, `Swift61Test`, Prettier/ESLint/tsc for Web, Node and React Native, swift-format for Swift and Apple, `composer refactor:check`, `composer lint-twig`.
