### PR TITLE
fix(cli): settle file events before comparing contents

### DIFF
--- a/templates/cli/internal/watch/watch.go
+++ b/templates/cli/internal/watch/watch.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 )
@@ -27,6 +29,8 @@ type Watcher struct {
 	ignored      Ignored
 	fingerprints map[string][sha256.Size]byte
 	done         chan struct{}
+	finished     chan struct{}
+	stop         sync.Once
 }
 
 // Start watches a directory tree, calling changed with each relative,
@@ -47,6 +51,7 @@ func Start(root string, ignored Ignored, changed func(string)) (*Watcher, error)
 		ignored:      ignored,
 		fingerprints: make(map[string][sha256.Size]byte),
 		done:         make(chan struct{}),
+		finished:     make(chan struct{}),
 	}
 
 	if err := w.addTree(root); err != nil {
@@ -105,7 +110,42 @@ func (w *Watcher) relative(path string) (string, error) {
 	return filepath.ToSlash(relative), nil
 }
 
+// Wait for a quiet interval before fingerprinting: a truncate-and-rewrite can
+// otherwise be observed as an empty file before the writer restores its bytes.
+const settleDelay = 100 * time.Millisecond
+
+// A tree that never falls quiet would defer its changes forever, so a path is
+// fingerprinted this long after its first event however busy the tree stays.
+const settleLimit = time.Second
+
+// pending is a change waiting for its path to settle.
+//
+// The wait is per path rather than shared: a file first touched late in a busy
+// stretch still needs its own quiet interval, and a shared deadline would hand
+// it whatever milliseconds happened to be left.
+type pending struct {
+	event    fsnotify.Event
+	quiet    time.Time // no further events since
+	deadline time.Time // measured from the first event
+}
+
+// due reports when the change has to be handled, whether or not it settled.
+func (p *pending) due() time.Time {
+	if p.deadline.Before(p.quiet) {
+		return p.deadline
+	}
+
+	return p.quiet
+}
+
 func (w *Watcher) run(changed func(string)) {
+	defer close(w.finished)
+
+	changes := make(map[string]*pending)
+	timer := time.NewTimer(settleDelay)
+	timer.Stop()
+	defer timer.Stop()
+
 	for {
 		select {
 		case <-w.done:
@@ -115,7 +155,31 @@ func (w *Watcher) run(changed func(string)) {
 			if !ok {
 				return
 			}
-			w.handle(event, changed)
+			relative, err := w.relative(event.Name)
+			if err != nil || relative == "" || w.ignored(relative) {
+				continue
+			}
+			now := time.Now()
+			change, waiting := changes[event.Name]
+			if !waiting {
+				change = &pending{deadline: now.Add(settleLimit)}
+				changes[event.Name] = change
+			}
+			event.Op |= change.event.Op
+			change.event = event
+			change.quiet = now.Add(settleDelay)
+			schedule(timer, changes, now)
+
+		case <-timer.C:
+			now := time.Now()
+			for path, change := range changes {
+				if now.Before(change.due()) {
+					continue
+				}
+				w.handle(change.event, changed)
+				delete(changes, path)
+			}
+			schedule(timer, changes, now)
 
 		case _, ok := <-w.watcher.Errors:
 			if !ok {
@@ -126,6 +190,23 @@ func (w *Watcher) run(changed func(string)) {
 			// over one would be worse than missing it.
 		}
 	}
+}
+
+// schedule arms the timer for the earliest change due.
+func schedule(timer *time.Timer, changes map[string]*pending, now time.Time) {
+	var next time.Time
+	for _, change := range changes {
+		if due := change.due(); next.IsZero() || due.Before(next) {
+			next = due
+		}
+	}
+	if next.IsZero() {
+		timer.Stop()
+
+		return
+	}
+
+	timer.Reset(max(0, next.Sub(now)))
 }
 
 func (w *Watcher) handle(event fsnotify.Event, changed func(string)) {
@@ -197,11 +278,17 @@ func fingerprint(path string) ([sha256.Size]byte, error) {
 	return sha256.Sum256(contents), nil
 }
 
-// Close stops watching.
+// Close stops watching and waits for any change already being handled, so no
+// callback runs once it returns. It is safe to call more than once.
 func (w *Watcher) Close() error {
-	close(w.done)
+	var err error
+	w.stop.Do(func() {
+		close(w.done)
+		err = w.watcher.Close()
+	})
+	<-w.finished
 
-	return w.watcher.Close()
+	return err
 }
 
 // PrefixIgnored adapts a path-based predicate so a directory is skipped when

--- a/templates/cli/internal/watch/watch_test.go
+++ b/templates/cli/internal/watch/watch_test.go
@@ -3,6 +3,8 @@ package watch
 import (
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -14,20 +16,12 @@ func TestWatcherIgnoresMetadataOnlyChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	changes := make(chan string, 2)
-	watcher, err := Start(directory, func(string) bool { return false }, func(path string) {
-		changes <- path
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer watcher.Close()
+	changes, watcher := watch(t, directory)
 
 	future := time.Now().Add(time.Minute)
 	if err := os.Chtimes(path, future, future); err != nil {
 		t.Fatal(err)
 	}
-
 	assertNoChange(t, changes, "timestamp update")
 
 	if err := os.WriteFile(path, []byte("export const value = 1;\n"), 0o644); err != nil {
@@ -38,14 +32,249 @@ func TestWatcherIgnoresMetadataOnlyChanges(t *testing.T) {
 	if err := os.WriteFile(path, []byte("export const value = 2;\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	assertChange(t, changes, "main.ts", "content update")
+
+	if err := watcher.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("export const value = 3;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	assertNoChange(t, changes, "edit after close")
+}
+
+// An editor saving a file commonly truncates it and writes the bytes back, so
+// the file is briefly empty. That must not be reported as an edit, while a file
+// the user genuinely emptied must be.
+func TestWatcherIgnoresTruncateAndRewrite(t *testing.T) {
+	directory := t.TempDir()
+	path := filepath.Join(directory, "main.ts")
+	contents := []byte("export const value = 1;\n")
+	if err := os.WriteFile(path, contents, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changes, _ := watch(t, directory)
+
+	save(t, path, contents, 5*time.Millisecond)
+	assertNoChange(t, changes, "truncate and rewrite")
+
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	assertChange(t, changes, "main.ts", "emptied file")
+}
+
+// Close returns only once no callback can still be running. A caller tearing
+// down the reload queue its callback writes to would otherwise race a report
+// already in flight.
+func TestWatcherReportsNothingAfterClose(t *testing.T) {
+	directory := t.TempDir()
+	path := filepath.Join(directory, "main.ts")
+	if err := os.WriteFile(path, []byte("export const value = 1;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var mutex sync.Mutex
+	reporting := false
+	started := make(chan struct{})
+	watcher, err := Start(directory, func(string) bool { return false }, func(string) {
+		mutex.Lock()
+		reporting = true
+		mutex.Unlock()
+		close(started)
+
+		// Stands in for the work a real callback does between being handed a
+		// path and returning.
+		time.Sleep(time.Second)
+
+		mutex.Lock()
+		reporting = false
+		mutex.Unlock()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = watcher.Close() })
+
+	if err := os.WriteFile(path, []byte("export const value = 2;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("change was never reported")
+	}
+
+	if err := watcher.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	if reporting {
+		t.Fatal("close returned while a change was still being reported")
+	}
+}
+
+// An edit must be reported even though the tree around it never falls quiet.
+func TestWatcherReportsEditsWhileTreeIsBusy(t *testing.T) {
+	directory := t.TempDir()
+	edited := filepath.Join(directory, "main.ts")
+	if err := os.WriteFile(edited, []byte("export const value = 1;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changes, _ := watch(t, directory)
+	busy(t, filepath.Join(directory, "build.log"))
+
+	if err := os.WriteFile(edited, []byte("export const value = 2;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	awaitChange(t, changes, "main.ts", "edit in a busy tree")
+}
+
+// A file written continuously never falls quiet, so it has to be reported on
+// some bound instead. Waiting for it to settle would mean never reloading it.
+func TestWatcherReportsFileThatNeverSettles(t *testing.T) {
+	directory := t.TempDir()
+	written := filepath.Join(directory, "main.ts")
+	if err := os.WriteFile(written, []byte("export const value = 1;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changes, _ := watch(t, directory)
+	busy(t, written)
+
+	awaitChange(t, changes, "main.ts", "continuously written file")
+}
+
+// Saving a file without changing it must stay silent however busy the rest of
+// the tree is: a save is still a truncate and a rewrite, and the quiet interval
+// one path needs cannot be spent by another path's activity.
+//
+// The saves are spaced so they drift against any batching the watcher does
+// rather than landing at the same point in it each time, since a save is only
+// ever ignored if it is ignored whenever it happens.
+func TestWatcherIgnoresUnchangedSavesWhileTreeIsBusy(t *testing.T) {
+	directory := t.TempDir()
+	saved := filepath.Join(directory, "main.ts")
+	contents := []byte("export const value = 1;\n")
+	if err := os.WriteFile(saved, contents, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changes, _ := watch(t, directory)
+	busy(t, filepath.Join(directory, "build.log"))
+
+	// A slow writer widens the window in which the file is empty, so a save
+	// that is not left to settle is caught rather than merely made likely.
+	for range 40 {
+		save(t, saved, contents, 60*time.Millisecond)
+		time.Sleep(130 * time.Millisecond)
+	}
+	time.Sleep(2 * time.Second)
+
+	for {
+		select {
+		case changed := <-changes:
+			if changed == "main.ts" {
+				t.Fatal("unchanged save was reported")
+			}
+		default:
+			return
+		}
+	}
+}
+
+// save writes a file the way an editor does, truncating it before restoring the
+// bytes so it is briefly empty on disk. The gap stands in for however long the
+// writer takes over its bytes.
+func save(t *testing.T, path string, contents []byte, gap time.Duration) {
+	t.Helper()
+
+	truncated, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := truncated.Close(); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(gap)
+	if err := os.WriteFile(path, contents, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// busy rewrites a file until the test ends, standing in for a build tool or a
+// test runner working in the tree.
+func busy(t *testing.T, path string) {
+	t.Helper()
+
+	stop := make(chan struct{})
+	stopped := make(chan struct{})
+	t.Cleanup(func() {
+		close(stop)
+		<-stopped
+	})
+
+	go func() {
+		defer close(stopped)
+		for line := 0; ; line++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_ = os.WriteFile(path, []byte(strings.Repeat("x", line%64+1)), 0o644)
+			time.Sleep(5 * time.Millisecond)
+		}
+	}()
+}
+
+func watch(t *testing.T, directory string) (<-chan string, *Watcher) {
+	t.Helper()
+
+	changes := make(chan string, 64)
+	watcher, err := Start(directory, func(string) bool { return false }, func(path string) {
+		changes <- path
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = watcher.Close() })
+
+	return changes, watcher
+}
+
+func assertChange(t *testing.T, changes <-chan string, want string, operation string) {
+	t.Helper()
 
 	select {
 	case changed := <-changes:
-		if changed != "main.ts" {
-			t.Fatalf("changed path = %q, want main.ts", changed)
+		if changed != want {
+			t.Fatalf("%s reported %q, want %q", operation, changed, want)
 		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("content update was not reported")
+	case <-time.After(5 * time.Second):
+		t.Fatalf("%s was not reported", operation)
+	}
+}
+
+// awaitChange waits for one path among reports about others.
+func awaitChange(t *testing.T, changes <-chan string, want string, operation string) {
+	t.Helper()
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case changed := <-changes:
+			if changed == want {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("%s was not reported", operation)
+		}
 	}
 }
 


### PR DESCRIPTION
`appwrite run` reloads a function when a watched file's contents change. This fixes two ways that goes wrong, and the second only exists because of the first.

## What breaks

An editor saving a file truncates it and writes the bytes back. Those are two filesystem operations, so between them the file is empty on disk. The watcher fingerprints on every notification, so it sees the empty file, decides the contents changed, and reloads — then sees the restored bytes, decides they changed again, and reloads a second time. Saving a file you did not edit rebuilds your function, twice.

Debouncing fixes that: wait for the notifications to stop, then fingerprint once. But a single timer reset by every event never fires while events keep arriving. A build tool, a test runner, or a dependency install writing into the same tree resets the timer every few milliseconds, and the edit the user is actually waiting on never reaches the reload queue at all — it sits in the pending map, along with everything else, for as long as the noise lasts. Trading spurious reloads for no reloads is not a fix.

So the wait is per path rather than shared. Each path settles on its own clock, and each carries its own cap of one second from its first event, so a tree that never falls quiet still reports within a bounded time. Sharing one deadline would have the same shape of bug in miniature: a file first touched late in a busy stretch gets only whatever milliseconds are left on it, and is fingerprinted mid-save — the spurious reload this exists to prevent.

## Reproduction

Three watcher variants — `main`, the debounce without the cap, and this PR — driven through the public `Start` API by the same harness. Two scenarios: saving an unchanged file ten times (every reload is one the user did not ask for), and editing a source file while a background writer rewrites a log every 5ms (the edit has to arrive).

**macOS 15 (kqueue), Go 1.25**

| variant | 10 unchanged saves, 5ms truncate gap | 10 unchanged saves, no gap | edit reported while busy |
|---|---|---|---|
| `main` | 20 reloads | 18 reloads | after 3ms |
| debounce, no cap | 0 reloads | 0 reloads | **never (>5s)** |
| this PR | 0 reloads | 0 reloads | after 1.001s |

**Linux (inotify), `golang:1.25`**

| variant | 10 unchanged saves, 5ms truncate gap | 10 unchanged saves, no gap | edit reported while busy |
|---|---|---|---|
| `main` | 20 reloads | 10 reloads | after 1ms |
| debounce, no cap | 0 reloads | 0 reloads | **never (>5s)** |
| this PR | 0 reloads | 0 reloads | after 1.002s |

Ten unchanged saves cost ten to twenty rebuilds today, depending on whether the kernel coalesces the truncate and the write into one notification or two. Both platforms starve identically without the cap, and both land on the one-second bound with it.

### What the cap costs

Almost nothing, because the clock is per path. An edit is reported once *its own* events stop, whatever the rest of the tree is doing. Over 25 edits made at random points during continuous background writing:

| min | median | p90 | max |
|---|---|---|---|
| 101ms | 101ms | 102ms | 104ms |

That is the 100ms settle and nothing more — the same latency an edit in a completely quiet tree pays. The one-second cap only binds for a file that is itself being written continuously, which is a log, not a source file.

An earlier revision of this PR shared one deadline across all pending paths. It fixed the starvation but charged every edit for the tree's noise: the same measurement gave a median of 575ms and a p90 of 878ms, spread uniformly across the cap window. Per-path settling is what makes the cap cheap.

## Changes

- Debounce events for 100ms and fingerprint once the path settles, so a truncate-and-rewrite is one decision rather than two.
- Settle each path on its own clock, with its own one-second cap, so continuous activity delays a reload instead of cancelling it and a save begun mid-stretch still gets a full quiet interval.
- `Close` drains the watcher instead of only signalling it, so no callback runs against a queue the caller has torn down. It stays idempotent.

## Tests

Three tests drive the watcher through `Start` rather than its internals, so a behaviour-preserving change to how the debounce is implemented cannot break them:

- a truncate-and-rewrite is not reported, while a file the user genuinely emptied is — fails on `main`
- an edit is reported while the rest of the tree stays busy
- a file that is itself written continuously is still reported, since it never falls quiet — fails without the cap
- repeated unchanged saves during background activity are never reported — fails on `main`, and fails with one shared deadline rather than per-path ones
- `Close` does not return while a report is still in flight — fails without the drain

Each was run against the version lacking its fix to confirm it fails there, rather than assumed to cover it. The saves in the busy test are spaced so they drift against any batching instead of landing at the same point in it each time, because a save is only ignored if it is ignored whenever it happens.

Verified with `gofmt` and `go vet`, and the suite run repeatedly under `-race` on macOS and on Linux (`golang:1.25`).

This was previously carried on the renovate deps branch (#1904); it belongs in its own PR.
