### PR TITLE
feat: derive optional security from OpenAPI alternatives

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "ext-mbstring": "*",
         "matthiasmullie/minify": "^1.3",
         "twig/twig": "^3.28",
-        "utopia-php/openapi": "^0.2.1"
+        "utopia-php/openapi": "^0.2.2"
     },
     "require-dev": {
         "brianium/paratest": "^7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fc53280e54d5e462f425f4b12674b5b8",
+    "content-hash": "4d31f79ecd8867a5fecb647eb11ea22d",
     "packages": [
         {
             "name": "matthiasmullie/minify",
@@ -450,16 +450,16 @@
         },
         {
             "name": "utopia-php/openapi",
-            "version": "0.2.1",
+            "version": "0.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/openapi.git",
-                "reference": "725109d69e298ae8d88f1ffc05f6d86624233abd"
+                "reference": "d39d668feb18425091431bf8baca26a678daf0af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/openapi/zipball/725109d69e298ae8d88f1ffc05f6d86624233abd",
-                "reference": "725109d69e298ae8d88f1ffc05f6d86624233abd",
+                "url": "https://api.github.com/repos/utopia-php/openapi/zipball/d39d668feb18425091431bf8baca26a678daf0af",
+                "reference": "d39d668feb18425091431bf8baca26a678daf0af",
                 "shasum": ""
             },
             "require": {
@@ -484,9 +484,9 @@
             "description": "Framework-independent OpenAPI 2.0, 3.0, and 3.1 parser with an immutable canonical model",
             "support": {
                 "issues": "https://github.com/utopia-php/openapi/issues",
-                "source": "https://github.com/utopia-php/openapi/tree/0.2.1"
+                "source": "https://github.com/utopia-php/openapi/tree/0.2.2"
             },
-            "time": "2026-09-04T16:56:24+00:00"
+            "time": "2026-09-08T17:06:56+00:00"
         }
     ],
     "packages-dev": [

--- a/src/SDK/Extension/Appwrite.php
+++ b/src/SDK/Extension/Appwrite.php
@@ -27,9 +27,6 @@ enum Appwrite: string
     /** On a path-bound security scheme: the client config key that fills it. */
     case CONFIG = 'config';
 
-    /** On a security scheme: configured by examples whenever an operation accepts it. */
-    case OPTIONAL = 'optional';
-
     /** Schemes an example configures on the client, flat or keyed by SDK platform. */
     case AUTH = 'auth';
 }

--- a/src/SDK/SDK.php
+++ b/src/SDK/SDK.php
@@ -590,7 +590,7 @@ class SDK
     protected function annotateSecurityPathParameters(Operation $operation): Operation
     {
         $securityParameters = [];
-        foreach ($operation->security[0]->schemes ?? [] as $schemeName => $scopes) {
+        foreach ($operation->acceptedSecuritySchemeNames() as $schemeName) {
             $scheme = $this->getSecurityScheme($schemeName);
             if (!$scheme instanceof SecurityScheme || ($scheme->extensions[Extension::APPWRITE->value][Appwrite::LOCATION->value] ?? '') !== 'path') {
                 continue;
@@ -1858,7 +1858,13 @@ class SDK
         $auth = $auth[$this->getParam('platform')] ?? $auth;
         $schemes = [];
         $pathSchemes = [];
+        $optional = \array_diff($operation->acceptedSecuritySchemeNames(), $operation->requiredSecuritySchemeNames());
         foreach (\array_keys($auth) as $name) {
+            // Example configuration is independent of API authentication. Only
+            // omit a candidate when security explicitly makes it optional.
+            if (\in_array($name, $optional, true)) {
+                continue;
+            }
             $scheme = $this->getSecurityScheme((string) $name);
             if (!$scheme instanceof SecurityScheme) {
                 continue;
@@ -1876,7 +1882,7 @@ class SDK
     protected function getOperationSecuritySchemes(Operation $operation, ?ParameterLocation $location = null, bool $includeGlobal = true): array
     {
         $schemes = [];
-        foreach ($operation->security[0]->schemes ?? [] as $name => $scopes) {
+        foreach ($operation->acceptedSecuritySchemeNames() as $name) {
             $scheme = $this->getSecurityScheme($name);
             if (!$scheme instanceof SecurityScheme) {
                 continue;

--- a/templates/android/docs/java/example.md.twig
+++ b/templates/android/docs/java/example.md.twig
@@ -25,7 +25,7 @@ Client client = new Client(context)
     {%~ if [(method | securitySchemes)]|length > 0 %}
     .setEndpoint("{{ endpointDocs | raw }}") // Your API Endpoint
     {%~ for node in [(method | securitySchemes)] %}
-    {%~ for key,header in node|keys|filter(h => not node[h].extensions['x-appwrite']['optional']) %}
+    {%~ for key,header in node|keys %}
     .set{{header | caseUcfirst}}("{{node[header].extensions['x-appwrite']['demo'] | raw }}"){% if loop.last %};{% endif %} // {{ node[header].description }}
     {%~ endfor %}
     {%~ endfor %}

--- a/templates/android/docs/kotlin/example.md.twig
+++ b/templates/android/docs/kotlin/example.md.twig
@@ -23,7 +23,7 @@ val client = Client(context)
     {%~ if [(method | securitySchemes)]|length > 0 %}
     .setEndpoint("{{ endpointDocs | raw }}") // Your API Endpoint
     {%~ for node in [(method | securitySchemes)] %}
-    {%~ for key,header in node|keys|filter(h => not node[h].extensions['x-appwrite']['optional']) %}
+    {%~ for key,header in node|keys %}
     .set{{header | caseUcfirst}}("{{node[header].extensions['x-appwrite']['demo'] | raw }}") // {{node[header].description}}
     {%~ endfor %}
     {%~ endfor %}

--- a/templates/dart/docs/example.md.twig
+++ b/templates/dart/docs/example.md.twig
@@ -21,7 +21,7 @@ Client client = Client()
     {%~ if [(method | securitySchemes)]|length > 0 %}
     .setEndpoint('{{ endpointDocs | raw }}') // Your API Endpoint
     {%~ for node in [(method | securitySchemes)] %}
-    {%~ for key,header in node|keys|filter(h => not node[h].extensions['x-appwrite']['optional']) %}
+    {%~ for key,header in node|keys %}
     .set{{header}}('{{node[header].extensions['x-appwrite']['demo'] | raw }}'){% if loop.last %};{% endif%} // {{node[header].description}}
     {%~ endfor %}
     {%~ endfor %}

--- a/templates/deno/docs/example.md.twig
+++ b/templates/deno/docs/example.md.twig
@@ -5,7 +5,7 @@ const client = new Client()
     {%~ if [(method | securitySchemes)]|length > 0 %}
     .setEndpoint('{{ endpointDocs | raw }}') // Your API Endpoint
     {%~ for node in [(method | securitySchemes)] %}
-    {%~ for key,header in node|keys|filter(h => not node[h].extensions['x-appwrite']['optional']) %}
+    {%~ for key,header in node|keys %}
     .set{{header}}('{{node[header].extensions['x-appwrite']['demo'] | raw }}'){% if loop.last %};{% endif%} // {{node[header].description}}
     {%~ endfor %}
     {%~ endfor %}

--- a/templates/dotnet/docs/example.md.twig
+++ b/templates/dotnet/docs/example.md.twig
@@ -14,7 +14,7 @@ Client client = new Client()
 {% if [(method | securitySchemes)]|length > 0 %}
     .SetEndPoint("{{ endpointDocs | raw }}") // Your API Endpoint
 {% for node in [(method | securitySchemes)] %}
-{% for key,header in node|keys|filter(h => not node[h].extensions['x-appwrite']['optional']) %}
+{% for key,header in node|keys %}
     .Set{{header | caseUcfirst}}("{{node[header].extensions['x-appwrite']['demo'] | raw }}"){% if loop.last %};{% endif %} // {{node[header].description}}
 {% endfor %}{% endfor %}{% endif %}
 

--- a/templates/flutter/docs/example.md.twig
+++ b/templates/flutter/docs/example.md.twig
@@ -25,7 +25,7 @@ Client client = Client()
     {%~ if [(method | securitySchemes)]|length > 0 %}
     .setEndpoint('{{ endpointDocs | raw }}') // Your API Endpoint
     {%~ for node in [(method | securitySchemes)] %}
-    {%~ for key,header in node|keys|filter(h => not node[h].extensions['x-appwrite']['optional']) %}
+    {%~ for key,header in node|keys %}
     .set{{header}}('{{node[header].extensions['x-appwrite']['demo'] | raw }}'){% if loop.last %};{% endif%} // {{node[header].description}}
     {%~ endfor %}
     {%~ endfor %}

--- a/templates/go/docs/example.md.twig
+++ b/templates/go/docs/example.md.twig
@@ -20,7 +20,7 @@ func main() {
 {% if [(method | securitySchemes)]|length > 0 %}
 		appwrite.WithEndpoint("{{ endpointDocs | raw }}"),
 {% for node in [(method | securitySchemes)] %}
-{% for key,header in node|keys|filter(h => not node[h].extensions['x-appwrite']['optional']) %}
+{% for key,header in node|keys %}
 		appwrite.With{{header}}("{{node[header].extensions['x-appwrite']['demo'] | raw }}"),
 {% endfor %}
 {% endfor %}

--- a/templates/kotlin/docs/java/example.md.twig
+++ b/templates/kotlin/docs/java/example.md.twig
@@ -23,7 +23,7 @@ Client client = new Client()
 {% if [(method | securitySchemes)]|length > 0 %}
     .setEndpoint("{{ endpointDocs | raw }}") // Your API Endpoint
 {% for node in [(method | securitySchemes)] %}
-{% for key,header in node|keys|filter(h => not node[h].extensions['x-appwrite']['optional']) %}
+{% for key,header in node|keys %}
     .set{{header | caseUcfirst}}("{{node[header].extensions['x-appwrite']['demo'] | raw }}"){% if loop.last %};{% endif %} // {{node[header].description}}
 {% endfor %}{% endfor %}{% endif %}
 

--- a/templates/kotlin/docs/kotlin/example.md.twig
+++ b/templates/kotlin/docs/kotlin/example.md.twig
@@ -23,7 +23,7 @@ val client = Client()
 {% if [(method | securitySchemes)]|length > 0 %}
     .setEndpoint("{{ endpointDocs | raw }}") // Your API Endpoint
 {% for node in [(method | securitySchemes)] %}
-{% for key,header in node|keys|filter(h => not node[h].extensions['x-appwrite']['optional']) %}
+{% for key,header in node|keys %}
     .set{{header | caseUcfirst}}("{{node[header].extensions['x-appwrite']['demo'] | raw }}") // {{node[header].description}}
 {% endfor %}{% endfor %}{% endif %}
 

--- a/templates/node/docs/example.md.twig
+++ b/templates/node/docs/example.md.twig
@@ -4,7 +4,7 @@ const sdk = require('node-{{ spec.info.title | caseDash }}');
 const fs = require('fs');
 {% endif %}
 
-{% set clientCalls = [] %}{% if [(method | securitySchemes)]|length > 0 %}{% set clientCalls = clientCalls|merge([{'call': 'setEndpoint', 'argument': endpointDocs, 'comment': 'Your API Endpoint'}]) %}{% for node in [(method | securitySchemes)] %}{% for key,header in node|keys|filter(h => not node[h].extensions['x-appwrite']['optional']) %}{% set clientCalls = clientCalls|merge([{'call': ('set' ~ header), 'argument': node[header].extensions['x-appwrite']['demo'], 'comment': node[header].description}]) %}{% endfor %}{% endfor %}{% endif %}
+{% set clientCalls = [] %}{% if [(method | securitySchemes)]|length > 0 %}{% set clientCalls = clientCalls|merge([{'call': 'setEndpoint', 'argument': endpointDocs, 'comment': 'Your API Endpoint'}]) %}{% for node in [(method | securitySchemes)] %}{% for key,header in node|keys %}{% set clientCalls = clientCalls|merge([{'call': ('set' ~ header), 'argument': node[header].extensions['x-appwrite']['demo'], 'comment': node[header].description}]) %}{% endfor %}{% endfor %}{% endif %}
 {{ clientCalls | jsClientChain('new sdk.Client()') | raw }}
 
 const {{ service.name | caseCamel | escapeKeyword }} = new sdk.{{service.name | caseUcfirst}}(client);

--- a/templates/php/docs/example.md.twig
+++ b/templates/php/docs/example.md.twig
@@ -24,7 +24,7 @@ $client = (new Client())
     {%~ if [(method | securitySchemes)]|length > 0 %}
     ->setEndpoint('{{ endpointDocs | raw }}') // Your API Endpoint
     {%~ for node in [(method | securitySchemes)] %}
-    {%~ for key,header in node|keys|filter(h => not node[h].extensions['x-appwrite']['optional']) %}
+    {%~ for key,header in node|keys %}
     ->set{{header}}('{{node[header].extensions['x-appwrite']['demo'] | raw }}'){% if loop.last%};{% endif%} // {{node[header].description}}
     {%~ endfor %}
     {%~ endfor %}

--- a/templates/python/docs/example.md.twig
+++ b/templates/python/docs/example.md.twig
@@ -66,7 +66,7 @@ client = Client()
 {% if [(method | securitySchemes)]|length > 0 %}
 client.set_endpoint('{{ endpointDocs | raw }}') # Your API Endpoint
 {% for node in [(method | securitySchemes)] %}
-{% for key,header in node|keys|filter(h => not node[h].extensions['x-appwrite']['optional']) %}
+{% for key,header in node|keys %}
 client.set_{{header | caseSnake}}('{{node[header].extensions['x-appwrite']['demo'] | raw }}') # {{node[header].description}}
 {% endfor %}
 {% endfor %}

--- a/templates/react-native/docs/example.md.twig
+++ b/templates/react-native/docs/example.md.twig
@@ -1,7 +1,7 @@
 ```javascript
 {% set importNames = ['Client', (service.name | caseUcfirst)] %}{% for parameter in (method | parameters('all')) %}{% if (parameter | enumValues) | length > 0 %}{% set importNames = importNames|merge([(parameter | enumName) | caseUcfirst]) %}{% endif %}{% endfor %}{% if (method | parameters('all')) | hasPermissionParam %}{% set importNames = importNames|merge(['Permission', 'Role']) %}{% endif %}{{ importNames | jsImport(language.params.npmPackage) | raw }}
 
-{% set clientCalls = [] %}{% if [(method | securitySchemes)]|length > 0 %}{% set clientCalls = clientCalls|merge([{'call': 'setEndpoint', 'argument': endpointDocs, 'comment': 'Your API Endpoint'}]) %}{% for node in [(method | securitySchemes)] %}{% for key,header in node|keys|filter(h => not node[h].extensions['x-appwrite']['optional']) %}{% set clientCalls = clientCalls|merge([{'call': ('set' ~ header), 'argument': node[header].extensions['x-appwrite']['demo'], 'comment': node[header].description}]) %}{% endfor %}{% endfor %}{% endif %}
+{% set clientCalls = [] %}{% if [(method | securitySchemes)]|length > 0 %}{% set clientCalls = clientCalls|merge([{'call': 'setEndpoint', 'argument': endpointDocs, 'comment': 'Your API Endpoint'}]) %}{% for node in [(method | securitySchemes)] %}{% for key,header in node|keys %}{% set clientCalls = clientCalls|merge([{'call': ('set' ~ header), 'argument': node[header].extensions['x-appwrite']['demo'], 'comment': node[header].description}]) %}{% endfor %}{% endfor %}{% endif %}
 {{ clientCalls | jsClientChain | raw }}
 
 const {{ service.name | caseCamel }} = new {{service.name | caseUcfirst}}(client{% if [] | length %}{% for parameter in [] %}, {{ parameter | paramExample }}{% endfor %}{% endif %});

--- a/templates/ruby/docs/example.md.twig
+++ b/templates/ruby/docs/example.md.twig
@@ -19,7 +19,7 @@ include {{ spec.info.title | caseUcfirst }}::Role
 client = Client.new
     .set_endpoint('{{ endpointDocs | raw }}') # Your API Endpoint
     {%~ for node in [(method | securitySchemes)] %}
-    {%~ for key,header in node|keys|filter(h => not node[h].extensions['x-appwrite']['optional']) %}
+    {%~ for key,header in node|keys %}
     .set_{{header|caseSnake}}('{{node[header].extensions['x-appwrite']['demo'] | raw }}') # {{node[header].description}}
     {%~ endfor %}
     {%~ endfor %}

--- a/templates/rust/docs/example.md.twig
+++ b/templates/rust/docs/example.md.twig
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = Client::new();
     client.set_endpoint("{{ endpointDocs | raw }}"); // Your API Endpoint
 {% for node in [(method | securitySchemes)] %}
-{% for key, header in node|keys|filter(h => not node[h].extensions['x-appwrite']['optional']) %}
+{% for key, header in node|keys %}
     client.set_{{ header | caseSnake }}("{{ node[header].extensions['x-appwrite']['demo'] | raw }}"); // {{ node[header].description }}
 {% endfor %}
 {% endfor %}

--- a/templates/swift/docs/example.md.twig
+++ b/templates/swift/docs/example.md.twig
@@ -12,7 +12,7 @@ let client = Client()
 {% if [(method | securitySchemes)]|length > 0 %}
     .setEndpoint("{{ endpointDocs | raw }}") // Your API Endpoint
 {% for node in [(method | securitySchemes)] %}
-{% for key,header in node|keys|filter(h => not node[h].extensions['x-appwrite']['optional']) %}
+{% for key,header in node|keys %}
     .set{{header | caseUcfirst}}("{{node[header].extensions['x-appwrite']['demo'] | raw }}") // {{node[header].description}}
 {% endfor %}
 {% endfor %}

--- a/templates/web/docs/example.md.twig
+++ b/templates/web/docs/example.md.twig
@@ -1,7 +1,7 @@
 ```javascript
 {% set importNames = ['Client', (service.name | caseUcfirst)] %}{% for parameter in (method | parameters('all')) %}{% if (parameter | enumValues) | length > 0 %}{% set importNames = importNames|merge([(parameter | enumName) | caseUcfirst]) %}{% endif %}{% endfor %}{% if (method | parameters('all')) | hasPermissionParam %}{% set importNames = importNames|merge(['Permission', 'Role']) %}{% endif %}{{ importNames | jsImport(language.params.npmPackage) | raw }}
 
-{% set clientCalls = [] %}{% if [(method | securitySchemes)]|length > 0 %}{% set clientCalls = clientCalls|merge([{'call': 'setEndpoint', 'argument': endpointDocs, 'comment': 'Your API Endpoint'}]) %}{% for node in [(method | securitySchemes)] %}{% for key,header in node|keys|filter(h => not node[h].extensions['x-appwrite']['optional']) %}{% set clientCalls = clientCalls|merge([{'call': ('set' ~ header), 'argument': node[header].extensions['x-appwrite']['demo'], 'comment': node[header].description}]) %}{% endfor %}{% endfor %}{% endif %}
+{% set clientCalls = [] %}{% if [(method | securitySchemes)]|length > 0 %}{% set clientCalls = clientCalls|merge([{'call': 'setEndpoint', 'argument': endpointDocs, 'comment': 'Your API Endpoint'}]) %}{% for node in [(method | securitySchemes)] %}{% for key,header in node|keys %}{% set clientCalls = clientCalls|merge([{'call': ('set' ~ header), 'argument': node[header].extensions['x-appwrite']['demo'], 'comment': node[header].description}]) %}{% endfor %}{% endfor %}{% endif %}
 {{ clientCalls | jsClientChain | raw }}
 
 const {{ service.name | caseCamel | escapeKeyword }} = new {{service.name | caseUcfirst}}(client{% if [] | length %}{% for parameter in [] %}, {{ parameter | paramExample }}{% endfor %}{% endif %});

--- a/tests/generation/GenerationTest.php
+++ b/tests/generation/GenerationTest.php
@@ -288,41 +288,6 @@ final class GenerationTest extends TestCase
         }
     }
 
-    public static function securityAlternatives(): iterable
-    {
-        yield 'optional last' => [[['Project' => [], 'Key' => []], ['Project' => [], 'Key' => [], 'Session' => []]], ['Project', 'Key'], ['Session']];
-        yield 'optional first' => [[['Project' => [], 'Key' => [], 'Session' => []], ['Project' => [], 'Key' => []]], ['Project', 'Key'], ['Session']];
-        yield 'all required' => [[['Project' => [], 'Key' => [], 'Session' => []]], ['Project', 'Key', 'Session'], []];
-        yield 'anonymous' => [[[], ['Project' => [], 'Key' => [], 'Session' => []]], [], ['Project', 'Key', 'Session']];
-        yield 'no requirements preserves example config' => [[], ['Project', 'Key', 'Session'], []];
-        yield 'unreferenced config is independent' => [[['Session' => []], []], ['Project', 'Key'], ['Session']];
-    }
-
-    #[DataProvider('securityAlternatives')]
-    public function testExamplesRespectSecurityAlternatives(array $security, array $present, array $absent): void
-    {
-        $document = \json_decode((string) \file_get_contents(self::FIXTURE), true, flags: JSON_THROW_ON_ERROR);
-        $document['paths']['/mock/tests/general/zzderivedauth']['get']['security'] = $security;
-        $dir = self::OUTPUT . '/optional-security';
-        $this->removeDirectory($dir);
-        new SDK(new PHP(), Parser::parse($document))
-            ->setName('test')
-            ->setNamespace('appwrite')
-            ->setVersion('0.0.1')
-            ->setPlatform('server')
-            ->generate($dir);
-        $example = \strtolower((string) \file_get_contents($dir . '/docs/examples/general/zzderivedauth.md'));
-        foreach ($present as $name) {
-            $this->assertStringContainsString('->set' . \strtolower((string) $name) . '(', $example);
-        }
-        foreach ($absent as $name) {
-            $this->assertStringNotContainsString('->set' . \strtolower((string) $name) . '(', $example);
-        }
-        // Optionality affects examples, not the available client setters.
-        $client = \strtolower((string) \file_get_contents($dir . '/src/Appwrite/Client.php'));
-        $this->assertStringContainsString('function setsession(', $client);
-    }
-
     /**
      * A JSON example for an untyped object array must render as Swift
      * dictionary literals, not as the JavaScript-style `{ ... }` the spec

--- a/tests/generation/GenerationTest.php
+++ b/tests/generation/GenerationTest.php
@@ -264,7 +264,8 @@ final class GenerationTest extends TestCase
     /**
      * A canonical document keys `x-appwrite.auth` by platform. The fixture's
      * platform-auth operation lists `Project` for client and `Project, Key` for
-     * server, and the server alias variant lists `Project, JWT`.
+     * server plus an optional Session, and the server alias variant lists
+     * `Project, JWT`. Optional security must not become example configuration.
      */
     public function testExampleCredentialsFollowPlatformAuth(): void
     {
@@ -285,6 +286,41 @@ final class GenerationTest extends TestCase
                 $this->assertStringNotContainsString($call, $files[$path], "php/{$platform} {$path} configures {$call}");
             }
         }
+    }
+
+    public static function securityAlternatives(): iterable
+    {
+        yield 'optional last' => [[['Project' => [], 'Key' => []], ['Project' => [], 'Key' => [], 'Session' => []]], ['Project', 'Key'], ['Session']];
+        yield 'optional first' => [[['Project' => [], 'Key' => [], 'Session' => []], ['Project' => [], 'Key' => []]], ['Project', 'Key'], ['Session']];
+        yield 'all required' => [[['Project' => [], 'Key' => [], 'Session' => []]], ['Project', 'Key', 'Session'], []];
+        yield 'anonymous' => [[[], ['Project' => [], 'Key' => [], 'Session' => []]], [], ['Project', 'Key', 'Session']];
+        yield 'no requirements preserves example config' => [[], ['Project', 'Key', 'Session'], []];
+        yield 'unreferenced config is independent' => [[['Session' => []], []], ['Project', 'Key'], ['Session']];
+    }
+
+    #[DataProvider('securityAlternatives')]
+    public function testExamplesRespectSecurityAlternatives(array $security, array $present, array $absent): void
+    {
+        $document = \json_decode((string) \file_get_contents(self::FIXTURE), true, flags: JSON_THROW_ON_ERROR);
+        $document['paths']['/mock/tests/general/zzderivedauth']['get']['security'] = $security;
+        $dir = self::OUTPUT . '/optional-security';
+        $this->removeDirectory($dir);
+        new SDK(new PHP(), Parser::parse($document))
+            ->setName('test')
+            ->setNamespace('appwrite')
+            ->setVersion('0.0.1')
+            ->setPlatform('server')
+            ->generate($dir);
+        $example = \strtolower((string) \file_get_contents($dir . '/docs/examples/general/zzderivedauth.md'));
+        foreach ($present as $name) {
+            $this->assertStringContainsString('->set' . \strtolower((string) $name) . '(', $example);
+        }
+        foreach ($absent as $name) {
+            $this->assertStringNotContainsString('->set' . \strtolower((string) $name) . '(', $example);
+        }
+        // Optionality affects examples, not the available client setters.
+        $client = \strtolower((string) \file_get_contents($dir . '/src/Appwrite/Client.php'));
+        $this->assertStringContainsString('function setsession(', $client);
     }
 
     /**

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -2550,7 +2550,7 @@
         "tags": [
           "general"
         ],
-        "description": "Fixture-only method whose example credentials are keyed by platform, as in the canonical document.",
+        "description": "Fixture-only method whose example credentials are keyed by platform; Session is accepted in only one security alternative and must not be configured by examples.",
         "x-appwrite": {
           "demo": "general\/zzderivedauth.md",
           "rate-limit": 0,
@@ -2568,7 +2568,8 @@
             },
             "server": {
               "Project": [],
-              "Key": []
+              "Key": [],
+              "Session": []
             }
           }
         },
@@ -2577,6 +2578,12 @@
             "Project": [],
             "Key": [],
             "JWT": []
+          },
+          {
+            "Project": [],
+            "Key": [],
+            "JWT": [],
+            "Session": []
           }
         ],
         "responses": {


### PR DESCRIPTION
## Owner-approved scope deferral

The owner approved deferring the remaining pre-existing schema issues and continuing this migration. Strict full-document validation still fails on the documented custom-array schemas; that failure is **deferred, not fixed or passing**. No additional schema-cleanup work is included in this rollout.

Proceed with the optional-security migration's review/CI and coordinated producer → Cloud/specs → generator release steps. Keep the temporary producer dependency pin and SDK compatibility/release sequencing explicit; this deferral is not approval to disable checks or merge unrelated fixes.

---

## Latest verification — includes enum-default fix #13545 (now merged)

Cloud head `12abbfeab6fd35ddccb669cd43cf8d55eb407068` locks producer integration commit `e36198300f0efe854d442526253ae2b7eab2c2fb`, which includes #13545's code.

- Both non-publishing workflows passed: [2.0.x](https://github.com/appwrite-labs/cloud/actions/runs/34260375332), [latest](https://github.com/appwrite-labs/cloud/actions/runs/34260378191).
- Artifacts are byte-identical: SHA256 `eb9761f869119e57c2f01e3eca3ec12e5bcda9e87ec5bfc8f6750bc4190d1001`.
- Comparison against the preceding object-default-fixed artifacts shows exactly **15 invalid enum defaults removed**, and no other parsed differences. Includes timezone, screenshot output, runtime/adapter, locale, encryption, password version, and region defaults.
- Producer formatter suite passed: **41 tests, 244 assertions**, plus targeted Pint.
- **Strict validation still fails** on both artifacts: `[] is not of type 'string'`. The same failure category exists in the published document.
- A recursive schema scan finds 10 string schemas with empty-array defaults: OAuth2 `resource` on authorize GET/POST, device authorization, PAR, and token; WAF `conditions` on bypass, challenge, deny, rate-limit, and redirect creation. Their source validators declare arrays (`Multiple(..., TYPE_ARRAY)` and WAF `Conditions`), but the producer's fallback maps them to string. Removing defaults alone would hide the underlying type mismatch.

No PRs merged by this verification, no spec publication or deployment. The release gate remains blocked on these custom-array schema mappings and the previously listed SDK compatibility checks. Earlier sections below are historical evidence.

---

## Latest verification — includes merged #13544

Producer #13543 now includes main through `f66db6e969` (merged object-default fix); head `e4d63346abff7a70f04c820862b2d285e66b2595`. Cloud #5716 locks that producer commit at Cloud head `6f68bc428`.

- Producer formatter tests: **39 tests, 222 assertions**, passing; targeted Pint passes.
- Cloud `composer validate --no-check-publish` passes; only the server-ce lock reference changed.
- Non-publishing specs workflows passed: [2.0.x](https://github.com/appwrite-labs/cloud/actions/runs/34259378879), [latest](https://github.com/appwrite-labs/cloud/actions/runs/34259381747).
- Both artifacts are byte-identical: SHA256 `a5fad5d320ab9592181451b7c479f5d85f603f6d895a829f353374fea81694bb`.
- Compared with the previous genuine candidate artifacts, exactly **16 defaults changed from `[]` to `{}`**, with no other parsed differences. The optional-security migration is unchanged.
- Strict `openapi-spec-validator` now gets past the empty-object-default failure but fails on screenshot `timezone`: `GET /avatars/screenshots`, parameter index 9, has `default: ""` outside its titled `oneOf` timezone enum. This field is unchanged from the previous artifact. **Full spec validation remains blocked**, not passing.
- No specs were published or deployments performed. Historical verification below refers to earlier commits/artifacts; SDK output parity has not been rerun after the object-default fix.

---

## Summary

Part of [CLO-4377](https://linear.app/appwrite/issue/CLO-4377/openapi3-standards). Companion producer: [appwrite/appwrite#13543](https://github.com/appwrite/appwrite/pull/13543).

- Require `utopia-php/openapi ^0.2.2` and lock 0.2.2, which provides accepted/required security scheme names.
- Read accepted schemes across all alternatives for path bindings and operation security consumers instead of only `security[0]`.
- Omit optional example candidates using accepted-minus-required names. Preserve `x-appwrite.auth` as the separate source of example configuration, including candidates not referenced by API security.
- Remove `Appwrite::OPTIONAL` and direct legacy extension checks from 17 example templates.
- Extend the shared fixture and generated-output coverage for optional/required credentials, alternative order, anonymous access, no security, independent example config, and preserved client setters.

No OAuth scopes are merged. Generic security semantics live in OpenAPI 0.2.2, not in a generator helper.

## Rollout gate

**Do not release against the currently published old specs.** Removing the legacy checks changes impersonation examples until the replacement security alternatives are published. Keep this draft until genuine Cloud generation, structural/live-spec baseline comparisons, and deployed-generator compatibility checks are complete. Coordinate producer promotion and canonical `2.0.x`/`latest` publication before releasing this generator.

No Cloud promotion, specs publishing, or releases were performed.

## Verification

Passing:

- `vendor/bin/phpunit --testsuite Generation` — 91 tests, 1,154 assertions, 4 skipped.
- `vendor/bin/phpunit tests/e2e/PHP85Test.php` — 1 test, 145 assertions against the Docker mock API.
- `composer refactor:check` — passed.
- `composer lint-twig` — 586 files, zero errors.
- `vendor/bin/phpcs src/SDK/SDK.php src/SDK/Extension/Appwrite.php tests/generation/GenerationTest.php` — passed.
- `git diff --check` — passed.
- Regenerated with `SDK_GEN_SPEC_FILE=$PWD/tests/resources/spec-openapi3.json php example.php <target> <platform>` for PHP, Unity, Web, Node, Ruby, Python, Dart, Flutter, React Native, Go, Swift, Apple, .NET, Android, Kotlin, Rust, and CLI. Inspected the PHP example: Project/Key retained, optional Session omitted.
- Go/CLI `gofmt` check passed on the initial generated trees.

Blocked / incomplete:

- Clean Web/Node/React Native fixture regeneration fails Prettier checks in `general.ts` and several Node model files. Compared generated `src/` files against an isolated unchanged-HEAD generation using the same fixture: no source differences. These failures predate this change. Chained lint/typecheck/test commands therefore did not run.
- Clean CLI fixture build fails on missing go.sum entries and fixture-only SDK services; vet/test did not run. No dependency or generated-output patching was done to force a pass.
- Remaining language formatter/static-analysis/e2e checks, Deno example.php regeneration (covered by Generation suite), genuine Cloud spec generation, canonical validation, and live-spec baseline comparison are not complete.

The passing PHP e2e uses fixture generation, not the new full Appwrite/Cloud document.

### Subsequent genuine Cloud verification

[Cloud #5716](https://github.com/appwrite-labs/cloud/pull/5716): non-publishing specs runs passed for [2.0.x](https://github.com/appwrite-labs/cloud/actions/runs/34257058117) and [latest](https://github.com/appwrite-labs/cloud/actions/runs/34257061099). Both artifacts are byte-identical, SHA256 `5454c86362e1ee39d0eaa0d1f1282d965b334041824bc047336fe262a6c27740`.

A [controlled producer-parent run](https://github.com/appwrite-labs/cloud/actions/runs/34257451096), using the same Cloud code, proves exactly 3 optional-extension removals and 16 security-array changes, with no other parsed differences. PHP SDK client/server/console complete trees match old generator `3418a5dbd` + genuine baseline versus this PR `9e1423673` + genuine candidate, using isolated generator source autoloading and clean output directories.

The artifacts have 1,022 operations, 77 aliases, and 16 schemes. Differences from the published 1,020-operation spec include independent OAuth/DNS changes, also present in the controlled baseline. Strict OpenAPI validation still fails on an object schema with `default: []`, as does the published spec. Cross-language parity and deployed-generator compatibility remain pending. No screenshots apply to these nonvisual changes.
