### PR TITLE
fix: infer response media and Rust bodyless results from OpenAPI

### DIFF
--- a/src/SDK/Extension/Appwrite.php
+++ b/src/SDK/Extension/Appwrite.php
@@ -15,9 +15,6 @@ enum Appwrite: string
     /** Method aliases generated from one operation. */
     case METHODS = 'methods';
 
-    /** Content types an operation produces when no response declares content. */
-    case PRODUCES = 'produces';
-
     /** Whether an operation is part of a packaging flow. */
     case PACKAGING = 'packaging';
 

--- a/src/SDK/Language/Rust.php
+++ b/src/SDK/Language/Rust.php
@@ -2,8 +2,6 @@
 
 namespace Appwrite\SDK\Language;
 
-use Appwrite\SDK\Extension;
-use Appwrite\SDK\Extension\Appwrite;
 use Utopia\OpenAPI\Model\ArraySchema;
 use Utopia\OpenAPI\Model\Operation;
 use Utopia\OpenAPI\Model\Parameter;
@@ -540,10 +538,8 @@ class Rust extends Language
             return 'crate::error::Result<crate::models::' . $this->toPascalCase($models[0]) . '>';
         }
 
-        // Emptiness follows the produced content types, not the response
-        // codes: a 204 whose produced type is recorded in x-appwrite still
-        // returns a body to deserialize, and narrowing it to `()` would be a
-        // breaking change for every caller binding the result.
+        // Response content determines whether a body exists, independently
+        // of the default Accept header used for content negotiation.
         return $this->getProducedTypes($method) === []
             ? 'crate::error::Result<()>'
             : 'crate::error::Result<serde_json::Value>';
@@ -559,9 +555,6 @@ class Rust extends Language
                     $produces[] = $contentType;
                 }
             }
-        }
-        if ($produces === []) {
-            $produces = $method->extensions[Extension::APPWRITE->value][Appwrite::PRODUCES->value] ?? [];
         }
         return $produces;
     }

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -1810,7 +1810,7 @@ class SDK
             }
         }
         if ($produces === []) {
-            $produces = $operation->extensions[Extension::APPWRITE->value][Appwrite::PRODUCES->value] ?? [];
+            $produces = ['application/json'];
         }
         return $produces;
     }

--- a/templates/rust/CHANGELOG.md.twig
+++ b/templates/rust/CHANGELOG.md.twig
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [{{ sdk.version }}] - TBD
 
-### Changed
-- **Breaking:** Methods whose responses declare no content now return `Result<()>` instead of `Result<serde_json::Value>`. Callers binding these results must use `()`; no response body has been added.
-- Requests default to `Accept: application/json` when responses declare no content. Explicit response media types remain unchanged; `x-appwrite.produces` is no longer used.
-
 ### Added
 - Initial release of {{ spec.info.title }} Rust SDK
 - Full support for {{ spec.info.title }} API {{ spec.info.version }}

--- a/templates/rust/CHANGELOG.md.twig
+++ b/templates/rust/CHANGELOG.md.twig
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [{{ sdk.version }}] - TBD
 
+### Changed
+- **Breaking:** Methods whose responses declare no content now return `Result<()>` instead of `Result<serde_json::Value>`. Callers binding these results must use `()`; no response body has been added.
+- Requests default to `Accept: application/json` when responses declare no content. Explicit response media types remain unchanged; `x-appwrite.produces` is no longer used.
+
 ### Added
 - Initial release of {{ spec.info.title }} Rust SDK
 - Full support for {{ spec.info.title }} API {{ spec.info.version }}

--- a/templates/rust/tests/tests.rs
+++ b/templates/rust/tests/tests.rs
@@ -145,7 +145,7 @@ async fn test_general_service(client: &Client, string_in_array: &[String]) -> Re
 
     println!("Invalid endpoint URL: htp://cloud.appwrite.io/v1");
 
-    let _ = general.empty().await;
+    let (): () = general.empty().await?;
 
     // Test Queries
     test_queries();

--- a/tests/generation/GenerationTest.php
+++ b/tests/generation/GenerationTest.php
@@ -318,6 +318,21 @@ final class GenerationTest extends TestCase
         yield 'apple' => ['apple', 'client'];
     }
 
