### PR TITLE
fix: keep GraphQL variables in the documented JS SDK call

### DIFF
--- a/mock-server/app/http.php
+++ b/mock-server/app/http.php
@@ -581,6 +581,24 @@ App::get('/v1/mock/tests/general/optional')
         $response->json(['result' => "width={$width},height={$height},name={$name}"]);
     });
 
+App::post('/v1/mock/tests/general/query')
+    ->desc('Create Query')
+    ->groups(['mock'])
+    ->label('scope', 'public')
+    ->label('sdk.auth', [APP_AUTH_TYPE_SESSION, APP_AUTH_TYPE_KEY, APP_AUTH_TYPE_JWT])
+    ->label('sdk.namespace', 'general')
+    ->label('sdk.method', 'createQuery')
+    ->label('sdk.description', 'Mock a request whose only parameter is a free-form object.')
+    ->label('sdk.response.code', Response::STATUS_CODE_OK)
+    ->label('sdk.response.type', Response::CONTENT_TYPE_JSON)
+    ->label('sdk.response.model', Response::MODEL_MOCK)
+    ->label('sdk.mock', true)
+    ->param('query', [], new Assoc(), 'Sample free-form object param')
+    ->inject('response')
+    ->action(function (array $query, UtopiaSwooleResponse $response) {
+        $response->json(['result' => \json_encode($query)]);
+    });
+
 App::post('/v1/mock/tests/general/nullable')
     ->desc('Nullable Test')
     ->groups(['mock'])

--- a/src/SDK/Language/Web.php
+++ b/src/SDK/Language/Web.php
@@ -507,8 +507,9 @@ class Web extends JS
      * still dispatch positionally or the trailing arguments are discarded.
      *
      * @param array<int, string> $keys
+     * @param array<int, string> $operands
      */
-    protected function formatOverloadCondition(bool $hasRequired, array $keys, bool $hasRest = false): string
+    protected function formatOverloadCondition(bool $hasRequired, array $keys, bool $hasRest = false, array $operands = []): string
     {
         $indent = str_repeat(' ', 12);
         $shape = [
@@ -529,6 +530,8 @@ class Web extends JS
                 ? $group
                 : '(' . implode(' ||' . "\n" . $groupIndent . str_repeat(' ', 4), $keys) . ')';
         }
+
+        array_push($shape, ...$operands);
 
         if (!$hasRequired) {
             // The optional-params form nests the object test inside `!paramsOrFirst || (...)`,
@@ -1057,6 +1060,7 @@ class Web extends JS
                     || str_starts_with($firstParamType, 'boolean');
 
                 $keys = [];
+                $operands = [];
                 if (!$isPrimitive) {
                     foreach ($params as $param) {
                         $name = $this->escapeKeyword($this->toCamelCase($param->name));
@@ -1066,11 +1070,17 @@ class Web extends JS
                     if (isset($method->requestBody?->content['multipart/form-data'])) {
                         $keys[] = "'onProgress' in paramsOrFirst";
                     }
+
+                    // A lone free-form object can carry its own parameter name as a key, as in
+                    // graphql.query({ query: '...', variables }), so a string there is the positional form.
+                    if (count($params) === 1 && $firstParamType === 'object') {
+                        $operands[] = 'typeof paramsOrFirst.' . $this->escapeKeyword($this->toCamelCase($params[0]->name)) . " !== 'string'";
+                    }
                 }
 
                 $hasRest = count($params) > 1;
 
-                return $this->formatOverloadCondition($hasRequired, $keys, $hasRest);
+                return $this->formatOverloadCondition($hasRequired, $keys, $hasRest, $operands);
             }, ['is_safe' => ['html']]),
         ]);
     }

--- a/tests/e2e/Base.php
+++ b/tests/e2e/Base.php
@@ -94,6 +94,11 @@ abstract class Base extends TestCase
         'width=0,height=64,name=zero',
     ];
 
