### PR TITLE
fix(cli): use Go SDK v7.3.0 for current console APIs

### DIFF
--- a/templates/cli/go.mod.twig
+++ b/templates/cli/go.mod.twig
@@ -7,7 +7,7 @@ go 1.26.5
 // so anything added by hand to the generated file is lost on the next run.
 require (
 {% if not sdk.test %}
-	github.com/appwrite/sdk-for-go/v7 v7.2.0-rc.5
+	github.com/appwrite/sdk-for-go/v7 v7.3.0
 {% endif %}
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0


### PR DESCRIPTION
## Summary

Bump the CLI template's Go SDK dependency from `v7.2.0-rc.5` to the published `v7.3.0` release.

The live console spec includes Kakao and TikTok OAuth endpoints that the previous pin does not expose, so generated CLI code fails to compile. Go SDK v7.3.0 includes those APIs.

- Release: https://github.com/appwrite/sdk-for-go/releases/tag/v7.3.0
- Previous failing CLI job: https://github.com/appwrite/sdk-generator/actions/runs/34596375204/job/103252967496

Only `templates/cli/go.mod.twig` changes; no generated SDK files are edited or committed.

## Verification

Regenerated using `php example.php cli console`, then ran in `examples/cli`:

- `go mod tidy` — passed; resolves published v7.3.0.
- `test -z "$(gofmt -l .)"` — passed.
- `go build ./...` — passed.
- `go vet ./...` — passed.
- `go test -race ./...` — passed.
- `go build -o appwrite .` — passed.
- Version, help (`USAGE` and `GET STARTED`), and bash completion smoke checks — passed.

Additional generator checks:
- `composer refactor:check` — passed.
- `composer lint-twig` — passed (586 files, zero errors).
- `vendor/bin/phpunit --testsuite Generation` — passed (87 tests, 1,132 assertions, four skipped).

### GitHub Actions

- [Validation workflow](https://github.com/appwrite/sdk-generator/actions/runs/34600202267) — **passed**, including all SDK validation jobs.
- [CLI (console) job](https://github.com/appwrite/sdk-generator/actions/runs/34600202267/job/103265356440) — **passed**: generation idempotency, formatting/build/vet/race tests, compiled-binary smoke tests, and npm launcher/package checks.

Local checks used Go 1.27.1. Live Appwrite API E2E was not run locally. This is a nonvisual CLI dependency change; no screenshots apply.