+    public function testRustBodylessResponsesUseUnitWithJsonAccept(): void
+    {
+        $files = $this->generate('rust', 'server');
+        $general = $files['src/services/general.rs'];
+
+        foreach (['empty', 'redirect'] as $method) {
+            $this->assertMatchesRegularExpression(
+                '/pub async fn ' . $method . '\(&self\) -> crate::error::result<\(\)> \{[^}]*api_headers\.insert\("accept"\.to_string\(\), "application\/json"\.to_string\(\)\);/s',
+                $general,
+            );
+        }
+
+        $this->assertStringContainsString('"application/json, text/plain".to_string()', $general);
+    }
+
     #[DataProvider('languages')]
     public function testEnumsAreDeclared(string $name): void
     {

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -1912,10 +1912,7 @@
           "packaging": false,
           "auth": {
             "Project": []
-          },
-          "produces": [
-            "text\/html"
-          ]
+          }
         },
         "security": [
           {
@@ -2225,10 +2222,7 @@
           "packaging": false,
           "auth": {
             "Project": []
-          },
-          "produces": [
-            "text\/plain"
-          ]
+          }
         },
         "security": [
           {


### PR DESCRIPTION
# Derive Accept and Rust response types from standard response content

PR 4/4. CLO-4377: https://linear.app/appwrite/issue/CLO-4377/openapi3-standards
[Appwrite #13524](https://github.com/appwrite/appwrite/pull/13524) and canonical specs [latest #110](https://github.com/appwrite/specs/pull/110) / [2.0.x #111](https://github.com/appwrite/specs/pull/111) are merged. Both published documents match the reviewed SHA256 `7bf999d8faec746c1fb0ead1f0539dfaa8aead401405b2b697358e7059667f98` and contain no `x-appwrite.produces`. The branch is in sync with SDK-generator main; no parser release is required. Cloud's older server-ce pin remains unchanged; the owner explicitly approved publishing specs without waiting for that promotion.

## Generated SDK changes
Actual generated Rust console `account.delete_billing_address`:
```diff
 pub async fn delete_billing_address(
     &self,
     billing_address_id: impl Into<String>,
-) -> crate::error::Result<serde_json::Value> {
+) -> crate::error::Result<()> {
```
Actual generated Rust `account.delete` now sends:
```rust
api_headers.insert("content-type".to_string(), "application/json".to_string());
api_headers.insert("accept".to_string(), "application/json".to_string());
```
Actual generated Node server adds this metadata for bodyless operations:
```js
accept: 'application/json',
```
Spec evidence: genuine CE `sitesDeleteLog` after-generation still declares only:
```json
"responses": {"204": {"description": "No content"}}
```
There is no response body, and no fallback extension. Explicit response content continues to determine Accept; binary/location and OAuth return branches are unchanged. Existing Swagger2 produces remains supported through the parser's standard response content conversion.

## Breaking change / release notes
Rust methods previously inferred as `Result<serde_json::Value>` solely from the extension now return `Result<()>`. Callers binding those results must use `()` and must not expect JSON from a bodyless response. Keep this breaking API correction and the JSON Accept fallback in the eventual Rust SDK release notes; the changelog template is intentionally unchanged. Apply Rust SDK breaking-change version policy at publication.

## Measured output
Fixed published canonical baseline (1,020 operations) has 117 bodyless operations: 49 with old extension and 68 without. Clean actual Rust generations show **11 client / 23 server / 38 console** corrected signatures and **14 / 54 / 60** added Accept headers respectively. Counts depend on platform/exclusions/aliases. Other targets have only JSON Accept additions and necessary comma formatting; CLI/GraphQL output is unchanged. Rust has only approved signature/header changes, documentation signatures and strengthened integration harness.

Standard Swagger2 1.8.x server: explicit media and Rust signatures preserved; 39 JSON Accept insertions only where no produced content exists.

## Validation
- No new unit tests. Added an output-shape check in the existing generation suite and strengthened the existing Rust integration call to require successful unit deserialization.
- New generation check observed red against baseline generator, green after. Full suite: 85 tests, 1,130 assertions, 4 existing skips.
- Docker e2e: Rust 1 test / 131 assertions; Node + PHP 2 tests / 298 assertions; Go 1 test / 134 assertions. PHP separately 1 / 142.
- PHP lint, Rector and Twig lint pass. Rust server cargo check and Rust client/server rustfmt pass.
- Go build/vet/test, Web/Node/React Native formatting/lint/types, Node build+830 tests, Dart, Kotlin/Android, Swift/Apple, C#/Unity, Python Black, Ruby RuboCop and PHP Pint/PHPStan/Rector pass.
- Existing published specs: 101 reference-valid documents; canonical and genuine CE before/after documents validator clean.

## Existing gate limitations
- Rust console rustfmt reports unchanged long constants in `usage_event_metric.rs`; reproduced on baseline.
- Flutter formatter reports the same 20 files on baseline and after; no generated files were formatted in place.
- Unchanged CLI cannot build without missing dependency/go.sum entries; reproduced on baseline. CLI output itself has zero differences.
- Node's first test invocation lacked a build; rerun after `npm run build` passed all 830 tests.
- Canonical artifacts are now publicly available following genuine x86 Cloud generation and specs #110/#111. Generation suite rerun passes: 85 tests / 1,130 assertions. Remote CI and Validation checks passed at `788f49ae7932608a5269d5049cad10f3b6bea429`; fresh checks follow the changelog-only revert. An additional local Rust e2e rerun initially encountered mock-server connectivity failures; one unchanged-code environment retry passed (1 test, 131 assertions).

## Follow-through
Cloud pins sdk-generator `4.9.*`; CE allows `^4.0`. After choosing and publishing the generator version, plan a targeted Cloud dependency promotion if that range excludes it. No speculative version bump here.

## Captured validation output

Actual command-output excerpts rendered locally and captured with Chromium. These are test-log screenshots, not live browser UI/e2e screenshots. Local configuration paths are excluded by selecting the public stdout excerpt; result text is unchanged.

![Captured command output](https://github.com/user-attachments/assets/a8c7e580-d10f-4dda-a5ba-cd130337c086)



Narrow regression and full generation suite passed at `788f49ae7932608a5269d5049cad10f3b6bea429`, based on SDK-generator main `f072d890699106748a9899a344a6932b31a41118`. Follow-up `b251f6eeb` removes only the proposed changelog-template entries; Rust server was regenerated successfully. No new unit tests.





