### PR TITLE
fix(rust): preserve required nullable model fields

### DIFF
--- a/templates/rust/src/models/model.rs.twig
+++ b/templates/rust/src/models/model.rs.twig
@@ -16,10 +16,14 @@ pub struct {{ definitionName | caseUcfirst | overrideIdentifier }} {
 {% set fieldName = fieldName | overrideIdentifier %}
     {{ property.description | rustdocComment(4) }}
     #[serde(rename = "{{ (property | schemaName) }}")]
-{% if (property | schemaRequired) %}
+{% if (property | schemaRequired) and not (property | schemaNullable) %}
     pub {{ fieldName }}: {{ property | propertyType(spec) | rustType }},
 {% else %}
+{% if not (property | schemaRequired) %}
     #[serde(skip_serializing_if = "Option::is_none")]
+{% else %}
+    #[serde(deserialize_with = "Option::deserialize")]
+{% endif %}
     pub {{ fieldName }}: Option<{{ property | propertyType(spec) | rustType }}>,
 {% endif %}
 {% endfor %}
@@ -40,7 +44,7 @@ impl {{ definitionName | caseUcfirst | overrideIdentifier }} {
 {% if not loop.first %}
 
 {% endif %}
-{% if not (property | schemaRequired) %}
+{% if not (property | schemaRequired) or (property | schemaNullable) %}
     /// Set {{ fieldName }}
 {{ [ 'mut self', fieldName ~ ': ' ~ (property | propertyType(spec) | rustType) ] | rustfmtFn(4, 'pub fn set_' ~ fieldName, 'Self') }}
 {{ ('Some(' ~ fieldName ~ ')') | rustfmtAssign(8, 'self.' ~ fieldName) }}

--- a/templates/rust/src/models/request_model.rs.twig
+++ b/templates/rust/src/models/request_model.rs.twig
@@ -12,10 +12,14 @@ pub struct {{ requestModelName | caseUcfirst | overrideIdentifier }} {
 {% set fieldName = fieldName | overrideIdentifier %}
     {{ property.description | rustdocComment(4) }}
     #[serde(rename = "{{ (property | schemaName) }}")]
-{% if (property | schemaRequired) %}
+{% if (property | schemaRequired) and not (property | schemaNullable) %}
     pub {{ fieldName }}: {{ property | propertyType(spec) | rustType }},
 {% else %}
+{% if not (property | schemaRequired) %}
     #[serde(skip_serializing_if = "Option::is_none")]
+{% else %}
+    #[serde(deserialize_with = "Option::deserialize")]
+{% endif %}
     pub {{ fieldName }}: Option<{{ property | propertyType(spec) | rustType }}>,
 {% endif %}
 {% endfor %}
@@ -29,7 +33,7 @@ impl {{ requestModelName | caseUcfirst | overrideIdentifier }} {
 {% if not loop.first %}
 
 {% endif %}
-{% if not (property | schemaRequired) %}
+{% if not (property | schemaRequired) or (property | schemaNullable) %}
     /// Set {{ fieldName }}
 {{ [ 'mut self', fieldName ~ ': ' ~ (property | propertyType(spec) | rustType) ] | rustfmtFn(4, 'pub fn set_' ~ fieldName, 'Self') }}
 {{ ('Some(' ~ fieldName ~ ')') | rustfmtAssign(8, 'self.' ~ fieldName) }}


### PR DESCRIPTION
Rust model generation currently uses whether a property is required to decide whether its type is `T` or `Option<T>`. A required property with `nullable: true` therefore becomes a non-nullable Rust field, and deserializing an allowed JSON `null` fails.

This change respects nullability in both response and request model templates. Required nullable properties use `Option<T>`, serialize `None` as an explicit `null`, and still reject a missing property. Their getters return optional references. Optional properties retain the existing omission behavior, and required non-nullable properties remain unchanged. The implementation is driven by schema flags, with no field or service exceptions.

The issue was found while testing `Postgresql::create_branch` in the published Rust SDK 0.14.0. The API created the branch, but decoding its response failed with `Serialization error: invalid type: null, expected i64`. The response contained `credentialGeneration: null`. There is also an upstream schema mismatch: the published schema currently declares that property as a required integer without `nullable: true`. That schema needs correcting separately; this PR does not infer nullability from descriptions or claim to resolve the schema mismatch itself.

No regression tests or fixtures are added. Validation uses the existing suites and temporary local checks.

Validation passed:

- Regenerated the Rust server SDK from the current published spec.
- Rust 1.83 formatting check.
- Existing Rust end-to-end suite: 131 assertions.
- All 585 Twig templates linted; Rector check passed.
- Temporary nullable-field checks verified null/value round trips, rejection of missing required fields, and unchanged non-nullable behavior.
