### PR TITLE
fix(node): surface API errors from redirect()

### DIFF
--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -622,9 +622,15 @@ class Client {
             const responseText = await response.text();
             let data: any = { message: responseText };
             if (
-                response.headers.get('content-type')?.includes('application/json')
+                response.headers
+                    .get('content-type')
+                    ?.includes('application/json')
             ) {
-                data = JSONbig.parse(responseText);
+                try {
+                    data = JSONbig.parse(responseText);
+                } catch {
+                    // Keep the raw body as the message when the JSON is malformed
+                }
             }
             throw new {{spec.info.title | caseUcfirst}}Exception(
                 data?.message,

--- a/templates/node/src/client.ts.twig
+++ b/templates/node/src/client.ts.twig
@@ -618,6 +618,22 @@ class Client {
             redirect: 'manual',
         });
 
+        if (400 <= response.status) {
+            const responseText = await response.text();
+            let data: any = { message: responseText };
+            if (
+                response.headers.get('content-type')?.includes('application/json')
+            ) {
+                data = JSONbig.parse(responseText);
+            }
+            throw new {{spec.info.title | caseUcfirst}}Exception(
+                data?.message,
+                response.status,
+                data?.type,
+                responseText,
+            );
+        }
+
         if (response.status !== 301 && response.status !== 302) {
             throw new {{spec.info.title | caseUcfirst}}Exception('Invalid redirect', response.status);
         }


### PR DESCRIPTION
## Summary

`Client.redirect()` in the Node SDK threw `Invalid redirect` for any response other than a 301/302 and dropped the body, so a failing `createOAuth2Token` (invalid key, unknown project, missing scope) gave no hint of the cause. It now reads 4xx/5xx bodies the way `call()` does, so the exception carries the server's `message`, `type` and `response`. Other non-redirect statuses still throw `Invalid redirect`.

The dotnet, kotlin, python and php clients already surface the body on this path.

Part of appwrite/appwrite#8090.

## Verification

`createOAuth2Token` against a local Appwrite with a real project and an invalid API key. The patched client is node-appwrite 29.0.0 with the same change applied to `dist/client.js`.

| Client | Server | Exception |
|---|---|---|
| node-appwrite 29.0.0 | main | `Invalid redirect`, type `""` |
| patched | main | message is the HTML error page |
| patched | appwrite/appwrite#13625 | `The current user is not authorized to perform the requested action.`, type `user_unauthorized` |