+    protected const OBJECT_PARAM_RESPONSES = [
+        '{"query":"query { mock }","variables":{"id":1}}',
+        '{"query":"query { mock }"}',
+    ];
+
     protected const UNION_RESPONSES = [
         'GET:/v1/mock/tests/union:passed',
         'test-data',

--- a/tests/e2e/Node18Test.php
+++ b/tests/e2e/Node18Test.php
@@ -51,6 +51,7 @@ final class Node18Test extends Base
         ...Base::ENUM_RESPONSES,
         ...Base::MODEL_RESPONSES,
         ...Base::OPTIONAL_PARAM_RESPONSES,
+        ...Base::OBJECT_PARAM_RESPONSES,
         ...Base::EXCEPTION_RESPONSES,
         ...Base::OAUTH_RESPONSES,
         ...Base::QUERY_HELPER_RESPONSES,

--- a/tests/e2e/Node20Test.php
+++ b/tests/e2e/Node20Test.php
@@ -51,6 +51,7 @@ final class Node20Test extends Base
         ...Base::ENUM_RESPONSES,
         ...Base::MODEL_RESPONSES,
         ...Base::OPTIONAL_PARAM_RESPONSES,
+        ...Base::OBJECT_PARAM_RESPONSES,
         ...Base::EXCEPTION_RESPONSES,
         ...Base::OAUTH_RESPONSES,
         ...Base::QUERY_HELPER_RESPONSES,

--- a/tests/e2e/Node26Test.php
+++ b/tests/e2e/Node26Test.php
@@ -51,6 +51,7 @@ final class Node26Test extends Base
         ...Base::ENUM_RESPONSES,
         ...Base::MODEL_RESPONSES,
         ...Base::OPTIONAL_PARAM_RESPONSES,
+        ...Base::OBJECT_PARAM_RESPONSES,
         ...Base::EXCEPTION_RESPONSES,
         ...Base::OAUTH_RESPONSES,
         ...Base::QUERY_HELPER_RESPONSES,

--- a/tests/e2e/ReactNativeTest.php
+++ b/tests/e2e/ReactNativeTest.php
@@ -51,6 +51,7 @@ final class ReactNativeTest extends Base
         ...Base::ENUM_RESPONSES,
         ...Base::MODEL_RESPONSES,
         ...Base::OPTIONAL_PARAM_RESPONSES,
+        ...Base::OBJECT_PARAM_RESPONSES,
         ...Base::EXCEPTION_RESPONSES,
         ...Base::REALTIME_RESPONSES,
         ...Base::QUERY_HELPER_RESPONSES,

--- a/tests/e2e/WebChromiumTest.php
+++ b/tests/e2e/WebChromiumTest.php
@@ -50,6 +50,7 @@ final class WebChromiumTest extends Base
         ...Base::ENUM_RESPONSES,
         ...Base::MODEL_RESPONSES,
         ...Base::OPTIONAL_PARAM_RESPONSES,
+        ...Base::OBJECT_PARAM_RESPONSES,
         ...Base::UNION_RESPONSES,
         ...Base::EXCEPTION_RESPONSES,
         ...Base::REALTIME_RESPONSES,

--- a/tests/e2e/WebNodeTest.php
+++ b/tests/e2e/WebNodeTest.php
@@ -47,6 +47,7 @@ final class WebNodeTest extends Base
         ...Base::ENUM_RESPONSES,
         ...Base::MODEL_RESPONSES,
         ...Base::OPTIONAL_PARAM_RESPONSES,
+        ...Base::OBJECT_PARAM_RESPONSES,
         ...Base::UNION_RESPONSES,
         ...Base::EXCEPTION_RESPONSES,
         ...Base::QUERY_HELPER_RESPONSES,

--- a/tests/e2e/languages/node/test.js
+++ b/tests/e2e/languages/node/test.js
@@ -239,6 +239,13 @@ async function start() {
     response = await general.getOptional(0, 64, 'zero');
     console.log(response.result);
 
+    // A lone object param keeps its own `query` key, as in graphql.query({ query, variables })
+    response = await general.createQuery({ query: 'query { mock }', variables: { id: 1 } });
+    console.log(response.result);
+
+    response = await general.createQuery({ query: { query: 'query { mock }' } });
+    console.log(response.result);
+
     try {
         response = await general.error400();
     } catch(error) {

--- a/tests/e2e/languages/react-native/browser.js
+++ b/tests/e2e/languages/react-native/browser.js
@@ -162,6 +162,13 @@ import {
     response = await general.getOptional(0, 64, 'zero');
     console.log(response.result);
 
+    // A lone object param keeps its own `query` key, as in graphql.query({ query, variables })
+    response = await general.createQuery({ query: 'query { mock }', variables: { id: 1 } });
+    console.log(response.result);
+
+    response = await general.createQuery({ query: { query: 'query { mock }' } });
+    console.log(response.result);
+
     // Exception responses
     try {
         response = await general.error400();

--- a/tests/e2e/languages/web/index.html
+++ b/tests/e2e/languages/web/index.html
@@ -264,6 +264,13 @@
             response = await general.getOptional(0, 64, 'zero');
             console.log(response.result);
 
+            // A lone object param keeps its own `query` key, as in graphql.query({ query, variables })
+            response = await general.createQuery({ query: 'query { mock }', variables: { id: 1 } });
+            console.log(response.result);
+
+            response = await general.createQuery({ query: { query: 'query { mock }' } });
+            console.log(response.result);
+
             // Union types test - returns `mock` type
             response = await general.getUnion({ type: 'mock' });
             console.log(response.result);

--- a/tests/e2e/languages/web/node.js
+++ b/tests/e2e/languages/web/node.js
@@ -159,6 +159,13 @@ async function start() {
     response = await general.getOptional(0, 64, 'zero');
     console.log(response.result);
 
+    // A lone object param keeps its own `query` key, as in graphql.query({ query, variables })
+    response = await general.createQuery({ query: 'query { mock }', variables: { id: 1 } });
+    console.log(response.result);
+
+    response = await general.createQuery({ query: { query: 'query { mock }' } });
+    console.log(response.result);
+
     // Union types test - returns `mock` type
     response = await general.getUnion({ type: 'mock' });
     console.log(response.result);

--- a/tests/resources/spec-openapi3.json
+++ b/tests/resources/spec-openapi3.json
@@ -1716,6 +1716,72 @@
         ]
       }
     },
+    "\/mock\/tests\/general\/query": {
+      "post": {
+        "summary": "Create Query",
+        "operationId": "generalCreateQuery",
+        "tags": [
+          "general"
+        ],
+        "description": "Mock a request whose only parameter is a free-form object.",
+        "x-appwrite": {
+          "demo": "general\/create-query.md",
+          "rate-limit": 0,
+          "rate-time": 3600,
+          "rate-key": "url:{url},ip:{ip}",
+          "scope": "public",
+          "platforms": [
+            "client",
+            "server"
+          ],
+          "packaging": false,
+          "auth": {
+            "Project": []
+          }
+        },
+        "security": [
+          {
+            "Project": [],
+            "Key": [],
+            "JWT": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Mock",
+            "content": {
+              "application\/json": {
+                "schema": {
+                  "$ref": "#\/components\/schemas\/mock"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application\/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "object",
+                    "description": "Sample free-form object param",
+                    "default": null,
+                    "example": {
+                      "query": "query { mock }"
+                    }
+                  }
+                },
+                "required": [
+                  "query"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
     "\/mock\/tests\/general\/nullable": {
       "post": {
         "summary": "Nullable Test",


### PR DESCRIPTION
## What does this PR do?

The JS SDKs (web, node, react-native) drop `variables` from the GraphQL call shown in the Appwrite docs.

`graphql.query` and `graphql.mutation` take a single free-form `object` parameter named `query`. The params-object overload is selected when `'query' in paramsOrFirst`, and a GraphQL request object has a `query` key as well, so the documented call is read as the params form:

```js
graphql.mutation({
    query: 'mutation CreateAccount($email: String!) { ... }',
    variables: { email: '...' },
});
```

Before:

```json
{"query":"mutation CreateAccount($email: String!) { ... }"}
```

After:

```json
{"query":{"query":"mutation CreateAccount($email: String!) { ... }","variables":{"email":"..."}}}
```

Current Appwrite servers answer the flat body with HTTP 500 (appwrite/appwrite#13605 turns it into a 400), so every documented GraphQL call fails with the current SDKs.

When a method's only parameter is a free-form `object`, `getOverloadCondition` now adds `typeof paramsOrFirst.<name> !== 'string'`. Generated from the Appwrite 2.0.x spec, this operand in `graphql.query` and `graphql.mutation` is the only change in web, node and react-native:

```diff
             'query' in paramsOrFirst &&
+            typeof paramsOrFirst.query !== 'string'
```

The params form (`{ query: { query, variables } }`, `{ query: [...] }`), positional batches, `{ query: null }` and the `Missing required parameter` throw for `{ query: undefined }` behave as before. The documented shape resolves to the positional overload, which stays marked `@deprecated`.

## Test Plan

- Generated web (client), node (server) and react-native (client) from `open-api3-2.0.x.json` before and after the change: only `src/services/graphql.ts` differs.
- `npm run format:check`, `lint`, `analyse` and `build` pass for all three; `npm run test` passes for node (832 tests).
- Ran the generated `graphql.ts` before and after with a recording client and replayed the web payloads against an Appwrite server: the documented mutation reaches the resolver with its variables, and the documented query returns data instead of HTTP 500.
- `vendor/bin/phpunit --testsuite Generation`, `phpcs` and `rector --dry-run` pass.
- e2e: a `general.createQuery` fixture takes a lone free-form `query` object; the node, web and react-native scripts call it with `{ query, variables }` and `{ query: { query } }`, and the mock echoes what it received. Node20 and WebNode pass; with `Web.php` reverted, Node20 fails with ``Invalid `query` param: Value must be a valid object``.
